### PR TITLE
If inputs required for tls not present throw proper error. 

### DIFF
--- a/Tasks/HelmDeployV0/src/downloadsecurefiles.ts
+++ b/Tasks/HelmDeployV0/src/downloadsecurefiles.ts
@@ -11,6 +11,7 @@ async function run() {
 
     if(!enableTls) {
         tl.debug(tl.loc("SkipDownloadSecureFiles"));
+        return;
     }
 
     var caCert = tl.getInput('caCert', true);
@@ -30,4 +31,8 @@ async function run() {
     }
 }
 
-run();
+run().then(()=>{
+    // do nothing
+}, (reason)=> {
+        tl.setResult(tl.TaskResult.Failed, reason);
+});

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 138,
-        "Patch": 9
+        "Patch": 10
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 138,
-    "Patch": 9
+    "Patch": 10
   },
   "demands": [],
   "groups": [


### PR DESCRIPTION
If tls enabled and inputs required for tls not present throw proper error. 
If tls not enabled, return immediately instead of moving ahead.