### PR TITLE
Prevent the gulp task from using local gulp folder as command

### DIFF
--- a/Tasks/Gulp/gulptask.ts
+++ b/Tasks/Gulp/gulptask.ts
@@ -14,7 +14,7 @@ tl.cd(cwd);
 var gulp = tl.which('gulp', false);
 
 tl.debug('check path : ' + gulp);
-if(!tl.exist(gulp)) {
+if(!tl.exist(gulp) || tl.stats(gulp).isDirectory()) {
 	tl.debug('not found global installed gulp, try to find gulp locally.');
 	var gt = tl.createToolRunner(tl.which('node', true));
 


### PR DESCRIPTION
task.which(..) is picking up gulp local folder instead of the actual gulp command
