### PR TITLE
Adds "Cleanup Old Test Results" Flag to Dotnet Test Task

### DIFF
--- a/Tasks/DotNetCoreCLIV2/README.md
+++ b/Tasks/DotNetCoreCLIV2/README.md
@@ -51,3 +51,4 @@ Options specific to **dotnet restore** command
 
 Options specific to **dotnet test** command
 * **Publish test results\*:** Enabling this option will generate a test results TRX file in $(Agent.TempDirectory) and results will be published to the server. This option appends --logger trx --results-directory $(Agent.TempDirectory) to the command line arguments.
+* **Cleanup Old test results\*:** Enabling this option will delete all test result TRX files under $(Agent.TempDirectory). This is currently only available on the Windows platform.

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -118,7 +118,10 @@ export class dotNetExe {
         }
 
         // Remove old trx files
-        this.removeOldTestResultFiles(resultsDirectory);
+        const cleanupOldTestResults: boolean = tl.getBoolInput('cleanupOldTestResults', false) || false;
+        if (cleanupOldTestResults) {
+            this.removeOldTestResultFiles(resultsDirectory);
+        }
 
         // Use empty string when no project file is specified to operate on the current directory
         const projectFiles = this.getProjectFiles();

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -133,6 +133,15 @@
             "helpMarkDown": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect “Code coverage”` option to the command line arguments. This is currently only available on the Windows platform."
         },
         {
+            "name": "cleanupOldTestResults",
+            "type": "boolean",
+            "label": "Cleanup Old Test Results",
+            "defaultValue": "true",
+            "visibleRule": "command = test",
+            "required": false,
+            "helpMarkDown": "Enabling this option will delete ALL TRX files (test results) under `$(Agent.TempDirectory)`. This is currently only available on the Windows platform."
+        },
+        {
             "name": "zipAfterPublish",
             "type": "boolean",
             "visibleRule": "command = publish",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -133,6 +133,15 @@
       "helpMarkDown": "ms-resource:loc.input.help.publishTestResults"
     },
     {
+      "name": "cleanupOldTestResults",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.cleanupOldTestResults",
+      "defaultValue": "true",
+      "visibleRule": "command = test",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.cleanupOldTestResults"
+    },
+    {
       "name": "zipAfterPublish",
       "type": "boolean",
       "visibleRule": "command = publish",


### PR DESCRIPTION
Adds a Flag to delete any/existing/all test result files i.e. TRX files from Agent.TempDirectory. By default, it is true because that's the current behavior. 

Users have option to turn this off if they prefer to keep the TRX files under Temp dir for any reason(s). 

