### PR TITLE
XamarinAndroidV1: don't clean multiple times

### DIFF
--- a/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
+++ b/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
@@ -29,9 +29,6 @@ try {
 
     # Format the MSBuild args.
     $msBuildArguments = Format-MSBuildArguments -MSBuildArguments $msbuildArguments -Configuration $configuration
-    if($clean) {
-        $msBuildArguments = "$msBuildArguments /t:clean"
-    }
     if($target) {
         $msBuildArguments = "$msBuildArguments /t:$target"
     }
@@ -64,7 +61,7 @@ try {
     $msbuildLocation = Select-MSBuildPath -Method $msbuildLocationMethod -Location $msbuildLocation -PreferredVersion $msbuildVersion -Architecture $msbuildArchitecture
 
     # build each project file
-    Invoke-BuildTools -SolutionFiles $projectFiles -MSBuildLocation $msbuildLocation -MSBuildArguments $msBuildArguments
+    Invoke-BuildTools -SolutionFiles $projectFiles -MSBuildLocation $msbuildLocation -MSBuildArguments $msBuildArguments -Clean:$clean
 } finally {
      Trace-VstsLeavingInvocation $MyInvocation
 }

--- a/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
+++ b/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
@@ -64,7 +64,7 @@ try {
     $msbuildLocation = Select-MSBuildPath -Method $msbuildLocationMethod -Location $msbuildLocation -PreferredVersion $msbuildVersion -Architecture $msbuildArchitecture
 
     # build each project file
-    Invoke-BuildTools -SolutionFiles $projectFiles -MSBuildLocation $msbuildLocation -MSBuildArguments $msBuildArguments -Clean:$clean
+    Invoke-BuildTools -SolutionFiles $projectFiles -MSBuildLocation $msbuildLocation -MSBuildArguments $msBuildArguments
 } finally {
      Trace-VstsLeavingInvocation $MyInvocation
 }

--- a/Tasks/XamarinAndroidV1/package-lock.json
+++ b/Tasks/XamarinAndroidV1/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.118.tgz",
       "integrity": "sha512-N33cKXGSqhOYaPiT4xUGsYlPPDwFtQM/6QxJxuMXA/7BcySW+lkn2yigWP7vfs4daiL/7NJNU6DMCqg5N4B+xQ=="
     },
+    "@types/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -61,6 +66,11 @@
         "vsts-task-lib": "1.1.0"
       },
       "dependencies": {
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        },
         "vsts-task-lib": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-1.1.0.tgz",
@@ -96,11 +106,6 @@
       "requires": {
         "vsts-task-lib": "2.2.1"
       }
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "once": {
       "version": "1.4.0",

--- a/Tasks/XamarinAndroidV1/package.json
+++ b/Tasks/XamarinAndroidV1/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/microsoft/vsts-tasks#readme",
   "dependencies": {
     "@types/node": "^6.0.101",
+    "@types/q": "^1.5.1",
     "java-common": "file:../../_build/Tasks/Common/java-common-1.0.0.tgz",
     "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz",
     "vsts-task-lib": "^2.0.3-preview"

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 143,
-        "Patch": 1
+        "Minor": 147,
+        "Patch": 0
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -3,6 +3,7 @@
   "name": "XamarinAndroid",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "https://go.microsoft.com/fwlink/?LinkID=613728",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
   "visibility": [
@@ -11,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 143,
+    "Minor": 147,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamarinAndroidV1/tsconfig.json
+++ b/Tasks/XamarinAndroidV1/tsconfig.json
@@ -1,6 +1,10 @@
 {
     "compilerOptions": {
         "target": "ES6",
-        "module": "commonjs"
+        "module": "commonjs",
+        "alwaysStrict": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true
     }
 }

--- a/Tasks/XamarinAndroidV1/tsconfig.json
+++ b/Tasks/XamarinAndroidV1/tsconfig.json
@@ -2,9 +2,6 @@
     "compilerOptions": {
         "target": "ES6",
         "module": "commonjs",
-        "alwaysStrict": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true
+        "strict": true
     }
 }

--- a/Tasks/XamarinAndroidV1/xamarinandroid.ts
+++ b/Tasks/XamarinAndroidV1/xamarinandroid.ts
@@ -9,24 +9,24 @@ async function run() {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
         //read inputs
-        const project: string = tl.getPathInput('project', true);
-        const target: string = tl.getInput('target');
-        const outputDir: string = tl.getInput('outputDir');
-        const configuration: string = tl.getInput('configuration');
-        const createAppPackage: boolean = tl.getBoolInput('createAppPackage');
-        const clean: boolean = tl.getBoolInput('clean');
-        const msbuildArguments: string = tl.getInput('msbuildArguments');
+        const project: string | null = tl.getPathInput('project', true);
+        const target: string | null = tl.getInput('target');
+        const outputDir: string | null = tl.getInput('outputDir');
+        const configuration: string | null = tl.getInput('configuration');
+        const createAppPackage: boolean | null = tl.getBoolInput('createAppPackage');
+        const clean: boolean | null = tl.getBoolInput('clean');
+        const msbuildArguments: string| null = tl.getInput('msbuildArguments');
 
         // find jdk to be used during the build
         const jdkSelection: string = tl.getInput('jdkSelection') || 'JDKVersion'; // fall back to JDKVersion for older version of tasks
 
-        let specifiedJavaHome: string | null = null;
+        let specifiedJavaHome: string | null | undefined = null;
         let javaTelemetryData: { jdkVersion: string } | null = null;
 
         if (jdkSelection === 'JDKVersion') {
             tl.debug('Using JDK version to find JDK path');
-            const jdkVersion: string = tl.getInput('jdkVersion');
-            const jdkArchitecture: string = tl.getInput('jdkArchitecture');
+            const jdkVersion: string | null = tl.getInput('jdkVersion');
+            const jdkArchitecture: string | null = tl.getInput('jdkArchitecture');
             javaTelemetryData = { jdkVersion };
 
             if (jdkVersion !== 'default') {
@@ -44,7 +44,7 @@ async function run() {
 
         const buildLocationMethod: string = tl.getInput('msbuildLocationMethod') || 'version';
 
-        const buildToolLocation: string = tl.getPathInput('msbuildLocation');
+        const buildToolLocation: string | null = tl.getPathInput('msbuildLocation');
         if (buildToolLocation) {
             // msbuildLocation was specified, use it for back compat
             if (buildToolLocation.endsWith('xbuild') || buildToolLocation.endsWith('msbuild')) {
@@ -66,7 +66,7 @@ async function run() {
         tl.debug('Build tool path = ' + buildToolPath);
 
         // Resolve files for the specified value or pattern
-        const filesList: string[] = tl.findMatch(null, project, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false });
+        const filesList: string[] = tl.findMatch('', project, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false });
 
         // Fail if no matching .csproj files were found
         if (!filesList || filesList.length === 0) {

--- a/Tasks/XamarinAndroidV1/xamarinandroid.ts
+++ b/Tasks/XamarinAndroidV1/xamarinandroid.ts
@@ -1,57 +1,50 @@
-import path = require('path');
-import tl = require('vsts-task-lib/task');
+import * as path from 'path';
+import * as tl from 'vsts-task-lib/task';
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
-import msbuildHelpers = require('msbuildhelpers/msbuildhelpers');
-import javacommons = require('java-common/java-common');
+import * as msbuildHelpers from 'msbuildhelpers/msbuildhelpers';
+import * as javacommons from 'java-common/java-common';
 
 async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
         //read inputs
-        let project: string = tl.getPathInput('project', true);
-        let target: string = tl.getInput('target');
-        let outputDir: string = tl.getInput('outputDir');
-        let configuration: string = tl.getInput('configuration');
-        let createAppPackage: boolean = tl.getBoolInput('createAppPackage');
-        let clean: boolean = tl.getBoolInput('clean');
-        let msbuildArguments: string = tl.getInput('msbuildArguments');
+        const project: string = tl.getPathInput('project', true);
+        const target: string = tl.getInput('target');
+        const outputDir: string = tl.getInput('outputDir');
+        const configuration: string = tl.getInput('configuration');
+        const createAppPackage: boolean = tl.getBoolInput('createAppPackage');
+        const clean: boolean = tl.getBoolInput('clean');
+        const msbuildArguments: string = tl.getInput('msbuildArguments');
 
         // find jdk to be used during the build
-        let jdkSelection: string = tl.getInput('jdkSelection');
-        if (!jdkSelection) {
-            jdkSelection = 'JDKVersion'; //fallback to JDKVersion for older version of tasks
-        }
-        let specifiedJavaHome = null;
-        let javaTelemetryData = null;
+        const jdkSelection: string = tl.getInput('jdkSelection') || 'JDKVersion'; // fall back to JDKVersion for older version of tasks
+
+        let specifiedJavaHome: string | null = null;
+        let javaTelemetryData: { jdkVersion: string } | null = null;
 
         if (jdkSelection === 'JDKVersion') {
             tl.debug('Using JDK version to find JDK path');
-            let jdkVersion: string = tl.getInput('jdkVersion');
-            let jdkArchitecture: string = tl.getInput('jdkArchitecture');
-            javaTelemetryData = { "jdkVersion": jdkVersion };
+            const jdkVersion: string = tl.getInput('jdkVersion');
+            const jdkArchitecture: string = tl.getInput('jdkArchitecture');
+            javaTelemetryData = { jdkVersion };
 
             if (jdkVersion !== 'default') {
                 specifiedJavaHome = javacommons.findJavaHome(jdkVersion, jdkArchitecture);
             }
-        }
-        else {
+        } else {
             tl.debug('Using path from user input to find JDK');
-            let jdkUserInputPath: string = tl.getPathInput('jdkUserInputPath', true, true);
-            specifiedJavaHome = jdkUserInputPath;
-            javaTelemetryData = { "jdkVersion": "custom" };
+            specifiedJavaHome = tl.getPathInput('jdkUserInputPath', true, true);
+            javaTelemetryData = { jdkVersion: "custom" };
         }
         javacommons.publishJavaTelemetry('XamarinAndroid', javaTelemetryData);
 
         //find build tool path to use
-        let buildToolPath: string;
+        let buildToolPath: string | undefined;
 
-        let buildLocationMethod: string = tl.getInput('msbuildLocationMethod');
-        if (!buildLocationMethod) {
-            buildLocationMethod = 'version';
-        }
+        const buildLocationMethod: string = tl.getInput('msbuildLocationMethod') || 'version';
 
-        let buildToolLocation: string = tl.getPathInput('msbuildLocation');
+        const buildToolLocation: string = tl.getPathInput('msbuildLocation');
         if (buildToolLocation) {
             // msbuildLocation was specified, use it for back compat
             if (buildToolLocation.endsWith('xbuild') || buildToolLocation.endsWith('msbuild')) {
@@ -63,7 +56,7 @@ async function run() {
             tl.checkPath(buildToolPath, 'build tool');
         } else if (buildLocationMethod === 'version') {
             // msbuildLocation was not specified, look up by version
-            let msbuildVersion: string = tl.getInput('msbuildVersion');
+            const msbuildVersion: string = tl.getInput('msbuildVersion');
             buildToolPath = await msbuildHelpers.getMSBuildPath(msbuildVersion);
         }
 
@@ -73,17 +66,17 @@ async function run() {
         tl.debug('Build tool path = ' + buildToolPath);
 
         // Resolve files for the specified value or pattern
-        let filesList: string[] = tl.findMatch(null, project, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false });
+        const filesList: string[] = tl.findMatch(null, project, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false });
 
         // Fail if no matching .csproj files were found
         if (!filesList || filesList.length === 0) {
             throw tl.loc('NoMatchingProjects', project);
         }
 
-        for (let file of filesList) {
+        for (const file of filesList) {
             try {
                 // run the build for each matching project
-                let buildRunner: ToolRunner = tl.tool(buildToolPath);
+                const buildRunner: ToolRunner = tl.tool(buildToolPath);
                 buildRunner.arg(file);
                 buildRunner.argIf(clean, '/t:Clean');
                 buildRunner.argIf(target, '/t:' + target);
@@ -101,13 +94,9 @@ async function run() {
             }
             tl.setResult(tl.TaskResult.Succeeded, tl.loc('XamarinAndroidSucceeded'));
         }
-
     } catch (err) {
         tl.setResult(tl.TaskResult.Failed, err);
     }
 }
 
 run();
-
-
-


### PR DESCRIPTION
See https://developercommunity.visualstudio.com/content/problem/431495/xamarinandroid-task-cleantrue-executes-twice.html

The call to `Invoke-BuildTools` already has a switch to add the clean target, so we don't need to add it manually.

Adding some stricter checks to the TypeScript task while we are bumping the version.

**Testing**
* Ran a pipeline with and without the changes.

Before:
`Project "D:\a\1\s\App1\App1\App1.Droid\App1.Droid.csproj" on node 1 (Clean;clean;PackageForAndroid target(s)).`

After:
`Project "D:\a\1\s\App1\App1\App1.Droid\App1.Droid.csproj" on node 1 (Clean;PackageForAndroid target(s)).`

