### PR TITLE
Disabling Universal task on prem

### DIFF
--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/en-US/resources.resjson
@@ -80,5 +80,6 @@
   "loc.messages.FailedToGetArtifactTool": "Failed to get artifact tool from service. %s",
   "loc.messages.Error_UnexpectedErrorFailedToGetToolMetadata": "Failed to get artifact tool metadata from source url %s",
   "loc.messages.FailedToGetLatestPackageVersion": "Failed to get package versions",
-  "loc.messages.Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages"
+  "loc.messages.Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages",
+  "loc.messages.Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server."
 }

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -8,8 +8,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 145,
-        "Patch": 2
+        "Minor": 147,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",
@@ -433,6 +433,7 @@
         "FailedToGetArtifactTool": "Failed to get artifact tool from service. %s",
         "Error_UnexpectedErrorFailedToGetToolMetadata": "Failed to get artifact tool metadata from source url %s",
         "FailedToGetLatestPackageVersion": "Failed to get package versions",
-        "Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages"
+        "Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages",
+        "Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server."
     }
 }

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -8,8 +8,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 145,
-    "Patch": 2
+    "Minor": 147,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",
@@ -433,6 +433,7 @@
     "FailedToGetArtifactTool": "ms-resource:loc.messages.FailedToGetArtifactTool",
     "Error_UnexpectedErrorFailedToGetToolMetadata": "ms-resource:loc.messages.Error_UnexpectedErrorFailedToGetToolMetadata",
     "FailedToGetLatestPackageVersion": "ms-resource:loc.messages.FailedToGetLatestPackageVersion",
-    "Warn_CredentialsNotFound": "ms-resource:loc.messages.Warn_CredentialsNotFound"
+    "Warn_CredentialsNotFound": "ms-resource:loc.messages.Warn_CredentialsNotFound",
+    "Error_UniversalPackagesNotSupportedOnPrem": "ms-resource:loc.messages.Error_UniversalPackagesNotSupportedOnPrem"
   }
 }

--- a/Tasks/UniversalPackagesV0/universalmain.ts
+++ b/Tasks/UniversalPackagesV0/universalmain.ts
@@ -14,6 +14,11 @@ async function main(): Promise<void> {
     let artifactToolPath: string;
 
     try {
+        const serverType = tl.getVariable("System.ServerType");
+        if (!serverType || serverType.toLowerCase() !== "hosted"){
+            throw new Error(tl.loc("Error_UniversalPackagesNotSupportedOnPrem"));
+        }
+
         const localAccessToken = pkgLocationUtils.getSystemAccessToken();
         const serviceUri = tl.getEndpointUrl("SYSTEMVSSCONNECTION", false);
         const blobUri = await pkgLocationUtils.getBlobstoreUriFromBaseServiceUri(


### PR DESCRIPTION
Universal packages are not supported in Azure DevOps Server, which is why the Universal task fails in that environment. This provides a better error message to the user.