### PR TITLE
Changed Azure CLI task to use agent's temp directory for all of it's …

### DIFF
--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -32,11 +32,12 @@ export class azureclitask {
             }
             else {
                 var script: string = tl.getInput("inlineScript", true);
+                scriptPath = path.join(tl.getVariable('Agent.TempDirectory'), "azureclitaskscript" + new Date().getTime());
                 if (os.type() != "Windows_NT") {
-                    scriptPath = path.join(os.tmpdir(), "azureclitaskscript" + new Date().getTime() + ".sh");
+                    scriptPath = scriptPath + ".sh";
                 }
                 else {
-                    scriptPath = path.join(os.tmpdir(), "azureclitaskscript" + new Date().getTime() + ".bat");
+                    scriptPath = scriptPath + ".bat";
                 }
                 this.createFile(scriptPath, script);
             }
@@ -140,14 +141,8 @@ export class azureclitask {
     }
 
     private static setConfigDirectory(): void {
-        var configDirName: string = "c" + new Date().getTime(); // 'c' denotes config
-        if (tl.osType().match(/^Win/)) {
-            this.azCliConfigPath = path.join(process.env.USERPROFILE, ".azclitask", configDirName);
-        }
-        else {
-            this.azCliConfigPath = path.join(process.env.HOME, ".azclitask", configDirName);
-        }
-
+        var configDirName: string = "config" + new Date().getTime();
+        this.azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask", configDirName);
         process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
     }
 

--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -32,7 +32,7 @@ export class azureclitask {
             }
             else {
                 var script: string = tl.getInput("inlineScript", true);
-                scriptPath = path.join(tl.getVariable('Agent.TempDirectory'), "azureclitaskscript" + new Date().getTime());
+                scriptPath = path.join(tl.getVariable('Agent.TempDirectory'), "azscript");
                 if (os.type() != "Windows_NT") {
                     scriptPath = scriptPath + ".sh";
                 }
@@ -141,8 +141,7 @@ export class azureclitask {
     }
 
     private static setConfigDirectory(): void {
-        var configDirName: string = "config" + new Date().getTime();
-        this.azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask", configDirName);
+        this.azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), "azconfig");
         process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
     }
 

--- a/Tasks/AzureCLIV1/task.loc.json
+++ b/Tasks/AzureCLIV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 143,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
…generated files.

This change is to fix this issue: #8561 

I made changes to always use the agent's temp directory for Azure CLI config and for the batch file that it generates from inline script. We shouldn't be using date time as a source of "unique" dir / file name, but now that it's generated in temp directory it doesn't really matter.

To test it, I ran 8 Azure CLI tasks in parallel phase on 8 VSTS agent at once.
Before the change, 40% of builds would fail with error message mentioned in issue.
After the change, all builds passed.

@bishal-pdMSFT For review?