### PR TITLE
Add support for removing custom targets for a 'clean build'

### DIFF
--- a/Tasks/MSBuild/MSBuild.ps1
+++ b/Tasks/MSBuild/MSBuild.ps1
@@ -13,6 +13,7 @@ try {
     [string]$platform = Get-VstsInput -Name Platform
     [string]$configuration = Get-VstsInput -Name Configuration
     [bool]$clean = Get-VstsInput -Name Clean -AsBool
+    [bool]$removeTargetsForClean = Get-VstsInput -Name RemoveTargetsForClean -AsBool
     [bool]$maximumCpuCount = Get-VstsInput -Name MaximumCpuCount -AsBool
     [bool]$restoreNuGetPackages = Get-VstsInput -Name RestoreNuGetPackages -AsBool
     [bool]$logProjectEvents = Get-VstsInput -Name LogProjectEvents -AsBool
@@ -41,7 +42,7 @@ try {
     $global:ErrorActionPreference = 'Continue'
 
     # Build each solution.
-    Invoke-BuildTools -NuGetRestore:$restoreNuGetPackages -SolutionFiles $solutionFiles -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean:$clean -NoTimelineLogger:(!$logProjectEvents) -CreateLogFile:$createLogFile
+    Invoke-BuildTools -NuGetRestore:$restoreNuGetPackages -SolutionFiles $solutionFiles -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean:$clean -RemoveTargetsForClean:$removeTargetsForClean -NoTimelineLogger:(!$logProjectEvents) -CreateLogFile:$createLogFile
 } finally {
     Trace-VstsLeavingInvocation $MyInvocation
 }

--- a/Tasks/MSBuild/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MSBuild/Strings/resources.resjson/en-US/resources.resjson
@@ -12,6 +12,8 @@
   "loc.input.help.msbuildArguments": "Additional arguments passed to MSBuild (on Windows) and xbuild (on Mac).",
   "loc.input.label.clean": "Clean",
   "loc.input.help.clean": "Run a clean build (/t:clean) prior to the build.",
+  "loc.input.label.removeTargetsForClean": "Remove Custom Targets",
+  "loc.input.help.removeTargetsForClean": "Remove all custom targets from MSBuild Arguments when running the clean build.",
   "loc.input.label.maximumCpuCount": "Build in Parallel",
   "loc.input.help.maximumCpuCount": "If your MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If your target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
   "loc.input.label.restoreNugetPackages": "Restore NuGet Packages",

--- a/Tasks/MSBuild/task.json
+++ b/Tasks/MSBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 55
+        "Patch": 56
     },
     "demands": [
         "msbuild"
@@ -63,6 +63,15 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Run a clean build (/t:clean) prior to the build."
+        },
+        {
+            "name": "removeTargetsForClean",
+            "type": "boolean",
+            "label": "Remove Custom Targets",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Remove all custom targets from MSBuild Arguments when running the clean build.",
+            "visibleRule": "clean = true"
         },
         {
             "name": "maximumCpuCount",

--- a/Tasks/MSBuild/task.loc.json
+++ b/Tasks/MSBuild/task.loc.json
@@ -12,7 +12,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 55
+    "Patch": 56
   },
   "demands": [
     "msbuild"
@@ -63,6 +63,15 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.clean"
+    },
+    {
+      "name": "removeTargetsForClean",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.removeTargetsForClean",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.removeTargetsForClean",
+      "visibleRule": "clean = true"
     },
     {
       "name": "maximumCpuCount",

--- a/Tasks/VSBuild/VSBuild.ps1
+++ b/Tasks/VSBuild/VSBuild.ps1
@@ -13,6 +13,7 @@ try {
     [string]$platform = Get-VstsInput -Name Platform
     [string]$configuration = Get-VstsInput -Name Configuration
     [bool]$clean = Get-VstsInput -Name Clean -AsBool
+    [bool]$removeTargetsForClean = Get-VstsInput -Name RemoveTargetsForClean -AsBool
     [bool]$maximumCpuCount = Get-VstsInput -Name MaximumCpuCount -AsBool
     [bool]$restoreNugetPackages = Get-VstsInput -Name RestoreNugetPackages -AsBool
     [bool]$logProjectEvents = Get-VstsInput -Name LogProjectEvents -AsBool
@@ -60,7 +61,7 @@ try {
     $global:ErrorActionPreference = 'Continue'
 
     # Build each solution.
-    Invoke-BuildTools -NuGetRestore:$RestoreNuGetPackages -SolutionFiles $solutionFiles -MSBuildLocation $MSBuildLocation -MSBuildArguments $MSBuildArgs -Clean:$Clean -NoTimelineLogger:(!$LogProjectEvents) -CreateLogFile:$createLogFile
+    Invoke-BuildTools -NuGetRestore:$RestoreNuGetPackages -SolutionFiles $solutionFiles -MSBuildLocation $MSBuildLocation -MSBuildArguments $MSBuildArgs -Clean:$Clean -RemoveTargetsForClean:$removeTargetsForClean -NoTimelineLogger:(!$LogProjectEvents) -CreateLogFile:$createLogFile
 } finally {
     Trace-VstsLeavingInvocation $MyInvocation
 }

--- a/Tasks/VSBuild/task.json
+++ b/Tasks/VSBuild/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 49
+        "Patch": 50
     },
     "demands": [
         "msbuild",
@@ -63,6 +63,15 @@
             "label": "Clean",
             "defaultValue": "false",
             "required": false
+        },
+        {
+            "name": "removeTargetsForClean",
+            "type": "boolean",
+            "label": "Remove Custom Targets",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Remove all custom targets from MSBuild Arguments when running the clean build.",
+            "visibleRule": "clean = true"
         },
         {
             "name": "maximumCpuCount",


### PR DESCRIPTION
**Description:** The current implementation of the MSBuild and VSBuild tasks support running a 'clean build' prior to the actual build (clean option). If custom targets are provided (/t option in addition MSBuild arguments), those targets are executed during the 'clean build'. In many (if not most) cases, this is not the intended behavior and the only solution with the current task version is to use separate MSBuild/VSBuild tasks and explicitly call the clean target.

**Solution:** An option has been added to the MSBuild and VSBuild tasks to remove all custom targets when running a 'clean build'.

**Question:** Would such an option make sense in the XamarinAndroidBuild task as well? It also uses the MSBuildHelpers module, which contains my changes.

**Testing:** Manual.