### PR TITLE
Update DeleteFilesV1 to use most recent version of task-lib

### DIFF
--- a/Tasks/DeleteFilesV1/deletefiles.ts
+++ b/Tasks/DeleteFilesV1/deletefiles.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import os = require('os');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 (() => {
@@ -62,7 +62,7 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
     }
 
     // apply the match patterns
-    let matches: string[] = tl.match(foundPaths, patterns, matchOptions);
+    let matches: string[] = tl.match(foundPaths, patterns, null, matchOptions);
 
     // sort by length (descending) so files are deleted before folders
     matches = matches.sort((a: string, b: string) => {

--- a/Tasks/DeleteFilesV1/package-lock.json
+++ b/Tasks/DeleteFilesV1/package-lock.json
@@ -1,9 +1,22 @@
 {
   "name": "vsts-deletefiles-tasks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.7.7",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
+      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -23,32 +36,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -61,24 +48,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "q": {
       "version": "1.5.1",
@@ -95,33 +64,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
-      "requires": {
-        "glob": "6.0.4",
-        "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "node-uuid": "1.4.8",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "vso-node-api": "0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     }
   }
 }

--- a/Tasks/DeleteFilesV1/package.json
+++ b/Tasks/DeleteFilesV1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-deletefiles-tasks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Azure Pipelines DeleteFiles Task",
   "main": "deletefiles.js",
   "scripts": {
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/microsoft/vsts-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^0.9.20"
+    "azure-pipelines-task-lib": "^2.7.7"
   }
 }


### PR DESCRIPTION
While all other task-lib functions used by DeleteFilesV1 haven't changed significantly, tl.match() has (it used to use semver and now I believe it does its own matching). I think this should solve #4936.