### PR TITLE
Fix Failing Catch Block

### DIFF
--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -15,13 +15,9 @@ export async function run(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug('Unable to get packaging URIs, using default collection URI');
+        tl.debug('Unable to get packaging URIs');
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable('System.TeamFoundationCollectionUri');
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl
-        };
+        throw new Error(error);
     }
 
     const buildIdentityDisplayName: string = null;

--- a/Tasks/DotNetCoreCLIV2/restorecommand.ts
+++ b/Tasks/DotNetCoreCLIV2/restorecommand.ts
@@ -15,13 +15,9 @@ export async function run(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug('Unable to get packaging URIs, using default collection URI');
+        tl.debug('Unable to get packaging URIs');
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable('System.TeamFoundationCollectionUri');
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl
-        };
+        throw new Error(error);
     }
 
     const buildIdentityDisplayName: string = null;

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 147,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/MavenV2/mavenutil.ts
+++ b/Tasks/MavenV2/mavenutil.ts
@@ -199,12 +199,9 @@ async function collectFeedRepositories(pomContents:string): Promise<any> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.Maven);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl
-        };
+        throw new Error(error);
     }
 
     let packageUrl = packagingLocation.DefaultPackagingUri;

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 143,
-        "Patch": 3
+        "Minor": 147,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/mavenutil.ts
+++ b/Tasks/MavenV3/mavenutil.ts
@@ -199,11 +199,9 @@ async function collectFeedRepositories(pomContents:string): Promise<any> {
         try {
             packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.Maven);
         } catch (error) {
-            tl.debug("Unable to get packaging URIs, using default collection URI");
+            tl.debug("Unable to get packaging URIs");
             tl.debug(JSON.stringify(error));
-            packagingLocation = {
-                PackagingUris: [collectionUrl],
-                DefaultPackagingUri: collectionUrl};
+            throw new Error(error);
         }
 
         let packageUrl = packagingLocation.DefaultPackagingUri;

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 143,
-        "Patch": 3
+        "Minor": 147,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/NpmAuthenticateV0/npmauth.ts
+++ b/Tasks/NpmAuthenticateV0/npmauth.ts
@@ -71,13 +71,9 @@ async function main(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.Npm);
     } catch (error) {
-        tl.debug('Unable to get packaging URIs, using default collection URI');
+        tl.debug('Unable to get packaging URIs');
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable('System.TeamFoundationCollectionUri');
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl
-        };
+        throw new Error(error);
     }
     let LocalNpmRegistries = await npmutil.getLocalNpmRegistries(workingDirectory, packagingLocation.PackagingUris);
     

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 147,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV0/npmtask.ts
+++ b/Tasks/NpmV0/npmtask.ts
@@ -198,12 +198,9 @@ async function addBuildCredProviderEnv(env: EnvironmentDictionary) : Promise<Env
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.Npm);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     var urlPrefixes : string[] = packagingLocation.PackagingUris;

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 2,
-        "Patch": 26
+        "Minor": 147,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV1/npm.ts
+++ b/Tasks/NpmV1/npm.ts
@@ -17,13 +17,9 @@ async function main(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.Npm);
     } catch (error) {
-        tl.debug('Unable to get packaging URIs, using default collection URI');
+        tl.debug('Unable to get packaging URIs');
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable('System.TeamFoundationCollectionUri');
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl
-        };
+        throw new Error(error);
     }
     const forcedUrl = tl.getVariable('Npm.PackagingCollectionUrl');
     if (forcedUrl) {

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 147,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/nugetcustom.ts
+++ b/Tasks/NuGetCommandV2/nugetcustom.ts
@@ -22,12 +22,9 @@ export async function run(nuGetPath: string): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     nutil.setConsoleCodePage();

--- a/Tasks/NuGetCommandV2/nugetpublisher.ts
+++ b/Tasks/NuGetCommandV2/nugetpublisher.ts
@@ -39,12 +39,9 @@ export async function run(nuGetPath: string): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     const buildIdentityDisplayName: string = null;

--- a/Tasks/NuGetCommandV2/nugetrestore.ts
+++ b/Tasks/NuGetCommandV2/nugetrestore.ts
@@ -31,12 +31,9 @@ export async function run(nuGetPath: string): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     const buildIdentityDisplayName: string = null;

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 147,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetInstallerV0/nugetinstaller.ts
+++ b/Tasks/NuGetInstallerV0/nugetinstaller.ts
@@ -28,12 +28,9 @@ async function main(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     let buildIdentityDisplayName: string = null;

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 146,
+        "Minor": 147,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetPublisherV0/nugetpublisher.ts
+++ b/Tasks/NuGetPublisherV0/nugetpublisher.ts
@@ -27,12 +27,9 @@ async function main(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     let buildIdentityDisplayName: string = null;

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,8 +9,8 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
-        "Minor": 145,
-        "Patch": 1
+        "Minor": 147,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetRestoreV1/nugetinstaller.ts
+++ b/Tasks/NuGetRestoreV1/nugetinstaller.ts
@@ -33,12 +33,9 @@ async function main(): Promise<void> {
         tl.debug("getting the uris");
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
     tl.debug("got the uris");
     let buildIdentityDisplayName: string = null;

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 8
+        "Minor": 147,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/nuget.ts
+++ b/Tasks/NuGetV0/nuget.ts
@@ -22,12 +22,9 @@ async function main(): Promise<void> {
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
     } catch (error) {
-        tl.debug("Unable to get packaging URIs, using default collection URI");
+        tl.debug("Unable to get packaging URIs");
         tl.debug(JSON.stringify(error));
-        const collectionUrl = tl.getVariable("System.TeamFoundationCollectionUri");
-        packagingLocation = {
-            PackagingUris: [collectionUrl],
-            DefaultPackagingUri: collectionUrl};
+        throw new Error(error);
     }
 
     tl.setResourcePath(path.join(__dirname, "task.json"));

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,7 +10,7 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-        "Minor": 145,
+        "Minor": 147,
         "Patch": 0
     },
     "runsOn": [


### PR DESCRIPTION
Catch block would always result in error. Removed this call which was causing an obfuscating error and simply rethrowing the original.