### PR TITLE
Updating JenkinsQueueJobV2 task to use typed-rest-client

### DIFF
--- a/Tasks/JenkinsQueueJobV2/Tests/L0.ts
+++ b/Tasks/JenkinsQueueJobV2/Tests/L0.ts
@@ -32,7 +32,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Input required: serverEndpoint') !== -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Input required: serverEndpoint'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
 
@@ -56,7 +56,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Input required: jobName') !== -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Input required: jobName'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {
@@ -74,7 +74,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Input required: captureConsole') != -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Input required: captureConsole'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {
@@ -92,7 +92,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Input required: capturePipeline') != -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Input required: capturePipeline'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {
@@ -110,7 +110,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Input required: parameterizedJob') != -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Input required: parameterizedJob'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {
@@ -128,7 +128,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Error: Invalid URI "bogusURL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)"') != -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Invalid URI "bogusURL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)"'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {
@@ -146,7 +146,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         try {
             tr.run();
 
-            assert(tr.stderr.indexOf('Error: Invalid URI "bogusURL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)"') != -1, 'should have written to stderr');
+            assert(tr.stdOutContained('Invalid URI "bogusURL/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)"'), 'should have written to stdout');
             assert(tr.failed, 'task should have failed');
             done();
         } catch (err) {

--- a/Tasks/JenkinsQueueJobV2/Tests/package-lock.json
+++ b/Tasks/JenkinsQueueJobV2/Tests/package-lock.json
@@ -31,35 +31,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "dev": true,
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -75,27 +46,6 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
       "dev": true
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
-      "dev": true
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -103,9 +53,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
     "shelljs": {
@@ -114,36 +64,25 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "http://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.1"
-      }
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "http://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
+      "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "dev": true,
       "requires": {
-        "glob": "6.0.4",
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
-        "node-uuid": "1.4.8",
         "q": "1.5.1",
-        "semver": "5.5.1",
+        "semver": "5.6.0",
         "shelljs": "0.3.0",
-        "vso-node-api": "0.6.1"
+        "uuid": "3.3.2"
       }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
     }
   }
 }

--- a/Tasks/JenkinsQueueJobV2/Tests/package.json
+++ b/Tasks/JenkinsQueueJobV2/Tests/package.json
@@ -2,7 +2,7 @@
   "name": "vsts-tasks-jenkinsqueuejob",
   "devDependencies": {
     "@types/mocha": "^5.2.0",
-    "vsts-task-lib": "0.9.20"
+    "vsts-task-lib": "2.4.0"
   },
   "description": "Azure Pipelines Jenkins Queue Job Task",
   "repository": {

--- a/Tasks/JenkinsQueueJobV2/jenkinsqueuejobtask.ts
+++ b/Tasks/JenkinsQueueJobV2/jenkinsqueuejobtask.ts
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import tl = require('vsts-task-lib/task');
-import fs = require('fs');
 import path = require('path');
-import shell = require('shelljs');
-import Q = require('q');
 import util = require('./util');
 
 import { Job } from './job';
@@ -116,7 +113,6 @@ async function doWork() {
         tl.setVariable('JENKINS_JOB_ID', rootJob.ExecutableNumber.toString());
     } catch (e) {
         tl.debug(e.message);
-        tl._writeError(e);
         tl.setResult(tl.TaskResult.Failed, e.message);
     }
 }

--- a/Tasks/JenkinsQueueJobV2/jobsearch.ts
+++ b/Tasks/JenkinsQueueJobV2/jobsearch.ts
@@ -3,7 +3,6 @@
 
 import tl = require('vsts-task-lib/task');
 import Q = require('q');
-//import request = require('request');
 
 import { Job, JobState } from './job';
 import { JobQueue } from './jobqueue';
@@ -80,38 +79,6 @@ export class JobSearch {
                     defer.reject(err);
                 }
             });
-
-
-
-
-            // request.get({ url: apiTaskUrl, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallBack(err, httpResponse, body) {
-            //     if (!thisSearch.Initialized) { // only initialize once
-            //         if (err) {
-            //             if (err.code == 'ECONNRESET') {
-            //                 tl.debug(err);
-            //                 // resolve but do not initialize -- a job will trigger this again
-            //                 defer.resolve(null);
-            //             } else {
-            //                 defer.reject(err);
-            //             }
-            //         } else if (httpResponse.statusCode !== 200) {
-            //             defer.reject(util.getFullErrorMessage(httpResponse, 'Unable to retrieve job: ' + thisSearch.identifier));
-            //         } else {
-            //             const parsedBody: any = JSON.parse(body);
-            //             tl.debug(`parsedBody for: ${apiTaskUrl} : ${JSON.stringify(parsedBody)}`);
-            //             thisSearch.Initialized = true;
-            //             thisSearch.ParsedTaskBody = parsedBody;
-            //             // if this is the first time this job is triggered, there will be no lastBuild information, and we assume the
-            //             // build number is 1 in this case
-            //             thisSearch.initialSearchBuildNumber = (thisSearch.ParsedTaskBody.lastBuild) ? thisSearch.ParsedTaskBody.lastBuild.number : 1;
-            //             thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber;
-            //             thisSearch.searchDirection = -1;  // start searching backwards
-            //             defer.resolve(null);
-            //         }
-            //     } else {
-            //         defer.resolve(null);
-            //     }
-            // }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
         } else { // already initialized
             defer.resolve(null);
         }
@@ -337,65 +304,6 @@ export class JobSearch {
                 thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
                 return;
             });
-
-
-
-            // request.get({ url: url, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallback(err, httpResponse, body) {
-            //     tl.debug('locateExecution().requestCallback()');
-            //     if (err) {
-            //         util.handleConnectionResetError(err); // something went bad
-            //         thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
-            //         return;
-            //     } else if (httpResponse.statusCode === 404) {
-            //         // try again in the future
-            //         thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
-            //     } else if (httpResponse.statusCode !== 200) {
-            //         util.failReturnCode(httpResponse, 'Job pipeline tracking failed to read downstream project');
-            //     } else {
-            //         const parsedBody: any = JSON.parse(body);
-            //         tl.debug(`parsedBody for: ${url} : ${JSON.stringify(parsedBody)}`);
-
-            //         /**
-            //          * This is the list of all reasons for this job execution to be running.
-            //          * Jenkins may 'join' several pipelined jobs so all will be listed here.
-            //          * e.g. suppose A -> C and B -> C.  If both A & B scheduled C around the same time before C actually started,
-            //          * Jenkins will join these requests and only run C once.
-            //          * So, for all jobs being tracked (within this code), one is consisdered the main job (which will be followed), and
-            //          * all others are considered joined and will not be tracked further.
-            //          */
-            //         const findCauses = function(actions) {
-            //             for (const i in actions) {
-            //                 if (actions[i].causes) {
-            //                     return actions[i].causes;
-            //                 }
-            //             }
-
-            //             return null;
-            //         };
-
-            //         const causes: any = findCauses(parsedBody.actions);
-            //         thisSearch.foundCauses[thisSearch.nextSearchBuildNumber] = causes;
-            //         thisSearch.DetermineMainJob(thisSearch.nextSearchBuildNumber, function (mainJob: Job, secondaryJobs: Job[]) {
-            //             if (mainJob != null) {
-            //                 //found the mainJob, so make sure it's running!
-            //                 mainJob.SetStreaming(thisSearch.nextSearchBuildNumber);
-            //             }
-            //         });
-
-            //         if (thisSearch.searchDirection < 0) { // currently searching backwards
-            //             if (thisSearch.nextSearchBuildNumber <= 1 || parsedBody.timestamp < thisSearch.queue.RootJob.ParsedExecutionResult.timestamp) {
-            //                 //either found the very first job, or one that was triggered before the root job was; need to change search directions
-            //                 thisSearch.searchDirection = 1;
-            //                 thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber + 1;
-            //             } else {
-            //                 thisSearch.nextSearchBuildNumber--;
-            //             }
-            //         } else {
-            //             thisSearch.nextSearchBuildNumber++;
-            //         }
-            //         return thisSearch.stopWork(0); // immediately poll again because there might be more jobs
-            //     }
-            // }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
         }
     }
 }

--- a/Tasks/JenkinsQueueJobV2/jobsearch.ts
+++ b/Tasks/JenkinsQueueJobV2/jobsearch.ts
@@ -3,12 +3,13 @@
 
 import tl = require('vsts-task-lib/task');
 import Q = require('q');
-import request = require('request');
+//import request = require('request');
 
 import { Job, JobState } from './job';
 import { JobQueue } from './jobqueue';
 
 import util = require('./util');
+import { WebRequest, sendRequest, sendRetriableRequest, WebResponse } from "./webclient";
 
 export class JobSearch {
     private taskUrl: string; // URL for the job definition
@@ -43,23 +44,23 @@ export class JobSearch {
         if (!thisSearch.Initialized) { //only initialize once
             const apiTaskUrl: string = util.addUrlSegment(thisSearch.taskUrl, '/api/json?tree=downstreamProjects[name,url,color],lastBuild[number]');
             tl.debug('getting job task URL:' + apiTaskUrl);
-            request.get({ url: apiTaskUrl, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallBack(err, httpResponse, body) {
+
+            var request = new WebRequest();
+            request.uri = apiTaskUrl;
+            request.method = "GET";
+            request.headers = {
+                "Content-Type": "application/json; charset=utf-8",
+                "Authorization": 'Basic ' + new Buffer(thisSearch.queue.TaskOptions.username + ':' + thisSearch.queue.TaskOptions.password).toString('base64')
+            };
+        
+            var response = sendRequest(request).then(async (response: WebResponse) => {
                 if (!thisSearch.Initialized) { // only initialize once
-                    if (err) {
-                        if (err.code == 'ECONNRESET') {
-                            tl.debug(err);
-                            // resolve but do not initialize -- a job will trigger this again
-                            defer.resolve(null);
-                        } else {
-                            defer.reject(err);
-                        }
-                    } else if (httpResponse.statusCode !== 200) {
-                        defer.reject(util.getFullErrorMessage(httpResponse, 'Unable to retrieve job: ' + thisSearch.identifier));
+                    if (response.statusCode !== 200) {
+                        defer.reject(util.getFullErrorMessage(response, 'Unable to retrieve job: ' + thisSearch.identifier));
                     } else {
-                        const parsedBody: any = JSON.parse(body);
-                        tl.debug(`parsedBody for: ${apiTaskUrl} : ${JSON.stringify(parsedBody)}`);
+                        tl.debug(`parsedBody for: ${apiTaskUrl} : ${JSON.stringify(response.body)}`);
                         thisSearch.Initialized = true;
-                        thisSearch.ParsedTaskBody = parsedBody;
+                        thisSearch.ParsedTaskBody = response.body;
                         // if this is the first time this job is triggered, there will be no lastBuild information, and we assume the
                         // build number is 1 in this case
                         thisSearch.initialSearchBuildNumber = (thisSearch.ParsedTaskBody.lastBuild) ? thisSearch.ParsedTaskBody.lastBuild.number : 1;
@@ -70,7 +71,47 @@ export class JobSearch {
                 } else {
                     defer.resolve(null);
                 }
-            }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
+            }).catch(function (err) {
+                if (err.code == 'ECONNRESET') {
+                    tl.debug(err);
+                    // resolve but do not initialize -- a job will trigger this again
+                    defer.resolve(null);
+                } else {
+                    defer.reject(err);
+                }
+            });
+
+
+
+
+            // request.get({ url: apiTaskUrl, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallBack(err, httpResponse, body) {
+            //     if (!thisSearch.Initialized) { // only initialize once
+            //         if (err) {
+            //             if (err.code == 'ECONNRESET') {
+            //                 tl.debug(err);
+            //                 // resolve but do not initialize -- a job will trigger this again
+            //                 defer.resolve(null);
+            //             } else {
+            //                 defer.reject(err);
+            //             }
+            //         } else if (httpResponse.statusCode !== 200) {
+            //             defer.reject(util.getFullErrorMessage(httpResponse, 'Unable to retrieve job: ' + thisSearch.identifier));
+            //         } else {
+            //             const parsedBody: any = JSON.parse(body);
+            //             tl.debug(`parsedBody for: ${apiTaskUrl} : ${JSON.stringify(parsedBody)}`);
+            //             thisSearch.Initialized = true;
+            //             thisSearch.ParsedTaskBody = parsedBody;
+            //             // if this is the first time this job is triggered, there will be no lastBuild information, and we assume the
+            //             // build number is 1 in this case
+            //             thisSearch.initialSearchBuildNumber = (thisSearch.ParsedTaskBody.lastBuild) ? thisSearch.ParsedTaskBody.lastBuild.number : 1;
+            //             thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber;
+            //             thisSearch.searchDirection = -1;  // start searching backwards
+            //             defer.resolve(null);
+            //         }
+            //     } else {
+            //         defer.resolve(null);
+            //     }
+            // }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
         } else { // already initialized
             defer.resolve(null);
         }
@@ -240,62 +281,121 @@ export class JobSearch {
         } else {
             const url: string  = util.addUrlSegment(thisSearch.taskUrl, thisSearch.nextSearchBuildNumber + '/api/json?tree=actions[causes[shortDescription,upstreamBuild,upstreamProject,upstreamUrl]],timestamp');
             tl.debug('pipeline, locating child execution URL:' + url);
-            request.get({ url: url, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallback(err, httpResponse, body) {
+
+            var request = new WebRequest();
+            request.uri = url;
+            request.method = "GET";
+            request.headers = {
+                "Content-Type": "application/json; charset=utf-8",
+                "Authorization": 'Basic ' + new Buffer(thisSearch.queue.TaskOptions.username + ':' + thisSearch.queue.TaskOptions.password).toString('base64')
+            };
+        
+            var response = sendRetriableRequest(request).then(async (response: WebResponse) => {
                 tl.debug('locateExecution().requestCallback()');
-                if (err) {
-                    util.handleConnectionResetError(err); // something went bad
-                    thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
-                    return;
-                } else if (httpResponse.statusCode === 404) {
-                    // try again in the future
-                    thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
-                } else if (httpResponse.statusCode !== 200) {
-                    util.failReturnCode(httpResponse, 'Job pipeline tracking failed to read downstream project');
-                } else {
-                    const parsedBody: any = JSON.parse(body);
-                    tl.debug(`parsedBody for: ${url} : ${JSON.stringify(parsedBody)}`);
 
-                    /**
-                     * This is the list of all reasons for this job execution to be running.
-                     * Jenkins may 'join' several pipelined jobs so all will be listed here.
-                     * e.g. suppose A -> C and B -> C.  If both A & B scheduled C around the same time before C actually started,
-                     * Jenkins will join these requests and only run C once.
-                     * So, for all jobs being tracked (within this code), one is consisdered the main job (which will be followed), and
-                     * all others are considered joined and will not be tracked further.
-                     */
-                    const findCauses = function(actions) {
-                        for (const i in actions) {
-                            if (actions[i].causes) {
-                                return actions[i].causes;
-                            }
+                /**
+                 * This is the list of all reasons for this job execution to be running.
+                 * Jenkins may 'join' several pipelined jobs so all will be listed here.
+                 * e.g. suppose A -> C and B -> C.  If both A & B scheduled C around the same time before C actually started,
+                 * Jenkins will join these requests and only run C once.
+                 * So, for all jobs being tracked (within this code), one is consisdered the main job (which will be followed), and
+                 * all others are considered joined and will not be tracked further.
+                 */
+                const findCauses = function(actions) {
+                    for (const i in actions) {
+                        if (actions[i].causes) {
+                            return actions[i].causes;
                         }
-
-                        return null;
-                    };
-
-                    const causes: any = findCauses(parsedBody.actions);
-                    thisSearch.foundCauses[thisSearch.nextSearchBuildNumber] = causes;
-                    thisSearch.DetermineMainJob(thisSearch.nextSearchBuildNumber, function (mainJob: Job, secondaryJobs: Job[]) {
-                        if (mainJob != null) {
-                            //found the mainJob, so make sure it's running!
-                            mainJob.SetStreaming(thisSearch.nextSearchBuildNumber);
-                        }
-                    });
-
-                    if (thisSearch.searchDirection < 0) { // currently searching backwards
-                        if (thisSearch.nextSearchBuildNumber <= 1 || parsedBody.timestamp < thisSearch.queue.RootJob.ParsedExecutionResult.timestamp) {
-                            //either found the very first job, or one that was triggered before the root job was; need to change search directions
-                            thisSearch.searchDirection = 1;
-                            thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber + 1;
-                        } else {
-                            thisSearch.nextSearchBuildNumber--;
-                        }
-                    } else {
-                        thisSearch.nextSearchBuildNumber++;
                     }
-                    return thisSearch.stopWork(0); // immediately poll again because there might be more jobs
+
+                    return null;
+                };
+
+                const causes: any = findCauses(response.body.actions);
+                thisSearch.foundCauses[thisSearch.nextSearchBuildNumber] = causes;
+                thisSearch.DetermineMainJob(thisSearch.nextSearchBuildNumber, function (mainJob: Job, secondaryJobs: Job[]) {
+                    if (mainJob != null) {
+                        //found the mainJob, so make sure it's running!
+                        mainJob.SetStreaming(thisSearch.nextSearchBuildNumber);
+                    }
+                });
+
+                if (thisSearch.searchDirection < 0) { // currently searching backwards
+                    if (thisSearch.nextSearchBuildNumber <= 1 || response.body.timestamp < thisSearch.queue.RootJob.ParsedExecutionResult.timestamp) {
+                        //either found the very first job, or one that was triggered before the root job was; need to change search directions
+                        thisSearch.searchDirection = 1;
+                        thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber + 1;
+                    } else {
+                        thisSearch.nextSearchBuildNumber--;
+                    }
+                } else {
+                    thisSearch.nextSearchBuildNumber++;
                 }
-            }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
+                return thisSearch.stopWork(0); // immediately poll again because there might be more jobs
+            }).catch(function (err) {
+                util.handleConnectionResetError(err); // something went bad
+                thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
+                return;
+            });
+
+
+
+            // request.get({ url: url, strictSSL: thisSearch.queue.TaskOptions.strictSSL }, function requestCallback(err, httpResponse, body) {
+            //     tl.debug('locateExecution().requestCallback()');
+            //     if (err) {
+            //         util.handleConnectionResetError(err); // something went bad
+            //         thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
+            //         return;
+            //     } else if (httpResponse.statusCode === 404) {
+            //         // try again in the future
+            //         thisSearch.stopWork(thisSearch.queue.TaskOptions.pollIntervalMillis);
+            //     } else if (httpResponse.statusCode !== 200) {
+            //         util.failReturnCode(httpResponse, 'Job pipeline tracking failed to read downstream project');
+            //     } else {
+            //         const parsedBody: any = JSON.parse(body);
+            //         tl.debug(`parsedBody for: ${url} : ${JSON.stringify(parsedBody)}`);
+
+            //         /**
+            //          * This is the list of all reasons for this job execution to be running.
+            //          * Jenkins may 'join' several pipelined jobs so all will be listed here.
+            //          * e.g. suppose A -> C and B -> C.  If both A & B scheduled C around the same time before C actually started,
+            //          * Jenkins will join these requests and only run C once.
+            //          * So, for all jobs being tracked (within this code), one is consisdered the main job (which will be followed), and
+            //          * all others are considered joined and will not be tracked further.
+            //          */
+            //         const findCauses = function(actions) {
+            //             for (const i in actions) {
+            //                 if (actions[i].causes) {
+            //                     return actions[i].causes;
+            //                 }
+            //             }
+
+            //             return null;
+            //         };
+
+            //         const causes: any = findCauses(parsedBody.actions);
+            //         thisSearch.foundCauses[thisSearch.nextSearchBuildNumber] = causes;
+            //         thisSearch.DetermineMainJob(thisSearch.nextSearchBuildNumber, function (mainJob: Job, secondaryJobs: Job[]) {
+            //             if (mainJob != null) {
+            //                 //found the mainJob, so make sure it's running!
+            //                 mainJob.SetStreaming(thisSearch.nextSearchBuildNumber);
+            //             }
+            //         });
+
+            //         if (thisSearch.searchDirection < 0) { // currently searching backwards
+            //             if (thisSearch.nextSearchBuildNumber <= 1 || parsedBody.timestamp < thisSearch.queue.RootJob.ParsedExecutionResult.timestamp) {
+            //                 //either found the very first job, or one that was triggered before the root job was; need to change search directions
+            //                 thisSearch.searchDirection = 1;
+            //                 thisSearch.nextSearchBuildNumber = thisSearch.initialSearchBuildNumber + 1;
+            //             } else {
+            //                 thisSearch.nextSearchBuildNumber--;
+            //             }
+            //         } else {
+            //             thisSearch.nextSearchBuildNumber++;
+            //         }
+            //         return thisSearch.stopWork(0); // immediately poll again because there might be more jobs
+            //     }
+            // }).auth(thisSearch.queue.TaskOptions.username, thisSearch.queue.TaskOptions.password, true);
         }
     }
 }

--- a/Tasks/JenkinsQueueJobV2/package-lock.json
+++ b/Tasks/JenkinsQueueJobV2/package-lock.json
@@ -22,20 +22,23 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
+        "fast-deep-equal": "2.0.1",
         "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -53,9 +56,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -63,26 +66,17 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true,
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "0.14.5"
       }
     },
-    "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -93,15 +87,10 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -115,24 +104,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        }
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -148,18 +119,18 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true,
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extsprintf": {
       "version": "1.3.0",
@@ -167,9 +138,9 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -182,13 +153,13 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.21"
       }
     },
     "getpass": {
@@ -199,47 +170,19 @@
         "assert-plus": "1.0.0"
       }
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "requires": {
-        "ajv": "5.5.2",
+        "ajv": "6.6.2",
         "har-schema": "2.0.0"
       }
-    },
-    "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-      "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
-      }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -248,22 +191,8 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.16.0"
       }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -278,8 +207,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "optional": true
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -287,9 +215,9 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -308,24 +236,24 @@
       }
     },
     "mime-db": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
     },
     "mime-types": {
-      "version": "2.1.17",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "1.37.0"
       }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -334,32 +262,24 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+    },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -367,103 +287,135 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "request": {
-      "version": "2.83.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
+        "aws4": "1.8.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
+        "mime-types": "2.1.21",
+        "oauth-sign": "0.9.0",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
     "shelljs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-      "requires": {
-        "hoek": "4.2.0"
-      }
-    },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
       "requires": {
-        "asn1": "0.2.3",
+        "asn1": "0.2.4",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
+        "ecc-jsbn": "0.1.2",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
-    "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-    },
     "tough-cookie": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "requires": {
+        "psl": "1.1.31",
         "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
+    },
+    "tunnel": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "optional": true
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typed-rest-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.7.tgz",
+      "integrity": "sha512-0u+4yiprNuCoXzWllWuDB81i5Riyg0nwrMFs9RczRjU0ZzIWG4lodtXNxoBL19Jb9I8qVN/VTBG7x+mR2kvq+A==",
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
+      }
+    },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "2.1.1"
+      }
     },
     "uuid": {
       "version": "3.2.1",
@@ -480,40 +432,18 @@
         "extsprintf": "1.3.0"
       }
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "1.5.1"
-      }
-    },
     "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
+      "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
-        "glob": "6.0.4",
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
-        "node-uuid": "1.4.8",
         "q": "1.5.1",
-        "semver": "5.5.0",
+        "semver": "5.6.0",
         "shelljs": "0.3.0",
-        "vso-node-api": "0.6.1"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        }
+        "uuid": "3.2.1"
       }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }

--- a/Tasks/JenkinsQueueJobV2/package.json
+++ b/Tasks/JenkinsQueueJobV2/package.json
@@ -5,7 +5,8 @@
     "@types/q": "^1.0.7",
     "@types/shelljs": "^0.3.0",
     "request": "^2.65.0",
-    "vsts-task-lib": "0.9.20"
+    "typed-rest-client": "1.0.7",
+    "vsts-task-lib": "2.4.0"
   },
   "description": "Azure Pipelines Jenkins Queue Job Task",
   "repository": {

--- a/Tasks/JenkinsQueueJobV2/task.json
+++ b/Tasks/JenkinsQueueJobV2/task.json
@@ -13,7 +13,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 145,
+        "Minor": 147,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/JenkinsQueueJobV2/task.loc.json
+++ b/Tasks/JenkinsQueueJobV2/task.loc.json
@@ -13,7 +13,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 145,
+    "Minor": 147,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/JenkinsQueueJobV2/unzip.ts
+++ b/Tasks/JenkinsQueueJobV2/unzip.ts
@@ -45,7 +45,7 @@ function sevenZipExtract(file: string, destinationFolder: string): void {
     return handleExecResult(sevenZip.execSync(getOptions()), file);
 }
 
-function handleExecResult(execResult: tr.IExecResult, file: string): void {
+function handleExecResult(execResult: tr.IExecSyncResult, file: string): void {
     if (execResult.code != tl.TaskResult.Succeeded) {
         tl.debug('execResult: ' + JSON.stringify(execResult));
         const message: string = 'Extraction failed for file: ' + file +

--- a/Tasks/JenkinsQueueJobV2/util.ts
+++ b/Tasks/JenkinsQueueJobV2/util.ts
@@ -22,7 +22,6 @@ export function failReturnCode(httpResponse, message: string): void {
     const fullMessage = getFullErrorMessage(httpResponse, message);
     tl.debug(message);
     tl.error(fullMessage);
-    tl._writeError(message);
     tl.setResult(tl.TaskResult.Failed, message);
 }
 

--- a/Tasks/JenkinsQueueJobV2/webclient.ts
+++ b/Tasks/JenkinsQueueJobV2/webclient.ts
@@ -1,0 +1,122 @@
+import tl = require('vsts-task-lib/task');
+import httpClient = require("typed-rest-client/HttpClient");
+import httpInterfaces = require("typed-rest-client/Interfaces");
+import util = require("util");
+
+let proxyUrl: string = tl.getVariable("agent.proxyurl");
+var requestOptions: httpInterfaces.IRequestOptions = proxyUrl ? {
+    proxy: {
+        proxyUrl: proxyUrl,
+        proxyUsername: tl.getVariable("agent.proxyusername"),
+        proxyPassword: tl.getVariable("agent.proxypassword"),
+        proxyBypassHosts: tl.getVariable("agent.proxybypasslist") ? JSON.parse(tl.getVariable("agent.proxybypasslist")) : null
+    }
+} : {};
+
+requestOptions.ignoreSslError = ('true' !== tl.getEndpointDataParameter(this.serverEndpoint, 'acceptUntrustedCerts', true));;
+
+var httpCallbackClient = new httpClient.HttpClient(tl.getVariable("AZURE_HTTP_USER_AGENT"), null, requestOptions);
+
+export class WebRequest {
+    public method: string;
+    public uri: string;
+    // body can be string or ReadableStream
+    public body: string;
+    public headers: any;
+}
+
+export class WebResponse {
+    public statusCode: number;
+    public statusMessage: string;
+    public headers: any;
+    public body: any;
+}
+
+export class WebRequestOptions {
+    public retriableErrorCodes: string[];
+    public retryCount: number;
+    public retryIntervalInSeconds: number;
+    public retriableStatusCodes: number[];
+    public retryRequestTimedout: boolean;
+}
+
+export async function sendRetriableRequest(request: WebRequest, options?: WebRequestOptions): Promise<WebResponse> {
+    let i = 0;
+    let retryCount = options && options.retryCount ? options.retryCount : 5;
+    let retryIntervalInSeconds = options && options.retryIntervalInSeconds ? options.retryIntervalInSeconds : 2;
+    let retriableErrorCodes = options && options.retriableErrorCodes ? options.retriableErrorCodes : ["ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "ESOCKETTIMEDOUT", "ECONNREFUSED", "EHOSTUNREACH", "EPIPE", "EA_AGAIN"];
+    let retriableStatusCodes = options && options.retriableStatusCodes ? options.retriableStatusCodes : [401, 404, 408, 409, 500, 502, 503, 504];
+    let timeToWait: number = retryIntervalInSeconds;
+    while (true) {
+        try {
+            let response: WebResponse = await sendRequest(request);
+            if (retriableStatusCodes.indexOf(response.statusCode) != -1 && ++i < retryCount) {
+                tl.debug(util.format("Encountered a retriable status code: %s. Message: '%s'.", response.statusCode, response.statusMessage));
+                await sleepFor(timeToWait);
+                timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;
+                continue;
+            }
+
+            return response;
+        }
+        catch (error) {
+            if (retriableErrorCodes.indexOf(error.code) != -1 && ++i < retryCount) {
+                tl.debug(util.format("Encountered a retriable error:%s. Message: %s.", error.code, error.message));
+                await sleepFor(timeToWait);
+                timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;
+            }
+            else {
+                if (error.code) {
+                    console.log("##vso[task.logissue type=error;code=" + error.code + ";]");
+                }
+
+                throw error;
+            }
+        }
+    }
+}
+
+export async function sendRequest(request: WebRequest): Promise<WebResponse> {
+    tl.debug(util.format("[%s]%s", request.method, request.uri));
+    var response: httpClient.HttpClientResponse = await httpCallbackClient.request(request.method, request.uri, request.body, request.headers);
+    return await toWebResponse(response);
+}
+
+export async function sendRequestNoParsing(request: WebRequest): Promise<httpClient.HttpClientResponse> {
+    tl.debug(util.format("[%s]%s", request.method, request.uri));
+    return await httpCallbackClient.request(request.method, request.uri, request.body, request.headers);
+}
+
+export function sleepFor(sleepDurationInSeconds): Promise<any> {
+    return new Promise((resolve, reject) => {
+        setTimeout(resolve, sleepDurationInSeconds * 1000);
+    });
+}
+
+async function sendRequestInternal(request: WebRequest): Promise<WebResponse> {
+    tl.debug(util.format("[%s]%s", request.method, request.uri));
+    var response: httpClient.HttpClientResponse = await httpCallbackClient.request(request.method, request.uri, request.body, request.headers);
+    return await toWebResponse(response);
+}
+
+async function toWebResponse(response: httpClient.HttpClientResponse): Promise<WebResponse> {
+    var res = new WebResponse();
+    if (response) {
+        res.statusCode = response.message.statusCode;
+        res.statusMessage = response.message.statusMessage;
+        res.headers = response.message.headers;
+        var body = await response.readBody();
+        if (body) {
+            try {
+                res.body = JSON.parse(body);
+            }
+            catch (error) {
+                tl.debug("Could not parse response: " + JSON.stringify(error));
+                tl.debug("Response: " + JSON.stringify(res.body));
+                res.body = body;
+            }
+        }
+    }
+
+    return res;
+}

--- a/Tasks/JenkinsQueueJobV2/webclient.ts
+++ b/Tasks/JenkinsQueueJobV2/webclient.ts
@@ -93,12 +93,6 @@ export function sleepFor(sleepDurationInSeconds): Promise<any> {
     });
 }
 
-async function sendRequestInternal(request: WebRequest): Promise<WebResponse> {
-    tl.debug(util.format("[%s]%s", request.method, request.uri));
-    var response: httpClient.HttpClientResponse = await httpCallbackClient.request(request.method, request.uri, request.body, request.headers);
-    return await toWebResponse(response);
-}
-
 async function toWebResponse(response: httpClient.HttpClientResponse): Promise<WebResponse> {
     var res = new WebResponse();
     if (response) {


### PR DESCRIPTION
The JenkinsQueueJobV2 task is using an older vsts-task-lib version and the requests library. Updating the task to take in a newer task-lib version and the typed-rest-client.  The newly added webclient class provides a wrapper around the typed-rest-client library allowing for us to customize the retry logic for calls to Jenkins and additional error logging.

**The util class still needs to be updated to use the new webclient. The logic that submits jobs to Jenkins will require additional work in order to port it over to the webclient. All other classes have been updated.**

Tested in a local deployment that mirrors BuildCanary.
Updated and ran L0 tests.