### PR TITLE
Warn if installing an expired Apple certificate.

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -539,7 +539,9 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
 
     function onLine(line: string) {
         if (line) {
-            const { key, value } = splitIntoKeyValue(line);
+            const tuple = splitIntoKeyValue(line);
+            const key = tuple.key;
+            const value = tuple.value;
 
             if (key === 'SHA1 Fingerprint') {
                 fingerprint = value.replace(/:/g, '').trim();

--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -544,13 +544,18 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
             const value = tuple.value;
 
             if (key === 'SHA1 Fingerprint') {
+                // Example value: "BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+                // Remove colons separating each octet.
                 fingerprint = value.replace(/:/g, '').trim();
             } else if (key === 'subject') {
+                // Example value: "/UID=E848ASUQZY/CN=iPhone Developer: Chris Sidi (7RZ3N927YF)/OU=DJ8T2973U7/O=Chris Sidi/C=US"
+                // Extract the common name.
                 const matches: string[] = value.match(/\/CN=([^/]+)/);
                 if (matches && matches[1]) {
                     commonName = matches[1].trim();
                 }
             } else if (key === 'notBefore') {
+                // Example value: "Nov 13 03:37:42 2018 GMT"
                 notBefore = new Date(value);
             } else if (key === 'notAfter') {
                 notAfter = new Date(value);
@@ -726,6 +731,7 @@ function getUserProvisioningProfilesPath(): string {
 }
 
 function splitIntoKeyValue(line: string): {key: string, value: string} {
+    // Don't use `split`. The value may contain `=` (e.g. "/UID=E848ASUQZY/CN=iPhone Developer: ...")
     const index: number = line.indexOf('=');
 
     if (index) {

--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -540,8 +540,8 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
     function onLine(line: string) {
         if (line) {
             const tuple = splitIntoKeyValue(line);
-            const key = tuple.key;
-            const value = tuple.value;
+            const key: string = tuple.key;
+            const value: string = tuple.value;
 
             if (key === 'SHA1 Fingerprint') {
                 // Example value: "BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
@@ -27,6 +27,6 @@
   "loc.messages.SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
   "loc.messages.SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
   "loc.messages.InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
-  "loc.messages.CertNotValidUntilWarning": "Certificate isn't valid until %s",
-  "loc.messages.CertExpiredWarning": "Certificate expired on %s"
+  "loc.messages.CertNotValidYetError": "%s (%s) certificate isn't valid until %s",
+  "loc.messages.CertExpiredError": "%s (%s) Certificate expired on %s"
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
@@ -26,5 +26,7 @@
   "loc.messages.P12PrivateKeyNameNotFound": "Failed to identify the private key name: %s",
   "loc.messages.SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
   "loc.messages.SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
-  "loc.messages.InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple."
+  "loc.messages.InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
+  "loc.messages.CertNotValidUntilWarning": "Certificate isn't valid until %s",
+  "loc.messages.CertExpiredWarning": "Certificate expired on %s"
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
@@ -27,6 +27,6 @@
   "loc.messages.SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
   "loc.messages.SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
   "loc.messages.InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
-  "loc.messages.CertNotValidYetError": "%s (%s) certificate isn't valid until %s",
-  "loc.messages.CertExpiredError": "%s (%s) Certificate expired on %s"
+  "loc.messages.CertNotValidYetError": "Certificate \"%s\" (fingerprint: %s) isn't valid until %s",
+  "loc.messages.CertExpiredError": "Certificate \"%s\" (fingerprint: %s) expired on %s"
 }

--- a/Tasks/InstallAppleCertificateV2/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0.ts
@@ -116,10 +116,10 @@ describe('InstallAppleCertificate Suite', function () {
         done();
     });
 
-    it('Installs valid certificate', (done: MochaDone) => {
+    it('Installs certificate valid for a brief time', (done: MochaDone) => {
         this.timeout(1000);
 
-        let tp: string = path.join(__dirname, 'L0CertificateValid.js');
+        let tp: string = path.join(__dirname, 'L0CertificateValidForABriefTime.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();

--- a/Tasks/InstallAppleCertificateV2/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0.ts
@@ -116,6 +116,35 @@ describe('InstallAppleCertificate Suite', function () {
         done();
     });
 
+    it('Installs valid certificate', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp: string = path.join(__dirname, 'L0CertificateValid.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
+    it('Fails on expired certificate', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp: string = path.join(__dirname, 'L0FailOnExpiredCertificate.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.failed, 'task should have failed');
+        assert(tr.errorIssues.length > 0, 'should have written to stderr');
+        assert(tr.errorIssues[0].indexOf('Error: loc_mock_CertExpiredError') >= 0, 'error message should match expected');
+
+        done();
+    });
+
     it('Fails on windows', (done: MochaDone) => {
         this.timeout(1000);
 

--- a/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValid.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValid.ts
@@ -28,8 +28,8 @@ Math.random = function (): number {
     return 1337;
 }
 
-// Create a certificate that's been valid only for 10 minutes and expires in 10 minutes.
-// toOpensslString returns UTC date strings, so our testing includes that date comparisons properly account for timezones.
+// Have our certificate be valid only for a very short window of time. We need to test that our date comparisons
+// properly account for timezones. Someone ahead of UTC shouldn't have to wait to use a newly created certificate.
 
 // 10 minutes ago.
 const notBefore: Date = new Date(new Date().getTime() - 10 * 60 * 1000);

--- a/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValid.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValid.ts
@@ -1,0 +1,115 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'preinstallcert.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('certSecureFile', 'mySecureFileId');
+tr.setInput('certPwd', 'mycertPwd');
+tr.setInput('keychain', 'temp');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// Mock Math.random() to always return the same value for our tests.
+Math.random = function (): number {
+    return 1337;
+}
+
+// Create a certificate that's been valid only for 10 minutes and expires in 10 minutes.
+// toOpensslString returns UTC date strings, so our testing includes that date comparisons properly account for timezones.
+
+// 10 minutes ago.
+const notBefore: Date = new Date(new Date().getTime() - 10 * 60 * 1000);
+
+// 10 minutes from now.
+const notAfter: Date = new Date(new Date().getTime() + 10 * 60 * 1000);
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "openssl": "/usr/bin/openssl",
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
+    },
+    "checkPath": {
+        "/usr/bin/openssl": true,
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true,
+        "/build/temp/ios_signing_temp.keychain": false
+    },
+    "exec": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+            "code": 0,
+            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=${toOpensslString(notBefore)}\nnotAfter=${toOpensslString(notAfter)}\n`
+        },
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
+        "/usr/bin/security create-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "keychain created"
+        },
+        "/usr/bin/security set-keychain-settings -lut 7200 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "keychain settings"
+        },
+        "/usr/bin/security unlock-keychain -p 115 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "keychain unlocked"
+        },
+        "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k 115 /build/temp/ios_signing_temp.keychain": {
+            "code": 0,
+            "stdout": "dumped keychain key"
+        },
+        "/usr/bin/security list-keychain -d user": {
+            "code": 0,
+            "stdout": "/user/bin/login.keychain\n/build/temp/ios_signing_temp.keychain"
+        }
+    }
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
+
+tr.run();
+
+// Return a UTC date in this format: "Nov 13 03:37:42 2018 GMT"
+function toOpensslString(datetime: Date): string {
+    const dateSegments: string[] = datetime.toUTCString().split(' ');
+
+    if (dateSegments.length != 6) {
+        throw new Error('Expected 6 segments in the date string');
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString
+    const date = dateSegments[1];
+    const monthName = dateSegments[2];
+    const year = dateSegments[3];
+    const time = dateSegments[4];
+
+    return `${monthName} ${date} ${time} ${year} GMT`;
+}

--- a/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
@@ -28,8 +28,8 @@ Math.random = function (): number {
     return 1337;
 }
 
-// Have our certificate be valid only for a very short window of time. We need to test that our date comparisons
-// properly account for timezones. Someone ahead of UTC shouldn't have to wait to use a newly created certificate.
+// Have our certificate be valid only for a very short window of time. This confirms our date comparisons properly
+// account for timezones. Someone in a timezone ahead of UTC shouldn't have to wait to use a newly created certificate.
 
 // 10 minutes ago.
 const notBefore: Date = new Date(new Date().getTime() - 10 * 60 * 1000);

--- a/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
@@ -1,0 +1,74 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'preinstallcert.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('certSecureFile', 'mySecureFileId');
+tr.setInput('certPwd', 'mycertPwd');
+tr.setInput('keychain', 'temp');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// Mock Math.random() to always return the same value for our tests.
+Math.random = function (): number {
+    return 1337;
+}
+
+// 24 hours ago
+// This date string is generated to ensure the positive test, L0CertificateValid.ts, is actually testing expiration times.
+const expiredDate: Date = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "openssl": "/usr/bin/openssl"
+    },
+    "checkPath": {
+        "/usr/bin/openssl": true
+    },
+    "exec": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+            "code": 0,
+            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2017 GMT\nnotAfter=${toOpensslString(expiredDate)}\n`
+        }
+    }
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
+
+tr.run();
+
+// Return a UTC date in this format: "Nov 13 03:37:42 2018 GMT"
+function toOpensslString(datetime: Date): string {
+    const dateSegments: string[] = datetime.toUTCString().split(' ');
+
+    if (dateSegments.length != 6) {
+        throw new Error('Expected 6 segments in the date string');
+    }
+
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString
+    const date = dateSegments[1];
+    const monthName = dateSegments[2];
+    const year = dateSegments[3];
+    const time = dateSegments[4];
+
+    return `${monthName} ${date} ${time} ${year} GMT`;
+}

--- a/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
@@ -28,9 +28,9 @@ Math.random = function (): number {
     return 1337;
 }
 
-// 24 hours ago
-// This date string is generated to ensure the positive test, L0CertificateValid.ts, is actually testing expiration times.
-const expiredDate: Date = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+// 10 minutes ago. The notAfter date string is generated instead of hardcoded to ensure the positive test,
+// L0CertificateValid.ts, is actually testing expiration times since reading them from the certificate is best effort.
+const expiredDate: Date = new Date(new Date().getTime() - 10 * 60 * 1000);
 
 // provide answers for task mock
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
@@ -45,13 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/build/temp/ios_signing_temp.keychain": false
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass: | /usr/bin/openssl x509 -noout -subject": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass: | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US"
-        },
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass: | /usr/bin/openssl x509 -noout -fingerprint": {
-            "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass: -passout pass:115 | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychain.ts
@@ -41,13 +41,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/lib/login.keychain": true
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -subject": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US"
-        },
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint": {
-            "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
@@ -45,13 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/build/temp/ios_signing_temp.keychain": false
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -subject": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US"
-        },
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint": {
-            "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0UserSupplyCN.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0UserSupplyCN.ts
@@ -42,13 +42,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/lib/login.keychain": true
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -subject": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US"
-        },
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint": {
-            "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/preinstallcert.ts
@@ -25,8 +25,13 @@ async function run() {
 
         let certPwd: string = tl.getInput('certPwd');
 
-        // get the P12 details - SHA1 hash and common name (CN)
-        let { fingerprint, commonName, notBefore, notAfter } = await sign.getP12Properties(certPath, certPwd);
+        // get the P12 details - SHA1 hash, common name (CN) and expiration.
+        const p12Properties = await sign.getP12Properties(certPath, certPwd);
+        let commonName = p12Properties.commonName;
+        const fingerprint = p12Properties.fingerprint,
+            notBefore = p12Properties.notBefore,
+            notAfter = p12Properties.notAfter;
+
         // give user an option to override the CN as a workaround if we can't parse the certificate's subject.
         let commonNameOverride: string = tl.getInput('certSigningIdentity', false);
         if (commonNameOverride) {

--- a/Tasks/InstallAppleCertificateV2/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/preinstallcert.ts
@@ -33,13 +33,13 @@ async function run() {
             notAfter = p12Properties.notAfter;
 
         // give user an option to override the CN as a workaround if we can't parse the certificate's subject.
-        let commonNameOverride: string = tl.getInput('certSigningIdentity', false);
+        const commonNameOverride: string = tl.getInput('certSigningIdentity', false);
         if (commonNameOverride) {
             commonName = commonNameOverride;
         }
 
         if (!fingerprint || !commonName) {
-            throw tl.loc('INVALID_P12');
+            throw new Error(tl.loc('INVALID_P12'));
         }
         tl.setTaskVariable('APPLE_CERTIFICATE_SHA1HASH', fingerprint);
 

--- a/Tasks/InstallAppleCertificateV2/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/preinstallcert.ts
@@ -27,10 +27,10 @@ async function run() {
 
         // get the P12 details - SHA1 hash, common name (CN) and expiration.
         const p12Properties = await sign.getP12Properties(certPath, certPwd);
-        let commonName = p12Properties.commonName;
-        const fingerprint = p12Properties.fingerprint,
-            notBefore = p12Properties.notBefore,
-            notAfter = p12Properties.notAfter;
+        let commonName: string = p12Properties.commonName;
+        const fingerprint: string = p12Properties.fingerprint,
+            notBefore: Date = p12Properties.notBefore,
+            notAfter: Date = p12Properties.notAfter;
 
         // give user an option to override the CN as a workaround if we can't parse the certificate's subject.
         const commonNameOverride: string = tl.getInput('certSigningIdentity', false);
@@ -46,13 +46,13 @@ async function run() {
         // set the signing identity output variable.
         tl.setVariable('signingIdentity', commonName);
 
-        // Warn if the certificate is not yet valid or expired. If the dates are undefined or invalid, the conditions will return false.
+        // Warn if the certificate is not yet valid or expired. If the dates are undefined or invalid, the comparisons below will return false.
         const now: Date = new Date();
         if (notBefore > now) {
-            tl.warning(tl.loc('CertNotValidUntilWarning', notBefore));
+            throw new Error(tl.loc('CertNotValidYetError', commonName, fingerprint, notBefore));
         }
         if (notAfter < now) {
-            tl.warning(tl.loc('CertExpiredWarning', notAfter));
+            throw new Error(tl.loc('CertExpiredError', commonName, fingerprint, notAfter));
         }
 
         // install the certificate in specified keychain, keychain is created if required

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 141,
-        "Patch": 2
+        "Minor": 145,
+        "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [
@@ -135,6 +135,8 @@
         "P12PrivateKeyNameNotFound": "Failed to identify the private key name: %s",
         "SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
         "SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
-        "InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple."
+        "InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
+        "CertNotValidUntilWarning": "Certificate isn't valid until %s",
+        "CertExpiredWarning": "Certificate expired on %s"
     }
 }

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -136,7 +136,7 @@
         "SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
         "SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
         "InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
-        "CertNotValidYetError": "%s (%s) certificate isn't valid until %s",
-        "CertExpiredError": "%s (%s) Certificate expired on %s"
+        "CertNotValidYetError": "Certificate \"%s\" (fingerprint: %s) isn't valid until %s",
+        "CertExpiredError": "Certificate \"%s\" (fingerprint: %s) expired on %s"
     }
 }

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -136,7 +136,7 @@
         "SetKeyPartitionListCommandNotFound": "Skipping unnecessary keychain partition_id ACL assignment on this older OS. The security command 'set-key-partition-list' was introduced in macOS Sierra (10.12).",
         "SetKeyPartitionListCommandFailed": "Error setting the partition_id ACL for the private key. Verify that the `Keychain password` is correct, or use a `Temporary Keychain` instead.",
         "InstallRequiresMac": "Install Apple Certificate requires a macOS agent. Installing Apple Certificates on Linux or Windows is not supported by Apple.",
-        "CertNotValidUntilWarning": "Certificate isn't valid until %s",
-        "CertExpiredWarning": "Certificate expired on %s"
+        "CertNotValidYetError": "%s (%s) certificate isn't valid until %s",
+        "CertExpiredError": "%s (%s) Certificate expired on %s"
     }
 }

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 141,
+    "Minor": 145,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -135,6 +135,8 @@
     "P12PrivateKeyNameNotFound": "ms-resource:loc.messages.P12PrivateKeyNameNotFound",
     "SetKeyPartitionListCommandNotFound": "ms-resource:loc.messages.SetKeyPartitionListCommandNotFound",
     "SetKeyPartitionListCommandFailed": "ms-resource:loc.messages.SetKeyPartitionListCommandFailed",
-    "InstallRequiresMac": "ms-resource:loc.messages.InstallRequiresMac"
+    "InstallRequiresMac": "ms-resource:loc.messages.InstallRequiresMac",
+    "CertNotValidUntilWarning": "ms-resource:loc.messages.CertNotValidUntilWarning",
+    "CertExpiredWarning": "ms-resource:loc.messages.CertExpiredWarning"
   }
 }

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -136,7 +136,7 @@
     "SetKeyPartitionListCommandNotFound": "ms-resource:loc.messages.SetKeyPartitionListCommandNotFound",
     "SetKeyPartitionListCommandFailed": "ms-resource:loc.messages.SetKeyPartitionListCommandFailed",
     "InstallRequiresMac": "ms-resource:loc.messages.InstallRequiresMac",
-    "CertNotValidUntilWarning": "ms-resource:loc.messages.CertNotValidUntilWarning",
-    "CertExpiredWarning": "ms-resource:loc.messages.CertExpiredWarning"
+    "CertNotValidYetError": "ms-resource:loc.messages.CertNotValidYetError",
+    "CertExpiredError": "ms-resource:loc.messages.CertExpiredError"
   }
 }


### PR DESCRIPTION
Provide a helpful warning that the certificate being installed has expired (or is not yet valid).

<img width="1097" alt="screen shot 2018-12-11 at 1 23 06 am" src="https://user-images.githubusercontent.com/7145717/49782174-6e1d7480-fce3-11e8-92ad-80cda7dd4c3f.png">

It's not always obvious that your Xcode or Xamarin iOS build failed because the certificate added to a keychain has expired:

```
2018-12-09T22:51:17.5540930Z /Library/Frameworks/Mono.framework/External/xbuild/Xamarin/iOS/Xamarin.iOS.Common.targets(646,3): error : iOS code signing key 'iPhone Developer: Chris Sidi (7RZ3N927YF)' not found in keychain. [/Users/vsts/agent/2.144.0/work/1/s/iOS/UsingUITest.iOS.csproj]
2018-12-09T22:51:17.5561690Z Done Building Project "/Users/vsts/agent/2.144.0/work/1/s/iOS/UsingUITest.iOS.csproj" (default targets) -- FAILED.
2018-12-09T22:51:17.5694810Z Done Building Project "/Users/vsts/agent/2.144.0/work/1/s/UsingUITest.sln" (default targets) -- FAILED.
2018-12-09T22:51:17.5837840Z
2018-12-09T22:51:17.5838350Z Build FAILED.

2018-12-09T22:51:17.6517100Z ##[error]Xamarin.iOS task failed with error Error: /Library/Frameworks/Mono.framework/Versions/Current/Commands/msbuild failed with return code: 1. For guidance on setting up the build definition, see https://go.microsoft.com/fwlink/?LinkId=760847.
```