### PR TITLE
trim trailing backslash if it exists - fixes #6628

### DIFF
--- a/Tasks/PublishSymbols/PublishSymbols.ps1
+++ b/Tasks/PublishSymbols/PublishSymbols.ps1
@@ -56,6 +56,7 @@ try {
 
         # Get the inputs.
         [string]$SymbolsPath = Get-VstsInput -Name 'SymbolsPath'
+        $SymbolsPath = $SymbolsPath.TrimEnd('\')
 
         if ([string]$SourceFolder = (Get-VstsInput -Name 'SourceFolder') -and
             $SourceFolder -ne (Get-VstsTaskVariable -Name 'Build.SourcesDirectory' -Require)) {


### PR DESCRIPTION
Trim the trailing backslash from the `Path to publish symbols`.  This fixes #6628 .