### PR TITLE
Prefix package sources with feed- when writing packageSourceCredentials in nuget.config

### DIFF
--- a/Tasks/Common/packaging-common/nuget/NuGetConfigHelper2.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetConfigHelper2.ts
@@ -90,6 +90,15 @@ export class NuGetConfigHelper2 {
                     tl.debug('Setting auth for internal source ' + source.feedUri);
                     // Removing source first
                     this.removeSourceFromTempNugetConfig(source);
+
+                    // Cannot add tag that starts with number as a child node of PackageSourceCredentials because of
+                    // Bug in nuget 4.9.1 and dotnet 2.1.500
+                    // https://github.com/NuGet/Home/issues/7517
+                    // https://github.com/NuGet/Home/issues/7524
+                    // so working around this by prefixing source with string
+                    tl.debug('Prefixing internal source feed name ' + source.feedName + ' with feed-');
+                    source.feedName = 'feed-' + source.feedName;
+
                     // Re-adding source with creds
                     this.addSourceWithUsernamePasswordToTempNuGetConfig(source, "VssSessionToken", this.authInfo.internalAuthInfo.accessToken);
                 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 144,
-        "Patch": 2
+        "Patch": 3
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 144,
-    "Patch": 2
+    "Patch": 3
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -8,8 +8,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 53
+        "Minor": 144,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 52
+        "Patch": 53
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -8,8 +8,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 0,
-    "Patch": 53
+    "Minor": 144,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 52
+    "Patch": 53
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Fixes a bug in nuget.exe version 4.9.1 and dotnet core 2.1.500 where nuget.exe fails to create a tag that starts with number. With this change, 1source will be rewritten as feed-1source in source key and tag in packageSourceCredentials.
```
<PackageSourceCredentials>
    <1source>
    </1source>
<PackageSourceCredentials>
```