### PR TITLE
Add rollout status to commands in KubernetesV1 task

### DIFF
--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -232,6 +232,36 @@ describe('Kubernetes Suite', function() {
         done();
     });
 
+    it('Runs successfully for kubectl rollout status with configuration file', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.rolloutStatus;
+        process.env[shared.TestEnvVars.useConfigurationFile] = "true";    
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`[command]kubectl rollout status -f ${shared.formatPath("dir/deployment.yaml")} -o json`) != -1, "kubectl rollout status should run");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Runs successfully for kubectl rollout status with arguments', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.rolloutStatus;
+        process.env[shared.TestEnvVars.arguments] = "deployment/nginx";
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`[command]kubectl rollout status deployment/nginx -o json`) != -1, "kubectl rollout status should run");
+        console.log(tr.stderr);
+        done();
+    });
+
     it('Runs successfully for kubectl docker-registry secrets using Container Registry with forceUpdate', (done:MochaDone) => {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -145,6 +145,14 @@ a.exec[`kubectl apply -f ${ConfigurationFilePath} -o json`] = {
     "code": 0,
     "stdout": "successfully applied the configuration deployment.yaml"
 };
+a.exec[`kubectl rollout status -f ${ConfigurationFilePath} -o json`] = {
+    "code": 0,
+    "stdout": "successfully get rollout status with configuration deployment.yaml"
+};
+a.exec[`kubectl rollout status deployment/nginx -o json`] = {
+    "code": 0,
+    "stdout": "successfully get rollout status with arguments"
+};
 a.exec[`kubectl get pods -o json`] = {
     "code": 0,
     "stdout": "successfully ran get pods command"

--- a/Tasks/KubernetesV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesV1/Tests/TestShared.ts
@@ -37,6 +37,7 @@ export let Commands = {
     delete: "delete",
     exec: "exec",
     expose: "expose",
+    rolloutStatus : "rollout status",
     get: "get",
     logs: "logs",
     run: "run",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 19
+        "Patch": 20
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -136,6 +136,7 @@
                 "exec": "exec",
                 "expose": "expose",
                 "get": "get",
+                "rolloutStatus" : "rollout status",
                 "login": "login",
                 "logout": "logout",
                 "logs": "logs",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -136,6 +136,7 @@
         "exec": "exec",
         "expose": "expose",
         "get": "get",
+        "rolloutStatus": "rollout status",
         "login": "login",
         "logout": "logout",
         "logs": "logs",


### PR DESCRIPTION
Add **rollout status** to commands in KubernetesV1 task.

**rollout status** allows you to check and wait for completion of deployment of objects such as deployments, daemonsets, statefulsets - [kubectl reference](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#-em-status-em-)