### PR TITLE
Switching the authentication flag back to true

### DIFF
--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -446,7 +446,7 @@ export class Job {
                     thisJob.stopWork(0, JobState.Finishing);
                 }
             }
-        }).auth(thisJob.queue.TaskOptions.username, thisJob.queue.TaskOptions.password, false) //The 'false' flag forces the request to send proper authentication headers when retrying
+        }).auth(thisJob.queue.TaskOptions.username, thisJob.queue.TaskOptions.password, true)
         .on('error', (err) => { 
             throw err; 
         });

--- a/Tasks/JenkinsQueueJobV2/task.json
+++ b/Tasks/JenkinsQueueJobV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 144,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJobV2/task.loc.json
+++ b/Tasks/JenkinsQueueJobV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 144,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {


### PR DESCRIPTION
This change was causing some pipeline builds to hang with 403 errors. Reverting the flag back to true.