### PR TITLE
Update PublishTestResults and VsTest task

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/7595738/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/7790066/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 143,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 143,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/7734137/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/7790066/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 143,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 143,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
SAS caching addition in PublishTest library to make single call for retrieving sas for multiple file upload/download for TestLogStore.