### PR TITLE
Revert "Add rollout status to commands in KubernetesV1 task"

### DIFF
--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -238,36 +238,6 @@ describe('Kubernetes Suite', function() {
         done();
     });
 
-    it('Runs successfully for kubectl rollout status with configuration file', (done:MochaDone) => {
-        let tp = path.join(__dirname, 'TestSetup.js');
-        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-        process.env[shared.TestEnvVars.command] = shared.Commands.rolloutStatus;
-        process.env[shared.TestEnvVars.useConfigurationFile] = "true";    
-        tr.run();
-
-        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
-        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
-        assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]kubectl rollout status -f ${shared.formatPath("dir/deployment.yaml")} -o json`) != -1, "kubectl rollout status should run");
-        console.log(tr.stderr);
-        done();
-    });
-
-    it('Runs successfully for kubectl rollout status with arguments', (done:MochaDone) => {
-        let tp = path.join(__dirname, 'TestSetup.js');
-        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-        process.env[shared.TestEnvVars.command] = shared.Commands.rolloutStatus;
-        process.env[shared.TestEnvVars.arguments] = "deployment/nginx";
-        tr.run();
-
-        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
-        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
-        assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]kubectl rollout status deployment/nginx -o json`) != -1, "kubectl rollout status should run");
-        console.log(tr.stderr);
-        done();
-    });
-
     it('Runs successfully for kubectl docker-registry secrets using Container Registry with forceUpdate', (done:MochaDone) => {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -149,14 +149,6 @@ a.exec[`kubectl apply -f ${ConfigurationFilePath} -o json`] = {
     "code": 0,
     "stdout": "successfully applied the configuration deployment.yaml"
 };
-a.exec[`kubectl rollout status -f ${ConfigurationFilePath} -o json`] = {
-    "code": 0,
-    "stdout": "successfully get rollout status with configuration deployment.yaml"
-};
-a.exec[`kubectl rollout status deployment/nginx -o json`] = {
-    "code": 0,
-    "stdout": "successfully get rollout status with arguments"
-};
 a.exec[`kubectl get pods -o json`] = {
     "code": 0,
     "stdout": "successfully ran get pods command"

--- a/Tasks/KubernetesV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesV1/Tests/TestShared.ts
@@ -39,7 +39,6 @@ export let Commands = {
     delete: "delete",
     exec: "exec",
     expose: "expose",
-    rolloutStatus : "rollout status",
     get: "get",
     logs: "logs",
     run: "run",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -136,7 +136,6 @@
                 "exec": "exec",
                 "expose": "expose",
                 "get": "get",
-                "rolloutStatus" : "rollout status",
                 "login": "login",
                 "logout": "logout",
                 "logs": "logs",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -136,7 +136,6 @@
         "exec": "exec",
         "expose": "expose",
         "get": "get",
-        "rolloutStatus": "rollout status",
         "login": "login",
         "logout": "logout",
         "logs": "logs",


### PR DESCRIPTION
Reverts Microsoft/azure-pipelines-tasks#9029. This change is not required. 'Command' input is editable. You can type 'rollout' in command and can give remaining options in 'Arguments' input.

![image](https://user-images.githubusercontent.com/19663618/50594049-ec270280-0ec0-11e9-9766-1ac0d751ec3c.png)


