### PR TITLE
[Deploy] Treat the AppendDateTimeToLabel param as a bool

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/Publish-AzureCloudDeployment.ps1
@@ -10,7 +10,7 @@ try{
     $CsCfg = Get-VstsInput -Name CsCfg -Require
     $Slot = Get-VstsInput -Name Slot -Require
     $DeploymentLabel = Get-VstsInput -Name DeploymentLabel
-    $AppendDateTimeToLabel = Get-VstsInput -Name AppendDateTimeToLabel -Require
+    $AppendDateTimeToLabel = Get-VstsInput -Name AppendDateTimeToLabel -Require -AsBool
     $AllowUpgrade = Get-VstsInput -Name AllowUpgrade -Require -AsBool
     $SimultaneousUpgrade = Get-VstsInput -Name SimultaneousUpgrade -AsBool
     $ForceUpgrade = Get-VstsInput -Name ForceUpgrade -AsBool


### PR DESCRIPTION
In the AzureCloudPowerShellDeployment task the AppendDateTimeToLabel is ignored, should be treated like a Boolean.
