### PR TITLE
DockerV1 task - Change command options so that closer aligned to CLI

### DIFF
--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -82,7 +82,7 @@
             "name": "command",
             "type": "pickList",
             "label": "Command",
-            "defaultValue": "Build an image",
+            "defaultValue": "build",
             "required": true,
             "options": {
                 "build": "build",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -82,7 +82,7 @@
       "name": "command",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.command",
-      "defaultValue": "Build an image",
+      "defaultValue": "build",
       "required": true,
       "options": {
         "build": "build",


### PR DESCRIPTION
The command options that had to be provided in the YAML file are not very "friendly" to code. 
This PR changes those values to what they are expected to be on the command line. 
They are still descriptive enough so that users not familiar with the CLI can understand them.

My first PR to this project. Open to any feedback.

> Note: I wasn't able to get any of the tests to run following the documentation. I don't assume this change breaks anything, but if it does, push it back on me and I'll fix it.