### PR TITLE
Made command dropdown optional in Kubernetes V0 and V1 task

### DIFF
--- a/Tasks/KubernetesV0/src/kubernetesconfigmap.ts
+++ b/Tasks/KubernetesV0/src/kubernetesconfigmap.ts
@@ -6,6 +6,7 @@ import path = require('path');
 import * as fs from "fs";
 import * as kubernetesCommand from "./kubernetescommand";
 import ClusterConnection from "./clusterconnection";
+import * as utils from "./utilities";
 
 export function run(connection: ClusterConnection, configMapName: string): Promise<any> {
     if(tl.getBoolInput("forceUpdateConfigMap") == false)
@@ -70,7 +71,9 @@ function createConfigMap(connection: ClusterConnection, configMapName: string): 
     command.arg("configmap");
     command.arg(configMapName);
     command.line(getConfigMapArguments());
-    return connection.execCommand(command);
+    return connection.execCommand(command).fin(function cleanup() {
+        utils.setOutputVariable(configMapName);
+     });
 }
 
 function executeKubetclGetConfigmapCommand(connection: ClusterConnection, configMapName: string): any {

--- a/Tasks/KubernetesV0/src/kubernetessecret.ts
+++ b/Tasks/KubernetesV0/src/kubernetessecret.ts
@@ -5,6 +5,7 @@ import path = require('path');
 import * as tr from "vsts-task-lib/toolrunner";
 import * as kubernetesCommand from "./kubernetescommand";
 import ClusterConnection from "./clusterconnection";
+import * as utils from "./utilities";
 
 import AuthenticationToken from "docker-common/registryauthenticationprovider/registryauthenticationtoken"
 
@@ -63,7 +64,9 @@ function createDockerRegistrySecret(connection: ClusterConnection, authenticatio
         command.arg("--docker-password="+ authenticationToken.getPassword());
         command.arg("--docker-email="+ authenticationToken.getEmail());
        
-        return connection.execCommand(command);
+        return connection.execCommand(command).fin(function cleanup() {
+            utils.setOutputVariable(secret);
+         });
     }
     else
     {
@@ -88,5 +91,7 @@ function createGenericSecret(connection: ClusterConnection, secret: string): any
         command.line(secretArguments);
     }
 
-    return connection.execCommand(command);
+    return connection.execCommand(command).fin(function cleanup() {
+        utils.setOutputVariable(secret);
+     });
 }

--- a/Tasks/KubernetesV0/src/utilities.ts
+++ b/Tasks/KubernetesV0/src/utilities.ts
@@ -114,3 +114,10 @@ export function assertFileExists(path: string) {
         throw new Error(tl.loc('FileNotFoundException', path));
     }
 }
+
+export function setOutputVariable(value: string) {
+    var ouputVariableName =  tl.getInput("kubectlOutput", false);  
+    if(ouputVariableName) {
+        tl.setVariable(ouputVariableName, value);
+    }
+}

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 36
+        "Patch": 37
     },
     "demands": [],
     "preview": "false",
@@ -66,8 +66,8 @@
             "name": "command",
             "type": "pickList",
             "label": "Command",
-            "defaultValue": "apply",
-            "required": true,
+            "defaultValue": "",
+            "required": false,
             "options": {
                 "apply": "apply",
                 "create": "create",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 36
+    "Patch": 37
   },
   "demands": [],
   "preview": "false",
@@ -66,8 +66,8 @@
       "name": "command",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.command",
-      "defaultValue": "apply",
-      "required": true,
+      "defaultValue": "",
+      "required": false,
       "options": {
         "apply": "apply",
         "create": "create",

--- a/Tasks/KubernetesV1/src/kubernetes.ts
+++ b/Tasks/KubernetesV1/src/kubernetes.ts
@@ -12,7 +12,7 @@ tl.setResourcePath(path.join(__dirname, '..' , 'task.json'));
 tl.cd(tl.getInput("cwd"));
 
 var registryType = tl.getInput("containerRegistryType", true);
-var command = tl.getInput("command", true);
+var command = tl.getInput("command", false);
 
 var kubeconfigfilePath;
 if (command === "logout") {
@@ -53,8 +53,10 @@ async function run(clusterConnection: ClusterConnection, command: string)
     if(configMapName) {
         await kubectlConfigMap.run(clusterConnection, configMapName);
     }
-    
-    await executeKubectlCommand(clusterConnection, command);  
+
+    if(command) {
+        await executeKubectlCommand(clusterConnection, command);
+    }  
 }
 
 // execute kubectl command

--- a/Tasks/KubernetesV1/src/kubernetesconfigmap.ts
+++ b/Tasks/KubernetesV1/src/kubernetesconfigmap.ts
@@ -70,7 +70,9 @@ function createConfigMap(connection: ClusterConnection, configMapName: string): 
     command.arg("configmap");
     command.arg(configMapName);
     command.line(getConfigMapArguments());
-    return connection.execCommand(command);
+    return connection.execCommand(command).fin(function cleanup() {
+        tl.setVariable('KubectlOutput', configMapName);
+    });
 }
 
 function executeKubetclGetConfigmapCommand(connection: ClusterConnection, configMapName: string): any {

--- a/Tasks/KubernetesV1/src/kubernetessecret.ts
+++ b/Tasks/KubernetesV1/src/kubernetessecret.ts
@@ -67,7 +67,9 @@ function createDockerRegistrySecret(connection: ClusterConnection, authenticatio
         command.arg("--docker-password="+ authenticationToken.getPassword());
         command.arg("--docker-email="+ authenticationToken.getEmail());
        
-        return connection.execCommand(command);
+        return connection.execCommand(command).fin(function cleanup() {
+            tl.setVariable('KubectlOutput', secret);
+        });
     }
     else
     {
@@ -92,7 +94,9 @@ function createGenericSecret(connection: ClusterConnection, secret: string): any
         command.line(secretArguments);
     }
 
-    return connection.execCommand(command);
+    return connection.execCommand(command).fin(function cleanup() {
+        tl.setVariable('KubectlOutput', secret);
+    });
 }
 
 function getRegistryAuthenticationToken(): AuthenticationToken {

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 15
+        "Patch": 16
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -127,8 +127,8 @@
             "name": "command",
             "type": "pickList",
             "label": "Command",
-            "defaultValue": "apply",
-            "required": true,
+            "defaultValue": "",
+            "required": false,
             "options": {
                 "apply": "apply",
                 "create": "create",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -127,8 +127,8 @@
       "name": "command",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.command",
-      "defaultValue": "apply",
-      "required": true,
+      "defaultValue": "",
+      "required": false,
       "options": {
         "apply": "apply",
         "create": "create",


### PR DESCRIPTION
Right now, output variables are populated only with the output of the kubectl command.
As the command dropdown will be optional now, the output variable if there is no command specified 
will be populated with the name of the configmap or secret created.