### PR TITLE
Fix App Center Distribution bug for feature branches

### DIFF
--- a/Tasks/AppCenterDistributeV1/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0.ts
@@ -20,7 +20,7 @@ describe('AppCenterDistribute L0 Suite', function () {
 
     after(() => {
         delete process.env['BUILD_BUILDID'];
-        delete process.env['BUILD_SOURCEBRANCHNAME'];
+        delete process.env['BUILD_SOURCEBRANCH'];
         delete process.env['BUILD_SOURCEVERSION'];
         delete process.env['LASTCOMMITMESSAGE'];
     });
@@ -160,6 +160,26 @@ describe('AppCenterDistribute L0 Suite', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0PublishCommitInfo_2.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.succeeded, 'task should have succeeded');
+    });
+
+    it('Positive path: publish commit info for feature branch', function () {
+        this.timeout(4000);
+
+        let tp = path.join(__dirname, 'L0PublishCommitInfo_3.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.succeeded, 'task should have succeeded');
+    });
+
+    it('Positive path: publish commit info for tfvc branch', function () {
+        this.timeout(4000);
+
+        let tp = path.join(__dirname, 'L0PublishCommitInfo_4.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
@@ -20,7 +20,7 @@ tmr.setInput('symbolsType', 'AndroidJava');
 tmr.setInput('mappingTxtPath', '/test/path/to/mappings.txt');
 
 process.env['BUILD_BUILDID'] = '2';
-process.env['BUILD_SOURCEBRANCHNAME'] = 'master';
+process.env['BUILD_SOURCEBRANCH'] = 'refs/heads/master';
 process.env['BUILD_SOURCEVERSION'] = 'commitsha';
 
 //prepare upload

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
@@ -20,9 +20,8 @@ tmr.setInput('symbolsType', 'AndroidJava');
 tmr.setInput('mappingTxtPath', '/test/path/to/mappings.txt');
 
 process.env['BUILD_BUILDID'] = '2';
-process.env['BUILD_SOURCEBRANCH'] = 'refs/heads/master';
+process.env['BUILD_SOURCEBRANCH'] = 'refs/heads/feature/foobar';
 process.env['BUILD_SOURCEVERSION'] = 'commitsha';
-process.env['LASTCOMMITMESSAGE'] = 'commit message';
 
 //prepare upload
 nock('https://example.test')
@@ -58,9 +57,8 @@ nock('https://example.test')
         destinations: [{ id: "00000000-0000-0000-0000-000000000000" }],
         build: {
             id: '2',
-            branch: 'master',
-            commit_hash: 'commitsha',
-            commit_message: 'commit message'
+            branch: 'feature/foobar',
+            commit_hash: 'commitsha'
         }
     }))
     .reply(200);

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
@@ -20,9 +20,8 @@ tmr.setInput('symbolsType', 'AndroidJava');
 tmr.setInput('mappingTxtPath', '/test/path/to/mappings.txt');
 
 process.env['BUILD_BUILDID'] = '2';
-process.env['BUILD_SOURCEBRANCH'] = 'refs/heads/master';
+process.env['BUILD_SOURCEBRANCH'] = '$/teamproject/main';
 process.env['BUILD_SOURCEVERSION'] = 'commitsha';
-process.env['LASTCOMMITMESSAGE'] = 'commit message';
 
 //prepare upload
 nock('https://example.test')
@@ -58,9 +57,8 @@ nock('https://example.test')
         destinations: [{ id: "00000000-0000-0000-0000-000000000000" }],
         build: {
             id: '2',
-            branch: 'master',
-            commit_hash: 'commitsha',
-            commit_message: 'commit message'
+            branch: '$/teamproject/main',
+            commit_hash: 'commitsha'
         }
     }))
     .reply(200);

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -21,7 +21,7 @@ tmr.setInput('symbolsType', 'AndroidJava');
 tmr.setInput('mappingTxtPath', '/test/path/to/mappings.txt');
 
 process.env['BUILD_BUILDID'] = '2';
-process.env['BUILD_SOURCEBRANCH'] = 'master';
+process.env['BUILD_SOURCEBRANCH'] = 'refs/heads/master';
 process.env['BUILD_SOURCEVERSION'] = 'commitsha';
 
 //prepare upload

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -21,7 +21,7 @@ tmr.setInput('symbolsType', 'AndroidJava');
 tmr.setInput('mappingTxtPath', '/test/path/to/mappings.txt');
 
 process.env['BUILD_BUILDID'] = '2';
-process.env['BUILD_SOURCEBRANCHNAME'] = 'master';
+process.env['BUILD_SOURCEBRANCH'] = 'master';
 process.env['BUILD_SOURCEVERSION'] = 'commitsha';
 
 //prepare upload

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -168,7 +168,8 @@ function publishRelease(apiServer: string, releaseUrl: string, isMandatory: bool
         ]
     };
 
-    const branchName = process.env['BUILD_SOURCEBRANCHNAME'];
+    let branchName = process.env['BUILD_SOURCEBRANCH'];
+    branchName = getBranchName(branchName);
     const sourceVersion = process.env['BUILD_SOURCEVERSION'];
     const buildId = process.env['BUILD_BUILDID'];
 
@@ -202,6 +203,13 @@ function publishRelease(apiServer: string, releaseUrl: string, isMandatory: bool
     })
 
     return defer.promise;
+}
+
+function getBranchName(ref: string): string {
+    const gitRefsHeadsPrefix = 'refs/heads/';
+    if (ref) {
+        return ref.indexOf(gitRefsHeadsPrefix) === 0 ? ref.substr(gitRefsHeadsPrefix.length) : ref;
+    }
 }
 
 /**


### PR DESCRIPTION
The distribution task is using environment variable "BUILD_SOURCEBRANCHNAME" to get the branch name, which returns "testDistribute" if the branch name is "feature/testDistribute". Users expect the full branch name to be returned.