### PR TITLE
Add connectionStrings field to AzureRmWebAppDeployment v3 and v4

### DIFF
--- a/Tasks/AzureFunctionDeploymentV1/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/AzureFunctionDeploymentV1/Strings/resources.resjson/ja-jp/resources.resjson
@@ -56,7 +56,7 @@
   "loc.input.label.DeploymentType": "Deployment method",
   "loc.input.help.DeploymentType": "Choose the deployment method for the app.",
   "loc.input.label.Connectionstrings": "Connection strings",
-  "loc.input.help.Connectionstrings": "Edit web app configuration settings following the syntax -key value. Value containing spaces should be enclosed in double quotes.<br /> Example : -phpVersion 5.6 -linuxFxVersion: node|6.11",
+  "loc.input.help.Connectionstrings": "Edit App Service connection strings. Click [...] to add, remove or modify connection strings",
   "loc.input.label.TakeAppOfflineFlag": "Take App Offline",
   "loc.input.help.TakeAppOfflineFlag": "Select the option to take the Azure App Service offline by placing an app_offline.htm file in the root directory of the App Service before the sync operation begins. The file will be removed after the sync operation completes successfully.",
   "loc.input.label.SetParametersFile": "SetParameters file",

--- a/Tasks/AzureFunctionDeploymentV1/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/AzureFunctionDeploymentV1/Strings/resources.resjson/ja-jp/resources.resjson
@@ -7,7 +7,7 @@
   "loc.group.displayName.FileTransformsAndVariableSubstitution": "File Transforms & Variable Substitution Options",
   "loc.group.displayName.AdditionalDeploymentOptions": "Additional Deployment Options",
   "loc.group.displayName.PostDeploymentAction": "Post Deployment Action",
-  "loc.group.displayName.ApplicationAndConfigurationSettings": "Application and Configuration Settings",
+  "loc.group.displayName.ApplicationConfigurationSettingsAndConnectionstrings": "Application Settings, Configuration Settings and Connection strings",
   "loc.input.label.ConnectionType": "Connection type",
   "loc.input.help.ConnectionType": "Select the service connection type to use to deploy the Web App.",
   "loc.input.label.ConnectedServiceName": "Azure subscription",
@@ -55,6 +55,8 @@
   "loc.input.help.UseWebDeploy": "If unchecked we will auto-detect the best deployment method based on your app type, package format and other parameters. <br>Select the option to view the supported deployment methods and choose one for deploying your app.",
   "loc.input.label.DeploymentType": "Deployment method",
   "loc.input.help.DeploymentType": "Choose the deployment method for the app.",
+  "loc.input.label.Connectionstrings": "Connection strings",
+  "loc.input.help.Connectionstrings": "Edit web app configuration settings following the syntax -key value. Value containing spaces should be enclosed in double quotes.<br /> Example : -phpVersion 5.6 -linuxFxVersion: node|6.11",
   "loc.input.label.TakeAppOfflineFlag": "Take App Offline",
   "loc.input.help.TakeAppOfflineFlag": "Select the option to take the Azure App Service offline by placing an app_offline.htm file in the root directory of the App Service before the sync operation begins. The file will be removed after the sync operation completes successfully.",
   "loc.input.label.SetParametersFile": "SetParameters file",
@@ -198,6 +200,8 @@
   "loc.messages.UpdatedAppServiceConfigurationSettings": "Updated App Service Configuration settings.",
   "loc.messages.UpdatingAppServiceApplicationSettings": "Updating App Service Application settings. Data: %s",
   "loc.messages.UpdatedAppServiceApplicationSettings": "Updated App Service Application settings and Kudu Application settings.",
+  "loc.messages.UpdatingAppServiceConnectionstrings": "Updating App Service Connection strings. Data: %s",
+  "loc.messages.UpdatedAppServiceConnectionstrings": "Updated App Service Connection strings.",
   "loc.messages.MultipleResourceGroupFoundForAppService": "Multiple resource group found for App Service '%s'.",
   "loc.messages.PackageDeploymentUsingZipDeployFailed": "Package deployment using ZIP Deploy failed. Refer logs for more details.",
   "loc.messages.PackageDeploymentInitiated": "Package deployment using ZIP Deploy initiated.",
@@ -221,5 +225,7 @@
   "loc.messages.ASE_WebDeploySSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to pass -allowUntrusted in additional arguments of web deploy option.",
   "loc.messages.FailedToGetResourceID": "Failed to get resource ID for resource type '%s' and resource name '%s'. Error: %s",
   "loc.messages.JarPathNotPresent": "Java jar path is not present",
-  "loc.messages.FailedToUpdateApplicationInsightsResource": "Failed to update Application Insights '%s' Resource. Error: %s"
+  "loc.messages.FailedToUpdateApplicationInsightsResource": "Failed to update Application Insights '%s' Resource. Error: %s",
+  "loc.messages.FailedToGetAppServiceConnectionStrings": "Failed to get '%s' App Service connection strings. Error: %s.",
+  "loc.messages.FailedToUpdateAppServiceConnectionStrings": "Failed to update '%s' App Service connection strings. Error: %s."
 }

--- a/Tasks/AzureRmWebAppDeploymentV3/operations/AzureAppServiceUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/operations/AzureAppServiceUtility.ts
@@ -119,7 +119,7 @@ export class AzureAppServiceUtility {
 
         console.log(tl.loc('UpdatingAppServiceConfigurationSettings', JSON.stringify(properties)));
         await this._appService.patchConfiguration({'properties': properties});
-        console.log(tl.loc('UpdatedAppServiceConnectionstrings'));
+        console.log(tl.loc('UpdatedAppServiceConfigurationSettings'));
     }
 
     public async updateConnectionstrings(connectionstrings: any): Promise<void> {
@@ -140,7 +140,7 @@ export class AzureAppServiceUtility {
 
         console.log(tl.loc('UpdatingAppServiceConnectionstrings', JSON.stringify(connectionstringData)));
         await this._appService.patchConnectionStrings(connectionstringData);
-        console.log(tl.loc('UpdatedAppServiceConfigurationSettings'));
+        console.log(tl.loc('UpdatedAppServiceConnectionstrings'));
     }
 
     public async updateAndMonitorAppSettings(properties: any): Promise<void> {

--- a/Tasks/AzureRmWebAppDeploymentV3/operations/AzureAppServiceUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/operations/AzureAppServiceUtility.ts
@@ -119,6 +119,27 @@ export class AzureAppServiceUtility {
 
         console.log(tl.loc('UpdatingAppServiceConfigurationSettings', JSON.stringify(properties)));
         await this._appService.patchConfiguration({'properties': properties});
+        console.log(tl.loc('UpdatedAppServiceConnectionstrings'));
+    }
+
+    public async updateConnectionstrings(connectionstrings: any): Promise<void> {
+        try {
+            connectionstrings = JSON.parse(connectionstrings);
+        }
+        catch(exception) {
+            throw new Error(tl.loc('FailedToUpdateAppServiceConnectionStrings', this._appService.getName(), exception.toString()));
+        }
+
+        var connectionstringData = {};
+        for(var connectionstring of connectionstrings) {
+            connectionstringData[connectionstring.name] = {
+                'value': connectionstring.value,
+                'type': connectionstring.type
+            }
+        }
+
+        console.log(tl.loc('UpdatingAppServiceConnectionstrings', JSON.stringify(connectionstringData)));
+        await this._appService.patchConnectionStrings(connectionstringData);
         console.log(tl.loc('UpdatedAppServiceConfigurationSettings'));
     }
 

--- a/Tasks/AzureRmWebAppDeploymentV3/operations/TaskParameters.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/operations/TaskParameters.ts
@@ -26,7 +26,8 @@ export class TaskParametersUtility {
             ImageSource: tl.getInput('ImageSource', false),
             StartupCommand: tl.getInput('StartupCommand', false),
             WebAppUri: tl.getInput('WebAppUri', false),
-            ConfigurationSettings: tl.getInput('ConfigurationSettings', false)
+            ConfigurationSettings: tl.getInput('ConfigurationSettings', false),
+            Connectionstrings: tl.getInput('Connectionstrings', false)
         }
 
         taskParameters.isLinuxApp = taskParameters.WebAppKind && taskParameters.WebAppKind.indexOf("linux") >= 0;
@@ -110,6 +111,7 @@ export interface TaskParameters {
     RuntimeStack?: string;
     WebAppUri?: string;
     ConfigurationSettings?: string;
+    Connectionstrings?: string;
     /** Additional parameters */
     isLinuxApp?: boolean;
     isBuiltinLinuxWebApp?: boolean;

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
@@ -68,6 +68,10 @@ export class AzureRmWebAppDeploymentProvider implements IWebAppDeploymentProvide
             await this.appServiceUtility.updateConfigurationSettings(customApplicationSettings);
         }
 
+        if(this.taskParams.Connectionstrings) {
+            await this.appServiceUtility.updateConnectionstrings(this.taskParams.Connectionstrings);
+        }
+
         if(this.taskParams.ScriptType) {
             await this.kuduServiceUtility.runPostDeploymentScript(this.taskParams, this.virtualApplicationPath);
         }

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -335,7 +335,7 @@
             "defaultValue": "",
             "required": false,
             "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
-            "helpMarkDown": "Edit web app configuration settings following the syntax -key value. Value containing spaces should be enclosed in double quotes.<br /> Example : -phpVersion 5.6 -linuxFxVersion: node|6.11",
+            "helpMarkDown": "Edit App Service connection strings. Click [...] to add, remove or modify connection strings",
             "properties": {
                 "editorExtension": "ms.vss-services-azure.azure-app-service-connectionstring-view"
             }

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -42,8 +42,8 @@
             "visibleRule": "ConnectionType = AzureRM && WebAppKind != \"\" && WebAppKind != webAppContainer && WebAppkind != functionAppContainer"
         },
         {
-            "name": "ApplicationAndConfigurationSettings",
-            "displayName": "Application and Configuration Settings",
+            "name": "ApplicationConfigurationSettingsAndConnectionstrings",
+            "displayName": "Application Settings, Configuration Settings and Connection strings",
             "isExpanded": false,
             "visibleRule": "ConnectionType = AzureRM"
         }
@@ -298,7 +298,7 @@
             "label": "App settings",
             "defaultValue": "",
             "required": false,
-            "groupName": "ApplicationAndConfigurationSettings",
+            "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
             "helpMarkDown": "Edit web app application settings following the syntax -key value . Value containing spaces should be enclosed in double quotes.<br /> <b>Example</b> : -Port 5000 -RequestTimeout 5000 <br /> -WEBSITE_TIME_ZONE \"Eastern Standard Time\"",
             "properties": {
                 "editorExtension": "ms.vss-services-azure.parameters-grid"
@@ -310,7 +310,7 @@
             "label": "Configuration settings",
             "defaultValue": "",
             "required": false,
-            "groupName": "ApplicationAndConfigurationSettings",
+            "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
             "helpMarkDown": "Edit web app configuration settings following the syntax -key value. Value containing spaces should be enclosed in double quotes.<br /> Example : -phpVersion 5.6 -linuxFxVersion: node|6.11",
             "properties": {
                 "editorExtension": "ms.vss-services-azure.parameters-grid"
@@ -327,6 +327,18 @@
             "defaultValue": "false",
             "groupName": "AdditionalDeploymentOptions",
             "helpMarkDown": "If unchecked we will auto-detect the best deployment method based on your app type, package format and other parameters. <br>Select the option to view the supported deployment methods and choose one for deploying your app."
+        },
+        {
+            "name": "Connectionstrings",
+            "type": "multiLine",
+            "label": "Connection strings",
+            "defaultValue": "",
+            "required": false,
+            "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
+            "helpMarkDown": "Edit web app configuration settings following the syntax -key value. Value containing spaces should be enclosed in double quotes.<br /> Example : -phpVersion 5.6 -linuxFxVersion: node|6.11",
+            "properties": {
+                "editorExtension": "ms.vss-services-azure.azure-app-service-connectionstring-view"
+            }
         },
         {
             "name": "DeploymentType",
@@ -612,6 +624,8 @@
         "UpdatedAppServiceConfigurationSettings": "Updated App Service Configuration settings.",
         "UpdatingAppServiceApplicationSettings": "Updating App Service Application settings. Data: %s",
         "UpdatedAppServiceApplicationSettings": "Updated App Service Application settings and Kudu Application settings.",
+        "UpdatingAppServiceConnectionstrings": "Updating App Service Connection strings. Data: %s",
+        "UpdatedAppServiceConnectionstrings": "Updated App Service Connection strings.",
         "MultipleResourceGroupFoundForAppService": "Multiple resource group found for App Service '%s'.",
         "PackageDeploymentUsingZipDeployFailed": "Package deployment using ZIP Deploy failed. Refer logs for more details.",
         "PackageDeploymentInitiated": "Package deployment using ZIP Deploy initiated.",
@@ -636,6 +650,8 @@
         "FailedToGetResourceID": "Failed to get resource ID for resource type '%s' and resource name '%s'. Error: %s",
         "JarPathNotPresent": "Java jar path is not present",
         "FailedToUpdateApplicationInsightsResource": "Failed to update Application Insights '%s' Resource. Error: %s",
-        "RunFromZipPreventsFileInUseError": "Move from Web Deploy to RunFrom Package, which helps in avoiding FILE_IN_USE error. Note that Run From Package does not support msBuild package type. Please change your package format to use this deployment method."
+        "RunFromZipPreventsFileInUseError": "Move from Web Deploy to RunFrom Package, which helps in avoiding FILE_IN_USE error. Note that Run From Package does not support msBuild package type. Please change your package format to use this deployment method.",
+        "FailedToGetAppServiceConnectionStrings": "Failed to get '%s' App Service connection strings. Error: %s.",
+        "FailedToUpdateAppServiceConnectionStrings": "Failed to update '%s' App Service connection strings. Error: %s."
     }
 }

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -42,8 +42,8 @@
       "visibleRule": "ConnectionType = AzureRM && WebAppKind != \"\" && WebAppKind != webAppContainer && WebAppkind != functionAppContainer"
     },
     {
-      "name": "ApplicationAndConfigurationSettings",
-      "displayName": "ms-resource:loc.group.displayName.ApplicationAndConfigurationSettings",
+      "name": "ApplicationConfigurationSettingsAndConnectionstrings",
+      "displayName": "ms-resource:loc.group.displayName.ApplicationConfigurationSettingsAndConnectionstrings",
       "isExpanded": false,
       "visibleRule": "ConnectionType = AzureRM"
     }
@@ -298,7 +298,7 @@
       "label": "ms-resource:loc.input.label.AppSettings",
       "defaultValue": "",
       "required": false,
-      "groupName": "ApplicationAndConfigurationSettings",
+      "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
       "helpMarkDown": "ms-resource:loc.input.help.AppSettings",
       "properties": {
         "editorExtension": "ms.vss-services-azure.parameters-grid"
@@ -310,7 +310,7 @@
       "label": "ms-resource:loc.input.label.ConfigurationSettings",
       "defaultValue": "",
       "required": false,
-      "groupName": "ApplicationAndConfigurationSettings",
+      "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
       "helpMarkDown": "ms-resource:loc.input.help.ConfigurationSettings",
       "properties": {
         "editorExtension": "ms.vss-services-azure.parameters-grid"
@@ -327,6 +327,18 @@
       "defaultValue": "false",
       "groupName": "AdditionalDeploymentOptions",
       "helpMarkDown": "ms-resource:loc.input.help.UseWebDeploy"
+    },
+    {
+      "name": "Connectionstrings",
+      "type": "multiLine",
+      "label": "ms-resource:loc.input.label.Connectionstrings",
+      "defaultValue": "",
+      "required": false,
+      "groupName": "ApplicationConfigurationSettingsAndConnectionstrings",
+      "helpMarkDown": "ms-resource:loc.input.help.Connectionstrings",
+      "properties": {
+        "editorExtension": "ms.vss-services-azure.azure-app-service-connectionstring-view"
+      }
     },
     {
       "name": "DeploymentType",
@@ -612,6 +624,8 @@
     "UpdatedAppServiceConfigurationSettings": "ms-resource:loc.messages.UpdatedAppServiceConfigurationSettings",
     "UpdatingAppServiceApplicationSettings": "ms-resource:loc.messages.UpdatingAppServiceApplicationSettings",
     "UpdatedAppServiceApplicationSettings": "ms-resource:loc.messages.UpdatedAppServiceApplicationSettings",
+    "UpdatingAppServiceConnectionstrings": "ms-resource:loc.messages.UpdatingAppServiceConnectionstrings",
+    "UpdatedAppServiceConnectionstrings": "ms-resource:loc.messages.UpdatedAppServiceConnectionstrings",
     "MultipleResourceGroupFoundForAppService": "ms-resource:loc.messages.MultipleResourceGroupFoundForAppService",
     "PackageDeploymentUsingZipDeployFailed": "ms-resource:loc.messages.PackageDeploymentUsingZipDeployFailed",
     "PackageDeploymentInitiated": "ms-resource:loc.messages.PackageDeploymentInitiated",
@@ -636,6 +650,8 @@
     "FailedToGetResourceID": "ms-resource:loc.messages.FailedToGetResourceID",
     "JarPathNotPresent": "ms-resource:loc.messages.JarPathNotPresent",
     "FailedToUpdateApplicationInsightsResource": "ms-resource:loc.messages.FailedToUpdateApplicationInsightsResource",
-    "RunFromZipPreventsFileInUseError": "ms-resource:loc.messages.RunFromZipPreventsFileInUseError"
+    "RunFromZipPreventsFileInUseError": "ms-resource:loc.messages.RunFromZipPreventsFileInUseError",
+    "FailedToGetAppServiceConnectionStrings": "ms-resource:loc.messages.FailedToGetAppServiceConnectionStrings",
+    "FailedToUpdateAppServiceConnectionStrings": "ms-resource:loc.messages.FailedToUpdateAppServiceConnectionStrings"
   }
 }

--- a/Tasks/Common/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/Common/azure-arm-rest/Strings/resources.resjson/en-US/resources.resjson
@@ -137,5 +137,7 @@
   "loc.messages.ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release definition",
   "loc.messages.FailedToGetAzureMetricAlerts": "Failed to get Azure metric alerts: %s. Error: %s",
   "loc.messages.FailedToUpdateAzureMetricAlerts": "Failed to update Azure metric alert rule '%s' Resource. Error: %s",
-  "loc.messages.ResponseNotValid": "Response is not in a valid format"
+  "loc.messages.ResponseNotValid": "Response is not in a valid format",
+  "loc.messages.FailedToGetAppServiceConnectionStrings": "Failed to get '%s' App Service connection strings. Error: %s.",
+  "loc.messages.FailedToUpdateAppServiceConnectionStrings": "Failed to update '%s' App Service connection strings. Error: %s."
 }

--- a/Tasks/Common/azure-arm-rest/Tests/L0-azure-arm-app-service.ts
+++ b/Tasks/Common/azure-arm-rest/Tests/L0-azure-arm-app-service.ts
@@ -39,6 +39,10 @@ export function AzureAppServiceMockTests() {
             getMetadata(tr);
             console.log("\tvalidating updateMetadata");
             updateMetadata(tr);
+            console.log("\tvalidating getConnectionstrings");
+            getConnectionstrings(tr);
+            console.log("\tvalidating updateConnectionstrings");
+            updateConnectionstrings(tr);
         }
         catch(error) {
             passed = false;
@@ -82,8 +86,8 @@ function swap(tr) {
     assert(tr.stdOutContained('SwappingAppServiceSlotSlots MOCK_APP_SERVICE_NAME production MOCK_TARGET_SLOT'), 'Should have printed: SwappingAppServiceSlotSlots MOCK_APP_SERVICE_NAME production MOCK_TARGET_SLOT');
     assert(tr.stdOutContained('SwappedAppServiceSlotSlots MOCK_APP_SERVICE_NAME production MOCK_TARGET_SLOT'), 'Should have printed: SwappedAppServiceSlotSlots MOCK_APP_SERVICE_NAME production MOCK_TARGET_SLOT');
     assert(tr.stdOutContained('SwappingAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT'), 'Should have printed: SwappingAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT');
-    assert(tr.stdOutContained('Error: FailedToSwapAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT one of the slots is in stopped state. (CODE: 409)'),
-        'Should have printed: Error: FailedToSwapAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT one of the slots is in stopped state. (CODE: 409)');
+    assert(tr.stdOutContained('Error: FailedToSwapAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT one of the slots is in stopped state. (CODE: 501)'),
+        'Should have printed: Error: FailedToSwapAppServiceSlotSlots MOCK_APP_SERVICE_NAME MOCK_SLOT_NAME MOCK_TARGET_SLOT one of the slots is in stopped state. (CODE: 501)');
 }
 
 function get(tr) {
@@ -157,4 +161,18 @@ function updateMetadata(tr) {
         'Should have printed: MOCK_APP_SERVICE_NAME CONFIG_METADATA UPDATE ID: /subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/metadata');
     assert(tr.stdOutContained(' FailedToUpdateAppServiceMetadata MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)'), 
         'Should have printed: FailedToUpdateAppServiceMetadata MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)');
+}
+
+function getConnectionstrings(tr) {
+    assert(tr.stdOutContained('MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS GET ID: /subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings'),
+        'Should have printed: MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS GET ID: /subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings');
+    assert(tr.stdOutContained(' FailedToGetAppServiceConnectionStrings MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)'), 
+        'Should have printed:  FailedToGetAppServiceConnectionStrings MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)');
+}
+
+function updateConnectionstrings(tr) {
+    assert(tr.stdOutContained('MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS UPDATE ID: /subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings'),
+        'Should have printed: MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS UPDATE ID: /subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings');
+    assert(tr.stdOutContained(' FailedToUpdateAppServiceConnectionStrings MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)'), 
+        'Should have printed: FailedToUpdateAppServiceConnectionStrings MOCK_APP_SERVICE_NAME-MOCK_SLOT_NAME internal error occurred (CODE: 501)');
 }

--- a/Tasks/Common/azure-arm-rest/Tests/L0-azure-arm-appinsights-tests.ts
+++ b/Tasks/Common/azure-arm-rest/Tests/L0-azure-arm-appinsights-tests.ts
@@ -32,13 +32,13 @@ export function ApplicationInsightsTests() {
 function get(tr) {
     assert(tr.stdOutContained('GET APP INSIGHTS RESOURCE ID MOCKED: subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/MOCK_APP_INSIGHTS_NAME'),
         'Should have printed: GET APP INSIGHTS RESOURCE ID MOCKED: subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/MOCK_APP_INSIGHTS_NAME');
-    assert(tr.stdOutContained('FailedToGetApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 500)'),
-        'Should have printed: FailedToGetApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 500)');
+    assert(tr.stdOutContained('FailedToGetApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 501)'),
+        'Should have printed: FailedToGetApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 501)');
 }
 
 function update(tr) {
     assert(tr.stdOutContained('UPDATE APP INSIGHTS RESOURCE ID MOCKED: subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/MOCK_APP_INSIGHTS_NAME'),
         'Should have printed: UPDATE APP INSIGHTS RESOURCE ID MOCKED: subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/MOCK_APP_INSIGHTS_NAME');
-    assert(tr.stdOutContained('FailedToUpdateApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 500)'),
-        'Should have printed: FailedToUpdateApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 500)');
+    assert(tr.stdOutContained('FailedToUpdateApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 501)'),
+        'Should have printed: FailedToUpdateApplicationInsightsResource FAIL_MOCK_APP_INSIGHTS_NAME Internal Server error occured. (CODE: 501)');
 }

--- a/Tasks/Common/azure-arm-rest/Tests/azure-arm-app-service-tests.ts
+++ b/Tasks/Common/azure-arm-rest/Tests/azure-arm-app-service-tests.ts
@@ -321,6 +321,58 @@ class AzureAppServiceTests {
         }
     }
 
+    public static async getConnectionstrings() {
+        var appSerivce: AzureAppService = new AzureAppService(endpoint, "MOCK_RESOURCE_GROUP_NAME", "MOCK_APP_SERVICE_NAME");
+        try {
+            var value = await appSerivce.getConnectionstrings();
+            console.log('MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS GET ID: ' + value.id);
+        }
+        catch(error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'AzureAppServiceTests.getConnectionStrings() should have passed but failed');
+        }
+        
+        var appSerivceSlot: AzureAppService = new AzureAppService(endpoint, "MOCK_RESOURCE_GROUP_NAME", "MOCK_APP_SERVICE_NAME", "MOCK_SLOT_NAME");
+        try {
+            await appSerivceSlot.getConnectionstrings();
+            tl.setResult(tl.TaskResult.Failed, 'AzureAppServiceTests.getConnectionStrings() should have failed but passed');
+        }
+        catch(error) {
+            console.log(error);
+        }
+    }
+
+    public static async updateConnectionstrings() {
+        var appSettings = {
+            id: "/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/metadata",
+            name: "MOCK_APP_SERVICE_NAME",
+            type: "Microsoft.Web/sites",
+            kind: "app",
+            location: "South Central US",
+            properties: {
+                "alwaysOn": true
+            }
+        };
+
+        var appSerivce: AzureAppService = new AzureAppService(endpoint, "MOCK_RESOURCE_GROUP_NAME", "MOCK_APP_SERVICE_NAME");
+        try {
+            var value = await appSerivce.updateConnectionstrings(appSettings);
+            console.log('MOCK_APP_SERVICE_NAME CONFIG_CONNECTIONSTRINGS UPDATE ID: ' + value.id);
+        }
+        catch(error) {
+            console.log(error);
+            tl.setResult(tl.TaskResult.Failed, 'AzureAppServiceTests.updateConnectionStrings() should have passed but failed');
+        }
+        
+        var appSerivceSlot: AzureAppService = new AzureAppService(endpoint, "MOCK_RESOURCE_GROUP_NAME", "MOCK_APP_SERVICE_NAME", "MOCK_SLOT_NAME");
+        try {
+            await appSerivceSlot.updateConnectionstrings(appSettings);
+            tl.setResult(tl.TaskResult.Failed, 'AzureAppServiceTests.updateConnectionStrings() should have failed but passed');
+        }
+        catch(error) {
+            console.log(error);
+        }
+    }
 }
 
 async function RUNTESTS() {
@@ -338,6 +390,8 @@ async function RUNTESTS() {
     await AzureAppServiceTests.patchConfiguration();
     await AzureAppServiceTests.getMetadata();
     await AzureAppServiceTests.updateMetadata();
+    await AzureAppServiceTests.getConnectionstrings();
+    await AzureAppServiceTests.updateConnectionstrings();
 }
 
 RUNTESTS();

--- a/Tasks/Common/azure-arm-rest/Tests/mock_utils.ts
+++ b/Tasks/Common/azure-arm-rest/Tests/mock_utils.ts
@@ -119,7 +119,7 @@ export function mockAzureApplicationInsightsTests() {
             "content-type": "application/json; charset=utf-8"
         }
     }).get("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/FAIL_MOCK_APP_INSIGHTS_NAME?api-version=2015-05-01")
-    .reply(500, 'Internal Server error occured.').persist();
+    .reply(501, 'Internal Server error occured.').persist();
 
 
     nock('https://management.azure.com', {
@@ -142,7 +142,7 @@ export function mockAzureApplicationInsightsTests() {
             "content-type": "application/json; charset=utf-8"
         }
     }).put("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/microsoft.insights/components/FAIL_MOCK_APP_INSIGHTS_NAME?api-version=2015-05-01")
-    .reply(500, 'Internal Server error occured.').persist();
+    .reply(501, 'Internal Server error occured.').persist();
 }
 
 export function mockAzureAppServiceTests() {
@@ -214,7 +214,7 @@ export function mockAzureAppServiceTests() {
         targetSlot: "MOCK_TARGET_SLOT",
         preserveVnet: true
     }))
-    .reply(409,'one of the slots is in stopped state.').persist();
+    .reply(501,'one of the slots is in stopped state.').persist();
 
     nock('https://management.azure.com', {
         reqheaders: {
@@ -524,6 +524,71 @@ export function mockAzureAppServiceTests() {
         }
     }).put("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/slots/MOCK_SLOT_NAME/config/metadata?api-version=2016-08-01")
     .reply(501, 'internal error occurred').persist();
+
+    nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).post("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings/list?api-version=2016-08-01")
+    .reply(200, {
+        id: "/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings",
+        name: "MOCK_APP_SERVICE_NAME",
+        type: "Microsoft.Web/sites",
+        kind: "app",
+        location: "South Central US",
+        properties: {
+            "SqlAzureConnectionName": {
+                "value": "sqlazure_connection_value",
+                "type": "SQLAzure"
+            },
+            "CustomConnectionString": {
+                "value": "custom_connection_value",
+                "type": "Custom"
+            }
+        }
+    }).persist();
+    
+    nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).post("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/slots/MOCK_SLOT_NAME/config/connectionstrings/list?api-version=2016-08-01")
+    .reply(501, 'internal error occurred').persist();
+    
+    nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).put("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings?api-version=2016-08-01")
+    .reply(200, {
+        id: "/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/vincaAzureRG/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/config/connectionstrings",
+        name: "MOCK_APP_SERVICE_NAME",
+        type: "Microsoft.Web/sites",
+        kind: "app",
+        location: "South Central US",
+        properties: {
+            "CustomConnectionString": {
+                "value": "custom_connection_value",
+                "type": "Custom"
+            },
+            "MySqlConnectionName": {
+                "value": "MySqlConnection_value",
+                "type": "MySql"
+            }
+        }
+    }).persist();
+    
+    nock('https://management.azure.com', {
+        reqheaders: {
+            "authorization": "Bearer DUMMY_ACCESS_TOKEN",
+            "content-type": "application/json; charset=utf-8"
+        }
+    }).put("/subscriptions/MOCK_SUBSCRIPTION_ID/resourceGroups/MOCK_RESOURCE_GROUP_NAME/providers/Microsoft.Web/sites/MOCK_APP_SERVICE_NAME/slots/MOCK_SLOT_NAME/config/connectionstrings?api-version=2016-08-01")
+    .reply(501, 'internal error occurred').persist();
+
 }
 
 export function mockKuduServiceTests() {

--- a/Tasks/Common/azure-arm-rest/azure-arm-app-service.ts
+++ b/Tasks/Common/azure-arm-rest/azure-arm-app-service.ts
@@ -38,7 +38,7 @@ export class AzureAppService {
         try {
             var webRequest = new webClient.WebRequest();
             webRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             webRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/start`, {
                 '{ResourceGroupName}': this._resourceGroup,
                 '{name}': this._name
@@ -61,7 +61,7 @@ export class AzureAppService {
         try {
             var webRequest = new webClient.WebRequest();
             webRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             webRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/stop`, {
                 '{ResourceGroupName}': this._resourceGroup,
                 '{name}': this._name
@@ -84,7 +84,7 @@ export class AzureAppService {
         try {
             var webRequest = new webClient.WebRequest();
             webRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             webRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/restart`, {
                 '{ResourceGroupName}': this._resourceGroup,
                 '{name}': this._name
@@ -112,7 +112,7 @@ export class AzureAppService {
                 preserveVnet: preserveVNet
             });
 
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             webRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/slotsswap`, {
             '{ResourceGroupName}': this._resourceGroup,
             '{name}': this._name,
@@ -156,7 +156,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/publishingcredentials/list`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -188,7 +188,7 @@ export class AzureAppService {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'PUT';
             httpRequest.body = JSON.stringify(applicationSettings);
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/appsettings`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -237,7 +237,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'GET';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/web`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -261,7 +261,7 @@ export class AzureAppService {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'PUT';
             httpRequest.body = JSON.stringify(applicationSettings);
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/web`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -285,7 +285,7 @@ export class AzureAppService {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'PATCH';
             httpRequest.body = JSON.stringify(properties);
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/web`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -309,7 +309,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/metadata/list`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -333,7 +333,7 @@ export class AzureAppService {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'PUT';
             httpRequest.body = JSON.stringify(applicationSettings);
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/metadata`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -360,7 +360,63 @@ export class AzureAppService {
 
         await this.updateMetadata(applicationSettings);
     }
-    
+
+    public async getConnectionStrings(): Promise<AzureAppServiceConfigurationDetails> {
+        try {
+            var httpRequest = new webClient.WebRequest();
+            httpRequest.method = 'POST';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
+            httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/connectionstrings/list`,
+            {
+                '{resourceGroupName}': this._resourceGroup,
+                '{name}': this._name,
+            }, null, '2016-08-01');
+            
+            var response = await this._client.beginRequest(httpRequest);
+            if(response.statusCode != 200) {
+                throw ToError(response);
+            }
+
+            return response.body;
+        }
+        catch(error) {
+            throw Error(tl.loc('FailedToGetAppServiceConnectionStrings', this._getFormattedName(), this._client.getFormattedError(error)));
+        }
+    }
+
+    public async updateConnectionStrings(applicationSettings): Promise<AzureAppServiceConfigurationDetails> {
+        try {
+            var httpRequest = new webClient.WebRequest();
+            httpRequest.method = 'PUT';
+            httpRequest.body = JSON.stringify(applicationSettings);
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
+            httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/connectionstrings`,
+            {
+                '{resourceGroupName}': this._resourceGroup,
+                '{name}': this._name,
+            }, null, '2016-08-01');
+            
+            var response = await this._client.beginRequest(httpRequest);
+            if(response.statusCode != 200) {
+                throw ToError(response);
+            }
+
+            return response.body;
+        }
+        catch(error) {
+            throw Error(tl.loc('FailedToUpdateAppServiceConnectionStrings', this._getFormattedName(), this._client.getFormattedError(error)));
+        }
+    }
+
+    public async patchConnectionStrings(properties): Promise<void> {
+        var applicationSettings = await this.getConnectionStrings();
+        for(var key in properties) {
+            applicationSettings.properties[key] = properties[key];
+        }
+
+        await this.updateConnectionStrings(applicationSettings);
+    }
+
     public getSlot(): string {
         return this._slot ? this._slot : "production";
     }
@@ -369,7 +425,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/publishxml`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -393,7 +449,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'POST';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}/config/appsettings/list`,
             {
                 '{resourceGroupName}': this._resourceGroup,
@@ -416,7 +472,7 @@ export class AzureAppService {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'GET';
-            var slotUrl: string = !!this._slot ? `/slots/${this._slot}` : '';
+            var slotUrl: string = !!this._slot ? `/slots/${encodeURIComponent(this._slot)}` : '';
             httpRequest.uri = this._client.getRequestUri(`//subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Web/sites/{name}/${slotUrl}`,
             {
                 '{resourceGroupName}': this._resourceGroup,

--- a/Tasks/Common/azure-arm-rest/azure-arm-app-service.ts
+++ b/Tasks/Common/azure-arm-rest/azure-arm-app-service.ts
@@ -361,7 +361,7 @@ export class AzureAppService {
         await this.updateMetadata(applicationSettings);
     }
 
-    public async getConnectionStrings(): Promise<AzureAppServiceConfigurationDetails> {
+    public async getConnectionstrings(): Promise<AzureAppServiceConfigurationDetails> {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'POST';
@@ -384,7 +384,7 @@ export class AzureAppService {
         }
     }
 
-    public async updateConnectionStrings(applicationSettings): Promise<AzureAppServiceConfigurationDetails> {
+    public async updateConnectionstrings(applicationSettings): Promise<AzureAppServiceConfigurationDetails> {
         try {
             var httpRequest = new webClient.WebRequest();
             httpRequest.method = 'PUT';
@@ -409,12 +409,12 @@ export class AzureAppService {
     }
 
     public async patchConnectionStrings(properties): Promise<void> {
-        var applicationSettings = await this.getConnectionStrings();
+        var applicationSettings = await this.getConnectionstrings();
         for(var key in properties) {
             applicationSettings.properties[key] = properties[key];
         }
 
-        await this.updateConnectionStrings(applicationSettings);
+        await this.updateConnectionstrings(applicationSettings);
     }
 
     public getSlot(): string {

--- a/Tasks/Common/azure-arm-rest/azureModels.ts
+++ b/Tasks/Common/azure-arm-rest/azureModels.ts
@@ -235,7 +235,7 @@ export interface AzureAppServiceConfigurationDetails {
     type: string;
     kind?: string;
     location: string;
-    tags: string;
+    tags: {[key: string]: string};
     properties?: {[key: string]: any};
 }
 

--- a/Tasks/Common/azure-arm-rest/module.json
+++ b/Tasks/Common/azure-arm-rest/module.json
@@ -138,6 +138,8 @@
         "ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release definition",
         "FailedToGetAzureMetricAlerts": "Failed to get Azure metric alerts: %s. Error: %s",
         "FailedToUpdateAzureMetricAlerts": "Failed to update Azure metric alert rule '%s' Resource. Error: %s",
-        "ResponseNotValid": "Response is not in a valid format"
+        "ResponseNotValid": "Response is not in a valid format",
+        "FailedToGetAppServiceConnectionStrings": "Failed to get '%s' App Service connection strings. Error: %s.",
+        "FailedToUpdateAppServiceConnectionStrings": "Failed to update '%s' App Service connection strings. Error: %s."
     }
 }


### PR DESCRIPTION
I noticed there doesn't seem to be support for connection strings and saw #7231 was closed. I pulled it and rebased. Could this work for current release?