### PR TITLE
tl.find verbose logs off by default for vstest task

### DIFF
--- a/Tasks/VsTestV2/helpers.ts
+++ b/Tasks/VsTestV2/helpers.ts
@@ -242,9 +242,9 @@ export class Helper {
 
     // set the console code page to "UTF-8"
     public static setConsoleCodePage() {
-        tl.debug("Changing active code page to UTF-8");
-        const chcp = tl.tool(path.resolve(process.env.windir, "system32", "chcp.com"));
-        chcp.arg(["65001"]);
+        tl.debug('Changing active code page to UTF-8');
+        const chcp = tl.tool(path.resolve(process.env.windir, 'system32', 'chcp.com'));
+        chcp.arg(['65001']);
         chcp.execSync({ silent: true } as tr.IExecSyncOptions);
     }
 

--- a/Tasks/VsTestV2/nondistributedtest.ts
+++ b/Tasks/VsTestV2/nondistributedtest.ts
@@ -1,13 +1,8 @@
 import * as tl from 'vsts-task-lib/task';
 import * as tr from 'vsts-task-lib/toolrunner';
 import * as path from 'path';
-import * as models from './models';
-import * as inputParser from './inputparser';
 import * as utils from './helpers';
 import * as outStream from './outputstream';
-import * as ci from './cieventlogger';
-import { AreaCodes, ResultMessages } from './constants';
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
 import * as os from 'os';
 import * as uuid from 'uuid';
 import * as fs from 'fs';
@@ -25,27 +20,19 @@ export class NonDistributedTest {
 
     private async invokeDtaExecutionHost() {
         try {
-    
+
             console.log(tl.loc('runTestsLocally', 'vstest.console.exe'));
             console.log('========================================================');
-    
-            this.testAssemblyFiles = this.getTestAssemblies();
-            if (!this.testAssemblyFiles || this.testAssemblyFiles.length === 0) {
-                console.log('##vso[task.logissue type=warning;code=002004;]');
-                tl.warning(tl.loc('NoMatchingTestAssemblies', this.sourceFilter));
-                return;
-            }
-            
+
             const exitCode = await this.startDtaExecutionHost();
             tl.debug('DtaExecutionHost finished');
 
             if (exitCode !== 0 && !this.inputDataContract.ExecutionSettings.IgnoreTestFailures) {
                 tl.debug('Modules/DTAExecutionHost.exe process exited with code ' + exitCode);
                 tl.setResult(tl.TaskResult.Failed, tl.loc('VstestFailed'));
-                return;            
+                return;
             } else {
-                if (exitCode !== 0)
-                {
+                if (exitCode !== 0) {
                     console.log('Task marked as success because IgnoreTestFailures is enabled');
                 }
                 tl.debug(`Modules/DTAExecutionHost.exe exited with code ${exitCode}`);
@@ -57,45 +44,44 @@ export class NonDistributedTest {
             tl.setResult(tl.TaskResult.Failed, tl.loc('VstestFailedReturnCode'));
         }
     }
-    
+
     private async startDtaExecutionHost(): Promise<number> {
         let dtaExecutionHostTool = tl.tool(path.join(this.inputDataContract.VsTestConsolePath, 'vstest.console.exe'));
-    
+
         this.inputDataContract.TestSelectionSettings.TestSourcesFile = this.createTestSourcesFile();
         tl.cd(this.inputDataContract.TfsSpecificSettings.WorkFolder);
         let envVars: { [key: string]: string; } = process.env;
         dtaExecutionHostTool = tl.tool(path.join(__dirname, 'Modules/DTAExecutionHost.exe'));
-    
+
         // Invoke DtaExecutionHost with the input json file
         const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v1() + '.json');
         utils.Helper.removeEmptyNodes(this.inputDataContract);
-    
+
         try {
             fs.writeFileSync(inputFilePath, JSON.stringify(this.inputDataContract));
         } catch (e) {
             tl.setResult(tl.TaskResult.Failed, `Failed to write to the input json file ${inputFilePath} with error ${e}`);
         }
-    
+
         if (utils.Helper.isDebugEnabled()) {
             utils.Helper.uploadFile(inputFilePath);
         }
-    
+
         dtaExecutionHostTool.arg(['--inputFile', inputFilePath]);
-    
+
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.AccessToken', tl.getEndpointAuthorization('SystemVssConnection', true).parameters.AccessToken);
 
-        if(this.inputDataContract.ExecutionSettings.DiagnosticsSettings.Enabled)
-        {
+        if (this.inputDataContract.ExecutionSettings.DiagnosticsSettings.Enabled) {
             utils.Helper.addToProcessEnvVars(envVars, 'PROCDUMP_PATH', path.join(__dirname, 'ProcDump'));
         }
-    
+
         // hydra: See which of these are required in C# layer. Do we want this for telemetry??
         // utils.Helper.addToProcessEnvVars(envVars, 'DTA.AgentVersion', tl.getVariable('AGENT.VERSION'));
-    
+
         if (this.inputDataContract.UsingXCopyTestPlatformPackage) {
             envVars = utils.Helper.setProfilerVariables(envVars);
         }
-    
+
         const execOptions: tr.IExecOptions = <any>{
             IgnoreTestFailures: this.inputDataContract.ExecutionSettings.IgnoreTestFailures,
             env: envVars,
@@ -104,7 +90,7 @@ export class NonDistributedTest {
             // Keeping this code in case we want to change failOnStdErr
             errStream: new outStream.StringErrorWritable({ decodeStrings: false })
         };
-    
+
         // The error codes return below are not the same as tl.TaskResult which follows a different convention.
         // Here we are returning the code as returned to us by vstest.console in case of complete run
         // In case of a failure 1 indicates error to our calling function
@@ -116,17 +102,36 @@ export class NonDistributedTest {
             return 1;
         }
     }
-    
+
     private getTestAssemblies(): string[] {
         tl.debug('Searching for test assemblies in: ' + this.inputDataContract.TestSelectionSettings.SearchFolder);
-        return tl.findMatch(this.inputDataContract.TestSelectionSettings.SearchFolder, this.sourceFilter);
+
+        let sources;
+        try {
+            if (!utils.Helper.stringToBool(tl.getVariable('EnableVerboseFilesListing'))) {
+                tl.setVariable('System.Debug', 'false');
+            }
+            sources = tl.findMatch(this.inputDataContract.TestSelectionSettings.SearchFolder, this.sourceFilter);
+        } finally {
+            if (this.inputDataContract.Logging.DebugLogging) {
+                tl.setVariable('System.Debug', 'true');
+            }
+        }
+
+        return sources;
     }
-    
+
     private createTestSourcesFile(): string {
         try {
             console.log(tl.loc('UserProvidedSourceFilter', this.sourceFilter.toString()));
-    
-            const sources = tl.findMatch(this.inputDataContract.TestSelectionSettings.SearchFolder, this.sourceFilter);
+
+            const sources = this.getTestAssemblies();
+            if (!sources || sources.length === 0) {
+                console.log('##vso[task.logissue type=warning;code=002004;]');
+                tl.warning(tl.loc('NoMatchingTestAssemblies', this.sourceFilter));
+                return;
+            }
+
             tl.debug('tl match count :' + sources.length);
             const filesMatching = [];
             sources.forEach(function (match: string) {
@@ -134,12 +139,12 @@ export class NonDistributedTest {
                     filesMatching.push(match);
                 }
             });
-    
+
             tl.debug('Files matching count :' + filesMatching.length);
             if (filesMatching.length === 0) {
                 throw new Error(tl.loc('noTestSourcesFound', this.sourceFilter.toString()));
             }
-    
+
             const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v1() + '.src');
             fs.writeFileSync(tempFile, filesMatching.join(os.EOL));
             tl.debug('Test Sources file :' + tempFile);
@@ -150,6 +155,5 @@ export class NonDistributedTest {
     }
 
     private inputDataContract: InputDataContract;
-    private testAssemblyFiles: string[];
-    private sourceFilter = tl.getDelimitedInput('testAssemblyVer2', '\n', true);
+    private sourceFilter: string[] = tl.getDelimitedInput('testAssemblyVer2', '\n', true);
 }

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 140,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 140,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
doing this for multiple reasons:

Log file sizes are bloating up like crazy
Too much clutter in the logs
Additional time spent logging all this
customers might be more willing to directly attach the logs zip since test sources are no longer explicitly listed in the logs