### PR TITLE
Scope secret variables into CI

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -28,6 +28,9 @@ steps:
 # Filter out unchanged tasks
 - script: node ./ci/filter-tasks.js
   displayName: Filter out unchanged tasks
+  env:
+    PACKAGE_ENDPOINT: $(Package.Endpoint)
+    PACKAGE_TOKEN: $(Package.Token)
 
 # Build
 - script: node make.js build --task "$(task_pattern)"


### PR DESCRIPTION
This needs to happen in order for us to be able to only build partial for CI. These variables will only be available for CI so it should be safe. In addition, they are only scoped to read the packaging feed, not modify it in any way so its pretty low risk anyways.