### PR TITLE
Remove package section from table of contents

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -8,7 +8,7 @@
   * [Build a specific task (recommended):](#build-a-specific-task-recommended)
   * [Run Tests](#run-tests)
   * [Legacy Tests](#legacy-tests)
-- [Package](#package)
+
 
 # Contributing
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -9,7 +9,6 @@
   * [Run Tests](#run-tests)
   * [Legacy Tests](#legacy-tests)
 
-
 # Contributing
 
 This repo contains the in-the-box tasks for Azure Pipelines build. Tasks in this repo get deployed every three weeks to Azure Pipelines and appear in TFS quarterly updates.


### PR DESCRIPTION
In the "Contributing" documentation, the package section was removed in this commit: https://github.com/Microsoft/azure-pipelines-tasks/commit/ae6bc73951d80e338ba76101e26e9a6de23fcb2c#diff-9a764451fa9ed084b248aa8354b0324c but was not removed from the table of contents.