### PR TITLE
Use agent's temp directory instead of OS's.

### DIFF
--- a/Tasks/PackerBuildV0/src/utilities.ts
+++ b/Tasks/PackerBuildV0/src/utilities.ts
@@ -107,7 +107,7 @@ export function findMatch(root: string, patterns: string[] | string): string[] {
 }
 
 export function getTempDirectory(): string {
-    return os.tmpdir();
+    return tl.getVariable('Agent.TempDirectory');
 }
 
 export function getCurrentTime(): number {

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 19
+        "Patch": 20
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 19
+    "Patch": 20
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/src/utilities.ts
+++ b/Tasks/PackerBuildV1/src/utilities.ts
@@ -107,7 +107,7 @@ export function findMatch(root: string, patterns: string[] | string): string[] {
 }
 
 export function getTempDirectory(): string {
-    return os.tmpdir();
+    return tl.getVariable('Agent.TempDirectory');
 }
 
 export function getCurrentTime(): number {

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [],
     "preview": "true",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [],
   "preview": "true",


### PR DESCRIPTION
Fixes an issue where multiple agents installed on the same host may
clash with the same test directory.

Fixes #9785