### PR TITLE
[Utility][Symbols] Only create the build artifact for a symbol request when running as part of the build.

### DIFF
--- a/Tasks/PublishSymbols/PublishSymbols.ps1
+++ b/Tasks/PublishSymbols/PublishSymbols.ps1
@@ -197,7 +197,12 @@ try {
         [string] $encodedRequestName = [System.Web.HttpUtility]::UrlEncode($RequestName)
         # Use hash prefix for now to be compatible with older/current agents, RequestType is still different (than SymbolStore)
         [string] $requestUrl = "#$SymbolServiceUri/_apis/Symbol/requests?requestName=$encodedRequestName"
-        Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
+        [string] $hostType = (Get-VstsTaskVariable -Name 'System.HostType' -Require)
+        # Only create VSTS build artifact asociation when run during build.
+        if ($hostType -eq "BUILD")
+        {
+            Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
+        }
 
         & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
 


### PR DESCRIPTION
This PR unblocks the use of the Publish Symbols task in release definitions, by only publishing the build artifact when the task is run in a build definition.