### PR TITLE
Working directory label update

### DIFF
--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -56,7 +56,7 @@
         },
         {
             "name": "workingDir",
-            "label": "Working folder with package.json",
+            "label": "Working folder that contains package.json",
             "helpMarkDown": "Path to the folder containing the target package.json and .npmrc files. Select the folder, not the file e.g. \"/packages/mypackage\".",
             "type": "filePath"
         },


### PR DESCRIPTION
The label "Working folder with package.json" is misleading.
Suggesting to use "Working folder that contains package.json".

The following issue has also been updated on docs: https://github.com/MicrosoftDocs/vsts-docs/issues/2360
