### PR TITLE
Error if common changed and versions not bumped

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -156,9 +156,7 @@ var getTasksToBuildForPR = function() {
         }
     });
     if (shouldBeBumped.length > 0) {
-        // TODO - change this to an error once its proven to be working.
-        console.log('##vso[task.logissue type=warning;sourcepath=ci/filter-task.js;linenumber=160;]The following tasks should have their versions bumped due to changes in common:', shouldBeBumped);
-        // throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
+        throw new Error('The following tasks should have their versions bumped due to changes in common: ' + shouldBeBumped);
     }
 
     return toBeBuilt;


### PR DESCRIPTION
I think we can do this now that we've seen that this check seems to be working. I like the idea of enforcing this more strictly.