### PR TITLE
Packer Build V1: Fail fast if VHD source is specified for generating managed image

### DIFF
--- a/Tasks/PackerBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PackerBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -91,5 +91,6 @@
   "loc.messages.FailedToFetchSPNDetailsRemotely": "Could not fetch SPN details from the graph service connection. Error: %s.",
   "loc.messages.GetArtifactItemsNotSupported": "Get artifact items not supported, invalid code path",
   "loc.messages.CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode": "Could not fetch access token for Managed Service Principal. Please configure Managed Service Identity (MSI) for virtual machine 'https://aka.ms/azure-msi-docs'. Status code: %s, status message: %s",
-  "loc.messages.CouldNotFetchAccessTokenforMSIStatusCode": "Could not fetch access token for Managed Service Principal. Status code: %s, status message: %s"
+  "loc.messages.CouldNotFetchAccessTokenforMSIStatusCode": "Could not fetch access token for Managed Service Principal. Status code: %s, status message: %s",
+  "loc.messages.CreateManagedImageNotSupportedForVHDSource": "Creating managed image from a source VHD is not supported. You must set 'Base image source' input value to 'Gallery'."
 }

--- a/Tasks/PackerBuildV1/src/taskParameters.ts
+++ b/Tasks/PackerBuildV1/src/taskParameters.ts
@@ -42,8 +42,8 @@ export default class TaskParameters {
     constructor() {
         try {
             this.templateType = tl.getInput(constants.TemplateTypeInputName, true);
-            
-            if(this.templateType === constants.TemplateTypeCustom) {
+
+            if (this.templateType === constants.TemplateTypeCustom) {
                 this.customTemplateLocation = tl.getPathInput(constants.CustomTemplateLocationInputType, true, true);
                 console.log(tl.loc("ParsingCustomTemplateParameters"));
                 this.customTemplateParameters = JSON.parse(tl.getInput("customTemplateParameters"));
@@ -54,18 +54,19 @@ export default class TaskParameters {
                 this.location = tl.getInput(constants.LocationInputName, true);
                 this.isManagedImage = tl.getBoolInput(constants.ManagedImageInputName, false);
 
-                if(this.isManagedImage)
-                {
+                if (this.isManagedImage) {
                     this.managedImageName = tl.getInput(constants.ManagedImageNameInputName, true);
                 }
 
                 this.baseImageSource = tl.getInput(constants.BaseImageSourceInputName, true);
-                if(this.baseImageSource === constants.BaseImageSourceCustomVhd) {
-                    this.customBaseImageUrl = tl.getInput(constants.CustomImageUrlInputName, true);
-                    this.osType = tl.getInput(constants.CustomImageOsTypeInputName, true);
-                } else {
+                if (this.baseImageSource === constants.BaseImageSourceDefault) {
                     this.builtinBaseImage = tl.getInput(constants.BuiltinBaseImageInputName, true);
                     this._extractImageDetails();
+                } else if (this.isManagedImage) {
+                    throw (tl.loc("CreateManagedImageNotSupportedForVHDSource"));
+                } else {
+                    this.customBaseImageUrl = tl.getInput(constants.CustomImageUrlInputName, true);
+                    this.osType = tl.getInput(constants.CustomImageOsTypeInputName, true);
                 }
 
                 console.log(tl.loc("ResolvingDeployPackageInput"));
@@ -105,7 +106,7 @@ export default class TaskParameters {
 
     private _getResolvedPath(rootFolder: string, inputPath: string) {
         var matchingFiles = utils.findMatch(rootFolder, inputPath);
-        if(!utils.HasItems(matchingFiles)) {
+        if (!utils.HasItems(matchingFiles)) {
             throw tl.loc("ResolvedPathNotFound", inputPath, rootFolder);
         }
 
@@ -113,10 +114,10 @@ export default class TaskParameters {
     }
 
     private _normalizeRelativePathForTargetOS(inputPath: string) {
-        if(tl.osType().match(/^Win/) && !this.osType.toLowerCase().match(/^win/)) {
+        if (tl.osType().match(/^Win/) && !this.osType.toLowerCase().match(/^win/)) {
             var splitPath = inputPath.split(path.sep);
             return path.posix.join.apply(null, splitPath);
-        } else if(!tl.osType().match(/^Win/) && this.osType.toLocaleLowerCase().match(/^win/)) {
+        } else if (!tl.osType().match(/^Win/) && this.osType.toLocaleLowerCase().match(/^win/)) {
             var splitPath = inputPath.split(path.sep);
             return path.win32.join.apply(null, splitPath);
         }

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "preview": "true",
@@ -334,6 +334,7 @@
         "FailedToFetchSPNDetailsRemotely": "Could not fetch SPN details from the graph service connection. Error: %s.",
         "GetArtifactItemsNotSupported": "Get artifact items not supported, invalid code path",
         "CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode": "Could not fetch access token for Managed Service Principal. Please configure Managed Service Identity (MSI) for virtual machine 'https://aka.ms/azure-msi-docs'. Status code: %s, status message: %s",
-        "CouldNotFetchAccessTokenforMSIStatusCode": "Could not fetch access token for Managed Service Principal. Status code: %s, status message: %s"
+        "CouldNotFetchAccessTokenforMSIStatusCode": "Could not fetch access token for Managed Service Principal. Status code: %s, status message: %s",
+        "CreateManagedImageNotSupportedForVHDSource": "Creating managed image from a source VHD is not supported. You must set 'Base image source' input value to 'Gallery'."
     }
 }

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "preview": "true",
@@ -334,6 +334,7 @@
     "FailedToFetchSPNDetailsRemotely": "ms-resource:loc.messages.FailedToFetchSPNDetailsRemotely",
     "GetArtifactItemsNotSupported": "ms-resource:loc.messages.GetArtifactItemsNotSupported",
     "CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode": "ms-resource:loc.messages.CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode",
-    "CouldNotFetchAccessTokenforMSIStatusCode": "ms-resource:loc.messages.CouldNotFetchAccessTokenforMSIStatusCode"
+    "CouldNotFetchAccessTokenforMSIStatusCode": "ms-resource:loc.messages.CouldNotFetchAccessTokenforMSIStatusCode",
+    "CreateManagedImageNotSupportedForVHDSource": "ms-resource:loc.messages.CreateManagedImageNotSupportedForVHDSource"
   }
 }


### PR DESCRIPTION
This PR fails fast when VHD source is used. It will show appropriate error message to user. For information look at issue #9547 