### PR TITLE
Accept correct package name in folder or task.json

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -59,25 +59,24 @@ var getTasksToBuildForCI = async function() {
     });
 
     return makeOptions.tasks.filter(function (taskName) {
-        var lowerCaseName = taskName.toLowerCase();
-        if (lowerCaseName in packageMap) {
-            var packageVersion = packageMap[lowerCaseName]
-
-            var taskJsonPath = path.join(__dirname, '..', 'Tasks' , taskName, 'task.json');
-            if (fs.existsSync(taskJsonPath)){
-                var taskJson = JSON.parse(fs.readFileSync(taskJsonPath).toString());
+        var taskJsonPath = path.join(__dirname, '..', 'Tasks' , taskName, 'task.json');
+        if (fs.existsSync(taskJsonPath)){
+            var taskJson = JSON.parse(fs.readFileSync(taskJsonPath).toString());
+            var lowerCaseName = taskJson.name.toLowerCase();
+            if (lowerCaseName in packageMap || taskName.toLowerCase() in packageMap) {
+                var packageVersion = packageMap[lowerCaseName];
                 var localVersion = `${taskJson.version.Major}.${taskJson.version.Minor}.${taskJson.version.Patch}`;
                 
                 // Build if local version and package version are different.
                 return semver.neq(localVersion, packageVersion);
             }
             else {
-                console.log(`##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=75;]${taskJsonPath} does not exist`);
+                console.log(`##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=74;]${taskName} has not been published before`);
                 return true;
             }
         }
         else {
-            console.log(`##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=80;]${taskName} has not been published before`);
+            console.log(`##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=79;]${taskJsonPath} does not exist`);
             return true;
         }
     });


### PR DESCRIPTION
This contains the same changes that were reverted in #9275 but it also allows the packageName to be found using the folder name. The only difference in the code is ```|| taskName.toLowerCase() in packageMap``` in line 66.