### PR TITLE
fixes compat issue with powershellv2 task, bumps version

### DIFF
--- a/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
@@ -32,6 +32,6 @@
   "loc.messages.PS_FormattedCommand": "Formatted command: {0}",
   "loc.messages.PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
   "loc.messages.PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
+  "loc.messages.PS_InvalidTargetType": "Invalid TargetType '{0}'. The value must be one of: 'filePath' or 'inline'",
   "loc.messages.PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
-  "loc.messages.PS_InvalidTargetType": "Invalid TargetType '{0}'. The value must be one of: 'filePath' or 'inline'"
 }

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -34,7 +34,7 @@ async function run() {
 
             input_arguments = tl.getInput('arguments') || '';
         }
-        else if(input_targetType.toUpperCase() == 'INLINE') {
+        else if(input_targetType.toUpperCase() == 'INLINE' || input_targetType.length === 0) {
             input_script = tl.getInput('script', false) || '';
         }
         else {

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 140,
+        "Minor": 148,
         "Patch": 2
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -149,6 +149,7 @@
         "PS_FormattedCommand": "Formatted command: {0}",
         "PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
         "PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
+        "PS_InvalidTargetType": "Invalid TargetType '{0}'. The value must be one of: 'filePath' or 'inline'.",
         "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
     }
 }

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 140,
+    "Minor": 148,
     "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Now empty string matches the "inline" type, and applies the same fix to the Windows task version.
Bumps minor version number.
Fixes missing comma in resources.resjson.

Follow-up on PR #9557 