### PR TITLE
Add useXcpretty to Xcode template

### DIFF
--- a/templates/ci/xcode.yml
+++ b/templates/ci/xcode.yml
@@ -15,3 +15,4 @@ steps:
     sdk: 'iphoneos'
     configuration: 'Release'
     xcodeVersion: 'default' # Options: 8, 9, default, specifyPath
+    useXcpretty: 'true'     # Switch to false for verbose build output


### PR DESCRIPTION
Make it easier to diagnose why a failing build failed.

With xc pretty enabled, the only output you get is:

```
▸ Building XcodeHelloWorld/XcodeHelloWorld [Release]
▸ Check Dependencies
** BUILD FAILED **
 ##[error]Error: /usr/bin/xcodebuild failed with return code: 65
```