### PR TITLE
Ignore existing packages in NugetTaskV2 on Linux

### DIFF
--- a/Tasks/NuGetCommandV2/Tests/L0.ts
+++ b/Tasks/NuGetCommandV2/Tests/L0.ts
@@ -249,6 +249,20 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
+    it('succeeds when conflict occurs using NuGet.exe on Linux (allow conflict)', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflictOnLinux.js')
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.invokedToolCount == 1, 'should have run NuGet.exe once');
+        assert(tr.stdErrContained, "stderr output is here");
+        assert(tr.succeeded, 'should have succeeded');
+        assert.equal(tr.errorIssues.length, 0, "should have no errors");
+        done();
+    });
+
     it('fails when conflict occurs using VstsNuGetPush.exe (disallow conflict)', (done: MochaDone) => {
         this.timeout(1000);
 
@@ -403,7 +417,7 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('publish fails when duplicates are skipped and exit code!=[0|2]', (done: MochaDone) => {
+    it('publish fails when duplicates are skipped and exit code!=[0|2] on Windows_NT', (done: MochaDone) => {
         this.timeout(1000);
 
         let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflict.js')

--- a/Tasks/NuGetCommandV2/Tests/PublishTests/failWithContinueOnConflictOnLinux.ts
+++ b/Tasks/NuGetCommandV2/Tests/PublishTests/failWithContinueOnConflictOnLinux.ts
@@ -1,0 +1,52 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import util = require('../NugetMockHelper');
+
+let taskPath = path.join(__dirname, '../..', 'nugetcommandmain.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+let nmh: util.NugetMockHelper = new util.NugetMockHelper(tmr);
+
+nmh.setNugetVersionInputDefault();
+tmr.setInput('command', 'push');
+tmr.setInput('searchPatternPush', 'foo.nupkg');
+tmr.setInput('nuGetFeedType', 'internal');
+tmr.setInput('feedPublish', 'FeedFooId');
+tmr.setInput('allowPackageConflicts', 'true');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "osType": {},
+    "checkPath": {
+        "c:\\agent\\home\\directory\\foo.nupkg": true,
+        "/system/path/to/mono": true
+    },
+    "which": {
+        "mono": "/system/path/to/mono"
+    },
+    "exec": {
+        "/system/path/to/mono c:\\from\\tool\\installer\\nuget.exe push c:\\agent\\home\\directory\\foo.nupkg -NonInteractive -Source https://vsts/packagesource -ApiKey VSTS": {
+            "code": 1,
+            "stdout": "",
+            "stderr": "409 Conflict - The feed already contains"
+        }
+    },
+    "exist": {},
+    "stats": {
+        "c:\\agent\\home\\directory\\foo.nupkg": {
+            "isFile": true
+        }
+    },
+    "findMatch": {
+        "foo.nupkg": ["c:\\agent\\home\\directory\\foo.nupkg"]
+    }
+};
+nmh.setAnswers(a);
+a.osType["osType"] = "Linux";
+process.env["NUGET_FORCEVSTSNUGETPUSHFORPUSH"] = "true";
+nmh.registerNugetUtilityMock(["c:\\agent\\home\\directory\\foo.nupkg"]);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+nmh.registerVstsNuGetPushRunnerMock();
+
+tmr.run();

--- a/Tasks/NuGetCommandV2/nugetpublisher.ts
+++ b/Tasks/NuGetCommandV2/nugetpublisher.ts
@@ -245,7 +245,7 @@ export async function run(nuGetPath: string): Promise<void> {
                     environmentSettings);
 
                 for (const packageFile of filesList) {
-                    publishPackageNuGet(packageFile, publishOptions, authInfo);
+                    publishPackageNuGet(packageFile, publishOptions, authInfo, continueOnConflict);
                 }
             }
 
@@ -269,7 +269,8 @@ export async function run(nuGetPath: string): Promise<void> {
 function publishPackageNuGet(
     packageFile: string,
     options: PublishOptions,
-    authInfo: auth.NuGetExtendedAuthInfo)
+    authInfo: auth.NuGetExtendedAuthInfo,
+    continueOnConflict: boolean)
     : IExecSyncResult {
     const nugetTool = ngToolRunner.createNuGetToolRunner(options.nuGetPath, options.environment, authInfo);
 
@@ -296,9 +297,19 @@ function publishPackageNuGet(
     const execResult = nugetTool.execSync();
     if (execResult.code !== 0) {
         telemetry.logResult("Packaging", "NuGetCommand", execResult.code);
-        throw tl.loc("Error_NugetFailedWithCodeAndErr",
-            execResult.code,
-            execResult.stderr ? execResult.stderr.trim() : execResult.stderr);
+        if(continueOnConflict && execResult.stderr.indexOf("The feed already contains")>0){
+            tl.debug(`A conflict ocurred with package ${packageFile}, ignoring it since "Allow duplicates" was selected.`);
+            return {
+                code: 0,
+                stdout: execResult.stderr,
+                stderr: null,
+                error: null
+            };
+        } else {
+            throw tl.loc("Error_NugetFailedWithCodeAndErr",
+                execResult.code,
+                execResult.stderr ? execResult.stderr.trim() : execResult.stderr);
+        }
     }
     return execResult;
 }
@@ -337,9 +348,6 @@ function publishPackageVstsNuGetPush(packageFile: string, options: IVstsNuGetPus
 function shouldUseVstsNuGetPush(isInternalFeed: boolean, conflictsAllowed: boolean, nugetExePath: string): boolean {
     if (tl.osType() !== "Windows_NT"){
         tl.debug("Running on a non-windows platform so NuGet.exe will be used.");
-        if(conflictsAllowed){
-            tl.warning(tl.loc("Warning_SkipConflictsNotSupportedUnixAgents"));
-        }
         return false;
     }
 

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 148,
-        "Patch": 2
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",


### PR DESCRIPTION
In the issue https://github.com/Microsoft/azure-pipelines-tasks/issues/3606 there was a request for allow skipping existing NuGet packages. The implementation was working on Windows agents, but on Linux not.
This pull request changes behaviour on Linux agents to support such functionality. 