### PR TITLE
Remove node 5 tests

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -71,21 +71,6 @@ steps:
     testRunTitle: 'Node 6 Test Results'
     searchFolder: '$(System.DefaultWorkingDirectory)/testresults'
 
-# Test with node 5
-- script: node make.js test --node 5 --runner ts
-  displayName: Test with node 5
-  condition: ne(variables['numTasks'], 0)
-- script: node make.js testLegacy --node 5 --runner ts --task "$(task_pattern)"
-  displayName: Legacy tests with node 5
-  condition: ne(variables['numTasks'], 0)
-- task: PublishTestResults@2
-  displayName: Publish Test Results test-*.xml
-  condition: ne(variables['numTasks'], 0)
-  inputs:
-    testResultsFiles: 'test-*.xml'
-    testRunTitle: 'Node 5 Test Results'
-    searchFolder: '$(System.DefaultWorkingDirectory)/testresults'
-
 # Only when building on Windows:
 - ${{ if eq(parameters.os, 'Windows_NT') }}:
 


### PR DESCRIPTION
I think we should consider this. Right now we're spending ~1/4 of our build time on Node 5 tests and I haven't seen any errors caught because we're doing that. There should also be parity between the 2 versions anyways, and this will simplify things a bit as we move forward to building some things with Node 10.