### PR TITLE
Start of help URLs that can be displayed without Markdown parsing

### DIFF
--- a/Tasks/ANTV1/task.json
+++ b/Tasks/ANTV1/task.json
@@ -3,6 +3,7 @@
     "name": "Ant",
     "friendlyName": "Ant",
     "description": "Build with Apache Ant",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613718",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613718)",
     "category": "Build",
     "visibility": [

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -3,6 +3,7 @@
     "name": "AndroidSigning",
     "friendlyName": "Android Signing",
     "description": "Sign and align Android APK files",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613717",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613717)",
     "category": "Build",
     "visibility": [

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -3,6 +3,7 @@
     "name": "AndroidSigning",
     "friendlyName": "Android Signing",
     "description": "Sign and align Android APK files",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613717",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613717)",
     "category": "Build",
     "visibility": [

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -3,6 +3,7 @@
     "name": "AppCenterDistribute",
     "friendlyName": "App Center Distribute",
     "description": "Distribute app builds to testers and users via App Center",
+    "helpUrl": "https://aka.ms/appcentersupport/",
     "helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AppCenterTestV1/task.json
+++ b/Tasks/AppCenterTestV1/task.json
@@ -3,6 +3,7 @@
     "name": "AppCenterTest",
     "friendlyName": "App Center Test",
     "description": "Test app packages with Visual Studio App Center.",
+    "helpUrl": "https://aka.ms/appcentersupport",
     "helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport).",
     "category": "Test",
     "visibility": [

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Archive Files",
     "description": "Archive files using compression formats such as .7z, .rar, .tar.gz, and .zip.",
     "author": "Microsoft Corporation",
+    "helpUrl": "http://go.microsoft.com/fwlink/?LinkId=809083",
     "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkId=809083)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Azure App Service Manage",
     "description": "Start, Stop, Restart, Slot swap, Install site extensions or Enable Continuous Monitoring for an Azure App Service",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=831573",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=831573)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureCLIV1/task.json
+++ b/Tasks/AzureCLIV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Azure CLI",
     "description": "Run Azure CLI commands against an Azure subscription in a Shell script when runnning on Linux agent or Batch script when running on Windows agent.",
     "author": "Microsoft Corporation",
+    "helpUrl": "http://go.microsoft.com/fwlink/?LinkID=827160",
     "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkID=827160)",
     "releaseNotes": "What's new in Version 1.0:\n- Supports the new Azure CLI 2.0 which is Python based\n- Works with cross-platform agents (Linux, macOS, or Windows)\n- For working with Azure CLI 1.0 (node.js-based), switch to task version 0.0\n- Limitations:\n - No support for Azure Classic subscriptions. Azure CLI 2.0 supports only Azure Resource Manager (ARM) subscriptions.",
     "category": "Deploy",

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureCloudPowerShellDeployment",
     "friendlyName": "Azure Cloud Service Deployment",
     "description": "Deploy an Azure Cloud Service",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613748",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613748)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureFileCopy",
     "friendlyName": "Azure File Copy",
     "description": "Copy files to Azure blob or VM(s)",
+    "helpUrl": "https://aka.ms/azurefilecopyreadme",
     "helpMarkDown": "[More Information](https://aka.ms/azurefilecopyreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -3,6 +3,7 @@
     "name": "AzureFileCopy",
     "friendlyName": "Azure File Copy",
     "description": "Copy files to Azure blob or VM(s)",
+    "helpUrl": "https://aka.ms/azurefilecopyreadme",
     "helpMarkDown": "[More Information](https://aka.ms/azurefilecopyreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -3,6 +3,7 @@
     "name": "AzureFileCopy",
     "friendlyName": "Azure File Copy",
     "description": "Copy files to Azure blob or VM(s)",
+    "helpUrl": "https://aka.ms/azurefilecopyreadme",
     "helpMarkDown": "[More Information](https://aka.ms/azurefilecopyreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFunctionAppContainerV1/task.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureFunctionAppContainer",
     "friendlyName": "Azure Function for Container",
     "description": "Update Function Apps with Docker Containers",
+    "helpUrl": "https://aka.ms/azurefunctiononcontainerdeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurefunctiononcontainerdeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureFunctionApp",
     "friendlyName": "Azure Function",
     "description": "Update Azure Function on Windows, Function on Linux with built-in images, ASP.NET, .NET Core, PHP, Python or Node.js based Web applications",
+    "helpUrl": "https://aka.ms/azurefunctiondeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurefunctiondeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureFunctionV1/task.json
+++ b/Tasks/AzureFunctionV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Invoke Azure Function",
     "description": "Invoke an Azure Function as a part of your pipeline.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870235",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=870235)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -3,6 +3,7 @@
   "name": "AzureIoTEdge",
   "friendlyName": "Azure IoT Edge",
   "description": "Azure IoT Edge pipelines tasks for continuous integration(build and push docker image) and continuous deployment(create Edge deployment on Azure)",
+  "helpUrl": "https://aka.ms/azure-iot-edge-ci-cd-docs",
   "helpMarkDown": "Visit the [documentation](https://aka.ms/azure-iot-edge-ci-cd-docs) for help",
   "category": "Build",
   "visibility": [

--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureKeyVault",
     "friendlyName": "Azure Key Vault",
     "description": "Download Azure Key Vault Secrets",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=848891",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=848891)",
     "category": "Deploy",
     "releaseNotes": "Works with cross-platform agents (Linux, macOS, or Windows)",

--- a/Tasks/AzureMonitorAlertsV0/task.json
+++ b/Tasks/AzureMonitorAlertsV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Azure Monitor Alerts",
     "description": "Configure alerts on available metrics for an Azure resource",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=859947",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=859947)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureMonitorV0/task.json
+++ b/Tasks/AzureMonitorV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Query Classic Azure Monitor Alerts",
     "description": "Observe the configured classic Azure monitor rules for active alerts.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870240",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870240)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/AzureMonitorV1/task.json
+++ b/Tasks/AzureMonitorV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Query Azure Monitor Alerts",
     "description": "Observe the configured Azure monitor rules for active alerts.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870240",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870240)",
     "category": "Utility",
     "preview": true,

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureMysqlDeployment",
     "friendlyName": "Azure Database for MySQL Deployment",
     "description": "Run your scripts and make changes to your Azure Database for MySQL.",
+    "helpUrl": "https://aka.ms/mysqlazuredeployreadme",
     "helpMarkDown": "[More Information](https://aka.ms/mysqlazuredeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureNLBManagementV1/task.json
+++ b/Tasks/AzureNLBManagementV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Azure Network Load Balancer",
     "description": "Connect/Disconnect an Azure virtual machine's network interface to a Load Balancer's backend address pool",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=837723",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=837723)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -3,6 +3,8 @@
   "name": "AzurePolicyCheckGate",
   "friendlyName": "Security and compliance assessment",
   "description": "Security and compliance assessment with Azure policies on resources that belong to the resource group and Azure subscription",
+  "helpUrl": "",
+  "helpMarkDown": "",
   "category": "Deploy",
   "visibility": [
     "Release"

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -3,6 +3,7 @@
     "name": "AzurePowerShell",
     "friendlyName": "Azure PowerShell",
     "description": "Run a PowerShell script within an Azure environment",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613749",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613749)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -3,6 +3,7 @@
     "name": "AzurePowerShell",
     "friendlyName": "Azure PowerShell",
     "description": "Run a PowerShell script within an Azure environment",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613749",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613749)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureResourceGroupDeploymentV2/task.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.json
@@ -3,6 +3,7 @@
     "name": "AzureResourceGroupDeployment",
     "friendlyName": "Azure Resource Group Deployment",
     "description": "Deploy an Azure resource manager (ARM) template to a resource group. You can also start, stop, delete, deallocate all Virtual Machines (VM) in a resource group",
+    "helpUrl": "https://aka.ms/argtaskreadme",
     "helpMarkDown": "[More Information](https://aka.ms/argtaskreadme)",
     "category": "Deploy",
     "releaseNotes": "-Works with cross-platform agents (Linux, macOS, or Windows)\n- Supports Template JSONs located at any publicly accessible http/https URLs.\n- Enhanced UX for Override parameters which can now be viewed/edited in a grid.\n- NAT rule mapping for VMs which are backed by an Load balancer.\n- \"Resource group\" field is now renamed as \"VM details for  WinRM\" and is included in the section \"Advanced deployment options for virtual machines\".\n- Limitations: \n - No support for Classic subscriptions. Only for ARM subscriptions are supported.\n - No support for PowerShell syntax as the task is now node.js based. Ensure the case sensitivity of the parameter names match, when you override the template parameters. Also, remove the PowerShell cmdlets like \"ConvertTo-SecureString\" when you migrate from version 1.0 to version 2.0.",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -3,6 +3,7 @@
     "name": "AzureRmWebAppDeployment",
     "friendlyName": "Azure App Service Deploy",
     "description": "Update Azure App Services on Windows, Web App on Linux with built-in images or Docker containers, ASP.NET, .NET Core, PHP, Python or Node.js based Web applications, Function Apps, Mobile Apps, API applications, Web Jobs using Web Deploy / Kudu REST APIs",
+    "helpUrl": "https://aka.ms/azurermwebdeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurermwebdeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -3,6 +3,7 @@
     "name": "AzureRmWebAppDeployment",
     "friendlyName": "Azure App Service Deploy",
     "description": "Update Azure App Services on Windows, Web App on Linux with built-in images or Docker containers, ASP.NET, .NET Core, PHP, Python or Node.js based Web applications, Function Apps on Windows or Linux with Docker Containers, Mobile Apps, API applications, Web Jobs using Web Deploy / Kudu REST APIs",
+    "helpUrl": "https://aka.ms/azurermwebdeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurermwebdeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -3,6 +3,7 @@
     "name": "AzureVmssDeployment",
     "friendlyName": "Azure VM scale set Deployment",
     "description": "Deploy Virtual Machine scale set image",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=852117",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=852117)",
     "category": "Deploy",
     "releaseNotes": "- Updates Azure Virtual Machine scale set with a custom machine image.",

--- a/Tasks/AzureWebAppContainerV1/task.json
+++ b/Tasks/AzureWebAppContainerV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureWebAppContainer",
     "friendlyName": "Azure Web App for Container",
     "description": "Update Azure App Services on Docker containers",
+    "helpUrl": "https://aka.ms/azurewebapponcontainerdeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurewebapponcontainerdeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/AzureWebAppV1/task.json
+++ b/Tasks/AzureWebAppV1/task.json
@@ -3,6 +3,7 @@
     "name": "AzureWebApp",
     "friendlyName": "Azure Web App",
     "description": "Update Azure App Services on Windows, Web App on Linux with built-in images, ASP.NET, .NET Core, PHP, Python or Node.js based Web applications, Mobile Apps, API applications",
+    "helpUrl": "https://aka.ms/azurewebappdeployreadme",
     "helpMarkDown": "[More information](https://aka.ms/azurewebappdeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -3,6 +3,7 @@
     "name": "Bash",
     "friendlyName": "Bash",
     "description": "Run a Bash script on macOS, Linux, or Windows",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613738",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613738)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/BatchScriptV1/task.json
+++ b/Tasks/BatchScriptV1/task.json
@@ -3,6 +3,7 @@
     "name": "BatchScript",
     "friendlyName": "Batch Script",
     "description": "Run a windows cmd or bat script and optionally allow it to change the environment",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613733",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613733)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/CMakeV1/task.json
+++ b/Tasks/CMakeV1/task.json
@@ -3,6 +3,7 @@
     "name": "CMake",
     "friendlyName": "CMake",
     "description": "Build with the CMake cross-platform build system",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613719",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613719)",
     "category": "Build",
     "visibility": [

--- a/Tasks/CUrlUploaderV2/task.json
+++ b/Tasks/CUrlUploaderV2/task.json
@@ -3,6 +3,7 @@
     "name": "cURLUploader",
     "friendlyName": "cURL Upload Files",
     "description": "Use cURL to upload files.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=627418",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627418)",
     "category": "Utility",
     "author": "Microsoft Corporation",

--- a/Tasks/ChefKnifeV1/task.json
+++ b/Tasks/ChefKnifeV1/task.json
@@ -3,6 +3,7 @@
     "name": "ChefKnife",
     "friendlyName": "Chef Knife",
     "description": "Run Scripts with knife commands on your chef workstation",
+    "helpUrl": "https://aka.ms/chef-knife-readme",
     "helpMarkDown": "[More Information](https://aka.ms/chef-knife-readme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/ChefV1/task.json
+++ b/Tasks/ChefV1/task.json
@@ -3,6 +3,7 @@
     "name": "Chef",
     "friendlyName": "Chef",
     "description": "Deploy to Chef environments by editing environment attributes",
+    "helpUrl": "https://aka.ms/chef-readme",
     "helpMarkDown": "[More Information](https://aka.ms/chef-readme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -3,6 +3,7 @@
     "name": "CmdLine",
     "friendlyName": "Command Line",
     "description": "Run a command line script using cmd.exe on Windows and bash on macOS and Linux.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613735",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613735)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/CocoaPodsV0/task.json
+++ b/Tasks/CocoaPodsV0/task.json
@@ -3,6 +3,7 @@
     "name": "CocoaPods",
     "friendlyName": "CocoaPods",
     "description": "CocoaPods is a dependency manager for Swift and Objective-C Cocoa projects. This task runs 'pod install'.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613745",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613745)",
     "category": "Package",
     "visibility": [

--- a/Tasks/CondaEnvironmentV0/task.json
+++ b/Tasks/CondaEnvironmentV0/task.json
@@ -3,6 +3,7 @@
     "name": "CondaEnvironment",
     "friendlyName": "Conda Environment",
     "description": "Create and activate a Conda environment.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=873466",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
     "category": "Package",
     "runsOn": [

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -3,6 +3,7 @@
     "name": "CondaEnvironment",
     "friendlyName": "Conda Environment",
     "description": "Create and activate a Conda environment.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=873466",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
     "category": "Package",
     "runsOn": [

--- a/Tasks/CopyFilesOverSSHV0/task.json
+++ b/Tasks/CopyFilesOverSSHV0/task.json
@@ -3,6 +3,7 @@
     "name": "CopyFilesOverSSH",
     "friendlyName": "Copy Files Over SSH",
     "description": "Copy files or build artifacts to a remote machine over SSH",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=821894",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=821894)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -3,6 +3,7 @@
     "name": "CopyFiles",
     "friendlyName": "Copy Files",
     "description": "Copy files from source folder to target folder using match patterns (The match patterns will only match file paths, not folder paths)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=708389",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=708389)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/DecryptFileV1/task.json
+++ b/Tasks/DecryptFileV1/task.json
@@ -3,6 +3,8 @@
     "name": "DecryptFile",
     "friendlyName": "Decrypt File (OpenSSL)",
     "description": "A thin utility task for file decryption using OpenSSL.",
+    "helpUrl": "",
+    "helpMarkDown": "",
     "category": "Utility",
     "visibility": [
         "Build",

--- a/Tasks/DelayV1/task.json
+++ b/Tasks/DelayV1/task.json
@@ -3,6 +3,7 @@
     "name": "Delay",
     "friendlyName": "Delay",
     "description": "Delay further execution of the workflow by a fixed time.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870239",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870239)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/DeleteFilesV1/task.json
+++ b/Tasks/DeleteFilesV1/task.json
@@ -3,6 +3,7 @@
     "name": "DeleteFiles",
     "friendlyName": "Delete Files",
     "description": "Delete files or folders. (The minimatch patterns will only match file paths, not folder paths)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=722333",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=722333)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/DeployVisualStudioTestAgentV2/task.json
+++ b/Tasks/DeployVisualStudioTestAgentV2/task.json
@@ -3,6 +3,7 @@
     "name": "DeployVisualStudioTestAgent",
     "friendlyName": "Visual Studio Test Agent Deployment",
     "description": "Deprecated: This task and it’s companion task (Run Functional Tests) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent job setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=838890",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?LinkId=838890)",
     "category": "Test",
     "visibility": [

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -3,6 +3,7 @@
     "name": "DockerCompose",
     "friendlyName": "Docker Compose",
     "description": "Build, push or run multi-container Docker applications. Task can be used with Docker or Azure Container registry.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=848006",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=848006)",
     "category": "Build",
     "visibility": [

--- a/Tasks/DockerInstallerV0/task.json
+++ b/Tasks/DockerInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "DockerInstaller",
     "friendlyName": "Docker CLI installer",
     "description": "Install Docker CLI on agent machine.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Tool",
     "visibility": [

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -3,6 +3,7 @@
     "name": "Docker",
     "friendlyName": "Docker",
     "description": "Build, tag, push, or run Docker images, or run a Docker command. Task can be used with Docker or Azure Container registry.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=848006",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=848006)",
     "category": "Build",
     "visibility": [

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -3,6 +3,7 @@
     "name": "Docker",
     "friendlyName": "Docker",
     "description": "Build, tag, push, or run Docker images, or run a Docker command. Task can be used with Docker or Azure Container registry.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=848006",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=848006)",
     "category": "Build",
     "visibility": [

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -4,6 +4,7 @@
     "friendlyName": ".NET Core",
     "description": "Build, test, package, or publish a dotnet application, or run a custom dotnet command. For package commands, supports NuGet.org and authenticated feeds like Package Management and MyGet.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=832194",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=832194)",
     "category": "Build",
     "visibility": [

--- a/Tasks/DotNetCoreInstallerV0/task.json
+++ b/Tasks/DotNetCoreInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "DotNetCoreInstaller",
     "friendlyName": ".NET Core SDK Installer",
     "description": "Acquires a specific version of the .NET Core SDK from internet or the local cache and adds it to the PATH. Use this task to change the version of .NET Core used in subsequent tasks.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=853651",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=853651)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -3,6 +3,7 @@
     "name": "DownloadBuildArtifacts",
     "friendlyName": "Download Build Artifacts",
     "description": "Download Build Artifacts",
+    "helpUrl": "",
     "helpMarkDown": "",
     "category": "Utility",
     "author": "Microsoft Corporation",

--- a/Tasks/DownloadFileshareArtifactsV0/task.json
+++ b/Tasks/DownloadFileshareArtifactsV0/task.json
@@ -3,6 +3,7 @@
     "name": "DownloadFileshareArtifacts",
     "friendlyName": "Download Fileshare Artifacts",
     "description": "Download artifacts from a file share e.g \\\\share\\drop",
+    "helpUrl": "",
     "helpMarkDown": "",
     "category": "Utility",
     "author": "Microsoft Corporation",

--- a/Tasks/DownloadGithubReleasesV0/task.json
+++ b/Tasks/DownloadGithubReleasesV0/task.json
@@ -4,6 +4,7 @@
   "friendlyName": "Download GitHub Releases",
   "description": "Download GitHub Releases",
   "author": "Microsoft Corporation",
+  "helpUrl": "",
   "helpMarkDown": "",
   "category": "Utility",
   "demands": [],

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -3,6 +3,7 @@
     "name": "DownloadPackage",
     "friendlyName": "Download Package",
     "description": "Download a package from a Package Management feed in Azure Artifacts or TFS. \r\n Requires the Package Management extension.",
+    "helpUrl": "",
     "helpMarkDown": "Needs Package Management extension to be installed",
     "category": "Utility",
     "author": "ms-vscs-rm",

--- a/Tasks/DownloadPipelineArtifactV0/task.json
+++ b/Tasks/DownloadPipelineArtifactV0/task.json
@@ -3,6 +3,7 @@
     "name": "DownloadPipelineArtifact",
     "friendlyName": "Download Pipeline Artifact",
     "description": "Download Pipeline Artifact",
+    "helpUrl": "",
     "helpMarkDown": "Download named artifact from a pipeline to a local path.",
     "category": "Utility",
     "author": "Microsoft Corporation",

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -3,6 +3,7 @@
     "name": "DownloadSecureFile",
     "friendlyName": "Download Secure File",
     "description": "Download a secure file to a temporary location on the build or release agent",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=862069",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=862069)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Extract Files",
     "description": "Extract a variety of archive and compression files such as .7z, .rar, .tar.gz, and .zip.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=800269",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=800269)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "File Transform",
     "description": "File Transform",
     "author": "Microsoft Corporation",
+    "helpUrl": "",
     "helpMarkDown": "File transformation and variable substitution task: Update tokens in your XML based configuration files and then replaces those tokens with variable values. <br/>Currently only XML, JSON file formats are supported for variable substitution.",
     "category": "Utility",
     "visibility": [

--- a/Tasks/FtpUploadV1/task.json
+++ b/Tasks/FtpUploadV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "FTP Upload",
     "description": "FTP Upload",
     "author": "Microsoft Corporation",
+    "helpUrl": "",
     "helpMarkDown": "Upload files to a remote machine using the File Transfer Protocol (FTP), or securely with FTPS.  [More Information](http://go.microsoft.com/fwlink/?LinkId=809084).",
     "category": "Utility",
     "visibility": [

--- a/Tasks/GitHubReleaseV0/task.json
+++ b/Tasks/GitHubReleaseV0/task.json
@@ -3,6 +3,7 @@
     "name": "GitHubRelease",
     "friendlyName": "GitHub Release",
     "description": "Create, edit, or delete a GitHub release.",
+    "helpUrl": "https://aka.ms/AA3aeiw",
     "helpMarkDown": "[More Information](https://aka.ms/AA3aeiw)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/GoToolV0/task.json
+++ b/Tasks/GoToolV0/task.json
@@ -3,6 +3,7 @@
     "name": "GoTool",
     "friendlyName": "Go Tool Installer",
     "description": "Finds or downloads a specific version of Go in the tools cache and adds it to the PATH. Use this to set the version of Go used in subsequent tasks.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=867581",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=867581)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/GoV0/task.json
+++ b/Tasks/GoV0/task.json
@@ -3,6 +3,7 @@
     "name": "Go",
     "friendlyName": "Go",
     "description": "Get, build, or test a Go application, or run a custom Go command.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=867582",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=867582)",
     "author": "Microsoft Corporation",
     "category": "Build",

--- a/Tasks/GradleV2/task.json
+++ b/Tasks/GradleV2/task.json
@@ -3,6 +3,7 @@
     "name": "Gradle",
     "friendlyName": "Gradle",
     "description": "Build using a Gradle wrapper script",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613720",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613720)",
     "category": "Build",
     "visibility": [

--- a/Tasks/GruntV0/task.json
+++ b/Tasks/GruntV0/task.json
@@ -3,6 +3,7 @@
     "name": "Grunt",
     "friendlyName": "Grunt",
     "description": "The JavaScript Task Runner",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=627413",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627413)",
     "category": "Build",
     "visibility": [

--- a/Tasks/GulpV0/task.json
+++ b/Tasks/GulpV0/task.json
@@ -3,6 +3,7 @@
     "name": "Gulp",
     "friendlyName": "Gulp",
     "description": "Node.js streaming task based build system",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613721",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613721)",
     "category": "Build",
     "visibility": [

--- a/Tasks/GulpV1/task.json
+++ b/Tasks/GulpV1/task.json
@@ -3,6 +3,7 @@
     "name": "Gulp",
     "friendlyName": "Gulp",
     "description": "Node.js streaming task based build system",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613721",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613721)",
     "category": "Build",
     "visibility": [

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -3,6 +3,7 @@
     "name": "HelmDeploy",
     "friendlyName": "Package and deploy Helm charts",
     "description": "Deploy, configure, update your Kubernetes cluster in Azure Container Service by running helm commands.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "HelmInstaller",
     "friendlyName": "Helm tool installer",
     "description": "Install Helm and Kubernetes on agent machine.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Tool",
     "visibility": [

--- a/Tasks/IISWebAppDeployment/task.json
+++ b/Tasks/IISWebAppDeployment/task.json
@@ -3,6 +3,7 @@
     "name": "IISWebAppDeployment",
     "friendlyName": "[Deprecated] IIS Web App Deployment",
     "description": "Deploy by MSDeploy, create/update website & app pools",
+    "helpUrl": "https://aka.ms/iiswebappdeploydeprecatedreadme",
     "helpMarkDown": "[More Information](https://aka.ms/iiswebappdeploydeprecatedreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -3,6 +3,7 @@
     "name": "IISWebAppDeploymentOnMachineGroup",
     "friendlyName": "IIS Web App Deploy",
     "description": "Deploy a website or web application using Web Deploy",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=866789",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=866789)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/IISWebAppManagementOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppManagementOnMachineGroupV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "IIS Web App Manage",
     "description": "Create or update a Website, Web App, Virtual Directories, and Application Pool",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://aka.ms/iis-webapp-management-readme",
     "helpMarkDown": "[More Information](https://aka.ms/iis-webapp-management-readme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -3,6 +3,7 @@
     "name": "InstallAppleCertificate",
     "friendlyName": "Install Apple Certificate",
     "description": "Install an Apple certificate required to build on a macOS agent",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=862067",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?LinkID=862067)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -3,6 +3,7 @@
     "name": "InstallAppleProvisioningProfile",
     "friendlyName": "Install Apple Provisioning Profile",
     "description": "Install an Apple provisioning profile required to build on a macOS agent",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=862068",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=862068)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -3,6 +3,7 @@
     "name": "InstallSSHKey",
     "friendlyName": "Install SSH Key",
     "description": "Install an SSH key prior to a build or release",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=875267",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=875267)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/InvokeRestApiV1/task.json
+++ b/Tasks/InvokeRestApiV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Invoke REST API",
     "description": "Invoke a REST API as a part of your pipeline.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870236",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=870236)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "JavaToolInstaller",
     "friendlyName": "Java Tool Installer",
     "description": "Acquires a specific version of Java from a user supplied Azure blob or the tools cache and sets JAVA_HOME. Use this task to change the version of Java used in Java tasks.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=875287",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=875287)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -3,6 +3,7 @@
     "name": "JenkinsDownloadArtifacts",
     "friendlyName": "Jenkins Download Artifacts",
     "description": "Download artifacts produced by a Jenkins job",
+    "helpUrl": "",
     "helpMarkDown": "Download artifacts produced by a [Jenkins](https://jenkins.io/) job.",
     "category": "Utility",
     "visibility": [

--- a/Tasks/JenkinsQueueJobV2/task.json
+++ b/Tasks/JenkinsQueueJobV2/task.json
@@ -3,6 +3,7 @@
     "name": "JenkinsQueueJob",
     "friendlyName": "Jenkins Queue Job",
     "description": "Queue a job on a Jenkins server",
+    "helpUrl": "http://go.microsoft.com/fwlink/?LinkId=816956",
     "helpMarkDown": "This task queues a job on a [Jenkins](https://jenkins.io/) server. Full integration capabilities require installation of the [Team Foundation Server Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin) on Jenkins. [More Information](http://go.microsoft.com/fwlink/?LinkId=816956).",
     "category": "Build",
     "visibility": [

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -3,6 +3,7 @@
     "name": "KubernetesManifest",
     "friendlyName": "Manifest based Kubernetes deployments",
     "description": "Manifest based deployments to kubernetes",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Deploy",
     "preview": true,

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -3,6 +3,7 @@
     "name": "Kubernetes",
     "friendlyName": "Deploy to Kubernetes",
     "description": "Deploy, configure, update your Kubernetes cluster in Azure Container Service by running kubectl commands.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -3,6 +3,7 @@
     "name": "Kubernetes",
     "friendlyName": "Deploy to Kubernetes",
     "description": "Deploy, configure, update your Kubernetes cluster in Azure Container Service by running kubectl commands.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=851275",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -3,6 +3,7 @@
     "name": "MSBuild",
     "friendlyName": "MSBuild",
     "description": "Build with MSBuild",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613724",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613724)",
     "category": "Build",
     "visibility": [

--- a/Tasks/ManualInterventionV8/task.json
+++ b/Tasks/ManualInterventionV8/task.json
@@ -3,6 +3,7 @@
     "name": "ManualIntervention",
     "friendlyName": "Manual Intervention",
     "description": "Pause deployment and wait for intervention",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870234",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870234)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -3,6 +3,7 @@
     "name": "Maven",
     "friendlyName": "Maven",
     "description": "Build with Apache Maven",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613723",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613723)",
     "category": "Build",
     "visibility": [

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -3,6 +3,7 @@
     "name": "Maven",
     "friendlyName": "Maven",
     "description": "Build with Apache Maven",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613723",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613723)",
     "category": "Build",
     "visibility": [

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -3,6 +3,7 @@
     "name": "MysqlDeploymentOnMachineGroup",
     "friendlyName": "MySQL Database Deploy",
     "description": "This is an early preview. Run your scripts and make changes to your MySQL Database.",
+    "helpUrl": "https://aka.ms/mysql-deployment-on-machine-group",
     "helpMarkDown": "[More Information](https://aka.ms/mysql-deployment-on-machine-group)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -3,6 +3,7 @@
     "name": "NodeTool",
     "friendlyName": "Node Tool Installer",
     "description": "Finds or Downloads and caches specified version spec of Node and adds it to the PATH.",
+    "helpUrl": "",
     "helpMarkDown": "",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -3,6 +3,7 @@
     "name": "npmAuthenticate",
     "friendlyName": "npm Authenticate (for task runners)",
     "description": "Don't use this task if you're also using the npm task. Provides npm credentials to an .npmrc file in your repository for the scope of the build. This enables npm task runners like Gulp and Grunt to authenticate with private registries.",
+    "helpUrl": "",
     "helpMarkDown": "",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -3,6 +3,7 @@
     "name": "Npm",
     "friendlyName": "npm",
     "description": "Run an npm command",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613746",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613746)",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -3,6 +3,7 @@
     "name": "Npm",
     "friendlyName": "npm",
     "description": "Install and publish npm packages, or run an npm command. Supports npmjs.com and authenticated registries like Package Management.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613746",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613746)",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetCommand",
     "friendlyName": "NuGet",
     "description": "Restore, pack, or push NuGet packages, or run a NuGet command. Supports NuGet.org and authenticated feeds like Package Management and MyGet. Uses NuGet.exe and works with .NET Framework apps. For .NET Core and .NET Standard apps, use the .NET Core task.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613747",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613747)",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetInstaller",
     "friendlyName": "NuGet Installer",
     "description": "Installs or restores missing NuGet packages",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613747",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613747)",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NuGetPackagerV0/task.json
+++ b/Tasks/NuGetPackagerV0/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetPackager",
     "friendlyName": "NuGet Packager",
     "description": "Deprecated: use the “NuGet” task instead. It works with the new Tool Installer framework so you can easily use new versions of NuGet without waiting for a task update, provides better support for authenticated feeds outside this account/collection, and uses NuGet 4 by default.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=627416",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627416)",
     "category": "Package",
     "author": "Lawrence Gripper",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetPublisher",
     "friendlyName": "NuGet Publisher",
     "description": "Deprecated: use the “NuGet” task instead. It works with the new Tool Installer framework so you can easily use new versions of NuGet without waiting for a task update, provides better support for authenticated feeds outside this account/collection, and uses NuGet 4 by default.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=627417",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=627417)",
     "category": "Package",
     "author": "Lawrence Gripper",

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetRestore",
     "friendlyName": "NuGet Restore",
     "description": "Restores NuGet packages in preparation for a Visual Studio Build step.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613747",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613747)",
     "category": "Package",
     "author": "Microsoft Corporation",

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -3,6 +3,7 @@
     "name": "NuGetToolInstaller",
     "friendlyName": "NuGet Tool Installer",
     "description": "Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=852538",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=852538)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -6,6 +6,8 @@
     "category": "Package",
     "author": "Microsoft Corporation",
     "preview": "true",
+    "helpUrl": "",
+    "helpMarkDown": "",
     "version": {
         "Major": 0,
         "Minor": 145,

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -3,6 +3,7 @@
     "name": "PackerBuild",
     "friendlyName": "Build Machine Image",
     "description": "Build machine image using Packer. This image can be used for Azure Virtual machine scale set deployment",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=845329",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=845329)",
     "category": "Deploy",
     "releaseNotes": "- Works with cross-platform agents (Linux, macOS, or Windows)\n- Supports building images for both Windows and Linux. These images can be used to deploy Azure Virtual machine scale set.",

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -3,6 +3,7 @@
     "name": "PackerBuild",
     "friendlyName": "Build Machine Image",
     "description": "Build machine image using Packer. This image can be used for Azure Virtual machine scale set deployment",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=845329",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=845329)",
     "category": "Deploy",
     "releaseNotes": "This task now supports managed disk images.",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Python Pip Authenticate",
     "description": "Authentication task for pip client used for installing python distributions.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://pip.pypa.io/en/stable/reference/pip_install/",
     "helpMarkDown": "[More Information](https://pip.pypa.io/en/stable/reference/pip_install/)",
     "category": "Package",
     "version": {

--- a/Tasks/PowerShellOnTargetMachinesV1/task.json
+++ b/Tasks/PowerShellOnTargetMachinesV1/task.json
@@ -3,6 +3,7 @@
     "name": "PowerShellOnTargetMachines",
     "friendlyName": "PowerShell on Target Machines",
     "description": "Execute PowerShell scripts on remote machine(s)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=627414",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=627414)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/PowerShellOnTargetMachinesV2/task.json
+++ b/Tasks/PowerShellOnTargetMachinesV2/task.json
@@ -3,6 +3,7 @@
     "name": "PowerShellOnTargetMachines",
     "friendlyName": "PowerShell on Target Machines",
     "description": "Execute PowerShell scripts on remote machine(s)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=627414",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=627414)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/PowerShellOnTargetMachinesV3/task.json
+++ b/Tasks/PowerShellOnTargetMachinesV3/task.json
@@ -3,6 +3,7 @@
     "name": "PowerShellOnTargetMachines",
     "friendlyName": "PowerShell on Target Machines",
     "description": "Execute PowerShell scripts on remote machine(s). This version of the task uses PSSession and Invoke-Command for remoting.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=873465",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=873465)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -3,6 +3,7 @@
     "name": "PowerShell",
     "friendlyName": "PowerShell",
     "description": "Run a PowerShell script on Windows, macOS, or Linux.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613736",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613736)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -3,6 +3,7 @@
     "name": "PublishBuildArtifacts",
     "friendlyName": "Publish Build Artifacts",
     "description": "Publish build artifacts to Azure Pipelines/TFS or a file share",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=708390",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=708390)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/PublishCodeCoverageResultsV1/task.json
+++ b/Tasks/PublishCodeCoverageResultsV1/task.json
@@ -3,6 +3,7 @@
     "name": "PublishCodeCoverageResults",
     "friendlyName": "Publish Code Coverage Results",
     "description": "Publish Cobertura or JaCoCo code coverage results from a build",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=626485",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=626485)",
     "category": "Test",
     "visibility": [

--- a/Tasks/PublishPipelineArtifactV0/task.json
+++ b/Tasks/PublishPipelineArtifactV0/task.json
@@ -3,6 +3,7 @@
     "name": "PublishPipelineArtifact",
     "friendlyName": "Publish Pipeline Artifact",
     "description": "Publish Pipeline Artifact",
+    "helpUrl": "",
     "helpMarkDown": "Publish a local directory or file as a named artifact for the current pipeline.",
     "category": "Utility",
     "author": "Microsoft Corporation",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -3,6 +3,7 @@
     "name": "PublishSymbols",
     "friendlyName": "Index Sources & Publish Symbols",
     "description": "Index your source code and publish symbols to a file share or Azure Artifacts Symbol Server",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613722",
     "helpMarkDown": "See [more information](https://go.microsoft.com/fwlink/?LinkID=613722) on how to use this task.",
     "category": "Build",
     "visibility": [

--- a/Tasks/PublishTestResultsV1/task.json
+++ b/Tasks/PublishTestResultsV1/task.json
@@ -3,6 +3,7 @@
     "name": "PublishTestResults",
     "friendlyName": "Publish Test Results",
     "description": "Publish Test Results to VSTS/TFS",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613742",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613742)",
     "category": "Test",
     "visibility": [

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -3,6 +3,7 @@
     "name": "PublishTestResults",
     "friendlyName": "Publish Test Results",
     "description": "Publish Test Results to Azure Pipelines/TFS",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613742",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613742)",
     "category": "Test",
     "visibility": [

--- a/Tasks/PublishToAzureServiceBusV1/task.json
+++ b/Tasks/PublishToAzureServiceBusV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Publish To Azure Service Bus",
     "description": "Sends a message to azure service bus using a service connection (no agent required).",
     "category": "Utility",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870237",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870237)",
     "visibility": [
         "Build",

--- a/Tasks/PyPIPublisherV0/task.json
+++ b/Tasks/PyPIPublisherV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "PyPI Publisher",
     "description": "Create and upload an sdist or wheel to a PyPI-compatible index using Twine.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=875289",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=875289)",
     "category": "Package",
     "visibility": [

--- a/Tasks/PythonScriptV0/task.json
+++ b/Tasks/PythonScriptV0/task.json
@@ -3,6 +3,7 @@
     "name": "PythonScript",
     "friendlyName": "Python Script",
     "description": "Run a Python script.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=2006181",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?LinkID=2006181)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/QueryWorkItemsV0/task.json
+++ b/Tasks/QueryWorkItemsV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Query Work Items",
     "description": "Executes a work item query and checks for the number of items returned.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=870238",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870238)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/QuickPerfTestV1/task.json
+++ b/Tasks/QuickPerfTestV1/task.json
@@ -3,6 +3,7 @@
     "name": "QuickPerfTest",
     "friendlyName": "Cloud-based Web Performance Test",
     "description": "Runs a quick web performance test in the cloud with Azure Pipelines",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=613203",
     "helpMarkDown": "Triggers a cloud-based load test using Azure Pipelines. [Learn more](https://go.microsoft.com/fwlink/?linkid=613203)",
     "category": "Test",
     "visibility": [

--- a/Tasks/RunDistributedTestsV1/task.json
+++ b/Tasks/RunDistributedTestsV1/task.json
@@ -3,6 +3,7 @@
     "name": "RunVisualStudioTestsusingTestAgent",
     "friendlyName": "Run Functional Tests",
     "description": "Deprecated: This task and it’s companion task (Visual Studio Test Agent Deployment) are deprecated. Use the 'Visual Studio Test' task instead. The VSTest task can run unit as well as functional tests. Run tests on one or more agents using the multi-agent job setting. Use the 'Visual Studio Test Platform' task to run tests without needing Visual Studio on the agent. VSTest task also brings new capabilities such as automatically rerunning failed tests.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=624389",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?LinkId=624389)",
     "category": "Test",
     "visibility": [

--- a/Tasks/RunJMeterLoadTestV1/task.json
+++ b/Tasks/RunJMeterLoadTestV1/task.json
@@ -3,6 +3,7 @@
     "name": "ApacheJMeterLoadTest",
     "friendlyName": "Cloud-based Apache JMeter Load Test",
     "description": "Runs the Apache JMeter load test in cloud",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=784929",
     "helpMarkDown": "This task can be used to trigger an Apache JMeter load test in cloud using Azure Pipelines. [Learn more](https://go.microsoft.com/fwlink/?LinkId=784929)",
     "category": "Test",
     "visibility": [

--- a/Tasks/RunLoadTestV1/task.json
+++ b/Tasks/RunLoadTestV1/task.json
@@ -3,6 +3,7 @@
     "name": "CloudLoadTest",
     "friendlyName": "Cloud-based Load Test",
     "description": "Runs the load test in the cloud with Azure Pipelines",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=546976",
     "helpMarkDown": "This task triggers a cloud-based load test using Azure Pipelines. [Learn more](https://go.microsoft.com/fwlink/?linkid=546976)",
     "category": "Test",
     "visibility": [

--- a/Tasks/ServiceFabricComposeDeployV0/task.json
+++ b/Tasks/ServiceFabricComposeDeployV0/task.json
@@ -3,6 +3,7 @@
     "name": "ServiceFabricComposeDeploy",
     "friendlyName": "Service Fabric Compose Deploy",
     "description": "Deploy a docker-compose application to a Service Fabric cluster.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=847030",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=847030)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Service Fabric Application Deployment",
     "description": "Deploy a Service Fabric application to a cluster.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=820528",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=820528)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/ServiceFabricPowerShellV1/task.json
+++ b/Tasks/ServiceFabricPowerShellV1/task.json
@@ -3,6 +3,7 @@
     "name": "ServiceFabricPowerShell",
     "friendlyName": "Service Fabric PowerShell",
     "description": "Run a PowerShell script within the context of an Azure Service Fabric cluster connection.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=841538",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=841538)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/ServiceFabricUpdateManifestsV2/task.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Update Service Fabric Manifests",
     "description": "Automatically updates portions of the application and service manifests within a packaged Service Fabric application.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=820529",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=820529)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/ShellScriptV2/task.json
+++ b/Tasks/ShellScriptV2/task.json
@@ -3,6 +3,7 @@
     "name": "ShellScript",
     "friendlyName": "Shell Script",
     "description": "Run a shell script using bash",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613738",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613738)",
     "category": "Utility",
     "visibility": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -3,6 +3,7 @@
     "name": "SqlAzureDacpacDeployment",
     "friendlyName": "Azure SQL Database Deployment",
     "description": "Deploy Azure SQL DB using DACPAC or run scripts using SQLCMD",
+    "helpUrl": "https://aka.ms/sqlazuredeployreadme",
     "helpMarkDown": "[More Information](https://aka.ms/sqlazuredeployreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/SqlDacpacDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/SqlDacpacDeploymentOnMachineGroupV0/task.json
@@ -3,6 +3,7 @@
     "name": "SqlDacpacDeploymentOnMachineGroup",
     "friendlyName": "SQL Server Database Deploy",
     "description": "Deploy to SQL Server Database using DACPAC or SQL scripts",
+    "helpUrl": "https://aka.ms/sqldacpacmachinegroupreadme",
     "helpMarkDown": "[More Information](https://aka.ms/sqldacpacmachinegroupreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/SqlServerDacpacDeployment/task.json
+++ b/Tasks/SqlServerDacpacDeployment/task.json
@@ -3,6 +3,7 @@
     "name": "SqlServerDacpacDeployment",
     "friendlyName": "[Deprecated] SQL Server Database Deploy",
     "description": "Deploy SQL Server Database using DACPAC",
+    "helpUrl": "https://aka.ms/sqlserverdacpackdeprecatedreadme",
     "helpMarkDown": "[More Information](https://aka.ms/sqlserverdacpackdeprecatedreadme)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -3,6 +3,7 @@
     "name": "SSH",
     "friendlyName": "SSH",
     "description": "Run shell commands or a script on a remote machine using SSH",
+    "helpUrl": "http://go.microsoft.com/fwlink/?LinkId=821892",
     "helpMarkDown": "[More Information](http://go.microsoft.com/fwlink/?LinkId=821892)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Python Twine Upload Authenticate",
     "description": "Authentication for uploading python distributions using twine. Please add \"-r FeedName/EndpointName --config-file $(PYPIRC_PATH)\" to your twine upload command. For feeds present in this organization use feed name as repository(-r) otherwise use the endpoint name defined in the service connection.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://pypi.org/project/twine/",
     "helpMarkDown": "[More Information](https://pypi.org/project/twine/)",
     "category": "Package",
     "version": {

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -4,6 +4,7 @@
     "friendlyName": "Universal Packages",
     "description": "Download or publish Universal Packages.",
     "author": "Microsoft Corporation",
+    "helpUrl": "https://aka.ms/universalpackagesannounce",
     "helpMarkDown": "[More Information](https://aka.ms/universalpackagesannounce)",
     "category": "Package",
     "version": {

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -3,6 +3,7 @@
     "name": "UsePythonVersion",
     "friendlyName": "Use Python Version",
     "description": "Retrieves the specified version of Python from the tool cache. Optionally add it to PATH.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=871498",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=871498)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -3,6 +3,7 @@
     "name": "UseRubyVersion",
     "friendlyName": "Use Ruby Version",
     "description": "Retrieves the specified version of Ruby from the tool cache. Optionally add it to PATH.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=2005989",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=2005989)",
     "category": "Tool",
     "runsOn": [

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -3,6 +3,7 @@
     "name": "VSBuild",
     "friendlyName": "Visual Studio Build",
     "description": "Build with MSBuild and set the Visual Studio version property.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613727",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613727)",
     "category": "Build",
     "visibility": [

--- a/Tasks/VsTestPlatformToolInstallerV1/task.json
+++ b/Tasks/VsTestPlatformToolInstallerV1/task.json
@@ -3,7 +3,8 @@
     "name": "VisualStudioTestPlatformInstaller",
     "friendlyName": "Visual Studio Test Platform Installer",
     "description": "Acquires the test platform from nuget.org or the tools cache. Satisfies the ‘vstest’ demand and can be used for running tests and collecting diagnostic data using the Visual Studio Test task.",
-    "helpMarkDown": "<a href=\"https://www.nuget.org/packages/Microsoft.TestPlatform/\">Test platform package on NuGet</a>",
+    "helpUrl": "https://www.nuget.org/packages/Microsoft.TestPlatform/",
+    "helpMarkDown": "[Test platform package on NuGet](https://www.nuget.org/packages/Microsoft.TestPlatform/)",
     "category": "Tool",
     "runsOn": [
         "Agent",

--- a/Tasks/VsTestV1/task.json
+++ b/Tasks/VsTestV1/task.json
@@ -3,6 +3,7 @@
     "name": "VSTest",
     "friendlyName": "Visual Studio Test",
     "description": "Run tests with Visual Studio test runner",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=624539",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkId=624539)",
     "category": "Test",
     "visibility": [

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -3,6 +3,7 @@
     "name": "VSTest",
     "friendlyName": "Visual Studio Test",
     "description": "Run unit and functional tests (Selenium, Appium, Coded UI test, etc.) using the Visual Studio Test (VsTest) runner. Test frameworks that have a Visual Studio test adapter such as MsTest, xUnit, NUnit, Chutzpah (for JavaScript tests using QUnit, Mocha and Jasmine), etc. can be run. Tests can be distributed on multiple agents using this task (version 2).",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkId=835764",
     "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?LinkId=835764)",
     "category": "Test",
     "visibility": [

--- a/Tasks/WindowsMachineFileCopyV1/task.json
+++ b/Tasks/WindowsMachineFileCopyV1/task.json
@@ -3,6 +3,7 @@
     "name": "WindowsMachineFileCopy",
     "friendlyName": "Windows Machine File Copy",
     "description": "Copy files to remote machine(s)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=627415",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=627415)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/WindowsMachineFileCopyV2/task.json
+++ b/Tasks/WindowsMachineFileCopyV2/task.json
@@ -3,6 +3,7 @@
     "name": "WindowsMachineFileCopy",
     "friendlyName": "Windows Machine File Copy",
     "description": "Copy files to remote machine(s)",
+    "helpUrl": "https://go.microsoft.com/fwlink/?linkid=627415",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=627415)",
     "category": "Deploy",
     "visibility": [

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -3,6 +3,7 @@
     "name": "XamarinAndroid",
     "friendlyName": "Xamarin.Android",
     "description": "Build an Android app with Xamarin",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613728",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613728)",
     "category": "Build",
     "visibility": [

--- a/Tasks/XamarinTestCloudV1/task.json
+++ b/Tasks/XamarinTestCloudV1/task.json
@@ -2,7 +2,8 @@
     "id": "049918CB-1488-48EB-85E8-C318ECCAAA74",
     "name": "XamarinTestCloud",
     "friendlyName": "Xamarin Test Cloud",
-    "description": "[Depreciated] Testing mobile apps with Xamarin Test Cloud using Xamarin.UITest - recommended task is now AppCenterTest",
+    "description": "[Deprecated] Testing mobile apps with Xamarin Test Cloud using Xamarin.UITest - recommended task is now AppCenterTest",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613744",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613744)",
     "category": "Test",
     "visibility": [

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -3,6 +3,7 @@
     "name": "XamariniOS",
     "friendlyName": "Xamarin.iOS",
     "description": "Build an iOS app with Xamarin on macOS.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613729",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613729)",
     "category": "Build",
     "visibility": [

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -3,6 +3,7 @@
     "name": "Xcode",
     "friendlyName": "Xcode",
     "description": "Build, test, or archive an Xcode workspace on macOS. Optionally package an app.",
+    "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613730",
     "helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613730)",
     "category": "Build",
     "visibility": [


### PR DESCRIPTION
Nearly every task has a `helpMarkDown` property that looks like this, and the surrounding Markdown isn't very useful:

```json
"helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613718)",
```

@vtbassmatt, are you okay with me adding `helpURl` properties for raw help URLs to the tasks?  To date, the tasks only have them embedded in the `helpMarkDown` property.  They look pretty ugly when displayed in our logs unparsed.  It would be nicer to have the raw URLs that UIs can render however they'd like.

If you agree with this PR, then later I'd like to validate the URLs (some point to GitHub instead of our docs) and bump the tasks' patch version numbers.