### PR TITLE
[PowerShellV2] Check if targetType is filepath or inline

### DIFF
--- a/Tasks/PowerShellV2/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/de-de/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.PS_FormattedCommand": "Formatierter Befehl: {0}",
   "loc.messages.PS_InvalidErrorActionPreference": "ErrorActionPreference \"{0}\" ungültig. Der Wert muss \"Stop\", \"Continue\" oder \"SilentlyContinue\" sein.",
   "loc.messages.PS_InvalidFilePath": "Ungültiger Dateipfad \"{0}\". Ein Pfad zu einer PS1-Datei ist erforderlich.",
-  "loc.messages.PS_UnableToDetermineExitCode": "Unerwartete Ausnahme. Der Exitcode von PowerShell konnte nicht bestimmt werden."
+  "loc.messages.PS_UnableToDetermineExitCode": "Unerwartete Ausnahme. Der Exitcode von PowerShell konnte nicht bestimmt werden.",
+  "loc.messages.PS_InvalidTargetType": "TargetType \"{0}\" ungültig. Der Wert muss \"filePath\" oder \"inline\" sein.",
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
@@ -33,4 +33,5 @@
   "loc.messages.PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
   "loc.messages.PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
   "loc.messages.PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
+  "loc.messages.PS_InvalidTargetType": "Invalid TargetType '{0}'. The value must be one of: 'filePath' or 'inline'"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/es-es/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.PS_FormattedCommand": "Comando con formato: {0}",
   "loc.messages.PS_InvalidErrorActionPreference": "El valor \"{0}\" de ErrorActionPreference no es válido. El valor debe ser uno de los siguientes: \"Stop\", \"Continue\" o \"SilentlyContinue\"",
   "loc.messages.PS_InvalidFilePath": "La ruta de acceso de archivo \"{0}\" no es válida. Se necesita una ruta de acceso a un archivo .ps1.",
-  "loc.messages.PS_UnableToDetermineExitCode": "Excepción inesperada. No se puede determinar el código de salida de PowerShell."
+  "loc.messages.PS_UnableToDetermineExitCode": "Excepción inesperada. No se puede determinar el código de salida de PowerShell.",
+  "loc.messages.PS_InvalidTargetType": "El valor \"{0}\" de TargetType no es válido. El valor debe ser uno de los siguientes: \"filePath\" o \"inline\"",
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/fr-fr/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.PS_FormattedCommand": "Commande mise en forme : {0}",
   "loc.messages.PS_InvalidErrorActionPreference": "ErrorActionPreference '{0}' non valide. La valeur doit correspondre à 'Stop', 'Continue' ou 'SilentlyContinue'",
   "loc.messages.PS_InvalidFilePath": "Chemin de fichier '{0}' non valide. Le chemin d'un fichier .ps1 est obligatoire.",
-  "loc.messages.PS_UnableToDetermineExitCode": "Exception inattendue. Impossible de déterminer le code de sortie de PowerShell."
+  "loc.messages.PS_UnableToDetermineExitCode": "Exception inattendue. Impossible de déterminer le code de sortie de PowerShell.",
+  "loc.messages.PS_InvalidErrorActionPreference": "TargetType '{0}' non valide. La valeur doit correspondre à 'filePath' ou 'inline'",
 }

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -34,8 +34,11 @@ async function run() {
 
             input_arguments = tl.getInput('arguments') || '';
         }
-        else {
+        else if(input_targetType.toUpperCase() == 'INLINE') {
             input_script = tl.getInput('script', false) || '';
+        }
+        else {
+            throw new Error(tl.loc('PS_InvalidTargetType', input_targetType));
         }
 
         // Generate the script contents.

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -148,6 +148,7 @@
     "PS_FormattedCommand": "ms-resource:loc.messages.PS_FormattedCommand",
     "PS_InvalidErrorActionPreference": "ms-resource:loc.messages.PS_InvalidErrorActionPreference",
     "PS_InvalidFilePath": "ms-resource:loc.messages.PS_InvalidFilePath",
-    "PS_UnableToDetermineExitCode": "ms-resource:loc.messages.PS_UnableToDetermineExitCode"
+    "PS_UnableToDetermineExitCode": "ms-resource:loc.messages.PS_UnableToDetermineExitCode",
+    "PS_InvalidTargetType": "ms-resource:loc.messages.PS_InvalidTargetType"
   }
 }


### PR DESCRIPTION
This PR changes the behaviour of the PowerShellV2 task in that it will validate the value of `targetType` to be `filePath` or `inline` and throw an error if it isn't either of these values.

This prevents the task defaulting to running the inline script that only prints `Hello, world` if no script has been specified.