### PR TITLE
Fix "Canceled" typo in commands.md

### DIFF
--- a/docs/authoring/commands.md
+++ b/docs/authoring/commands.md
@@ -74,7 +74,7 @@ To invoke a logging command, simply emit the command via standard output. For ex
             </td>
             <td>
                 <p align="left">
-                    <code>result</code>=<code>Succeeded</code>|<code>SucceededWithIssues</code>|<code>Failed</code>|<code>Cancelled</code>|<code>Skipped</code>
+                    <code>result</code>=<code>Succeeded</code>|<code>SucceededWithIssues</code>|<code>Failed</code>|<code>Canceled</code>|<code>Skipped</code>
                 </p>
             </td>
             <td>
@@ -105,7 +105,7 @@ To invoke a logging command, simply emit the command via standard output. For ex
                     <code>finishtime</code>=Datetime <br>
                     <code>progress</code>=percentage of completion <br>
                     <code>state</code>=<code>Unknown</code>|<code>Initialized</code>|<code>InProgress</code>|<code>Completed</code> <br>
-                    <code>result</code>=<code>Succeeded</code>|<code>SucceededWithIssues</code>|<code>Failed</code>|<code>Cancelled</code>|<code>Skipped</code> <br>
+                    <code>result</code>=<code>Succeeded</code>|<code>SucceededWithIssues</code>|<code>Failed</code>|<code>Canceled</code>|<code>Skipped</code> <br>
                 </p>
             </td>
             <td>


### PR DESCRIPTION
`commands.md` documents "Cancelled" as a possible value for both the
`task.complete result` and `task.logdetail result` properties.

However, The Azure agent expects the alternate spelling "Canceled"
(one "l" character) and will throw an error "Unable to process command
'##vso[task.complete result=Cancelled;]DONE' successfully" when
presented with "Cancelled". This change updates the documentation to
reflect the behavior of the agent.