### PR TITLE
Build tasks affected by common changes

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -152,6 +152,7 @@ var getTasksToBuildForPR = function() {
     changedTasks.forEach(task => {
         if (!toBeBuilt.includes(task)) {
             shouldBeBumped.push(task);
+            toBeBuilt.push(task);
         }
     });
     // TODO: Add this back once diffing is working 100%


### PR DESCRIPTION
This won't be necessary once TODO is removed (should be soon), good to have for now.