### PR TITLE
http_proxy and no_proxy support for dotnet push and restore

### DIFF
--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -7,6 +7,7 @@ import * as tl from 'vsts-task-lib/task';
 
 import { IExecOptions } from 'vsts-task-lib/toolrunner';
 import { NuGetConfigHelper2 } from 'packaging-common/nuget/NuGetConfigHelper2';
+import * as ngRunner from 'packaging-common/nuget/NuGetToolRunner2';
 import * as pkgLocationUtils from 'packaging-common/locationUtilities';
 
 export async function run(): Promise<void> {
@@ -184,8 +185,8 @@ function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: 
     dotnet.arg(apiKey);
 
     // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
-
-    return dotnet.exec({ cwd: workingDirectory } as IExecOptions);
+    const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
+    return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
 }
 
 function useCredentialConfiguration(isInternalFeed: boolean): boolean {

--- a/Tasks/DotNetCoreCLIV2/restorecommand.ts
+++ b/Tasks/DotNetCoreCLIV2/restorecommand.ts
@@ -3,6 +3,7 @@ import * as Q from 'q';
 import * as utility from './Common/utility';
 import * as auth from 'packaging-common/nuget/Authentication';
 import { NuGetConfigHelper2 } from 'packaging-common/nuget/NuGetConfigHelper2';
+import * as ngRunner from 'packaging-common/nuget/NuGetToolRunner2';
 import * as path from 'path';
 import { IExecOptions } from 'vsts-task-lib/toolrunner';
 import * as nutil from 'packaging-common/nuget/Utility';
@@ -171,5 +172,6 @@ function dotNetRestoreAsync(dotnetPath: string, projectFile: string, packagesDir
         dotnet.arg(verbosity);
     }
 
-    return dotnet.exec({ cwd: path.dirname(projectFile) } as IExecOptions);
+    const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, configFile, null);
+    return dotnet.exec({ cwd: path.dirname(projectFile), env: envWithProxy } as IExecOptions);
 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -16,8 +16,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 145,
-        "Patch": 4
+        "Minor": 147,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -16,8 +16,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 145,
-    "Patch": 4
+    "Minor": 147,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 2,
         "Minor": 147,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 2,
     "Minor": 147,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Adds http_proxy and no_proxy support for DotNetCoreCLIV2 push and restore commands. 