### PR TITLE
Fix git diff using merge-base

### DIFF
--- a/Tasks/AndroidSigningV3/Tests/L0.ts
+++ b/Tasks/AndroidSigningV3/Tests/L0.ts
@@ -12,11 +12,6 @@ describe('AndroidSigning Suite v3', function () {
     after(() => {
         // empty
     });
-    
-    it('Should fail if CI is working', (done: MochaDone) => {
-        assert(1==0);
-        done();
-    });
 
     it('Do not sign or zipalign if nothing is selected', (done: MochaDone) => {
         this.timeout(1000);

--- a/Tasks/AndroidSigningV3/Tests/L0.ts
+++ b/Tasks/AndroidSigningV3/Tests/L0.ts
@@ -12,6 +12,11 @@ describe('AndroidSigning Suite v3', function () {
     after(() => {
         // empty
     });
+    
+    it('Should fail if CI is working', (done: MochaDone) => {
+        assert(1==0);
+        done();
+    });
 
     it('Do not sign or zipalign if nothing is selected', (done: MochaDone) => {
         this.timeout(1000);

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -111,7 +111,8 @@ var getTasksToBuildForPR = function() {
             sourceBranch = sourceBranch.split(':')[1];
         }
         run('git fetch origin pull/' + prId + '/head:' + sourceBranch);
-        run ('git checkout ' + sourceBranch);
+        run('git checkout master');
+        run('git checkout ' + sourceBranch);
     }
     catch (err) {
         // If unable to reach github, build everything.

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -119,7 +119,9 @@ var getTasksToBuildForPR = function() {
         return makeOptions.tasks;
     }
     run('git checkout master');
-    run('git diff --name-only master..' + sourceBranch).split('\n').forEach(filePath => {
+    run('git --no-pager diff --name-only ' + sourceBranch + ' $(git merge-base ' + sourceBranch + ' master)')
+        .split('\n')
+        .forEach(filePath => {
         if (filePath.slice(0, 5) == 'Tasks') {
             var taskPath = filePath.slice(6);
             if(taskPath.slice(0, 6) == 'Common') {

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -118,7 +118,6 @@ var getTasksToBuildForPR = function() {
         console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=112;]Unable to reach github, building all tasks', err);
         return makeOptions.tasks;
     }
-    run('git checkout master');
     var baseCommit = run('git merge-base ' + sourceBranch + ' master');
     run('git --no-pager diff --name-only ' + sourceBranch + ' ' + baseCommit)
         .split('\n')

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -119,7 +119,8 @@ var getTasksToBuildForPR = function() {
         return makeOptions.tasks;
     }
     run('git checkout master');
-    run('git --no-pager diff --name-only ' + sourceBranch + ' $(git merge-base ' + sourceBranch + ' master)')
+    var baseCommit = run('git merge-base ' + sourceBranch + ' master');
+    run('git --no-pager diff --name-only ' + sourceBranch + ' ' + baseCommit)
         .split('\n')
         .forEach(filePath => {
         if (filePath.slice(0, 5) == 'Tasks') {


### PR DESCRIPTION
Right now, when we compare what has changed for CI we bring in all commits that have happened on master after the pull branch was split off. This means we are building much more than we should. This fixes this problem using [merge-base](https://git-scm.com/docs/git-merge-base).

Additionally, right now we are checking out master at the end which means tests are being run on master, not the branch. This has been addressed by moving that logic above where we check out the appropriate branch.