### PR TITLE
[KubernetesManifest] Artifact Substitution Logic fix

### DIFF
--- a/Tasks/KubernetesManifestV0/src/actions/deploy.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/deploy.ts
@@ -123,7 +123,9 @@ function updateContainerImagesInConfigFiles(filePaths: string[], containers): st
         filePaths.forEach((filePath: string) => {
             var contents = fs.readFileSync(filePath).toString();
             containers.forEach((container: string) => {
-                let imageName = container.split(":")[0] + ":";
+                let imageName = container.split(":")[0];
+                if (imageName.indexOf("@") > 0)
+                    imageName = imageName.split("@")[0];
                 if (contents.indexOf(imageName) > 0) {
                     contents = utils.replaceAllTokens(contents, imageName, container);
                 }

--- a/Tasks/KubernetesManifestV0/src/actions/deploy.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/deploy.ts
@@ -127,7 +127,7 @@ function updateContainerImagesInConfigFiles(filePaths: string[], containers): st
                 if (imageName.indexOf("@") > 0)
                     imageName = imageName.split("@")[0];
                 if (contents.indexOf(imageName) > 0) {
-                    contents = utils.replaceAllTokens(contents, imageName, container);
+                    contents = utils.substituteImageNameInSpecFile(contents, imageName, container);
                 }
             });
 

--- a/Tasks/KubernetesManifestV0/src/utils/utilities.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/utilities.ts
@@ -64,24 +64,34 @@ export function annotateChildPods(kubectl: Kubectl, resourceType, resourceName, 
     return commandExecutionResults;
 }
 
-export function replaceAllTokens(currentString: string, replaceToken: string, replaceValue: string) {
-    let i = currentString.indexOf(replaceToken);
+/*
+    For example, 
+        currentString: `image: "example/example-image"`
+        imageName: `example/example-image`
+        imageNameWithNewTag: `example/example-image:identifiertag`
+    
+    This substituteImageNameInSpecFile function would return
+        return Value: `image: "example/example-image:identifiertag"`
+*/
+
+export function substituteImageNameInSpecFile(currentString: string, imageName: string, imageNameWithNewTag: string) {
+    let i = currentString.indexOf(imageName);
     if (i < 0) {
-        tl.debug(`No occurence of replacement token: ${replaceToken} found`);
+        tl.debug(`No occurence of replacement token: ${imageName} found`);
         return currentString;
     }
 
     let newString = "";
     currentString.split("\n")
         .forEach((line) => {
-            if (line.indexOf(replaceToken) > 0 && line.toLocaleLowerCase().indexOf("image") > 0) {
-                let i = line.indexOf(replaceToken);
+            if (line.indexOf(imageName) > 0 && line.toLocaleLowerCase().indexOf("image") > 0) {
+                let i = line.indexOf(imageName);
                 newString += line.substring(0, i);
                 let leftOverString = line.substring(i);
                 if (leftOverString.endsWith("\"")) {
-                    newString += replaceValue + "\"" + "\n";
+                    newString += imageNameWithNewTag + "\"" + "\n";
                 } else {
-                    newString += replaceValue + "\n";
+                    newString += imageNameWithNewTag + "\n";
                 }
             }
             else {

--- a/Tasks/KubernetesManifestV0/src/utils/utilities.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/utilities.ts
@@ -64,21 +64,32 @@ export function annotateChildPods(kubectl: Kubectl, resourceType, resourceName, 
     return commandExecutionResults;
 }
 
-export function replaceAllTokens(currentString: string, replaceToken, replaceValue) {
+export function replaceAllTokens(currentString: string, replaceToken: string, replaceValue: string) {
     let i = currentString.indexOf(replaceToken);
     if (i < 0) {
         tl.debug(`No occurence of replacement token: ${replaceToken} found`);
         return currentString;
     }
 
-    let newString = currentString.substring(0, i);
-    let leftOverString = currentString.substring(i);
-    newString += replaceValue + leftOverString.substring(Math.min(leftOverString.indexOf("\n"), leftOverString.indexOf("\"")));
-    if (newString == currentString) {
-        tl.debug(`All occurences replaced`);
-        return newString;
-    }
-    return replaceAllTokens(newString, replaceToken, replaceValue);
+    let newString = "";
+    currentString.split("\n")
+        .forEach((line) => {
+            if (line.indexOf(replaceToken) > 0 && line.toLocaleLowerCase().indexOf("image") > 0) {
+                let i = line.indexOf(replaceToken);
+                newString += line.substring(0, i);
+                let leftOverString = line.substring(i);
+                if (leftOverString.endsWith("\"")) {
+                    newString += replaceValue + "\"" + "\n";
+                } else {
+                    newString += replaceValue + "\n";
+                }
+            }
+            else {
+                newString += line + "\n";
+            }
+        });
+
+    return newString;
 }
 
 export function isEqual(str1: string, str2: string, stringComparer: StringComparer): boolean {

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "groups": [
@@ -148,7 +148,7 @@
             "defaultValue": "",
             "groupName": "config",
             "helpMarkDown": "Helm chart path to bake",
-            "visibleRule": "action = bake && renderType = helm"
+            "visibleRule": "action = bake && renderType = helm2"
         },
         {
             "name": "overrideFiles",
@@ -158,7 +158,7 @@
             "defaultValue": "",
             "groupName": "config",
             "helpMarkDown": "Override files to set",
-            "visibleRule": "action = bake && renderType = helm"
+            "visibleRule": "action = bake && renderType = helm2"
         },
         {
             "name": "overrides",
@@ -168,7 +168,7 @@
             "defaultValue": "",
             "groupName": "config",
             "helpMarkDown": "Override values to set",
-            "visibleRule": "action = bake && renderType = helm"
+            "visibleRule": "action = bake && renderType = helm2"
         },
         {
             "name": "resourceToPatch",

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "groups": [
@@ -148,7 +148,7 @@
       "defaultValue": "",
       "groupName": "config",
       "helpMarkDown": "ms-resource:loc.input.help.helmChart",
-      "visibleRule": "action = bake && renderType = helm"
+      "visibleRule": "action = bake && renderType = helm2"
     },
     {
       "name": "overrideFiles",
@@ -158,7 +158,7 @@
       "defaultValue": "",
       "groupName": "config",
       "helpMarkDown": "ms-resource:loc.input.help.overrideFiles",
-      "visibleRule": "action = bake && renderType = helm"
+      "visibleRule": "action = bake && renderType = helm2"
     },
     {
       "name": "overrides",
@@ -168,7 +168,7 @@
       "defaultValue": "",
       "groupName": "config",
       "helpMarkDown": "ms-resource:loc.input.help.overrides",
-      "visibleRule": "action = bake && renderType = helm"
+      "visibleRule": "action = bake && renderType = helm2"
     },
     {
       "name": "resourceToPatch",


### PR DESCRIPTION
1. The artifact substitution logic currently assumes that the images in the manifests have a tag by default in them. This PR removes that assumption. The artifact would be replaced if you have a spec like `image: imagename` in your manifest file.
2. The image name extraction from the `containers` input defaults on splitting with `:`, added handling for handling cases where sha256 is involved where the image name would look like `imagename@sha256:<sha>`