### PR TITLE
Making repository name input as editable.

### DIFF
--- a/Tasks/GitHubReleaseV0/task.json
+++ b/Tasks/GitHubReleaseV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/GitHubReleaseV0/task.json
+++ b/Tasks/GitHubReleaseV0/task.json
@@ -35,7 +35,8 @@
             "required": true,
             "helpMarkDown": "Specify the name of the GitHub repository in which GitHub releases will be created.",
             "properties": {
-                "DisableManageLink": "True"
+                "DisableManageLink": "True",
+                "EditableOptions": "True"
             }
         },
         {


### PR DESCRIPTION
Issue: fetch repository call getting timeout and user is not able to set the repository name.

Making it editable will allow user to type it manually.