### PR TITLE
Add support for AzureChinaCloud

### DIFF
--- a/Tasks/AzureIoTEdgeV2/deployimage.ts
+++ b/Tasks/AzureIoTEdgeV2/deployimage.ts
@@ -128,8 +128,16 @@ class azureclitask {
     var servicePrincipalKey = tl.getEndpointAuthorizationParameter(connectedService, "serviceprincipalkey", false);
     var tenantId = tl.getEndpointAuthorizationParameter(connectedService, "tenantid", false);
     var subscriptionName = tl.getEndpointDataParameter(connectedService, "SubscriptionName", true);
+    var environment = tl.getEndpointDataParameter(connectedService, "environment", true);
     // Work around for build agent az command will exit with non-zero code since configuration files are missing.
     tl.debug(tl.execSync("az", "--version", Constants.execSyncSilentOption).stdout);
+
+    // Set environment if it is not AzureCloud (global Azure)
+    if (environment && environment !== 'AzureCloud') {
+      let result = tl.execSync("az", `cloud set --name ${environment}`, Constants.execSyncSilentOption);
+      tl.debug(JSON.stringify(result));
+    }
+
     //login using svn
     let result = tl.execSync("az", "login --service-principal -u \"" + servicePrincipalId + "\" -p \"" + servicePrincipalKey + "\" --tenant \"" + tenantId + "\"", Constants.execSyncSilentOption);
     tl.debug(JSON.stringify(result));

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "instanceNameFormat": "Azure IoT Edge - $(action)",

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureIoTEdgeV2/telemetry.ts
+++ b/Tasks/AzureIoTEdgeV2/telemetry.ts
@@ -1,7 +1,7 @@
 import * as appInsights from 'applicationinsights';
 const metadata = {
   id: 'iot-edge-build-deploy',
-  version: '2.0.0',
+  version: '2.0.1',
   publisher: 'vsc-iot',
 }
 


### PR DESCRIPTION
- A customer using AzureChinaCloud reported that the Azure IoT Edge task doesn't support AzureChinaCloud. This pull request is to add AzureChinaCloud(including other Azure clouds as well) support.
- Our test team has already done an integration test for this PR.