### PR TITLE
[Kubernetes] Enabling environment variables option for the tasks

### DIFF
--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 40
+        "Patch": 41
     },
     "demands": [],
     "preview": "false",
@@ -342,6 +342,7 @@
         }
     ],
     "instanceNameFormat": "kubectl $(command)",
+    "showEnvironmentVariables": true,
     "execution": {
         "Node": {
             "target": "src//kubernetes.js"

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -342,6 +342,7 @@
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
+  "showEnvironmentVariables": true,
   "execution": {
     "Node": {
       "target": "src//kubernetes.js"

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 23
+        "Patch": 24
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -434,6 +434,7 @@
         }
     ],
     "instanceNameFormat": "kubectl $(command)",
+    "showEnvironmentVariables": true,
     "outputVariables": [
         {
             "name": "KubectlOutput",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 23
+    "Patch": 24
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -434,6 +434,7 @@
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
+  "showEnvironmentVariables": true,
   "outputVariables": [
     {
       "name": "KubectlOutput",


### PR DESCRIPTION
Variables marked as secrets are not always obfuscated in the logs. 
Adding support to use environment variables in the task. This would help the users to move away from passing secrets on to the command line.

In reference to https://github.com/Microsoft/azure-pipelines-tasks/issues/9633