### PR TITLE
Make cmdline task work with UTF8 encoding on WS < 1709

### DIFF
--- a/Tasks/CmdLineV2/cmdline.ps1
+++ b/Tasks/CmdLineV2/cmdline.ps1
@@ -27,10 +27,15 @@ try {
     $tempDirectory = Get-VstsTaskVariable -Name 'agent.tempDirectory' -Require
     Assert-VstsPath -LiteralPath $tempDirectory -PathType 'Container'
     $filePath = [System.IO.Path]::Combine($tempDirectory, "$([System.Guid]::NewGuid()).cmd")
+    $fileEncoding = [System.Console]::OutputEncoding
+    if ($fileEncoding.CodePage -eq 65001) {
+        # If UTF8, write without BOM
+        $fileEncoding = New-Object System.Text.UTF8Encoding $False
+    }
     $null = [System.IO.File]::WriteAllText(
         $filePath,
         $contents.ToString(),
-        ([System.Console]::OutputEncoding))
+        $fileEncoding)
 
     # Prepare the external command values.
     $cmdPath = $env:ComSpec

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 142,
-        "Patch": 2
+        "Minor": 146,
+        "Patch": 1
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines.",
     "showEnvironmentVariables": true,

--- a/Tasks/CmdLineV2/task.loc.json
+++ b/Tasks/CmdLineV2/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 142,
-    "Patch": 0
+    "Minor": 146,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "showEnvironmentVariables": true,


### PR DESCRIPTION
This correctly handles the earlier Windows Server versions - it no longer writes with a BOM so those versions can read the files correctly.