### PR TITLE
Set an env var to use shorter path for nuget cache (#9516)

### DIFF
--- a/Tasks/Common/packaging-common/nuget/NuGetToolRunner2.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolRunner2.ts
@@ -7,6 +7,7 @@ import {NuGetQuirkName, NuGetQuirks, defaultQuirks} from "./NuGetQuirks";
 import * as ngutil from "./Utility";
 import * as peParser from "../pe-parser";
 import * as commandHelper from "./CommandHelper";
+import * as path from "path";
 
 // NuGetToolRunner2 can handle environment setup for new authentication scenarios where
 // we are accessing internal or external package sources.
@@ -45,11 +46,14 @@ function prepareNuGetExeEnvironment(
     let env: EnvironmentDictionary = {};
     let originalCredProviderPath: string = null;
     let envVarCredProviderPathV2: string = null;
+    let nugetCacheDir: string = null;
+    let disableNuGetPluginCacheWorkaround: boolean = false;
 
     for (let e in input) {
         if (!input.hasOwnProperty(e)) {
             continue;
         }
+
         // NuGet.exe extensions only work with a single specific version of nuget.exe. This causes problems
         // whenever we update nuget.exe on the agent.
         if (e.toUpperCase() === "NUGET_EXTENSIONS_PATH") {
@@ -73,9 +77,34 @@ function prepareNuGetExeEnvironment(
             continue;
         }
 
+        if (e.toUpperCase() === "DISABLE_NUGET_PLUGINS_CACHE_WORKAROUND") {
+            // Specifically disable NUGET_PLUGINS_CACHE_PATH workaround
+            disableNuGetPluginCacheWorkaround = true;
+            continue;
+        }
+
+        // NuGet plugins cache
+        if (e.toUpperCase() === "NUGET_PLUGINS_CACHE_PATH") {
+            nugetCacheDir = input[e];
+            continue;
+        }
+
         env[e] = input[e];
     }
 
+    // If DISABLE_NUGET_PLUGINS_CACHE_WORKAROUND variable is not set 
+    // and nugetCacheDir is not populated by NUGET_PLUGINS_CACHE_PATH,
+    // set NUGET_PLUGINS_CACHE_PATH to the temp directory
+    // to work aroud the NuGet issue with long paths: https://github.com/NuGet/Home/issues/7770
+    if (nugetCacheDir == null && disableNuGetPluginCacheWorkaround === false) {
+        const tempDir = tl.getVariable('Agent.TempDirectory');
+        nugetCacheDir = path.join(tempDir, "NuGetPluginsCache");
+    }
+    if (nugetCacheDir != null) {
+        env["NUGET_PLUGINS_CACHE_PATH"] = nugetCacheDir;
+        tl.debug(`NUGET_PLUGINS_CACHE_PATH set to ${nugetCacheDir}`);
+    }
+    
     if (authInfo && authInfo.internalAuthInfo) {
         env["VSS_NUGET_ACCESSTOKEN"] = authInfo.internalAuthInfo.accessToken;
         env["VSS_NUGET_URI_PREFIXES"] = authInfo.internalAuthInfo.uriPrefixes.join(";");
@@ -459,6 +488,11 @@ function buildCredentialJson(authInfo: auth.NuGetExtendedAuthInfo): string {
                     break;
             }
         });
+
+        if (enpointCredentialsJson.endpointCredentials.length < 1) {
+            tl.debug(`None detected.`);
+            return null;
+        }
 
         const externalCredentials: string = JSON.stringify(enpointCredentialsJson);
         return externalCredentials;

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 147,
-        "Patch": 3
+        "Patch": 4
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 2,
     "Minor": 147,
-    "Patch": 2
+    "Patch": 4
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
* Set an env var to use shorter path for nuget cache

Cherry-picking https://github.com/Microsoft/azure-pipelines-tasks/pull/9516