### PR TITLE
Fix #6916 - fix for Publish Symbols failing in Release

### DIFF
--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -223,7 +223,11 @@ try {
         [string] $encodedRequestName = [System.Web.HttpUtility]::UrlEncode($RequestName)
         # Use hash prefix for now to be compatible with older/current agents, RequestType is still different (than SymbolStore)
         [string] $requestUrl = "#$SymbolServiceUri/_apis/Symbol/requests?requestName=$encodedRequestName"
-        Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
+
+        # Associating server artifact is not supported in Release.
+        if (-not $env:RELEASE_RELEASENAME) {
+            Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
+        }
 
         & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
 


### PR DESCRIPTION
The Publish Symbols task always fails when used from Release with this error:

> Associating server artifact is not supported in Release.

This skips the step that attempts to associate an artifact.

/cc @sprendermsft @arunkm
