### PR TITLE
update post job execution steps for iOS to not fail

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -477,7 +477,7 @@ export async function deleteProvisioningProfile(uuid: string): Promise<void> {
         const provProfiles: string[] = tl.findMatch(getUserProvisioningProfilesPath(), uuid.trim() + '*');
         if (provProfiles) {
             for (const provProfilePath of provProfiles) {
-                tl.warning('Deleting provisioning profile: ' + provProfilePath);
+                console.log('Deleting provisioning profile: ' + provProfilePath);
                 if (tl.exist(provProfilePath)) {
                     const deleteProfileCommand: ToolRunner = tl.tool(tl.which('rm', true));
                     deleteProfileCommand.arg(['-f', provProfilePath]);

--- a/Tasks/InstallAppleCertificateV2/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0.ts
@@ -159,4 +159,18 @@ describe('InstallAppleCertificate Suite', function () {
 
         done();
     });
+
+    it('postexecution should not fail for errors', function (done: MochaDone) {
+        this.timeout(1000);
+
+        let tp: string = path.join(__dirname, 'L0ErrorsInPostExecutionJob.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'postexecutionjob should have succeeded with warnings even when there are errors.');
+        assert(tr.stdout.indexOf('InstallRequiresMac'), 'warning for macos requirement should be shown.');
+        
+        done();
+    });
 });

--- a/Tasks/InstallAppleCertificateV2/Tests/L0ErrorsInPostExecutionJob.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0ErrorsInPostExecutionJob.ts
@@ -1,0 +1,33 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'postinstallcert.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('certSecureFile', 'mySecureFileId');
+tr.setInput('certPwd', 'mycertPwd');
+tr.setInput('keychain', 'temp');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'win32';
+}
+tr.registerMock('os', os);
+
+tr.run();
+

--- a/Tasks/InstallAppleCertificateV2/postinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/postinstallcert.ts
@@ -11,30 +11,30 @@ async function run() {
 
         // Check platform is macOS since demands are not evaluated on Hosted pools
         if (os.platform() !== 'darwin') {
-            throw new Error(tl.loc('InstallRequiresMac'));
-        }
+            console.log(tl.loc('InstallRequiresMac'));
+        } else {
+            let keychain: string = tl.getInput('keychain');
+            let keychainPath: string = tl.getTaskVariable('APPLE_CERTIFICATE_KEYCHAIN');
 
-        let keychain: string = tl.getInput('keychain');
-        let keychainPath: string = tl.getTaskVariable('APPLE_CERTIFICATE_KEYCHAIN');
+            let deleteCert: boolean = tl.getBoolInput('deleteCert');
+            let hash: string = tl.getTaskVariable('APPLE_CERTIFICATE_SHA1HASH');
+            if (deleteCert && hash) {
+                sign.deleteCert(keychainPath, hash);
+            }
 
-        let deleteCert: boolean = tl.getBoolInput('deleteCert');
-        let hash: string = tl.getTaskVariable('APPLE_CERTIFICATE_SHA1HASH');
-        if (deleteCert && hash) {
-            sign.deleteCert(keychainPath, hash);
-        }
+            let deleteKeychain: boolean = false;
+            if (keychain === 'temp') {
+                deleteKeychain = true;
+            } else if (keychain === 'custom') {
+                deleteKeychain = tl.getBoolInput('deleteCustomKeychain');
+            }
 
-        let deleteKeychain: boolean = false;
-        if (keychain === 'temp') {
-            deleteKeychain = true;
-        } else if (keychain === 'custom') {
-            deleteKeychain = tl.getBoolInput('deleteCustomKeychain');
-        }
-
-        if (deleteKeychain && keychainPath) {
-            await sign.deleteKeychain(keychainPath);
+            if (deleteKeychain && keychainPath) {
+                await sign.deleteKeychain(keychainPath);
+            }
         }
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err);
+        tl.warning(err);
     }
 }
 

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 145,
+        "Minor": 149,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 145,
+    "Minor": 149,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleProvisioningProfileV1/Tests/L0.ts
+++ b/Tasks/InstallAppleProvisioningProfileV1/Tests/L0.ts
@@ -106,4 +106,18 @@ describe('InstallAppleProvisioningProfile Suite', function () {
 
         done();
     });
+
+    it('postexecution should not fail for errors', function (done: MochaDone) {
+        this.timeout(1000);
+
+        let tp: string = path.join(__dirname, 'L0ErrorsInPostExecutionJob.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'postexecutionjob should have succeeded with warnings even when there are errors.');
+        assert(tr.stdout.indexOf('InstallRequiresMac'), 'warning for macos requirement should be shown.');
+        
+        done();
+    });
 });

--- a/Tasks/InstallAppleProvisioningProfileV1/Tests/L0ErrorsInPostExecutionJob.ts
+++ b/Tasks/InstallAppleProvisioningProfileV1/Tests/L0ErrorsInPostExecutionJob.ts
@@ -1,0 +1,35 @@
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'postinstallprovprofile.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('provisioningProfileLocation', 'secureFiles');
+tr.setInput('provProfileSecureFile', 'mySecureFileId');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'win32';
+}
+tr.registerMock('os', os);
+
+tr.run();
+

--- a/Tasks/InstallAppleProvisioningProfileV1/postinstallprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfileV1/postinstallprovprofile.ts
@@ -11,18 +11,18 @@ async function run() {
 
         // Check platform is macOS since demands are not evaluated on Hosted pools
         if (os.platform() !== 'darwin') {
-            throw new Error(tl.loc('InstallRequiresMac'));
-        }
-
-        let removeProfile: boolean = tl.getBoolInput('removeProfile');
-        if (removeProfile) {
-            let profileUUID: string = tl.getTaskVariable('APPLE_PROV_PROFILE_UUID');
-            if (profileUUID) {
-                await sign.deleteProvisioningProfile(profileUUID);
+            console.log(tl.loc('InstallRequiresMac'));
+        } else {
+            let removeProfile: boolean = tl.getBoolInput('removeProfile');
+            if (removeProfile) {
+                let profileUUID: string = tl.getTaskVariable('APPLE_PROV_PROFILE_UUID');
+                if (profileUUID) {
+                    await sign.deleteProvisioningProfile(profileUUID);
+                }
             }
         }
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err);
+        tl.warning(err);
     }
 }
 

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 144,
+        "Minor": 149,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 144,
+    "Minor": 149,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -91,5 +91,6 @@
   "loc.messages.FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
   "loc.messages.OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action.",
   "loc.messages.NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`.",
-  "loc.messages.XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed."
+  "loc.messages.XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed.",
+  "loc.messages.XcodeRequiresMac": "Using Xcode requires a macOS agent. Building with Xcode on Linux or Windows is not supported by Apple."
 }

--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -555,12 +555,23 @@ describe('Xcode L0 Suite', function () {
 
         tr.run();
 
-        assert(tr.stdout.indexOf('##vso[task.issue type=error;]loc_mock_XcprettyNotInstalled') > 0, 'error message should indicate that xcpretty has to be installed.')
-        assert(tr.failed, 'post xcode task should have failed');
+        assert(tr.stdout.indexOf('##vso[task.issue type=warning;]loc_mock_XcprettyNotInstalled') > 0, 'warning message should indicate that xcpretty has to be installed.')
+        assert(tr.succeeded, 'post xcode task should have succeeded with warnings');
         done();
     });
 
+    it('postexecution should not fail for errors', function (done: MochaDone) {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
+        let tp = path.join(__dirname, 'L0ErrorsInPostExecutionJob.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.succeeded, 'post xcode task should have succeeded with warnings even when there are errors.');
+        assert(tr.stdout.indexOf('XcodeRequiresMac'), 'warning for macos requirement should be shown.');
+        done();
+    });
 
     it('macOS auto export', function (done: MochaDone) {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);

--- a/Tasks/XcodeV5/Tests/L0ErrorsInPostExecutionJob.ts
+++ b/Tasks/XcodeV5/Tests/L0ErrorsInPostExecutionJob.ts
@@ -1,0 +1,51 @@
+
+import ma = require('vsts-task-lib/mock-answer');
+import tmrm = require('vsts-task-lib/mock-run');
+import path = require('path');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'postxcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+process.env['HOME'] = '/users/test'; //replace with mock of setVariable when task-lib has the support
+
+// Xcode task run tests
+tr.setInput('actions', 'test');
+tr.setInput('xcWorkspacePath', '**/*.xcodeproj/project.xcworkspace');
+tr.setInput('scheme', 'testScheme');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+tr.setInput('packageApp', 'false');
+tr.setInput('signingOption', 'default');
+tr.setInput('destinationPlatformOption', 'default');
+tr.setInput('destinationPlatform', '');
+tr.setInput('destinationTypeOption', 'simulators');
+tr.setInput('destinationSimulators', 'iPhone 7');
+tr.setInput('destinationDevices', '');
+tr.setInput('useXcpretty', 'true');
+tr.setInput('publishJUnitResults', 'true');
+tr.setInput('cwd', '/home/build');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "getVariable": {
+        "HOME": "/users/test"
+    },
+    "which": {
+        "xcpretty": "/users/xcpretty"
+    },
+    "findMatch": {
+        "/home/build/**/build/reports/junit.xml": [
+            "/home/build/testbuild1/build/reports/junit.xml"
+        ]
+    }
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
+
+tr.run();
+

--- a/Tasks/XcodeV5/Tests/L0TestResultsPublishFailsIfXcprettyNotInstalled.ts
+++ b/Tasks/XcodeV5/Tests/L0TestResultsPublishFailsIfXcprettyNotInstalled.ts
@@ -1,6 +1,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import os = require('os');
 
 let taskPath = path.join(__dirname, '..', 'postxcode.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
@@ -39,6 +40,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 };
 tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
 
 tr.run();
 

--- a/Tasks/XcodeV5/Tests/L0TestResultsPublishedInPostExecutionJob.ts
+++ b/Tasks/XcodeV5/Tests/L0TestResultsPublishedInPostExecutionJob.ts
@@ -2,6 +2,7 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
+import os = require('os');
 
 let taskPath = path.join(__dirname, '..', 'postxcode.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
@@ -40,6 +41,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     }
 };
 tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
 
 tr.run();
 

--- a/Tasks/XcodeV5/postxcode.ts
+++ b/Tasks/XcodeV5/postxcode.ts
@@ -1,3 +1,4 @@
+import os = require('os');
 import path = require('path');
 import tl = require('vsts-task-lib/task');
 import sign = require('ios-signing-common/ios-signing-common');
@@ -9,77 +10,82 @@ async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
-        //--------------------------------------------------------
-        // Test publishing - publish even if tests fail
-        //--------------------------------------------------------
-        let testResultsFiles: string;
-        const publishResults: boolean = tl.getBoolInput('publishJUnitResults', false);
-        const useXcpretty: boolean = tl.getBoolInput('useXcpretty', false);
-        const workingDir: string = tl.getPathInput('cwd');
-        
-        if (publishResults) {
-            if (!useXcpretty) {
-                throw tl.loc('UseXcprettyForTestPublishing');
-            } else if (useXcpretty && !tl.which('xcpretty')) {
-                throw tl.loc("XcprettyNotInstalled");
-            }
-            else {
-                // xcpretty is enabled and installed
-                testResultsFiles = tl.resolve(workingDir, '**/build/reports/junit.xml');
+        // Check platform is macOS since demands are not evaluated on Hosted pools
+        if (os.platform() !== 'darwin') {
+            console.log(tl.loc('XcodeRequiresMac'));
+        } else {
+            //--------------------------------------------------------
+            // Test publishing - publish even if tests fail
+            //--------------------------------------------------------
+            let testResultsFiles: string;
+            const publishResults: boolean = tl.getBoolInput('publishJUnitResults', false);
+            const useXcpretty: boolean = tl.getBoolInput('useXcpretty', false);
+            const workingDir: string = tl.getPathInput('cwd');
+            
+            if (publishResults) {
+                if (!useXcpretty) {
+                    throw tl.loc('UseXcprettyForTestPublishing');
+                } else if (useXcpretty && !tl.which('xcpretty')) {
+                    throw tl.loc("XcprettyNotInstalled");
+                }
+                else {
+                    // xcpretty is enabled and installed
+                    testResultsFiles = tl.resolve(workingDir, '**/build/reports/junit.xml');
 
-                if (testResultsFiles && 0 !== testResultsFiles.length) {
-                    //check for pattern in testResultsFiles
-                    let matchingTestResultsFiles: string[];
-                    if (testResultsFiles.indexOf('*') >= 0) {
-                        tl.debug('Pattern found in testResultsFiles parameter');
-                        matchingTestResultsFiles = tl.findMatch(workingDir, testResultsFiles, 
-                            { allowBrokenSymbolicLinks: false, followSpecifiedSymbolicLink: false, followSymbolicLinks: false }, 
-                            { matchBase: true, nocase: true });
-                    }
-                    else {
-                        tl.debug('No pattern found in testResultsFiles parameter');
-                        matchingTestResultsFiles = [testResultsFiles];
-                    }
+                    if (testResultsFiles && 0 !== testResultsFiles.length) {
+                        //check for pattern in testResultsFiles
+                        let matchingTestResultsFiles: string[];
+                        if (testResultsFiles.indexOf('*') >= 0) {
+                            tl.debug('Pattern found in testResultsFiles parameter');
+                            matchingTestResultsFiles = tl.findMatch(workingDir, testResultsFiles, 
+                                { allowBrokenSymbolicLinks: false, followSpecifiedSymbolicLink: false, followSymbolicLinks: false }, 
+                                { matchBase: true, nocase: true });
+                        }
+                        else {
+                            tl.debug('No pattern found in testResultsFiles parameter');
+                            matchingTestResultsFiles = [testResultsFiles];
+                        }
 
-                    if (!matchingTestResultsFiles) {
-                        tl.warning(tl.loc('NoTestResultsFound', testResultsFiles));
-                    } else {
-                        const TESTRUN_SYSTEM = "VSTS - xcode";
-                        const tp = new tl.TestPublisher("JUnit");
-                        tp.publish(matchingTestResultsFiles, false, "", "", "", true, TESTRUN_SYSTEM);
+                        if (!matchingTestResultsFiles) {
+                            tl.warning(tl.loc('NoTestResultsFound', testResultsFiles));
+                        } else {
+                            const TESTRUN_SYSTEM = "VSTS - xcode";
+                            const tp = new tl.TestPublisher("JUnit");
+                            tp.publish(matchingTestResultsFiles, false, "", "", "", true, TESTRUN_SYSTEM);
+                        }
                     }
                 }
             }
-        }
 
-        //clean up the temporary keychain, so it is not used to search for code signing identity in future builds
-        var keychainToDelete = utils.getTaskState('XCODE_KEYCHAIN_TO_DELETE')
-        if (keychainToDelete) {
-            try {
-                await sign.deleteKeychain(keychainToDelete);
-            } catch (err) {
-                tl.debug('Failed to delete temporary keychain. Error = ' + err);
-                tl.warning(tl.loc('TempKeychainDeleteFailed', keychainToDelete));
+            //clean up the temporary keychain, so it is not used to search for code signing identity in future builds
+            var keychainToDelete = utils.getTaskState('XCODE_KEYCHAIN_TO_DELETE')
+            if (keychainToDelete) {
+                try {
+                    await sign.deleteKeychain(keychainToDelete);
+                } catch (err) {
+                    tl.debug('Failed to delete temporary keychain. Error = ' + err);
+                    tl.warning(tl.loc('TempKeychainDeleteFailed', keychainToDelete));
+                }
             }
-        }
 
-        //delete provisioning profile if specified
-        var profileToDelete = utils.getTaskState('XCODE_PROFILE_TO_DELETE');
-        if (profileToDelete) {
-            try {
-                await sign.deleteProvisioningProfile(profileToDelete);
-            } catch (err) {
-                tl.debug('Failed to delete provisioning profile. Error = ' + err);
-                tl.warning(tl.loc('ProvProfileDeleteFailed', profileToDelete));
+            //delete provisioning profile if specified
+            var profileToDelete = utils.getTaskState('XCODE_PROFILE_TO_DELETE');
+            if (profileToDelete) {
+                try {
+                    await sign.deleteProvisioningProfile(profileToDelete);
+                } catch (err) {
+                    tl.debug('Failed to delete provisioning profile. Error = ' + err);
+                    tl.warning(tl.loc('ProvProfileDeleteFailed', profileToDelete));
+                }
             }
-        }
 
-        //upload detailed logs from xcodebuild if using xcpretty
-        utils.uploadLogFile(utils.getTaskState('XCODEBUILD_LOG'));
-        utils.uploadLogFile(utils.getTaskState('XCODEBUILD_ARCHIVE_LOG'));
-        utils.uploadLogFile(utils.getTaskState('XCODEBUILD_EXPORT_LOG'));
+            //upload detailed logs from xcodebuild if using xcpretty
+            utils.uploadLogFile(utils.getTaskState('XCODEBUILD_LOG'));
+            utils.uploadLogFile(utils.getTaskState('XCODEBUILD_ARCHIVE_LOG'));
+            utils.uploadLogFile(utils.getTaskState('XCODEBUILD_EXPORT_LOG'));
+        }
     } catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err);
+        tl.warning(err);
     }
 }
 

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 142,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",
     "demands": [
@@ -378,6 +378,7 @@
         "FailedToFindScheme": "Failed to find a scheme in the workspace. Use `Scheme` to specify a target scheme.",
         "OutputDirectoryIgnored": "Output directory for build output (binaries) ignored. Specifying an output directory is incompatible with the '%s' action.",
         "NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`.",
-        "XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed."
+        "XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed.",
+        "XcodeRequiresMac": "Using Xcode requires a macOS agent. Building with Xcode on Linux or Windows is not supported by Apple."
     }
 }

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 142,
-    "Patch": 1
+    "Minor": 149,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [
@@ -378,6 +378,7 @@
     "FailedToFindScheme": "ms-resource:loc.messages.FailedToFindScheme",
     "OutputDirectoryIgnored": "ms-resource:loc.messages.OutputDirectoryIgnored",
     "NoDestinationPlatformWarning": "ms-resource:loc.messages.NoDestinationPlatformWarning",
-    "XcprettyNotInstalled": "ms-resource:loc.messages.XcprettyNotInstalled"
+    "XcprettyNotInstalled": "ms-resource:loc.messages.XcprettyNotInstalled",
+    "XcodeRequiresMac": "ms-resource:loc.messages.XcodeRequiresMac"
   }
 }


### PR DESCRIPTION
Fix for: https://developercommunity.visualstudio.com/content/problem/446998/postjobexecution-hook-executed-despite-task-being.html

Post steps are always run, even if the task is skipped by conditions. So we need to safeguard the post steps. 