### PR TITLE
Fix smart quotes in docs on publishTestResults in DotNetCoreCLIv2

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DotNetCoreCLIV2/Strings/resources.resjson/en-US/resources.resjson
@@ -21,7 +21,7 @@
   "loc.input.label.arguments": "Arguments",
   "loc.input.help.arguments": "Arguments to the selected command. For example, build configuration, output folder, runtime. The arguments depend on the command selected.",
   "loc.input.label.publishTestResults": "Publish test results and code coverage",
-  "loc.input.help.publishTestResults": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect “Code coverage”` option to the command line arguments. This is currently only available on the Windows platform.",
+  "loc.input.help.publishTestResults": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect \"Code coverage\"` option to the command line arguments. This is currently only available on the Windows platform.",
   "loc.input.label.zipAfterPublish": "Zip Published Projects",
   "loc.input.help.zipAfterPublish": "If true, folder created by the publish command will be zipped.",
   "loc.input.label.modifyOutputPath": "Add project name to publish path",

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -131,7 +131,7 @@
             "defaultValue": "true",
             "visibleRule": "command = test",
             "required": false,
-            "helpMarkDown": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect “Code coverage”` option to the command line arguments. This is currently only available on the Windows platform."
+            "helpMarkDown": "Enabling this option will generate a test results TRX file in `$(Agent.TempDirectory)` and results will be published to the server. <br>This option appends `--logger trx --results-directory $(Agent.TempDirectory)` to the command line arguments. <br><br>Code coverage can be collected by adding `--collect \"Code coverage\"` option to the command line arguments. This is currently only available on the Windows platform."
         },
         {
             "name": "zipAfterPublish",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 147,
-    "Patch": 1
+    "Minor": 148,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Minor fix to the documentation for the publishTestResults in the dotnet test task, replacing the "smart quotes" with actual quotation marks.