### PR TITLE
Don't set output variable and Log warning if kubctl command output length more than 32k.

### DIFF
--- a/Tasks/KubernetesV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesV0/Strings/resources.resjson/en-US/resources.resjson
@@ -74,5 +74,6 @@
   "loc.messages.DownloadKubeCtlFailed": "Can not download the kubectl client of version %s. Check if the version is correct https://github.com/kubernetes/kubernetes/releases",
   "loc.messages.DownloadStableVersionFailed": "Can not download kubernetes stable version file from %s. Falling back to %s",
   "loc.messages.UsingLatestStableVersion": "Invalid version 1.7 specified in Version Spec input. Using latest stable version instead. Check for correct versions https://github.com/kubernetes/kubernetes/releases",
-  "loc.messages.ConfigurationFileNotFound": "No configuration file matching %s was found."
+  "loc.messages.ConfigurationFileNotFound": "No configuration file matching %s was found.",
+  "loc.messages.OutputVariableDataSizeExceeded": "Output variable not set as kubectl command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
 }

--- a/Tasks/KubernetesV0/src/kubernetes.ts
+++ b/Tasks/KubernetesV0/src/kubernetes.ts
@@ -20,6 +20,7 @@ tl.cd(tl.getInput("cwd"));
 // get the registry server authentication provider 
 var registryType = tl.getInput("containerRegistryType", true);
 var authenticationProvider : AuthenticationTokenProvider;
+const environmentVariableMaximumSize = 32766;
 
 if(registryType ==  "Azure Container Registry"){
     authenticationProvider = new ACRAuthenticationTokenProvider(tl.getInput("azureSubscriptionEndpoint"), tl.getInput("azureContainerRegistry"));
@@ -71,7 +72,7 @@ async function run(clusterConnection: ClusterConnection, registryAuthenticationT
 function executeKubectlCommand(clusterConnection: ClusterConnection) : any {
     var command = tl.getInput("command", true);
     var result = "";
-    var ouputVariableName =  tl.getInput("kubectlOutput", false);  
+    var outputVariableName =  tl.getInput("kubectlOutput", false);  
     var telemetry = {
         registryType: registryType,
         command: command
@@ -83,8 +84,13 @@ function executeKubectlCommand(clusterConnection: ClusterConnection) : any {
         JSON.stringify(telemetry));
     return kubectl.run(clusterConnection, command, (data) => result += data)
     .fin(function cleanup() {
-        if(ouputVariableName) {
-            tl.setVariable(ouputVariableName, result);
+        if(outputVariableName) {
+            var commandOutputLength = result.length;
+            if (commandOutputLength > environmentVariableMaximumSize) {
+                tl.warning(tl.loc('OutputVariableDataSizeExceeded', commandOutputLength, environmentVariableMaximumSize));
+            } else {
+                tl.setVariable(outputVariableName, result);
+            }
         }
     });
 }

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 36
+        "Patch": 37
     },
     "demands": [],
     "preview": "false",
@@ -361,6 +361,7 @@
         "DownloadKubeCtlFailed": "Can not download the kubectl client of version %s. Check if the version is correct https://github.com/kubernetes/kubernetes/releases",
         "DownloadStableVersionFailed": "Can not download kubernetes stable version file from %s. Falling back to %s",
         "UsingLatestStableVersion": "Invalid version 1.7 specified in Version Spec input. Using latest stable version instead. Check for correct versions https://github.com/kubernetes/kubernetes/releases",
-        "ConfigurationFileNotFound": "No configuration file matching %s was found."
+        "ConfigurationFileNotFound": "No configuration file matching %s was found.",
+        "OutputVariableDataSizeExceeded": "Output variable not set as kubectl command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
     }
 }

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 36
+    "Patch": 37
   },
   "demands": [],
   "preview": "false",
@@ -361,6 +361,7 @@
     "DownloadKubeCtlFailed": "ms-resource:loc.messages.DownloadKubeCtlFailed",
     "DownloadStableVersionFailed": "ms-resource:loc.messages.DownloadStableVersionFailed",
     "UsingLatestStableVersion": "ms-resource:loc.messages.UsingLatestStableVersion",
-    "ConfigurationFileNotFound": "ms-resource:loc.messages.ConfigurationFileNotFound"
+    "ConfigurationFileNotFound": "ms-resource:loc.messages.ConfigurationFileNotFound",
+    "OutputVariableDataSizeExceeded": "ms-resource:loc.messages.OutputVariableDataSizeExceeded"
   }
 }

--- a/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
@@ -86,5 +86,6 @@
   "loc.messages.UsingLatestStableVersion": "Invalid version 1.7 specified in Version Spec input. Using latest stable version instead. Check for correct versions https://github.com/kubernetes/kubernetes/releases",
   "loc.messages.NotAValidSemverVersion": "Version not specified in correct format. E.g: 1.8.2, v1.8.2, 2.8.2, v2.8.2.",
   "loc.messages.ConfigurationFileNotFound": "No configuration file matching %s was found.",
-  "loc.messages.KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found."
+  "loc.messages.KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found.",
+  "loc.messages.OutputVariableDataSizeExceeded": "Output variable not set as kubectl command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
 }

--- a/Tasks/KubernetesV1/src/kubernetes.ts
+++ b/Tasks/KubernetesV1/src/kubernetes.ts
@@ -13,6 +13,7 @@ tl.cd(tl.getInput("cwd"));
 
 var registryType = tl.getInput("containerRegistryType", true);
 var command = tl.getInput("command", true);
+const environmentVariableMaximumSize = 32766;
 
 var kubeconfigfilePath;
 if (command === "logout") {
@@ -81,6 +82,11 @@ function executeKubectlCommand(clusterConnection: ClusterConnection, command: st
     var result = "";
     return commandImplementation.run(clusterConnection, command, (data) => result += data)
     .fin(function cleanup() {
-        tl.setVariable('KubectlOutput', result);
+        var commandOutputLength = result.length;
+        if (commandOutputLength > environmentVariableMaximumSize) {
+            tl.warning(tl.loc("OutputVariableDataSizeExceeded", commandOutputLength, environmentVariableMaximumSize));
+        } else {
+            tl.setVariable('KubectlOutput', result);
+        }
     });
 }

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 15
+        "Patch": 16
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -435,6 +435,7 @@
         "UsingLatestStableVersion": "Invalid version 1.7 specified in Version Spec input. Using latest stable version instead. Check for correct versions https://github.com/kubernetes/kubernetes/releases",
         "NotAValidSemverVersion": "Version not specified in correct format. E.g: 1.8.2, v1.8.2, 2.8.2, v2.8.2.",
         "ConfigurationFileNotFound": "No configuration file matching %s was found.",
-        "KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found."
+        "KubernetesServiceConnectionNotFound": "Kubernetes service connection details not found.",
+        "OutputVariableDataSizeExceeded": "Output variable not set as kubectl command output exceeded the maximum supported length. Output length: %s, Maximum supported length: %s"
     }
 }

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 15
+    "Patch": 16
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -435,6 +435,7 @@
     "UsingLatestStableVersion": "ms-resource:loc.messages.UsingLatestStableVersion",
     "NotAValidSemverVersion": "ms-resource:loc.messages.NotAValidSemverVersion",
     "ConfigurationFileNotFound": "ms-resource:loc.messages.ConfigurationFileNotFound",
-    "KubernetesServiceConnectionNotFound": "ms-resource:loc.messages.KubernetesServiceConnectionNotFound"
+    "KubernetesServiceConnectionNotFound": "ms-resource:loc.messages.KubernetesServiceConnectionNotFound",
+    "OutputVariableDataSizeExceeded": "ms-resource:loc.messages.OutputVariableDataSizeExceeded"
   }
 }


### PR DESCRIPTION
Don't set output variable and Log warning if kubctl command output length more than 32k.