### PR TITLE
Grammar fix for FileAlreadyExistAt message

### DIFF
--- a/Tasks/CopyFilesV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFilesV2/Strings/resources.resjson/en-US/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.help.flattenFolders": "Flatten the folder structure and copy all files into the specified target folder.",
   "loc.messages.FoundNFiles": "found %d files",
   "loc.messages.CleaningTargetFolder": "Cleaning target folder: %s",
-  "loc.messages.FileAlreadyExistAt": "File %s already exist at %s",
+  "loc.messages.FileAlreadyExistAt": "File %s already exists at %s",
   "loc.messages.CopyingTo": "Copying %s to %s",
   "loc.messages.TargetIsDir": "Unable to copy file %s to %s. The target path already exists as a directory."
 }

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -91,7 +91,7 @@
     "messages": {
         "FoundNFiles": "found %d files",
         "CleaningTargetFolder": "Cleaning target folder: %s",
-        "FileAlreadyExistAt": "File %s already exist at %s",
+        "FileAlreadyExistAt": "File %s already exists at %s",
         "CopyingTo": "Copying %s to %s",
         "TargetIsDir": "Unable to copy file %s to %s. The target path already exists as a directory."
     }


### PR DESCRIPTION
Change “File %s already exist at %s" to “File %s already exists at %s", correcting the sentence’s noun-verb agreement.