### PR TITLE
Don't check out master

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -118,7 +118,6 @@ var getTasksToBuildForPR = function() {
         console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=112;]Unable to reach github, building all tasks', err);
         return makeOptions.tasks;
     }
-    run('git checkout master');
     run('git diff --name-only master..' + sourceBranch).split('\n').forEach(filePath => {
         if (filePath.slice(0, 5) == 'Tasks') {
             var taskPath = filePath.slice(6);


### PR DESCRIPTION
Right now this is running all remaining steps (build/test/etc...) on master instead of the checked out branch