### PR TITLE
fixes documentation for artifact.associate logging command

### DIFF
--- a/docs/authoring/commands.md
+++ b/docs/authoring/commands.md
@@ -302,11 +302,11 @@ To invoke a logging command, simply emit the command via standard output. For ex
                 <p align="left">
                     Create an artifact link, artifact location is required to be a file container path, VC path or UNC share path. <br>
                     <b>Examples:</b> <br>
-                    <code>##vso[artifact.associate type=container;artifactname=MyServerDrop]#/1/build</code> <br>
-                    <code>##vso[artifact.associate type=filepath;artifactname=MyFileShareDrop]\\MyShare\MyDropLocation</code> <br>
-                    <code>##vso[artifact.associate type=versioncontrol;artifactname=MyTfvcPath]$/MyTeamProj/MyFolder</code> <br>
-                    <code>##vso[artifact.associate type=gitref;artifactname=MyTag]refs/tags/MyGitTag</code> <br>
-                    <code>##vso[artifact.associate type=tfvclabel;artifactname=MyTag]MyTfvcLabel</code> <br>
+                    <code>##vso[artifact.associate artifacttype=container;artifactname=MyServerDrop]#/1/build</code> <br>
+                    <code>##vso[artifact.associate artifacttype=filepath;artifactname=MyFileShareDrop]\\MyShare\MyDropLocation</code> <br>
+                    <code>##vso[artifact.associate artifacttype=versioncontrol;artifactname=MyTfvcPath]$/MyTeamProj/MyFolder</code> <br>
+                    <code>##vso[artifact.associate artifacttype=gitref;artifactname=MyTag]refs/tags/MyGitTag</code> <br>
+                    <code>##vso[artifact.associate artifacttype=tfvclabel;artifactname=MyTag]MyTfvcLabel</code> <br>
                 </p>
             </td>
             <td>


### PR DESCRIPTION
`type` is incorrect, and gets ignored. `artifacttype` is the actual parameter name.

See `src\Agent.Worker/Build/ArtifactCommandExtension.cs` in the azure-pipelines-agent repo.