### PR TITLE
Loose equality on error codes

### DIFF
--- a/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
@@ -60,7 +60,7 @@ tmr.registerMock('vsts-task-tool-lib/tool', {
         if (url === `https://nodejs.org/dist/v5.10.1/node-v5.10.1-win-${os.arch()}.7z` ||
             url === `https://nodejs.org/dist/v5.10.1/node-v5.10.1-${os.platform()}-${os.arch()}.tar.gz`) {
             let err = new Error();
-            err['httpStatusCode'] = '404';
+            err['httpStatusCode'] = 404;
             throw err;
         }
         else if (url === `https://nodejs.org/dist/v5.10.1/win-${os.arch()}/node.exe`) {

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -138,7 +138,7 @@ async function acquireNode(version: string): Promise<string> {
     catch (err)
     {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == restm.HttpCodes.NotFound)
+            err['httpStatusCode'] == 404)
         {
             return await acquireNodeFromFallbackLocation(version);
         }
@@ -199,7 +199,7 @@ async function acquireNodeFromFallbackLocation(version: string): Promise<string>
     }
     catch (err) {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == restm.HttpCodes.NotFound)
+            err['httpStatusCode'] == 404)
         {
             exeUrl = `https://nodejs.org/dist/v${version}/node.exe`;
             libUrl = `https://nodejs.org/dist/v${version}/node.lib`;

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -138,7 +138,7 @@ async function acquireNode(version: string): Promise<string> {
     catch (err)
     {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] === '404')
+            err['httpStatusCode'] == '404')
         {
             return await acquireNodeFromFallbackLocation(version);
         }
@@ -199,7 +199,7 @@ async function acquireNodeFromFallbackLocation(version: string): Promise<string>
     }
     catch (err) {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] === '404')
+            err['httpStatusCode'] == '404')
         {
             exeUrl = `https://nodejs.org/dist/v${version}/node.exe`;
             libUrl = `https://nodejs.org/dist/v${version}/node.lib`;

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -138,7 +138,7 @@ async function acquireNode(version: string): Promise<string> {
     catch (err)
     {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == '404')
+            err['httpStatusCode'] == restm.HttpCodes.NotFound)
         {
             return await acquireNodeFromFallbackLocation(version);
         }
@@ -199,7 +199,7 @@ async function acquireNodeFromFallbackLocation(version: string): Promise<string>
     }
     catch (err) {
         if (err['httpStatusCode'] && 
-            err['httpStatusCode'] == '404')
+            err['httpStatusCode'] == restm.HttpCodes.NotFound)
         {
             exeUrl = `https://nodejs.org/dist/v${version}/node.exe`;
             libUrl = `https://nodejs.org/dist/v${version}/node.lib`;

--- a/Tasks/NodeToolV0/package-lock.json
+++ b/Tasks/NodeToolV0/package-lock.json
@@ -29,7 +29,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.3.tgz",
       "integrity": "sha512-5fRLCYhLtDb3hMWqQyH10qtF+Ud2JnNCXTCZ+9ktNdCcgslcuXkDTkFcJNk++MT29yDntDnlF1+jD+uVGumsbw==",
       "requires": {
-        "@types/node": "6.0.112"
+        "@types/node": "*"
       }
     },
     "balanced-match": {
@@ -42,7 +42,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -56,7 +56,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -114,11 +114,11 @@
       "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -126,12 +126,12 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.9.0.tgz",
       "integrity": "sha512-UjqceSJ0GLENtgDz2rXGcmR3Ehn3j7iNmbzzsnQlHNhR6gdkRlp5t9eAmMULmag1da6YAvZWVYBy37J5vQriWQ==",
       "requires": {
-        "@types/semver": "5.5.0",
-        "@types/uuid": "3.4.3",
-        "semver": "5.5.0",
-        "semver-compare": "1.0.0",
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
         "typed-rest-client": "1.0.7",
-        "uuid": "3.2.1",
+        "uuid": "^3.0.1",
         "vsts-task-lib": "2.4.0"
       }
     }

--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 145,
+        "Minor": 148,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 145,
+    "Minor": 148,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
Right now the fallbacks don't actually work because the tool-lib returns error codes as numbers not strings. This fixes this by doing loose equality which works for strings or numbers.