### PR TITLE
Harden SSH task (part 1)

### DIFF
--- a/Tasks/SshV0/package-lock.json
+++ b/Tasks/SshV0/package-lock.json
@@ -12,6 +12,23 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
       "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
     },
+    "@types/ssh2": {
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.37.tgz",
+      "integrity": "sha512-f6vjGBEgiH8rqJOVIoKU++Kf1U+BoDkCR6JjYB7MZISTdaK9ZfsF/rgPlLCQjTiKhT7ApUgiLfHYEIitexdIVA==",
+      "requires": {
+        "@types/node": "6.0.117",
+        "@types/ssh2-streams": "0.1.4"
+      }
+    },
+    "@types/ssh2-streams": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.4.tgz",
+      "integrity": "sha512-S4CXFWMnzoEqeX3MSCMAzfYLiMNOyEh0mPXZbaIZWyjFefZAC1mzVj0kIJNMM88LQ3LaVZLbm09GVLJAMpiwbw==",
+      "requires": {
+        "@types/node": "6.0.117"
+      }
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",

--- a/Tasks/SshV0/package.json
+++ b/Tasks/SshV0/package.json
@@ -2,8 +2,9 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.0.7",
-    "ssh2": "0.5.0",
+    "@types/ssh2": "^0.5.37",
     "scp2": "0.5.0",
+    "ssh2": "0.5.0",
     "vsts-task-lib": "0.8.3"
   }
 }

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -100,7 +100,7 @@ async function run() {
                     tl._writeLine(command);
                     const returnCode: string = await sshHelper.runCommandOnRemoteMachine(
                         command, sshClientConnection, remoteCmdOptions);
-                    tl.debug('Command ' + commands + ' completed with return code = ' + returnCode);
+                    tl.debug('Command ' + command + ' completed with return code = ' + returnCode);
                 }
             } else { // both other runOptions: inline and script
                 //setup script path on remote machine relative to user's $HOME directory

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -6,27 +6,27 @@ import sshHelper = require('./ssh2helpers');
 import { RemoteCommandOptions } from './ssh2helpers'
 
 async function run() {
-    var sshClientConnection: any;
-    var cleanUpScriptCmd: string;
-    var remoteCmdOptions: RemoteCommandOptions = new RemoteCommandOptions();
+    let sshClientConnection: any;
+    let cleanUpScriptCmd: string;
+    const remoteCmdOptions: RemoteCommandOptions = new RemoteCommandOptions();
 
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
         //read SSH endpoint input
-        var sshEndpoint = tl.getInput('sshEndpoint', true);
-        var username: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
-        var password: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
-        var privateKey: string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
-        var hostname: string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
-        var port: string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
+        const sshEndpoint = tl.getInput('sshEndpoint', true);
+        const username: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
+        const password: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
+        const privateKey: string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
+        const hostname: string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
+        let port: string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
         if (!port || port === '') {
             tl._writeLine(tl.loc('UseDefaultPort'));
             port = '22';
         }
 
         //setup the SSH connection configuration based on endpoint details
-        var sshConfig;
+        let sshConfig;
         if (privateKey && privateKey !== '') {
             tl.debug('Using private key for ssh connection.');
             sshConfig = {
@@ -48,10 +48,10 @@ async function run() {
         }
 
         //read the run options
-        var runOptions: string = tl.getInput('runOptions', true);
-        var commands: string[];
-        var scriptFile: string;
-        var args: string;
+        const runOptions: string = tl.getInput('runOptions', true);
+        let commands: string[];
+        let scriptFile: string;
+        let args: string;
 
         if (runOptions === 'commands') {
             // Split on '\n' and ';', flatten, and remove empty entries
@@ -60,9 +60,8 @@ async function run() {
                 .reduce((a, b) => a.concat(b))
                 .filter(s => s.length > 0);
         } else if (runOptions === 'inline') {
-            var inlineScript: string = tl.getInput('inline', true);
-            const scriptHeader: string = '#!';
-            if (inlineScript && !inlineScript.startsWith(scriptHeader)) {
+            let inlineScript: string = tl.getInput('inline', true);
+            if (inlineScript && !inlineScript.startsWith('#!')) {
                 const bashHeader: string = '#!/bin/bash';
                 tl.debug('No script header detected.  Adding: ' + bashHeader);
                 inlineScript = bashHeader + os.EOL + inlineScript;
@@ -80,7 +79,7 @@ async function run() {
             args = tl.getInput('args')
         }
 
-        var failOnStdErr: boolean = tl.getBoolInput('failOnStdErr');
+        const failOnStdErr: boolean = tl.getBoolInput('failOnStdErr');
         remoteCmdOptions.failOnStdErr = failOnStdErr;
 
         //setup the SSH connection
@@ -96,26 +95,26 @@ async function run() {
             tl._writeLine(tl.loc('SshConnectionSuccessful'));
             if (runOptions === 'commands') {
                 //run commands specified by the user
-                for (var i: number = 0; i < commands.length; i++) {
-                    tl.debug('Running command ' + commands[i] + ' on remote machine.');
-                    tl._writeLine(commands[i]);
-                    var returnCode: string = await sshHelper.runCommandOnRemoteMachine(
-                        commands[i], sshClientConnection, remoteCmdOptions);
-                    tl.debug('Command ' + commands[i] + ' completed with return code = ' + returnCode);
+                for (const command of commands) {
+                    tl.debug('Running command ' + command + ' on remote machine.');
+                    tl._writeLine(command);
+                    const returnCode: string = await sshHelper.runCommandOnRemoteMachine(
+                        command, sshClientConnection, remoteCmdOptions);
+                    tl.debug('Command ' + commands + ' completed with return code = ' + returnCode);
                 }
             } else { // both other runOptions: inline and script
                 //setup script path on remote machine relative to user's $HOME directory
-                var remoteScript = './' + path.basename(scriptFile);
-                var remoteScriptPath = '"' + remoteScript + '"';
-                var windowsEncodedRemoteScriptPath = remoteScriptPath;
-                var  isWin  =  os.type().match(/^Win/);
+                const remoteScript = './' + path.basename(scriptFile);
+                let remoteScriptPath = '"' + remoteScript + '"';
+                const windowsEncodedRemoteScriptPath = remoteScriptPath;
+                const isWin = os.type().match(/^Win/);
                 if (isWin) {
                     remoteScriptPath = '"' + remoteScript + "._unix" + '"';
                 }
                 tl.debug('remoteScriptPath = ' + remoteScriptPath);
 
                 //copy script file to remote machine
-                var scpConfig = sshConfig;
+                const scpConfig = sshConfig;
                 scpConfig.path = remoteScript;
                 tl.debug('Copying script to remote machine.');
                 await sshHelper.copyScriptToRemoteMachine(scriptFile, scpConfig);
@@ -123,7 +122,7 @@ async function run() {
                 //change the line encodings
                 if (isWin) {
                     tl.debug('Fixing the line endings in case the file was created in Windows');
-                    var removeLineEndingsCmd = 'tr -d \'\\015\' <' + windowsEncodedRemoteScriptPath + ' > ' + remoteScriptPath;
+                    const removeLineEndingsCmd = 'tr -d \'\\015\' <' + windowsEncodedRemoteScriptPath + ' > ' + remoteScriptPath;
                     tl._writeLine(removeLineEndingsCmd);
                     await sshHelper.runCommandOnRemoteMachine(removeLineEndingsCmd, sshClientConnection, remoteCmdOptions);
                 }
@@ -135,7 +134,7 @@ async function run() {
                     'chmod +x ' + remoteScriptPath, sshClientConnection, remoteCmdOptions);
 
                 //run remote script file with args on the remote machine
-                var runScriptCmd = remoteScriptPath;
+                let runScriptCmd = remoteScriptPath;
                 if (args) {
                     runScriptCmd = runScriptCmd.concat(' ' + args);
                 }

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -107,7 +107,7 @@ async function run() {
                 const remoteScript = './' + path.basename(scriptFile);
                 let remoteScriptPath = '"' + remoteScript + '"';
                 const windowsEncodedRemoteScriptPath = remoteScriptPath;
-                const isWin = os.type().match(/^Win/);
+                const isWin = os.platform() === 'win32';
                 if (isWin) {
                     remoteScriptPath = '"' + remoteScript + "._unix" + '"';
                 }

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -1,8 +1,8 @@
-import os = require('os');
-import path = require('path');
-import tl = require('vsts-task-lib/task');
-import fs = require('fs');
-import sshHelper = require('./ssh2helpers');
+import * as os from 'os';
+import * as path from 'path';
+import * as tl from 'vsts-task-lib/task';
+import * as fs from 'fs';
+import * as sshHelper from './ssh2helpers';
 import { RemoteCommandOptions } from './ssh2helpers'
 
 async function run() {

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -3,24 +3,24 @@ import path = require('path');
 import tl = require('vsts-task-lib/task');
 import fs = require('fs');
 import sshHelper = require('./ssh2helpers');
-import {RemoteCommandOptions} from './ssh2helpers'
+import { RemoteCommandOptions } from './ssh2helpers'
 
 async function run() {
     var sshClientConnection: any;
     var cleanUpScriptCmd: string;
-    var remoteCmdOptions : RemoteCommandOptions = new RemoteCommandOptions();
+    var remoteCmdOptions: RemoteCommandOptions = new RemoteCommandOptions();
 
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
         //read SSH endpoint input
         var sshEndpoint = tl.getInput('sshEndpoint', true);
-        var username:string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
-        var password:string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
-        var privateKey:string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
-        var hostname:string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
-        var port:string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
-        if(!port || port === '') {
+        var username: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'username', false);
+        var password: string = tl.getEndpointAuthorizationParameter(sshEndpoint, 'password', true); //passphrase is optional
+        var privateKey: string = process.env['ENDPOINT_DATA_' + sshEndpoint + '_PRIVATEKEY']; //private key is optional, password can be used for connecting
+        var hostname: string = tl.getEndpointDataParameter(sshEndpoint, 'host', false);
+        var port: string = tl.getEndpointDataParameter(sshEndpoint, 'port', true); //port is optional, will use 22 as default port if not specified
+        if (!port || port === '') {
             tl._writeLine(tl.loc('UseDefaultPort'));
             port = '22';
         }
@@ -48,22 +48,22 @@ async function run() {
         }
 
         //read the run options
-        var runOptions : string = tl.getInput('runOptions', true);
-        var commands : string[];
-        var scriptFile : string;
-        var args : string;
+        var runOptions: string = tl.getInput('runOptions', true);
+        var commands: string[];
+        var scriptFile: string;
+        var args: string;
 
         if (runOptions === 'commands') {
             // Split on '\n' and ';', flatten, and remove empty entries
             commands = tl.getDelimitedInput('commands', '\n', true)
-                         .map(s => s.split(';'))
-                         .reduce((a, b) => a.concat(b))
-                         .filter(s => s.length > 0);
+                .map(s => s.split(';'))
+                .reduce((a, b) => a.concat(b))
+                .filter(s => s.length > 0);
         } else if (runOptions === 'inline') {
             var inlineScript: string = tl.getInput('inline', true);
-            const scriptHeader:string = '#!';
+            const scriptHeader: string = '#!';
             if (inlineScript && !inlineScript.startsWith(scriptHeader)) {
-                const bashHeader: string =  '#!/bin/bash';
+                const bashHeader: string = '#!/bin/bash';
                 tl.debug('No script header detected.  Adding: ' + bashHeader);
                 inlineScript = bashHeader + os.EOL + inlineScript;
             }
@@ -80,7 +80,7 @@ async function run() {
             args = tl.getInput('args')
         }
 
-        var failOnStdErr : boolean = tl.getBoolInput('failOnStdErr');
+        var failOnStdErr: boolean = tl.getBoolInput('failOnStdErr');
         remoteCmdOptions.failOnStdErr = failOnStdErr;
 
         //setup the SSH connection
@@ -91,15 +91,15 @@ async function run() {
             tl.setResult(tl.TaskResult.Failed, tl.loc('ConnectionFailed', err));
         }
 
-        if(sshClientConnection) {
+        if (sshClientConnection) {
             //SSH connection successful
             tl._writeLine(tl.loc('SshConnectionSuccessful'));
             if (runOptions === 'commands') {
                 //run commands specified by the user
-                for (var i:number = 0; i < commands.length; i++) {
+                for (var i: number = 0; i < commands.length; i++) {
                     tl.debug('Running command ' + commands[i] + ' on remote machine.');
                     tl._writeLine(commands[i]);
-                    var returnCode:string = await sshHelper.runCommandOnRemoteMachine(
+                    var returnCode: string = await sshHelper.runCommandOnRemoteMachine(
                         commands[i], sshClientConnection, remoteCmdOptions);
                     tl.debug('Command ' + commands[i] + ' completed with return code = ' + returnCode);
                 }
@@ -108,9 +108,9 @@ async function run() {
                 var remoteScript = './' + path.basename(scriptFile);
                 var remoteScriptPath = '"' + remoteScript + '"';
                 var windowsEncodedRemoteScriptPath = remoteScriptPath;
-                var isWin = os.type().match(/^Win/);
+                var  isWin  =  os.type().match(/^Win/);
                 if (isWin) {
-                    remoteScriptPath =  '"' + remoteScript + "._unix" + '"';
+                    remoteScriptPath = '"' + remoteScript + "._unix" + '"';
                 }
                 tl.debug('remoteScriptPath = ' + remoteScriptPath);
 
@@ -156,12 +156,12 @@ async function run() {
         tl.setResult(tl.TaskResult.Failed, err);
     } finally {
         //clean up script file if needed
-        if(cleanUpScriptCmd) {
+        if (cleanUpScriptCmd) {
             try {
                 tl.debug('Deleting the script file copied to the remote machine.');
                 await sshHelper.runCommandOnRemoteMachine(
                     cleanUpScriptCmd, sshClientConnection, remoteCmdOptions);
-            } catch(err) {
+            } catch (err) {
                 tl.warning(tl.loc('RemoteScriptFileCleanUpFailed', err));
             }
         }

--- a/Tasks/SshV0/ssh2helpers.ts
+++ b/Tasks/SshV0/ssh2helpers.ts
@@ -4,7 +4,7 @@ var Ssh2Client = require('ssh2').Client;
 var Scp2Client = require('scp2');
 
 export class RemoteCommandOptions {
-    public failOnStdErr : boolean;
+    public failOnStdErr: boolean;
 }
 
 /**
@@ -13,7 +13,7 @@ export class RemoteCommandOptions {
  * @param scpConfig
  * @returns {Promise<string>|Promise<T>}
  */
-export function copyScriptToRemoteMachine(scriptFile : string, scpConfig : any) : Q.Promise<string> {
+export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q.Promise<string> {
     var defer = Q.defer<string>();
 
     Scp2Client.scp(scriptFile, scpConfig, (err) => {
@@ -33,7 +33,7 @@ export function copyScriptToRemoteMachine(scriptFile : string, scpConfig : any) 
  * @param sshConfig
  * @returns {Promise<any>|Promise<T>}
  */
-export function setupSshClientConnection(sshConfig: any) : Q.Promise<any> {
+export function setupSshClientConnection(sshConfig: any): Q.Promise<any> {
     var defer = Q.defer<any>();
     var client = new Ssh2Client();
     client.on('ready', () => {
@@ -51,7 +51,7 @@ export function setupSshClientConnection(sshConfig: any) : Q.Promise<any> {
  * @param options
  * @returns {Promise<string>|Promise<T>}
  */
-export function runCommandOnRemoteMachine(command: string, sshClient: any, options: RemoteCommandOptions) : Q.Promise<string> {
+export function runCommandOnRemoteMachine(command: string, sshClient: any, options: RemoteCommandOptions): Q.Promise<string> {
     const defer = Q.defer<string>();
     let stdErrWritten: boolean = false;
 

--- a/Tasks/SshV0/ssh2helpers.ts
+++ b/Tasks/SshV0/ssh2helpers.ts
@@ -1,7 +1,7 @@
 import tl = require('vsts-task-lib/task');
 import Q = require('q');
-var Ssh2Client = require('ssh2').Client;
-var Scp2Client = require('scp2');
+const Ssh2Client = require('ssh2').Client;
+const Scp2Client = require('scp2');
 
 export class RemoteCommandOptions {
     public failOnStdErr: boolean;
@@ -14,7 +14,7 @@ export class RemoteCommandOptions {
  * @returns {Promise<string>|Promise<T>}
  */
 export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q.Promise<string> {
-    var defer = Q.defer<string>();
+    const defer = Q.defer<string>();
 
     Scp2Client.scp(scriptFile, scpConfig, (err) => {
         if (err) {
@@ -34,8 +34,8 @@ export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q
  * @returns {Promise<any>|Promise<T>}
  */
 export function setupSshClientConnection(sshConfig: any): Q.Promise<any> {
-    var defer = Q.defer<any>();
-    var client = new Ssh2Client();
+    const defer = Q.defer<any>();
+    const client = new Ssh2Client();
     client.on('ready', () => {
         defer.resolve(client);
     }).on('error', (err) => {

--- a/Tasks/SshV0/ssh2helpers.ts
+++ b/Tasks/SshV0/ssh2helpers.ts
@@ -11,7 +11,7 @@ export class RemoteCommandOptions {
  * Uses scp2 to copy a file to remote machine
  * @param scriptFile
  * @param scpConfig
- * @returns {Promise<string>|Promise<T>}
+ * @returns {Promise<string>}
  */
 export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q.Promise<string> {
     const defer = Q.defer<string>();
@@ -31,7 +31,7 @@ export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q
 /**
  * Sets up an SSH client connection, when promise is fulfilled, returns the connection object
  * @param sshConfig
- * @returns {Promise<any>|Promise<T>}
+ * @returns {Promise<any>}
  */
 export function setupSshClientConnection(sshConfig: any): Q.Promise<any> {
     const defer = Q.defer<any>();
@@ -49,7 +49,7 @@ export function setupSshClientConnection(sshConfig: any): Q.Promise<any> {
  * @param command
  * @param sshClient
  * @param options
- * @returns {Promise<string>|Promise<T>}
+ * @returns {Promise<string>}
  */
 export function runCommandOnRemoteMachine(command: string, sshClient: any, options: RemoteCommandOptions): Q.Promise<string> {
     const defer = Q.defer<string>();

--- a/Tasks/SshV0/ssh2helpers.ts
+++ b/Tasks/SshV0/ssh2helpers.ts
@@ -1,7 +1,7 @@
-import tl = require('vsts-task-lib/task');
-import Q = require('q');
-const Ssh2Client = require('ssh2').Client;
-const Scp2Client = require('scp2');
+import * as tl from 'vsts-task-lib/task';
+import * as Q from 'q';
+import * as scp2 from 'scp2';
+import * as ssh2 from 'ssh2';
 
 export class RemoteCommandOptions {
     public failOnStdErr: boolean;
@@ -16,7 +16,7 @@ export class RemoteCommandOptions {
 export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q.Promise<string> {
     const defer = Q.defer<string>();
 
-    Scp2Client.scp(scriptFile, scpConfig, (err) => {
+    scp2.scp(scriptFile, scpConfig, (err) => {
         if (err) {
             defer.reject(tl.loc('RemoteCopyFailed', err));
         } else {
@@ -35,7 +35,7 @@ export function copyScriptToRemoteMachine(scriptFile: string, scpConfig: any): Q
  */
 export function setupSshClientConnection(sshConfig: any): Q.Promise<any> {
     const defer = Q.defer<any>();
-    const client = new Ssh2Client();
+    const client = new ssh2.Client();
     client.on('ready', () => {
         defer.resolve(client);
     }).on('error', (err) => {

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 0,
         "Minor": 145,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 0,
     "Minor": 145,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",


### PR DESCRIPTION
We are going to gradually harden our tasks as we touch them.  One thing we want to do is enable the strict TS compiler flags for our tasks.  That will amount to a bunch of added null checking and explicit `: any`, so I am going to do that in a separate change to keep things focused.

* Installed @types/ssh2
* var -> const | let
* TS import-from syntax (gives immutable, typed module objects)
* Ran VS Code formatting

**Testing**
* Ran successful builds with an inline SSH script on Windows and Linux