### PR TITLE
Revert "Fix permissions error when updating Conda"

### DIFF
--- a/Tasks/CondaEnvironmentV1/conda_internal.ts
+++ b/Tasks/CondaEnvironmentV1/conda_internal.ts
@@ -92,11 +92,11 @@ export function prependCondaToPath(condaRoot: string, platform: Platform): void 
  */
 export async function updateConda(condaRoot: string, platform: Platform): Promise<void> {
     try {
-        const conda = sudo('conda', platform);
+        const conda = task.tool('conda');
         conda.line('update --name base conda --yes');
         await conda.exec();
     } catch (e) {
-        task.debug('Failed to update conda. This is best effort. Continuing ...');
+        // Best effort
     }
 }
 

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 143,
-        "Patch": 0
+        "Minor": 140,
+        "Patch": 3
     },
     "demands": [],
     "instanceNameFormat": "Conda environment $(environmentName)",

--- a/Tasks/CondaEnvironmentV1/task.loc.json
+++ b/Tasks/CondaEnvironmentV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 143,
-    "Patch": 0
+    "Minor": 140,
+    "Patch": 2
   },
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
I'm reverting this because I realized the PR checks didn't run since GitHub webhooks are down.  I ran L0 tests on my Windows dev box but this change really needs to run x-plat.

See https://blog.github.com/2018-10-21-october21-incident-report/