### PR TITLE
Fix trailing slashes not working for PublishCodeCoverageResults report directory

### DIFF
--- a/Tasks/PublishCodeCoverageResultsV1/publishcodecoverageresults.ts
+++ b/Tasks/PublishCodeCoverageResultsV1/publishcodecoverageresults.ts
@@ -61,7 +61,7 @@ function resolvePathToSingleItem(workingDirectory:string, pathInput: string, isD
     if (pathInput) {
 
         // Find match patterns won't work if the directory has a trailing slash
-        if (isDirectory && (pathInput.endsWith("/") || pathInput.endsWith("\\"))) {
+        if (isDirectory && (pathInput.endsWith('/') || pathInput.endsWith('\\'))) {
             pathInput = pathInput.slice(0, -1);
         }
         // Resolve matches of the pathInput pattern

--- a/Tasks/PublishCodeCoverageResultsV1/publishcodecoverageresults.ts
+++ b/Tasks/PublishCodeCoverageResultsV1/publishcodecoverageresults.ts
@@ -19,7 +19,7 @@ async function run() {
         // Resolve the summary file path.
         // It may contain wildcards allowing the path to change between builds, such as for:
         // $(System.DefaultWorkingDirectory)\artifacts***$(Configuration)\testresults\coverage\cobertura.xml
-        var resolvedSummaryFile: string = resolvePathToSingleItem(workingDirectory, summaryFileLocation);
+        var resolvedSummaryFile: string = resolvePathToSingleItem(workingDirectory, summaryFileLocation, false);
         if (failIfCoverageIsEmpty && await ccUtil.isCodeCoverageFileEmpty(resolvedSummaryFile, codeCoverageTool)) {
             throw tl.loc('NoCodeCoverage');
         } else if (!tl.exist(resolvedSummaryFile)) {
@@ -28,7 +28,7 @@ async function run() {
             // Resolve the report directory.
             // It may contain wildcards allowing the path to change between builds, such as for:
             // $(System.DefaultWorkingDirectory)\artifacts***$(Configuration)\testresults\coverage
-            var resolvedReportDirectory: string = resolvePathToSingleItem(workingDirectory, reportDirectory);
+            var resolvedReportDirectory: string = resolvePathToSingleItem(workingDirectory, reportDirectory, true);
 
             // Get any 'Additional Files' to publish as build artifacts
             if (additionalFiles) {
@@ -54,12 +54,16 @@ async function run() {
 }
 
 // Resolves the specified path to a single item based on whether it contains wildcards
-function resolvePathToSingleItem(workingDirectory:string, pathInput: string) : string {
+function resolvePathToSingleItem(workingDirectory:string, pathInput: string, isDirectory: boolean) : string {
     // Default to using the specific pathInput value
     var resolvedPath: string = pathInput;
 
-    // Does the pathInput value contain wildcards?
     if (pathInput) {
+
+        // Find match patterns won't work if the directory has a trailing slash
+        if (isDirectory && (pathInput.endsWith("/") || pathInput.endsWith("\\"))) {
+            pathInput = pathInput.slice(0, -1);
+        }
         // Resolve matches of the pathInput pattern
         var pathMatches: string[] = tl.findMatch(
             workingDirectory,

--- a/Tasks/PublishCodeCoverageResultsV1/task.json
+++ b/Tasks/PublishCodeCoverageResultsV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 145,
+        "Minor": 148,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishCodeCoverageResultsV1/task.loc.json
+++ b/Tasks/PublishCodeCoverageResultsV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 145,
+    "Minor": 148,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
In #8913 to support relative paths for the report directory, `findMatch` was used for all report directory inputs (regardless of wildcards).

This highlighted a bug in the task where the report directory could not contain a trailing slash, as the report directory is passed in as a pattern to `findMatch`. It is intentional that `findMatch` does not work when a pattern contains a trailing slash (see https://github.com/Microsoft/azure-pipelines-task-lib/issues/491 for info on that).

Bug: #9389 

The fix for this is to remove trailing slashes for the report directory if the exist.

Testing:
Using [MicrosoftDocs/pipelines-java](https://github.com/MicrosoftDocs/pipelines-java) as sample repository
Tested the following combinations:

- Image: Ubuntu, Windows
- Relative and Absolute Report Directory Path
- With and without a trailing slash (used backslash on windows)