### PR TITLE
Fix escaping issue by consuming more recent task-lib

### DIFF
--- a/Tasks/VSBuildV1/make.json
+++ b/Tasks/VSBuildV1/make.json
@@ -9,7 +9,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.8.2",
+                "version": "0.11.0",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 147,
+        "Minor": 148,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 147,
+    "Minor": 148,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
This work has already been done in the task-lib/agent, just need to consume the most recent version.

Fixes #6314 and https://github.com/Microsoft/azure-pipelines-agent/issues/2033