### PR TITLE
SSH Task: Make sure the directory exists before trying to write the inline script file

### DIFF
--- a/Tasks/SshV0/package-lock.json
+++ b/Tasks/SshV0/package-lock.json
@@ -176,7 +176,7 @@
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "ssh2": {

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -66,13 +66,13 @@ async function run() {
                 tl.debug('No script header detected.  Adding: ' + bashHeader);
                 inlineScript = bashHeader + os.EOL + inlineScript;
             }
-            const scriptFileDir = os.tmpdir();
-            scriptFile = path.join(scriptFileDir, 'sshscript_' + new Date().getTime()); // default name
+            const tempDir = tl.getVariable('Agent.TempDirectory') || os.tmpdir();
+            scriptFile = path.join(tempDir, 'sshscript_' + new Date().getTime()); // default name
             try {
                 // Make sure the directory exists or else we will get ENOENT
-                if (!fs.existsSync(scriptFileDir))
+                if (!fs.existsSync(tempDir))
                 {
-                    tl.mkdirP(scriptFileDir);
+                    tl.mkdirP(tempDir);
                 }
                 fs.writeFileSync(scriptFile, inlineScript);
             } catch (err) {

--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -66,8 +66,14 @@ async function run() {
                 tl.debug('No script header detected.  Adding: ' + bashHeader);
                 inlineScript = bashHeader + os.EOL + inlineScript;
             }
-            scriptFile = path.join(os.tmpdir(), 'sshscript_' + new Date().getTime()); // default name
+            const scriptFileDir = os.tmpdir();
+            scriptFile = path.join(scriptFileDir, 'sshscript_' + new Date().getTime()); // default name
             try {
+                // Make sure the directory exists or else we will get ENOENT
+                if (!fs.existsSync(scriptFileDir))
+                {
+                    tl.mkdirP(scriptFileDir);
+                }
                 fs.writeFileSync(scriptFile, inlineScript);
             } catch (err) {
                 tl.error(tl.loc('FailedToWriteScript', err.message));

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 145,
-        "Patch": 1
+        "Minor": 147,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 145,
-    "Patch": 1
+    "Minor": 147,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",


### PR DESCRIPTION
We had a DTS that was caused by this task running on a Linux system with `$TEMP` overridden.  The directory it was pointing to did not exist, so the inline script was failing to be written to disk.

**Testing**
Created a pipeline with a pipeline variable `TEMP` set to a directory does not exist.
Verified that the current task fails with ENOENT.
Uploaded this version of the task and it succeeds.

Regression testing: ran a pipeline that did not have `$TEMP` overridden.