### PR TITLE
Update ssh2 package & Ignore disconnection failures

### DIFF
--- a/Tasks/CopyFilesOverSSHV0/copyfilesoverssh.ts
+++ b/Tasks/CopyFilesOverSSHV0/copyfilesoverssh.ts
@@ -6,7 +6,7 @@ import { SshHelper } from './sshhelper';
 // This method will find the list of matching files for the specified contents
 // This logic is the same as the one used by CopyFiles task except for allowing dot folders to be copied
 // This will be useful to put in the task-lib
-function getFilesToCopy(sourceFolder, contents: string[]): string[] {
+function getFilesToCopy(sourceFolder: string, contents: string[]): string[] {
     // include filter
     const includeContents: string[] = [];
     // exclude filter

--- a/Tasks/CopyFilesOverSSHV0/package-lock.json
+++ b/Tasks/CopyFilesOverSSHV0/package-lock.json
@@ -19,6 +19,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -83,7 +91,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -160,20 +168,20 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "ssh2": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.5.tgz",
-      "integrity": "sha1-x3gezS7OcwSiU89iD6taXCK7IjU=",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.2.tgz",
+      "integrity": "sha512-oaXu7faddvPFGavnLBkk0RFwLXvIzCPq6KqAC3ExlnFPAVIE1uo7pWHe9xmhNHXm+nIe7yg9qsssOm+ip2jijw==",
       "requires": {
-        "ssh2-streams": "0.1.20"
+        "ssh2-streams": "0.4.2"
       },
       "dependencies": {
         "ssh2-streams": {
-          "version": "0.1.20",
-          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
-          "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.2.tgz",
+          "integrity": "sha512-2rSj3oTIJnbAIzR3+XwIYef9wCOVrPQZNLL+fFPPjnPxf09tKkAbgrlYgh/1qynBTz65AUOS+s1zuko4M/GKCw==",
           "requires": {
             "asn1": "0.2.3",
-            "semver": "5.5.0",
+            "bcrypt-pbkdf": "1.0.2",
             "streamsearch": "0.1.2"
           }
         }
@@ -198,6 +206,11 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "vso-node-api": {
       "version": "0.6.1",

--- a/Tasks/CopyFilesOverSSHV0/package.json
+++ b/Tasks/CopyFilesOverSSHV0/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft.com/vsts-tasks#readme",
   "dependencies": {
     "scp2": "^0.5.0",
-    "ssh2": "^0.5.0",
+    "ssh2": "^0.8.2",
     "vsts-task-lib": "^0.9.20"
   }
 }

--- a/Tasks/CopyFilesOverSSHV0/sshhelper.ts
+++ b/Tasks/CopyFilesOverSSHV0/sshhelper.ts
@@ -29,10 +29,10 @@ export class SshHelper {
     }
 
     private async setupSshClientConnection() : Promise<void> {
-        let defer = Q.defer<void>();
+        const defer = Q.defer<void>();
         this.sshClient = new Ssh2Client();
         this.sshClient.once('ready', () => {
-            defer.resolve(null);
+            defer.resolve();
         }).once('error', (err) => {
             defer.reject(tl.loc('ConnectionFailed', err));
         }).connect(this.sshConfig);
@@ -40,7 +40,7 @@ export class SshHelper {
     }
 
     private async setupScpConnection() : Promise<void> {
-        let defer = Q.defer<void>();
+        const defer = Q.defer<void>();
         this.scpClient = new Scp2Client();
         this.scpClient.defaults(this.sshConfig);
         this.scpClient.sftp((err, sftp) => {
@@ -48,7 +48,7 @@ export class SshHelper {
                 defer.reject(tl.loc('ConnectionFailed', err));
             } else {
                 this.sftpClient = sftp;
-                defer.resolve(null);
+                defer.resolve();
             }
         })
         await defer.promise;
@@ -74,7 +74,7 @@ export class SshHelper {
         try {
             if (this.sftpClient) {
                 this.sftpClient.on('error', (err) => {
-                    tl.debug('sftpClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                    tl.debug('sftpClient: Ignoring error diconnecting: ' + err);
                 }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.sftpClient.close();
                 this.sftpClient = null;
@@ -85,7 +85,7 @@ export class SshHelper {
         try {
             if (this.sshClient) {
                 this.sshClient.on('error', (err) => {
-                    tl.debug('sshClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                    tl.debug('sshClient: Ignoring error diconnecting: ' + err);
                 }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.sshClient.end();
                 this.sshClient = null;
@@ -97,7 +97,7 @@ export class SshHelper {
         try {
             if (this.scpClient) {
                 this.scpClient.on('error', (err) => {
-                    tl.debug('scpClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                    tl.debug('scpClient: Ignoring error diconnecting: ' + err);
                 }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.scpClient.close();
                 this.scpClient = null;

--- a/Tasks/CopyFilesOverSSHV0/sshhelper.ts
+++ b/Tasks/CopyFilesOverSSHV0/sshhelper.ts
@@ -28,19 +28,19 @@ export class SshHelper {
         this.sshConfig = sshConfig;
     }
 
-    private setupSshClientConnection() : Q.Promise<void> {
-        var defer = Q.defer<void>();
+    private async setupSshClientConnection() : Promise<void> {
+        let defer = Q.defer<void>();
         this.sshClient = new Ssh2Client();
-        this.sshClient.on('ready', () => {
+        this.sshClient.once('ready', () => {
             defer.resolve(null);
-        }).on('error', (err) => {
+        }).once('error', (err) => {
             defer.reject(tl.loc('ConnectionFailed', err));
         }).connect(this.sshConfig);
-        return defer.promise;
+        await defer.promise;
     }
 
-    private setupScpConnection() : Q.Promise<void> {
-        var defer = Q.defer<void>();
+    private async setupScpConnection() : Promise<void> {
+        let defer = Q.defer<void>();
         this.scpClient = new Scp2Client();
         this.scpClient.defaults(this.sshConfig);
         this.scpClient.sftp((err, sftp) => {
@@ -51,7 +51,7 @@ export class SshHelper {
                 defer.resolve(null);
             }
         })
-        return defer.promise;
+        await defer.promise;
     }
 
     /**
@@ -63,7 +63,7 @@ export class SshHelper {
             await this.setupSshClientConnection();
             await this.setupScpConnection();
         } catch(err) {
-            throw tl.loc('ConnectionFailed', err);
+            throw new Error(tl.loc('ConnectionFailed', err));
         }
     }
 
@@ -73,6 +73,9 @@ export class SshHelper {
     closeConnection() {
         try {
             if (this.sftpClient) {
+                this.sftpClient.on('error', (err) => {
+                    tl.debug('sftpClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.sftpClient.close();
                 this.sftpClient = null;
             }
@@ -81,6 +84,9 @@ export class SshHelper {
         }
         try {
             if (this.sshClient) {
+                this.sshClient.on('error', (err) => {
+                    tl.debug('sshClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.sshClient.end();
                 this.sshClient = null;
             }
@@ -90,6 +96,9 @@ export class SshHelper {
 
         try {
             if (this.scpClient) {
+                this.scpClient.on('error', (err) => {
+                    tl.debug('scpClient: Ignoring error diconnecting: ' + JSON.stringify(err));
+                }); // ignore logout errors; see: https://github.com/mscdex/node-imap/issues/695
                 this.scpClient.close();
                 this.scpClient = null;
             }

--- a/Tasks/CopyFilesOverSSHV0/task.json
+++ b/Tasks/CopyFilesOverSSHV0/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 142,
-        "Patch": 2
+        "Minor": 148,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/CopyFilesOverSSHV0/task.loc.json
+++ b/Tasks/CopyFilesOverSSHV0/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 142,
-    "Patch": 2
+    "Minor": 148,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",


### PR DESCRIPTION
When we connect to an SSH server that's Windows, it will commonly error on the disconnect.  Elsewhere, the maintainer of the node SSH module we're using suggests to ignore the failures on logout.  Seems reasonable to me if we've successfully uploaded all of the files.