### PR TITLE
Clarify fail conditions of CopyFilesV2 by adding FailIfAlreadyExists option

### DIFF
--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -10,6 +10,7 @@ let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
 let targetFolder: string = tl.getPathInput('TargetFolder', true);
 let cleanTargetFolder: boolean = tl.getBoolInput('CleanTargetFolder', false);
 let overWrite: boolean = tl.getBoolInput('OverWrite', false);
+let failIfAlreadyExists: boolean = tl.getBoolInput('FailIfAlreadyExists', false);
 let flattenFolders: boolean = tl.getBoolInput('flattenFolders', false);
 
 // normalize the source folder path. this is important for later in order to accurately
@@ -102,7 +103,12 @@ if (matchedFiles.length > 0) {
 
             if (!overWrite) {
                 if (targetStats) { // exists, skip
-                    console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                    if (failIfAlreadyExists) {
+                        throw new Error(tl.loc('FileAlreadyExistAt', file, targetPath));
+                    }
+                    else {
+                        console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                    }
                 }
                 else { // copy
                     console.log(tl.loc('CopyingTo', file, targetPath));

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -72,6 +72,15 @@
             "groupName": "advanced"
         },
         {
+            "name": "FailIfAlreadyExists",
+            "type": "boolean",
+            "label": "Fail if file already exists",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "If file already exists in target folder and Overwrite is not selected, throw an error",
+            "groupName": "advanced"
+        },
+        {
             "name": "flattenFolders",
             "type": "boolean",
             "label": "Flatten Folders",


### PR DESCRIPTION
Addresses concerns raised in https://github.com/MicrosoftDocs/vsts-docs/issues/537 and https://github.com/MicrosoftDocs/vsts-docs/issues/354 by adding an option to fail the task if the target file already exists and Overwrite is false.