### PR TITLE
Users/pspill/upack savepublishmetadata default

### DIFF
--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 147,
-        "Patch": 2
+        "Patch": 3
     },
     "runsOn": [
         "Agent",

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 147,
-        "Patch": 3
+        "Minor": 148,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 147,
-    "Patch": 3
+    "Minor": 148,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 147,
-    "Patch": 2
+    "Patch": 3
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/universalpublish.ts
+++ b/Tasks/UniversalPackagesV0/universalpublish.ts
@@ -8,11 +8,11 @@ import * as artifactToolUtilities from "packaging-common/universal/ArtifactToolU
 import * as auth from "packaging-common/universal/Authentication";
 
 export async function run(artifactToolPath: string): Promise<void> {
-    let buildIdentityDisplayName: string = null;
-    let buildIdentityAccount: string = null;
+    const buildIdentityDisplayName: string = null;
+    const buildIdentityAccount: string = null;
     try {
         // Get directory to publish
-        let publishDir: string = tl.getInput("publishDirectory");
+        const publishDir: string = tl.getInput("publishDirectory");
         if (publishDir.length < 1)
         {
             tl.debug(tl.loc("Info_PublishDirectoryNotFound"));
@@ -25,7 +25,7 @@ export async function run(artifactToolPath: string): Promise<void> {
         let version: string;
         let accessToken: string;
         let feedUri: string;
-        let publishedPackageVar: string = tl.getInput("publishedPackageVar");
+        const publishedPackageVar: string = tl.getInput("publishedPackageVar");
         const versionRadio = tl.getInput("versionPublishSelector");
 
         // Feed Auth
@@ -40,7 +40,7 @@ export async function run(artifactToolPath: string): Promise<void> {
 
         let internalAuthInfo: auth.InternalAuthInfo;
 
-        let toolRunnerOptions = artifactToolRunner.getOptions();
+        const toolRunnerOptions = artifactToolRunner.getOptions();
 
         let sessionId: string;
 
@@ -58,28 +58,24 @@ export async function run(artifactToolPath: string): Promise<void> {
 
             toolRunnerOptions.env.UNIVERSAL_PUBLISH_PAT = internalAuthInfo.accessToken;
 
-            // creating session
-            const useSessionEnabled = tl.getVariable("Packaging.SavePublishMetadata");
-            if (useSessionEnabled) {
-                let packagingLocation: string;
-                try {
-                    // This call is to get the packaging URI(abc.pkgs.vs.com) which is same for all protocols.
-                    packagingLocation = await pkgLocationUtils.getNuGetUriFromBaseServiceUri(
-                        serviceUri,
-                        accessToken);
-                } catch (error) {
-                    tl.debug(JSON.stringify(error));
-                    packagingLocation = serviceUri;
-                }
-
-                const pkgConn = pkgLocationUtils.getWebApiWithProxy(packagingLocation, accessToken);
-                sessionId = await ProvenanceHelper.GetSessionId(
-                    feedId,
-                    "upack", /* must match protocol name on the server */
-                    pkgConn.serverUrl,
-                    [pkgConn.authHandler],
-                    pkgConn.options);
+            let packagingLocation: string;
+            try {
+                // This call is to get the packaging URI(abc.pkgs.vs.com) which is same for all protocols.
+                packagingLocation = await pkgLocationUtils.getNuGetUriFromBaseServiceUri(
+                    serviceUri,
+                    accessToken);
+            } catch (error) {
+                tl.debug(JSON.stringify(error));
+                packagingLocation = serviceUri;
             }
+
+            const pkgConn = pkgLocationUtils.getWebApiWithProxy(packagingLocation, accessToken);
+            sessionId = await ProvenanceHelper.GetSessionId(
+                feedId,
+                "upack", /* must match protocol name on the server */
+                pkgConn.serverUrl,
+                [pkgConn.authHandler],
+                pkgConn.options);
         }
         else {
             const externalAuthInfo = auth.GetExternalAuthInfo("externalEndpoints");
@@ -105,7 +101,11 @@ export async function run(artifactToolPath: string): Promise<void> {
         else{
             feedUri = await pkgLocationUtils.getFeedUriFromBaseServiceUri(serviceUri, accessToken);
 
-            let highestVersion = await artifactToolUtilities.getHighestPackageVersionFromFeed(feedUri, accessToken, feedId, packageName);
+            const highestVersion = await artifactToolUtilities.getHighestPackageVersionFromFeed(
+                feedUri,
+                accessToken,
+                feedId,
+                packageName);
 
             version = artifactToolUtilities.getVersionUtility(tl.getInput("versionPublishSelector"), highestVersion);
         }
@@ -141,8 +141,11 @@ export async function run(artifactToolPath: string): Promise<void> {
     }
 }
 
-function publishPackageUsingArtifactTool(publishDir: string, options: artifactToolRunner.IArtifactToolOptions, execOptions: IExecOptions) {
-    let command = new Array<string>();
+function publishPackageUsingArtifactTool(
+    publishDir: string,
+    options: artifactToolRunner.IArtifactToolOptions,
+    execOptions: IExecOptions) {
+    const command = new Array<string>();
     command.push("universal", "publish",
         "--feed", options.feedId,
         "--service", options.accountUrl,
@@ -154,7 +157,10 @@ function publishPackageUsingArtifactTool(publishDir: string, options: artifactTo
         "--description", tl.getInput("packagePublishDescription"));
 
     console.log(tl.loc("Info_Publishing", options.packageName, options.packageVersion, options.feedId));
-    const execResult: IExecSyncResult = artifactToolRunner.runArtifactTool(options.artifactToolPath, command, execOptions);
+    const execResult: IExecSyncResult = artifactToolRunner.runArtifactTool(
+        options.artifactToolPath,
+        command,
+        execOptions);
 
     if (execResult.code === 0) {
         return;


### PR DESCRIPTION
While publishing provenance data for published packages was in beta testing, users needed to opt in to this feature by setting build variable Packaging.SavePublishMetadata = true.  Opt-in is no longer required, and this variable is now used only to opt-out.