### PR TITLE
Deprecate Conda Environment task

### DIFF
--- a/Tasks/CondaEnvironmentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CondaEnvironmentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Conda Environment",
-  "loc.helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
-  "loc.description": "Create and activate a Conda environment.",
+  "loc.helpMarkDown": "[More information](https://aka.ms/pipelines-anaconda-guide)<br>[Task documentation](https://go.microsoft.com/fwlink/?linkid=873466)",
+  "loc.description": "This task is deprecated. Use `conda` directly in script to work with Anaconda environments.",
   "loc.instanceNameFormat": "Conda environment $(environmentName)",
   "loc.input.label.createCustomEnvironment": "Create a custom environment",
   "loc.input.help.createCustomEnvironment": "Create or reactivate a Conda environment instead of using the `base` environment (recommended for self-hosted agents).",

--- a/Tasks/CondaEnvironmentV1/task.json
+++ b/Tasks/CondaEnvironmentV1/task.json
@@ -2,9 +2,9 @@
     "id": "03DD16C3-43E0-4667-BA84-40515D27A410",
     "name": "CondaEnvironment",
     "friendlyName": "Conda Environment",
-    "description": "Create and activate a Conda environment.",
+    "description": "This task is deprecated. Use `conda` directly in script to work with Anaconda environments.",
     "helpUrl": "https://go.microsoft.com/fwlink/?linkid=873466",
-    "helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=873466)",
+    "helpMarkDown": "[More information](https://aka.ms/pipelines-anaconda-guide)<br>[Task documentation](https://go.microsoft.com/fwlink/?linkid=873466)",
     "category": "Package",
     "runsOn": [
         "Agent",
@@ -13,9 +13,10 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 144,
+        "Minor": 148,
         "Patch": 0
     },
+    "deprecated": true,
     "demands": [],
     "instanceNameFormat": "Conda environment $(environmentName)",
     "inputs": [

--- a/Tasks/CondaEnvironmentV1/task.loc.json
+++ b/Tasks/CondaEnvironmentV1/task.loc.json
@@ -13,9 +13,10 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 144,
+    "Minor": 148,
     "Patch": 0
   },
+  "deprecated": true,
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
We've decided to deprecate this in favor of using the conda CLI directly from script.  We have a guide with YAML snippets at https://aka.ms/pipelines-anaconda-guide

Designer UX:

![image](https://user-images.githubusercontent.com/33549821/52717735-bbca8d80-2f6f-11e9-8365-1e8dca0306bc.png)

YAML UX:

![image](https://user-images.githubusercontent.com/33549821/52717809-f16f7680-2f6f-11e9-9941-ee5e72c04aa2.png)
