### PR TITLE
Adding test case access token in environment variables

### DIFF
--- a/Tasks/VsTestV2/distributedtest.ts
+++ b/Tasks/VsTestV2/distributedtest.ts
@@ -63,6 +63,9 @@ export class DistributedTest {
             envVars = utils.Helper.setProfilerVariables(envVars);
         }
 
+        // Pass the test case acess token as an environment variable for security purposes.
+        utils.Helper.addToProcessEnvVars(envVars, 'Test.TestCaseAccessToken', tl.getVariable('Test.TestCaseAccessToken'));
+
         // Pass the acess token as an environment variable for security purposes
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.AccessToken', tl.getEndpointAuthorization('SystemVssConnection', true).parameters.AccessToken);
 

--- a/Tasks/VsTestV2/nondistributedtest.ts
+++ b/Tasks/VsTestV2/nondistributedtest.ts
@@ -82,6 +82,9 @@ export class NonDistributedTest {
     
         dtaExecutionHostTool.arg(['--inputFile', inputFilePath]);
     
+        // Pass the test case acess token as an environment variable for security purposes.
+        utils.Helper.addToProcessEnvVars(envVars, 'Test.TestCaseAccessToken', tl.getVariable('Test.TestCaseAccessToken'));
+
         utils.Helper.addToProcessEnvVars(envVars, 'DTA.AccessToken', tl.getEndpointAuthorization('SystemVssConnection', true).parameters.AccessToken);
 
         if(this.inputDataContract.ExecutionSettings.DiagnosticsSettings.Enabled)


### PR DESCRIPTION
Test case based data driven tests is a supported scenario. Check [this](https://docs.microsoft.com/en-us/vsts/release-notes/2017/dec-11-vsts) documentation for more details.

This scenario is no longer working.