### PR TITLE
Adding no_proxy support for NuGetCommand V2

### DIFF
--- a/Tasks/Common/packaging-common/Tests/L0.ts
+++ b/Tasks/Common/packaging-common/Tests/L0.ts
@@ -1,9 +1,7 @@
-import * as mockery from "mockery";
-
 import { npmcommon } from "./npmL0";
 import { nugetcommon } from "./nugetL0";
 
 describe("packaging-common Task Suite", function() {
     describe("nuget common", nugetcommon);
-    describe("npm common", npmcommon);
+    describe.skip("npm common", npmcommon);
 });

--- a/Tasks/Common/packaging-common/Tests/L0.ts
+++ b/Tasks/Common/packaging-common/Tests/L0.ts
@@ -3,5 +3,5 @@ import { nugetcommon } from "./nugetL0";
 
 describe("packaging-common Task Suite", function() {
     describe("nuget common", nugetcommon);
-    describe.skip("npm common", npmcommon);
+    describe("npm common", npmcommon);
 });

--- a/Tasks/Common/packaging-common/nuget/NuGetToolRunner2.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolRunner2.ts
@@ -126,6 +126,17 @@ function prepareNuGetExeEnvironment(
 
         if (proxybypass) {
             tl.debug(`Adding environment variable for NuGet proxy bypass: ${proxybypass}`);
+
+            // check if there are any existing NO_PROXY values
+            let existingNoProxy = process.env["NO_PROXY"];
+            if (existingNoProxy) {
+                existingNoProxy = existingNoProxy.trimRight();
+                // trim trailing comma
+                existingNoProxy = existingNoProxy.endsWith(',') ? existingNoProxy.slice(0,-1) : existingNoProxy;
+                // append our bypass list
+                proxybypass = existingNoProxy + ',' + proxybypass;
+            }
+
             env["NO_PROXY"] = proxybypass;
         }
     }

--- a/Tasks/NuGetCommandV2/nugetpublisher.ts
+++ b/Tasks/NuGetCommandV2/nugetpublisher.ts
@@ -197,6 +197,8 @@ export async function run(nuGetPath: string): Promise<void> {
             nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
         }
 
+        environmentSettings.registryUri = feedUri;
+
         const verbosity = tl.getInput("verbosityPush");
 
         const continueOnConflict: boolean = tl.getBoolInput("allowPackageConflicts");
@@ -232,7 +234,7 @@ export async function run(nuGetPath: string): Promise<void> {
                 }
             }
             else {
-                tl.debug("Using NuGet.exe to push the packages");
+                tl.debug("Using NuGet.exe to push the packages");           
                 const publishOptions = new PublishOptions(
                     nuGetPath,
                     feedUri,

--- a/Tasks/NuGetCommandV2/nugetrestore.ts
+++ b/Tasks/NuGetCommandV2/nugetrestore.ts
@@ -206,6 +206,7 @@ export async function run(nuGetPath: string): Promise<void> {
             }
         }
         tl.debug(`ConfigFile: ${configFile}`);
+        environmentSettings.configFile = configFile;
 
         try {
             const restoreOptions = new RestoreOptions(

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -8,8 +8,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 145,
-        "Patch": 3
+        "Minor": 147,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -8,8 +8,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 145,
-    "Patch": 3
+    "Minor": 147,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Fills the no_proxy variable with values inspired by agent.proxybypasslist when running NuGet restore or publish from NuGetCommandV2.