### PR TITLE
Add Environment variables input in docker task

### DIFF
--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 18
+        "Patch": 19
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",
@@ -358,6 +358,7 @@
         }
     ],
     "instanceNameFormat": "$(command)",
+    "showEnvironmentVariables": true,
     "execution": {
         "Node": {
             "target": "container.js"

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 18
+    "Patch": 19
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -358,6 +358,7 @@
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
+  "showEnvironmentVariables": true,
   "execution": {
     "Node": {
       "target": "container.js"


### PR DESCRIPTION
Add  environment variables input in docker task. This is helpful in passing secret variables defined in the release definition.

Related issue: #8483 

Note: What is asked in the issue can be accomplished using release variables as well. This is to enhance the experience and provide the ability to use secrets.