### PR TITLE
Adding option to not use help:effective-pom

### DIFF
--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -2,6 +2,7 @@
 import Q = require('q');
 import os = require('os');
 import path = require('path');
+import fs = require('fs');
 
 import tl = require('vsts-task-lib/task');
 import {ToolRunner} from 'vsts-task-lib/toolrunner';
@@ -29,6 +30,7 @@ var publishJUnitResults: string = tl.getInput('publishJUnitResults');
 var testResultsFiles: string = tl.getInput('testResultsFiles', true);
 var ccTool = tl.getInput('codeCoverageTool');
 var authenticateFeed = tl.getBoolInput('mavenFeedAuthenticate', true);
+var skipEffectivePomGeneration = tl.getBoolInput("skipEffectivePom", true);
 var isCodeCoverageOpted = (typeof ccTool != "undefined" && ccTool && ccTool.toLowerCase() != 'none');
 var failIfCoverageEmptySetting: boolean = tl.getBoolInput('failIfCoverageEmpty');
 var codeCoverageFailed: boolean = false;
@@ -150,14 +152,23 @@ async function execBuild() {
         .then(function (code) {
             // Setup tool runner to execute Maven goals
             if (authenticateFeed) {
-                var mvnRun = tl.tool(mvnExec);
-                mvnRun.arg('-f');
-                mvnRun.arg(mavenPOMFile);
-                mvnRun.arg('help:effective-pom');
-                if(mavenOptions) {
-                    mvnRun.line(mavenOptions);
+                var repositories;
+
+                if (skipEffectivePomGeneration)
+                {
+                    var pomContents = fs.readFileSync(mavenPOMFile, "utf8");
+                    repositories = util.collectFeedRepositories(pomContents);
+                } else {
+                    var mvnRun = tl.tool(mvnExec);
+                    mvnRun.arg('-f');
+                    mvnRun.arg(mavenPOMFile);
+                    mvnRun.arg('help:effective-pom');
+                    if(mavenOptions) {
+                        mvnRun.line(mavenOptions);
+                    }
+                    repositories = util.collectFeedRepositoriesFromEffectivePom( mvnRun.execSync()['stdout']);
                 }
-                return util.collectFeedRepositoriesFromEffectivePom(mvnRun.execSync()['stdout'])
+                return repositories
                 .then(function (repositories) {
                     if (!repositories || !repositories.length) {
                         tl.debug('No built-in repositories were found in pom.xml');

--- a/Tasks/MavenV3/mavenutil.ts
+++ b/Tasks/MavenV3/mavenutil.ts
@@ -187,7 +187,7 @@ interface RepositoryInfo {
     id:string;
 }
 
-async function collectFeedRepositories(pomContents:string): Promise<any> {
+export async function collectFeedRepositories(pomContents:string): Promise<any> {
     return convertXmlStringToJson(pomContents).then(async function (pomJson) {
         let repos:RepositoryInfo[] = [];
         if (!pomJson) {

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 3,
         "Minor": 143,
-        "Patch": 3
+        "Patch": 5
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [
@@ -300,6 +300,18 @@
             "defaultValue": "false",
             "groupName": "advanced",
             "helpMarkDown": "Automatically authenticate built-in Maven feeds from the Azure Artifacts/TFS [Package Management](https://marketplace.visualstudio.com/items?itemName=ms.feed) extension. If built-in Maven feeds are not in use, deselect this option for faster builds."
+        },
+        {
+            "name": "skipEffectivePom",
+            "aliases": [
+                "effectivePomSkip"
+            ],
+            "type": "boolean",
+            "label": "Skip generating effective POM while authenticating built-in feeds",
+            "required": true,
+            "defaultValue": "false",
+            "groupName": "advanced",
+            "helpMarkDown": "Authenticate built-in Maven feeds using the POM only, allowing parent POMs in Azure Artifacts/TFS [Package Management] feeds."
         },
         {
             "name": "sqAnalysisEnabled",


### PR DESCRIPTION
https://github.com/Microsoft/azure-pipelines-tasks/issues/8896

This change is adding a checkbox to disable the use of the effective POM during repository authentication. Because Maven needs to retrieve the parent POM(s) in order to generate an effective POM, its not possible to use built-in Azure Artifacts feed authentication with a parent POM stored in Azure Artifacts. 

Checking the new checkbox to disable the use of the effective POM causes authentication to happen with the raw POM itself, and enables this scenario. 