### PR TITLE
Remove demand for AndroidSDK

### DIFF
--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -11,12 +11,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 141,
-        "Patch": 2
+        "Minor": 145,
+        "Patch": 0
     },
     "demands": [
-        "JDK",
-        "AndroidSDK"
+        "JDK"
     ],
     "minimumAgentVersion": "2.116.0",
     "groups": [

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -11,12 +11,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 141,
+    "Minor": 145,
     "Patch": 0
   },
   "demands": [
-    "JDK",
-    "AndroidSDK"
+    "JDK"
   ],
   "minimumAgentVersion": "2.116.0",
   "groups": [

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -11,13 +11,12 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 141,
-        "Patch": 2
+        "Minor": 145,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",
     "demands": [
-        "JDK",
-        "AndroidSDK"
+        "JDK"
     ],
     "minimumAgentVersion": "2.116.0",
     "groups": [

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -11,13 +11,12 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 141,
+    "Minor": 145,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [
-    "JDK",
-    "AndroidSDK"
+    "JDK"
   ],
   "minimumAgentVersion": "2.116.0",
   "groups": [


### PR DESCRIPTION
Demands are not evaluated on Microsoft Hosted pools and are only used on "Self Hosted" pools. AndroidSDK is installed by Visual Studio in a custom location and can change based on the VS version installed, so it is not reliable to detect it on the agent anymore. We are remove this demand from tasks since the value it provides is limited. 