### PR TITLE
Add test run title option to DotNetCoreCLI task

### DIFF
--- a/Tasks/DotNetCoreCLIV2/README.md
+++ b/Tasks/DotNetCoreCLIV2/README.md
@@ -51,3 +51,4 @@ Options specific to **dotnet restore** command
 
 Options specific to **dotnet test** command
 * **Publish test results\*:** Enabling this option will generate a test results TRX file in $(Agent.TempDirectory) and results will be published to the server. This option appends --logger trx --results-directory $(Agent.TempDirectory) to the command line arguments.
+* **Test run title\*:** Provide a name for the test run.

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -112,6 +112,7 @@ export class dotNetExe {
     private async executeTestCommand(): Promise<void> {
         const dotnetPath = tl.which('dotnet', true);
         const enablePublishTestResults: boolean = tl.getBoolInput('publishTestResults', false) || false;
+        const testRunTitle: string = tl.getInput('testRunTitle', false) || '';
         const resultsDirectory = tl.getVariable('Agent.TempDirectory');
         if (enablePublishTestResults && enablePublishTestResults === true) {
             this.arguments = ` --logger trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
@@ -144,14 +145,14 @@ export class dotNetExe {
             }
         }
         if (enablePublishTestResults && enablePublishTestResults === true) {
-            this.publishTestResults(resultsDirectory);
+            this.publishTestResults(resultsDirectory, testRunTitle);
         }
         if (failedProjects.length > 0) {
             throw tl.loc('dotnetCommandFailed', failedProjects);
         }
     }
 
-    private publishTestResults(resultsDir: string): void {
+    private publishTestResults(resultsDir: string, testRunTitle: string): void {
         const buildConfig = tl.getVariable('BuildConfiguration');
         const buildPlaform = tl.getVariable('BuildPlatform');
         const matchingTestResultsFiles: string[] = tl.findMatch(resultsDir, '**/*.trx');
@@ -159,7 +160,7 @@ export class dotNetExe {
             tl.warning('No test result files were found.');
         } else {
             const tp: tl.TestPublisher = new tl.TestPublisher('VSTest');
-            tp.publish(matchingTestResultsFiles, 'false', buildPlaform, buildConfig, '', 'true', this.testRunSystem);
+            tp.publish(matchingTestResultsFiles, 'false', buildPlaform, buildConfig, testRunTitle, 'true', this.testRunSystem);
             //refer https://github.com/Microsoft/vsts-task-lib/blob/master/node/task.ts#L1620
         }
     }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -134,6 +134,15 @@
             "helpMarkDown": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect “Code coverage”` option to the command line arguments. This is currently only available on the Windows platform."
         },
         {
+            "name": "testRunTitle",
+            "type": "string",
+            "label": "Test run title",
+            "defaultValue": "",
+            "visibleRule": "command = test",
+            "required": false,
+            "helpMarkDown": "Provide a name for the test run."
+        },
+        {
             "name": "zipAfterPublish",
             "type": "boolean",
             "visibleRule": "command = publish",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -133,6 +133,15 @@
       "helpMarkDown": "ms-resource:loc.input.help.publishTestResults"
     },
     {
+      "name": "testRunTitle",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.testRunTitle",
+      "defaultValue": "",
+      "visibleRule": "command = test",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.testRunTitle"
+  },
+    {
       "name": "zipAfterPublish",
       "type": "boolean",
       "visibleRule": "command = publish",


### PR DESCRIPTION
Add a new option to specify the test run title in the DotNetCoreCLI task when the command is `test`. Currently any published test results get the default name of 'VSTest Test Run'.

The PublishTestResults task(s) already support specifying the test run title, so this is just ensuring parity.