### PR TITLE
Add second node tool fallback

### DIFF
--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -1,0 +1,50 @@
+import assert = require('assert');
+import path = require('path');
+import * as ttm from 'vsts-task-lib/mock-test';
+
+describe('NodeTool Suite', function () {
+    this.timeout(60000);
+
+    it('Succeeds when the first download is available', (done: MochaDone) => {
+        this.timeout(5000);
+
+        let tp: string = path.join(__dirname, 'L0FirstDownloadSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'NodeTool should have succeeded.');
+        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+
+        done();
+    });
+
+    it('Succeeds when the second download is available', (done: MochaDone) => {
+        this.timeout(5000);
+
+        let tp: string = path.join(__dirname, 'L0SecondDownloadSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'NodeTool should have succeeded.');
+        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+
+        done();
+    });
+
+    it('Succeeds when the third download is available', (done: MochaDone) => {
+        this.timeout(5000);
+
+        let tp: string = path.join(__dirname, 'L0ThirdDownloadSuccess.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'NodeTool should have succeeded.');
+        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+
+        done();
+    });
+
+});

--- a/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
@@ -1,0 +1,82 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'nodetool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSpec', '11.3.0');
+tmr.setInput('checkLatest', 'false');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "assertAgent": {
+        "2.115.1": true
+    }};
+tmr.setAnswers(a);
+
+
+//Create assertAgent and getVariable mocks
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() == 'agent.tempdirectory') {
+        return 'temp';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
+//Create tool-lib mock
+tmr.registerMock('vsts-task-tool-lib/tool', {
+    isExplicitVersion: function(versionSpec) {
+        return false;
+    },
+    findLocalTool: function(toolName, versionSpec) {
+        if (toolName != 'node') { 
+            throw new Error('Searching for wrong tool');
+        }
+        return false;
+    },
+    evaluateVersions: function(versions, versionSpec) {
+        let version: string;
+        for (let i = versions.length - 1; i >= 0; i--) {
+            let potential: string = versions[i];
+            let satisfied: boolean = potential === 'v11.3.0';
+            if (satisfied) {
+                version = potential;
+                break;
+            }
+        }
+        return version;
+    },
+    cleanVersion: function(version) {
+        return '11.3.0';
+    },
+    downloadTool(url) {
+        if (url === `https://nodejs.org/dist/v11.3.0/node-v11.3.0-win-${os.arch()}.7z` ||
+            url === `https://nodejs.org/dist/v11.3.0/node-v11.3.0-${os.platform()}-${os.arch()}.tar.gz`) {
+            return 'location';
+        }
+        else {
+            throw new Error('Incorrect URL');
+        }
+    },
+    extract7z(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    extractTar(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    cacheDir(dir, tool, version) {
+        return 'path to tool';
+    },
+    prependPath(toolPath) {
+        return;
+    }
+});
+
+tmr.run();

--- a/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
@@ -1,0 +1,90 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'nodetool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSpec', '5.10.1');
+tmr.setInput('checkLatest', 'false');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "assertAgent": {
+        "2.115.1": true
+    }};
+tmr.setAnswers(a);
+
+
+//Create assertAgent and getVariable mocks
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() == 'agent.tempdirectory') {
+        return 'temp';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
+//Create tool-lib mock
+tmr.registerMock('vsts-task-tool-lib/tool', {
+    isExplicitVersion: function(versionSpec) {
+        return false;
+    },
+    findLocalTool: function(toolName, versionSpec) {
+        if (toolName != 'node') { 
+            throw new Error('Searching for wrong tool');
+        }
+        return false;
+    },
+    evaluateVersions: function(versions, versionSpec) {
+        let version: string;
+        for (let i = versions.length - 1; i >= 0; i--) {
+            let potential: string = versions[i];
+            let satisfied: boolean = potential === 'v5.10.1';
+            if (satisfied) {
+                version = potential;
+                break;
+            }
+        }
+        return version;
+    },
+    cleanVersion: function(version) {
+        return '5.10.1';
+    },
+    downloadTool(url) {
+        if (url === `https://nodejs.org/dist/v5.10.1/node-v5.10.1-win-${os.arch()}.7z` ||
+            url === `https://nodejs.org/dist/v5.10.1/node-v5.10.1-${os.platform()}-${os.arch()}.tar.gz`) {
+            let err = new Error();
+            err['httpStatusCode'] = '404';
+            throw err;
+        }
+        else if (url === `https://nodejs.org/dist/v5.10.1/win-${os.arch()}/node.exe`) {
+            return 'exe_loc';
+        }
+        else if (url === `https://nodejs.org/dist/v5.10.1/win-${os.arch()}/node.lib`) {
+            return 'exe_lib';
+        }
+        else {
+            throw new Error('Incorrect URL');
+        }
+    },
+    extract7z(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    extractTar(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    cacheDir(dir, tool, version) {
+        return 'path to tool';
+    },
+    prependPath(toolPath) {
+        return;
+    }
+});
+
+tmr.run();

--- a/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
@@ -1,0 +1,96 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import os = require('os');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'nodetool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSpec', '0.12.18');
+tmr.setInput('checkLatest', 'false');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "assertAgent": {
+        "2.115.1": true
+    }};
+tmr.setAnswers(a);
+
+
+//Create assertAgent and getVariable mocks
+const tl = require('vsts-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() == 'agent.tempdirectory') {
+        return 'temp';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+
+//Create tool-lib mock
+tmr.registerMock('vsts-task-tool-lib/tool', {
+    isExplicitVersion: function(versionSpec) {
+        return false;
+    },
+    findLocalTool: function(toolName, versionSpec) {
+        if (toolName != 'node') { 
+            throw new Error('Searching for wrong tool');
+        }
+        return false;
+    },
+    evaluateVersions: function(versions, versionSpec) {
+        let version: string;
+        for (let i = versions.length - 1; i >= 0; i--) {
+            let potential: string = versions[i];
+            let satisfied: boolean = potential === 'v0.12.18';
+            if (satisfied) {
+                version = potential;
+                break;
+            }
+        }
+        return version;
+    },
+    cleanVersion: function(version) {
+        return '0.12.18';
+    },
+    downloadTool(url) {
+        let err = new Error();
+        err['httpStatusCode'] = '404';
+        if (url === `https://nodejs.org/dist/v0.12.18/node-v0.12.18-win-${os.arch()}.7z` ||
+            url === `https://nodejs.org/dist/v0.12.18/node-v0.12.18-${os.platform()}-${os.arch()}.tar.gz`) {
+            throw err;
+        }
+        else if (url === `https://nodejs.org/dist/v0.12.18/win-${os.arch()}/node.exe`) {
+            throw err;
+        }
+        else if (url === `https://nodejs.org/dist/v0.12.18/win-${os.arch()}/node.lib`) {
+            throw err;
+        }
+        else if (url === `https://nodejs.org/dist/v0.12.18/node.exe`) {
+            return 'exe_loc';
+        }
+        else if (url === `https://nodejs.org/dist/v0.12.18/node.lib`) {
+            return 'exe_lib';
+        }
+        else {
+            throw new Error('Incorrect URL');
+        }
+    },
+    extract7z(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    extractTar(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    cacheDir(dir, tool, version) {
+        return 'path to tool';
+    },
+    prependPath(toolPath) {
+        return;
+    }
+});
+
+tmr.run();

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -177,21 +177,35 @@ async function acquireNode(version: string): Promise<string> {
 // In this case, there will be two files located at:
 //      /dist/v5.10.1/win-x64/node.exe
 //      /dist/v5.10.1/win-x64/node.lib
-// This method attempts to download and cache the resources from this alternative location.
+// If this is not the structure, there may also be two files located at:
+//      /dist/v0.12.18/node.exe
+//      /dist/v0.12.18/node.lib
+// This method attempts to download and cache the resources from these alternative locations.
 // Note also that the files are normally zipped but in this case they are just an exe
 // and lib file in a folder, not zipped.
 async function acquireNodeFromFallbackLocation(version: string): Promise<string> {
-    let exeUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.exe`;
-    let libUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.lib`;
-
     // Create temporary folder to download in to
     let tempDownloadFolder: string = 'temp_' + Math.floor(Math.random() * 2000000000);
     let tempDir: string = path.join(taskLib.getVariable('agent.tempDirectory'), tempDownloadFolder);
     taskLib.mkdirP(tempDir);
+    try {
+        let exeUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.exe`;
+        let libUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.lib`;
 
-    let exeDownloadPath: string = await toolLib.downloadTool(exeUrl, path.join(tempDir, "node.exe"));
-    let libDownloadPath: string = await toolLib.downloadTool(libUrl, path.join(tempDir, "node.lib"));
+        await toolLib.downloadTool(exeUrl, path.join(tempDir, "node.exe"));
+        await toolLib.downloadTool(libUrl, path.join(tempDir, "node.lib"));
+    }
+    catch (err) {
+        if (err['httpStatusCode'] && 
+            err['httpStatusCode'] == '404')
+        {
+            let exeUrl: string = `https://nodejs.org/dist/v${version}/node.exe`;
+            let libUrl: string = `https://nodejs.org/dist/v${version}/node.lib`;
 
+            await toolLib.downloadTool(exeUrl, path.join(tempDir, "node.exe"));
+            await toolLib.downloadTool(libUrl, path.join(tempDir, "node.lib"));
+        }
+    }
     return await toolLib.cacheDir(tempDir, 'node', version);
 }
 

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -138,7 +138,7 @@ async function acquireNode(version: string): Promise<string> {
     catch (err)
     {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == '404')
+            err['httpStatusCode'] === '404')
         {
             return await acquireNodeFromFallbackLocation(version);
         }
@@ -188,22 +188,27 @@ async function acquireNodeFromFallbackLocation(version: string): Promise<string>
     let tempDownloadFolder: string = 'temp_' + Math.floor(Math.random() * 2000000000);
     let tempDir: string = path.join(taskLib.getVariable('agent.tempDirectory'), tempDownloadFolder);
     taskLib.mkdirP(tempDir);
+    let exeUrl: string;
+    let libUrl: string;
     try {
-        let exeUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.exe`;
-        let libUrl: string = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.lib`;
+        exeUrl = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.exe`;
+        libUrl = `https://nodejs.org/dist/v${version}/win-${os.arch()}/node.lib`;
 
         await toolLib.downloadTool(exeUrl, path.join(tempDir, "node.exe"));
         await toolLib.downloadTool(libUrl, path.join(tempDir, "node.lib"));
     }
     catch (err) {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == '404')
+            err['httpStatusCode'] === '404')
         {
-            let exeUrl: string = `https://nodejs.org/dist/v${version}/node.exe`;
-            let libUrl: string = `https://nodejs.org/dist/v${version}/node.lib`;
+            exeUrl = `https://nodejs.org/dist/v${version}/node.exe`;
+            libUrl = `https://nodejs.org/dist/v${version}/node.lib`;
 
             await toolLib.downloadTool(exeUrl, path.join(tempDir, "node.exe"));
             await toolLib.downloadTool(libUrl, path.join(tempDir, "node.lib"));
+        }
+        else {
+            throw err;
         }
     }
     return await toolLib.cacheDir(tempDir, 'node', version);

--- a/Tasks/NodeToolV0/package-lock.json
+++ b/Tasks/NodeToolV0/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
+    },
     "@types/node": {
       "version": "6.0.112",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.112.tgz",

--- a/Tasks/NodeToolV0/package-lock.json
+++ b/Tasks/NodeToolV0/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nodetool",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/NodeToolV0/package.json
+++ b/Tasks/NodeToolV0/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/microsoft/vsts-tasks#readme",
   "dependencies": {
+    "@types/mocha": "2.2.48",
     "@types/node": "^6.0.101",
     "@types/q": "^1.0.7",
     "typed-rest-client": "1.0.7",

--- a/Tasks/NodeToolV0/package.json
+++ b/Tasks/NodeToolV0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodetool",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Node Tool Installer",
   "main": "nodetool.js",
   "scripts": {

--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 136,
-        "Patch": 2
+        "Minor": 145,
+        "Patch": 0
     },
     "satisfies": [
         "Node"

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 136,
-    "Patch": 2
+    "Minor": 145,
+    "Patch": 0
   },
   "satisfies": [
     "Node"

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 136,
-    "Patch": 0
+    "Patch": 2
   },
   "satisfies": [
     "Node"


### PR DESCRIPTION
Currently, trying to run the Node tool installer on version '0.12', '0.10', '0.12.x', or '0.10.x' fails (and others probably do as well). This is because node doesn't seem to use a consistent folder structure - so right now we check https://nodejs.org/dist/v0.12.18/node-v0.12.18-win-x64.7z and as a fallback location we check https://nodejs.org/dist/v0.12.18/win-x64/node.exe, but neither of these contains the download files we need. To deal with this, we need to check a final location, https://nodejs.org/dist/v0.12.18/node.exe.

Fixes #8987 