### PR TITLE
Start to enforce rule: changes to common => version bump in associated tasks

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -156,7 +156,9 @@ var getTasksToBuildForPR = function() {
         }
     });
     if (shouldBeBumped.length > 0) {
-        throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
+        // TODO - change this to an error once its proven to be working.
+        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped, err);
+        // throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
     }
 
     return toBeBuilt;

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -155,10 +155,10 @@ var getTasksToBuildForPR = function() {
             toBeBuilt.push(task);
         }
     });
-    // TODO: Add this back once diffing is working 100%
-//     if (shouldBeBumped.length > 0) {
-//         throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
-//     }
+    if (shouldBeBumped.length > 0) {
+        throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
+    }
+
     return toBeBuilt;
 }
 

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -157,7 +157,7 @@ var getTasksToBuildForPR = function() {
     });
     if (shouldBeBumped.length > 0) {
         // TODO - change this to an error once its proven to be working.
-        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped, err);
+        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common: ', shouldBeBumped);
         // throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
     }
 

--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -157,7 +157,7 @@ var getTasksToBuildForPR = function() {
     });
     if (shouldBeBumped.length > 0) {
         // TODO - change this to an error once its proven to be working.
-        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common: ', shouldBeBumped);
+        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common:', shouldBeBumped);
         // throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
     }
 


### PR DESCRIPTION
This was commented out while we were letting everything else settle, might be time to add it back in. I think starting out as a warning is a safer rollout then just immediately erroring.