### PR TITLE
UniversalPackages workaround for os.arch issue

### DIFF
--- a/Tasks/Common/packaging-common/locationUtilities.ts
+++ b/Tasks/Common/packaging-common/locationUtilities.ts
@@ -226,7 +226,7 @@ export async function getFeedRegistryUrl(
 }
 
 // This should be replaced when retry is implemented in vso client.
-async function Retry<T>(cb : () => Promise<T>, max_retry: number, retry_delay: number) : Promise<T> {
+export async function Retry<T>(cb : () => Promise<T>, max_retry: number, retry_delay: number) : Promise<T> {
     try {
         return await cb();
     } catch(exception) {

--- a/Tasks/Common/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/Tasks/Common/packaging-common/universal/ArtifactToolUtilities.ts
@@ -45,11 +45,22 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
 
     let osName = tl.osType();
     let arch = os.arch();
-    if(osName === "Windows_NT"){
+    if (osName === "Windows_NT"){
         osName = "windows";
     }
     if (arch === "x64"){
         arch = "amd64";
+    }
+
+    // https://github.com/nodejs/node-v0.x-archive/issues/2862
+    if (arch === "ia32") {
+        if (process.env.PROCESSOR_ARCHITEW6432 != null && process.env.PROCESSOR_ARCHITEW6432.toUpperCase() === "AMD64") {
+            arch = "amd64";
+        }
+    }
+
+    if (arch.toLowerCase() !== "amd64") {
+        throw new Error(tl.loc("Error_ProcessorArchitectureNotSupported"));
     }
 
     const blobstoreAreaName = "clienttools";
@@ -58,37 +69,32 @@ export async function getArtifactToolFromService(serviceUri: string, accessToken
 
     const blobstoreConnection = pkgLocationUtils.getWebApiWithProxy(serviceUri, accessToken);
 
-    try{
-        const artifactToolGetUrl = await blobstoreConnection.vsoClient.getVersioningData(ApiVersion,
-            blobstoreAreaName, blobstoreAreaId, { toolName }, {osName, arch});
+    const artifactToolGetUrl = await pkgLocationUtils.Retry(async () => {
+        return await blobstoreConnection.vsoClient.getVersioningData(ApiVersion,
+        blobstoreAreaName, blobstoreAreaId, { toolName }, {osName, arch});
+    }, 4, 100);
 
-        const artifactToolUri =  await blobstoreConnection.rest.get(artifactToolGetUrl.requestUrl);
+    const artifactToolUri =  await blobstoreConnection.rest.get(artifactToolGetUrl.requestUrl);
 
-        if (artifactToolUri.statusCode !== 200){
-            tl.debug(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolUri.toString()));
-            throw new Error(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolGetUrl.requestUrl));
-        }
-
-        let artifactToolPath = toollib.findLocalTool(toolName, artifactToolUri.result['version']);
-        if (!artifactToolPath) {
-            tl.debug(tl.loc("Info_DownloadingArtifactTool", artifactToolUri.result['uri']));
-
-            const zippedToolsDir: string = await toollib.downloadTool(artifactToolUri.result['uri']);
-
-            tl.debug("Downloaded zipped artifact tool to " + zippedToolsDir);
-            const unzippedToolsDir = await extractZip(zippedToolsDir);
-
-            artifactToolPath = await toollib.cacheDir(unzippedToolsDir, "ArtifactTool", artifactToolUri.result['version']);
-        }
-        else{
-            tl.debug(tl.loc("Info_ResolvedToolFromCache", artifactToolPath));
-        }
-        return getArtifactToolLocation(artifactToolPath);
+    if (artifactToolUri.statusCode !== 200) {
+        tl.debug(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolUri.result.toString()));
+        throw new Error(tl.loc("Error_UnexpectedErrorFailedToGetToolMetadata", artifactToolGetUrl.requestUrl));
     }
-    catch(err){
-        tl.error(err);
-        tl.setResult(tl.TaskResult.Failed, tl.loc("FailedToGetArtifactTool", err));
+
+    let artifactToolPath = toollib.findLocalTool(toolName, artifactToolUri.result['version']);
+    if (!artifactToolPath) {
+        tl.debug(tl.loc("Info_DownloadingArtifactTool", artifactToolUri.result['uri']));
+
+        const zippedToolsDir: string = await toollib.downloadTool(artifactToolUri.result['uri']);
+
+        tl.debug("Downloaded zipped artifact tool to " + zippedToolsDir);
+        const unzippedToolsDir = await extractZip(zippedToolsDir);
+
+        artifactToolPath = await toollib.cacheDir(unzippedToolsDir, "ArtifactTool", artifactToolUri.result['version']);
+    } else {
+        tl.debug(tl.loc("Info_ResolvedToolFromCache", artifactToolPath));
     }
+    return getArtifactToolLocation(artifactToolPath);
 }
 
 export function getVersionUtility(versionRadio: string, highestVersion: string): string {

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 148,
-        "Patch": 2
+        "Minor": 149,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,8 +9,8 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 19
+        "Minor": 149,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,8 +9,8 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-        "Minor": 148,
-        "Patch": 3
+        "Minor": 149,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 149,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 149,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 148,
+        "Minor": 149,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 148,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 149,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,8 +9,8 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
-        "Minor": 148,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 145,
+        "Minor": 149,
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 149,
-        "Patch": 1
+        "Patch": 2
     },
     "preview": false,
     "satisfies": [

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,8 +10,8 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-        "Minor": 148,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 145,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 145,
-        "Patch": 2
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/en-US/resources.resjson
@@ -77,9 +77,10 @@
   "loc.messages.Info_UsingToolPath": "Using tool path: %s",
   "loc.messages.Info_UsingVersion": "Using version: %s",
   "loc.messages.FailedToGetPackageMetadata": "Failed to get package metadata.",
-  "loc.messages.FailedToGetArtifactTool": "Failed to get artifact tool from service. %s",
+  "loc.messages.FailedToGetArtifactTool": "Failed to get artifact tool. %s",
   "loc.messages.Error_UnexpectedErrorFailedToGetToolMetadata": "Failed to get artifact tool metadata from source url %s",
   "loc.messages.FailedToGetLatestPackageVersion": "Failed to get package versions",
   "loc.messages.Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages",
-  "loc.messages.Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server."
+  "loc.messages.Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server.",
+  "loc.messages.Error_ProcessorArchitectureNotSupported": "Universal Packages require an x64 agent."
 }

--- a/Tasks/UniversalPackagesV0/package-lock.json
+++ b/Tasks/UniversalPackagesV0/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/ltx": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@types/ltx/-/ltx-2.8.0.tgz",
-      "integrity": "sha512-qHnPVD0FFquypl7Yy8qqvDjhnX3c7toUYjjALK+bug7MfR2WCRTIjw+GUMfehRi/Mbhj5rLAQerPTnTCUzSCWg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@types/ltx/-/ltx-2.8.1.tgz",
+      "integrity": "sha512-SjgICSxqzd5ZJGveuFJfULEztuT6OlkMjammWl989w6Z7qrvHjizALrAevd4g1+lRq1jrBF6u3r7oxhTeoWtsw==",
       "requires": {
         "@types/node": "*"
       }
@@ -18,9 +18,9 @@
       "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
     },
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+      "version": "10.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.30.tgz",
+      "integrity": "sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q=="
     },
     "adm-zip": {
       "version": "0.4.13",

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 148,
-        "Patch": 1
+        "Minor": 149,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",
@@ -431,10 +431,11 @@
         "Info_UsingToolPath": "Using tool path: %s",
         "Info_UsingVersion": "Using version: %s",
         "FailedToGetPackageMetadata": "Failed to get package metadata.",
-        "FailedToGetArtifactTool": "Failed to get artifact tool from service. %s",
+        "FailedToGetArtifactTool": "Failed to get artifact tool. %s",
         "Error_UnexpectedErrorFailedToGetToolMetadata": "Failed to get artifact tool metadata from source url %s",
         "FailedToGetLatestPackageVersion": "Failed to get package versions",
         "Warn_CredentialsNotFound": "Could not determine credentials to use for Universal Packages",
-        "Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server."
+        "Error_UniversalPackagesNotSupportedOnPrem": "Universal Packages are not supported in Azure DevOps Server.",
+        "Error_ProcessorArchitectureNotSupported": "Universal Packages require an x64 agent."
     }
 }

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 148,
-    "Patch": 1
+    "Minor": 149,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",
@@ -435,6 +435,7 @@
     "Error_UnexpectedErrorFailedToGetToolMetadata": "ms-resource:loc.messages.Error_UnexpectedErrorFailedToGetToolMetadata",
     "FailedToGetLatestPackageVersion": "ms-resource:loc.messages.FailedToGetLatestPackageVersion",
     "Warn_CredentialsNotFound": "ms-resource:loc.messages.Warn_CredentialsNotFound",
-    "Error_UniversalPackagesNotSupportedOnPrem": "ms-resource:loc.messages.Error_UniversalPackagesNotSupportedOnPrem"
+    "Error_UniversalPackagesNotSupportedOnPrem": "ms-resource:loc.messages.Error_UniversalPackagesNotSupportedOnPrem",
+    "Error_ProcessorArchitectureNotSupported": "ms-resource:loc.messages.Error_ProcessorArchitectureNotSupported"
   }
 }

--- a/Tasks/UniversalPackagesV0/universalmain.ts
+++ b/Tasks/UniversalPackagesV0/universalmain.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
             "artifacttool");
     }
     catch (error) {
-        tl.setResult(tl.TaskResult.Failed, error.message);
+        tl.setResult(tl.TaskResult.Failed, tl.loc("FailedToGetArtifactTool", error.message));
         return;
     } finally{
         _logUniversalStartupVariables(artifactToolPath);


### PR DESCRIPTION
If the user is running x86 agent on windows, even on x64 architecture, artifact tool was failing to download due to the behaviour of os.arch.

This change fixes that behaviour, and fixes the related error reporting.