### PR TITLE
[Utility] Added option to select 7z level of compression.

### DIFF
--- a/Tasks/ArchiveFilesV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ArchiveFilesV2/Strings/resources.resjson/en-US/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.includeRootFolder": "If selected, the root folder name will be prepended to file paths within the archive. Otherwise, all file paths will start one level lower.<p>For example, suppose the selected root folder is: <b>`/home/user/output/classes/`</b>, and contains: <b>`com/acme/Main.class`</b>. <ul><li>If selected, the resulting archive would contain: <b>`classes/com/acme/Main.class`</b>.</li><li>Otherwise, the resulting archive would contain: <b>`com/acme/Main.class`</b>.</li></ul>",
   "loc.input.label.archiveType": "Archive type",
   "loc.input.help.archiveType": "Specify the compression scheme used.  To create <b>`foo.jar`</b>, for example, choose <b>`zip`</b> for the compression, and specify <b>`foo.jar`</b> as the archive file to create.  For all tar files (including compressed ones), choose <b>`tar`</b>.",
+  "loc.input.label.sevenZipCompression": "7z compression",
+  "loc.input.help.sevenZipCompression": "Optionally choose a compression level, or choose <b>`None`</b> to create an uncompressed 7z file.",
   "loc.input.label.tarCompression": "Tar compression",
   "loc.input.help.tarCompression": "Optionally choose a compression scheme, or choose <b>`None`</b> to create an uncompressed tar file.",
   "loc.input.label.archiveFile": "Archive file to create",

--- a/Tasks/ArchiveFilesV2/archivefiles.ts
+++ b/Tasks/ArchiveFilesV2/archivefiles.ts
@@ -109,6 +109,12 @@ function sevenZipArchive(archive: string, compression: string, files: string[]) 
         // Set highest logging level
         sevenZip.arg('-bb3');
     }
+
+    const sevenZipCompression = tl.getInput('sevenZipCompression', false);    
+    if(sevenZipCompression) {
+        sevenZip.arg('-mx=' + sevenZipCompression);
+    }
+
     sevenZip.arg(archive);
 
     const fileList: string = createFileList(files);

--- a/Tasks/ArchiveFilesV2/archivefiles.ts
+++ b/Tasks/ArchiveFilesV2/archivefiles.ts
@@ -110,9 +110,9 @@ function sevenZipArchive(archive: string, compression: string, files: string[]) 
         sevenZip.arg('-bb3');
     }
 
-    const sevenZipCompression = tl.getInput('sevenZipCompression', false);    
-    if(sevenZipCompression) {
-        sevenZip.arg('-mx=' + sevenZipCompression);
+    const sevenZipCompression = tl.getInput('sevenZipCompression', false);
+    if (sevenZipCompression) {
+        sevenZip.arg('-mx=' + mapSevenZipCompressionLevel(sevenZipCompression));
     }
 
     sevenZip.arg(archive);
@@ -121,6 +121,26 @@ function sevenZipArchive(archive: string, compression: string, files: string[]) 
     sevenZip.arg('@' + fileList);
 
     return handleExecResult(sevenZip.execSync(getOptions()), archive);
+}
+
+// map from YAML-friendly value to 7-Zip numeric value
+function mapSevenZipCompressionLevel(sevenZipCompression: string) {    
+    switch (sevenZipCompression.toLowerCase()) {
+        case "ultra":
+            return "9";
+        case "maximum":
+            return "7";
+        case "normal":
+            return "5";
+        case "fast":
+            return "3";
+        case "fastest":
+            return "1";
+        case "none":
+            return "0";
+        default:
+            return "5";
+    }
 }
 
 // linux & mac only

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -71,12 +71,12 @@
             "groupName": "archive",
             "visibleRule": "archiveType = 7z",
             "options": {
-                "9": "Ultra",
-                "7": "Maximum",
-                "5": "Normal",
-                "3": "Fast",
-                "1": "Fastest",
-                "0": "None"
+                "ultra": "Ultra",
+                "maximum": "Maximum",
+                "normal": "Normal",
+                "fast": "Fast",
+                "fastest": "Fastest",
+                "none": "None"
             }
         },
         {

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -18,7 +18,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 158,
+        "Minor": 159,
         "Patch": 0
     },
     "groups": [
@@ -59,6 +59,24 @@
                 "7z": "7z",
                 "tar": "tar",
                 "wim": "wim"
+            }
+        },
+        {
+            "name": "sevenZipCompression",
+            "type": "pickList",
+            "label": "7z compression",
+            "required": false,
+            "defaultValue": "5",
+            "helpMarkDown": "Optionally choose a compression level, or choose <b>`None`</b> to create an uncompressed 7z file.",
+            "groupName": "archive",
+            "visibleRule": "archiveType = 7z",
+            "options": {
+                "9": "Ultra",
+                "7": "Maximum",
+                "5": "Normal",
+                "3": "Fast",
+                "1": "Fastest",
+                "0": "None"
             }
         },
         {

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -71,12 +71,12 @@
       "groupName": "archive",
       "visibleRule": "archiveType = 7z",
       "options": {
-        "0": "None",
-        "1": "Fastest",
-        "3": "Fast",
-        "5": "Normal",
-        "7": "Maximum",
-        "9": "Ultra"
+        "ultra": "Ultra",
+        "maximum": "Maximum",
+        "normal": "Normal",
+        "fast": "Fast",
+        "fastest": "Fastest",
+        "none": "None"
       }
     },
     {

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 158,
+    "Minor": 159,
     "Patch": 0
   },
   "groups": [
@@ -59,6 +59,24 @@
         "7z": "7z",
         "tar": "tar",
         "wim": "wim"
+      }
+    },
+    {
+      "name": "sevenZipCompression",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.sevenZipCompression",
+      "required": false,
+      "defaultValue": "5",
+      "helpMarkDown": "ms-resource:loc.input.help.sevenZipCompression",
+      "groupName": "archive",
+      "visibleRule": "archiveType = 7z",
+      "options": {
+        "0": "None",
+        "1": "Fastest",
+        "3": "Fast",
+        "5": "Normal",
+        "7": "Maximum",
+        "9": "Ultra"
       }
     },
     {


### PR DESCRIPTION
Similarly to the `tarCompression` option, this change allows the user to select the level of compression for 7z files. 

The option names follow the [naming conventions used by 7z](https://sevenzip.osdn.jp/chm/cmdline/switches/method.htm#SevenZipX).