### PR TITLE
Updated RunJMeterLoadTestV1 to fail on JMeter assertion

### DIFF
--- a/Tasks/RunJMeterLoadTestV1/CltTasksUtility.ps1
+++ b/Tasks/RunJMeterLoadTestV1/CltTasksUtility.ps1
@@ -349,14 +349,14 @@ function CheckTestErrors($headers, $run, $CltAccountUrl, $MonitorThresholds)
     $thresholdExceeded = $false
     if ($MonitorThresholds)
     {
-        $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?type=ThresholdMessage&detailed=True&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
+        $uri = [String]::Format("{0}/_apis/clt/testruns/{1}/errors?type=Exception&detailed=True&{2}", $CltAccountUrl, $run.id, $global:apiVersion)
         $errors = InvokeRestMethod -contentType "application/json" -uri $uri -headers $headers
 
         if ($errors -and $errors.count -gt 0 -and  $errors.types.count -gt 0)
         {
             foreach ($subType in $errors.types.subTypes)
             {
-                if ($subType.subTypeName -eq 'Critical' -and $subType.occurrences -gt $ThresholdLimit)
+                if ($subType.subTypeName -eq 'WebException' -and $subType.occurrences -gt $ThresholdLimit)
                 {
                     $thresholdExceeded = $true
                     return $true;

--- a/Tasks/RunJMeterLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/RunJMeterLoadTestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -15,5 +15,7 @@
   "loc.input.help.runDuration": "Load test run duration in seconds.",
   "loc.input.label.geoLocation": "Load Location",
   "loc.input.help.geoLocation": "Geographical region to generate the load from.",
-  "loc.input.label.machineType": "Run load test using"
+  "loc.input.label.machineType": "Run load test using",
+  "loc.input.label.ThresholdLimit": "Number of permissible threshold violations",
+  "loc.input.help.ThresholdLimit": "Number of threshold violations above which the load test outcome is considered unsuccessful. A violation occurs when a JMeter assertion fails or a sample is marked as failed."
 }

--- a/Tasks/RunJMeterLoadTestV1/task.json
+++ b/Tasks/RunJMeterLoadTestV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 28
+        "Minor": 1,
+        "Patch": 0
     },
     "demands": [
         "azureps"
@@ -79,6 +79,13 @@
             "properties": {
                 "EditableOptions": "True"
             }
+        },
+        {
+            "name": "ThresholdLimit",
+            "type": "string",
+            "label": "Number of permissible threshold violations.",
+            "required": false,
+            "helpMarkDown": "Number of threshold violations above which the load test outcome is considered unsuccessful. A violation occurs when a JMeter assertion fails or a sample is marked as failed."
         },
         {
             "name": "geoLocation",

--- a/Tasks/RunJMeterLoadTestV1/task.loc.json
+++ b/Tasks/RunJMeterLoadTestV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 28
+    "Minor": 1,
+    "Patch": 0
   },
   "demands": [
     "azureps"
@@ -78,6 +78,13 @@
       "properties": {
         "EditableOptions": "True"
       }
+    },
+    {
+      "name": "ThresholdLimit",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.ThresholdLimit",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.ThresholdLimit"
     },
     {
       "name": "geoLocation",


### PR DESCRIPTION
Fixes #9423.

Adds an error threshold for errors triggered by beanshell scripts/assertions after which the build task will fail, marking the build as a failure. If unset, the build task will continue to run as it previously did.

Before (or after if threshold is not set):
![image](https://user-images.githubusercontent.com/5691564/51761855-03ea4480-2083-11e9-894a-2db88cbf578b.png)

After (with threshold set):
![image](https://user-images.githubusercontent.com/5691564/51761873-13698d80-2083-11e9-9b84-4bc593e2a622.png)
