### PR TITLE
bump up artifact-engine version in tasks

### DIFF
--- a/Tasks/DownloadFileshareArtifactsV0/package.json
+++ b/Tasks/DownloadFileshareArtifactsV0/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "vsts-task-lib": "2.1.0",
-    "artifact-engine": "0.1.24",
+    "artifact-engine": "0.1.26",
     "@types/node": "^6.0.101"
   }
 }

--- a/Tasks/DownloadFileshareArtifactsV0/task.json
+++ b/Tasks/DownloadFileshareArtifactsV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 141,
-        "Patch": 3
+        "Minor": 147,
+        "Patch": 0
     },
     "groups": [
         {

--- a/Tasks/DownloadFileshareArtifactsV0/task.loc.json
+++ b/Tasks/DownloadFileshareArtifactsV0/task.loc.json
@@ -3,13 +3,14 @@
   "name": "DownloadFileshareArtifacts",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Utility",
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 141,
-    "Patch": 2
+    "Minor": 147,
+    "Patch": 0
   },
   "groups": [
     {

--- a/Tasks/DownloadGitHubReleasesV0/package.json
+++ b/Tasks/DownloadGitHubReleasesV0/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "artifact-engine": "0.1.24",
+    "artifact-engine": "0.1.26",
     "vso-node-api": "^6.2.8-preview",
     "vsts-task-lib": "2.2.1",
     "@types/node": "^6.0.101",

--- a/Tasks/DownloadGitHubReleasesV0/task.json
+++ b/Tasks/DownloadGitHubReleasesV0/task.json
@@ -10,7 +10,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 146,
+    "Minor": 147,
     "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadGitHubReleasesV0/task.loc.json
+++ b/Tasks/DownloadGitHubReleasesV0/task.loc.json
@@ -10,7 +10,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 146,
+    "Minor": 147,
     "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/JenkinsDownloadArtifactsV1/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package.json
@@ -8,7 +8,7 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "artifact-engine": "0.1.24",
+    "artifact-engine": "0.1.26",
     "azure-arm-rest": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
     "azure-blobstorage-artifactProvider": "file:../../_build/Tasks/Common/azure-blobstorage-artifactProvider-1.0.0.tgz",
     "decompress-zip": "0.3.0",

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -3,6 +3,7 @@
   "name": "JenkinsDownloadArtifacts",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
+  "helpUrl": "",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Utility",
   "visibility": [


### PR DESCRIPTION
Bump up artifact-engine version from 0.1.24 to 0.1.26 in following tasks:

- DownloadFileshareArtifactsV0

- DownloadGitHubReleasesV0

- JenkinsDownloadArtifactsV1