### PR TITLE
 Let Use Python Version summon Anaconda

### DIFF
--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -66,4 +66,21 @@ describe('UsePythonVersion L0 Suite', function () {
         assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
         assert(testRunner.succeeded, 'task should have succeeded');
     });
+
+    it('finds conda', function () {
+        const testFile = path.join(__dirname, 'L0Anaconda.js');
+        const testRunner = new MockTestRunner(testFile);
+
+        testRunner.run();
+
+        const anacondaDir = path.join('/', 'miniconda');
+        const anacondaBinDir = os.platform() === 'win32'
+            ? path.join(anacondaDir, 'Scripts')
+            : path.join(anacondaDir, 'bin');
+
+        assert(didSetVariable(testRunner, 'pythonLocation', anacondaBinDir));
+        assert(didPrependPath(testRunner, anacondaBinDir));
+        assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
+        assert(testRunner.succeeded, 'task should have succeeded');
+    });
 });

--- a/Tasks/UsePythonVersionV0/Tests/L0Anaconda.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0Anaconda.ts
@@ -1,0 +1,27 @@
+import * as path from 'path';
+
+import { TaskMockRunner } from 'vsts-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'main.js');
+const taskRunner = new TaskMockRunner(taskPath);
+
+taskRunner.setInput('versionSpec', 'Anaconda');
+taskRunner.setInput('addToPath', 'true');
+taskRunner.setInput('architecture', 'x64');
+
+// Mock vsts-task-tool-lib
+const toolPath = path.join('/', 'usr', 'miniconda');
+taskRunner.registerMock('vsts-task-tool-lib/tool', {
+    findLocalTool: () => toolPath
+});
+
+taskRunner.registerMock('./toolutil', {
+    prependPathSafe: (toolPath: string) => {
+        console.log('##vso[task.prependpath]' + toolPath);
+    }
+});
+
+// `getVariable` is not supported by `TaskLibAnswers`
+process.env['CONDA'] = '/miniconda';
+
+taskRunner.run();

--- a/Tasks/UsePythonVersionV0/Tests/L0SucceedsWhenVersionIsFound.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0SucceedsWhenVersionIsFound.ts
@@ -6,13 +6,19 @@ const taskPath = path.join(__dirname, '..', 'main.js');
 const taskRunner = new TaskMockRunner(taskPath);
 
 taskRunner.setInput('versionSpec', '3.x');
-taskRunner.setInput('addToPath', 'false');
+taskRunner.setInput('addToPath', 'true');
 taskRunner.setInput('architecture', 'x64');
 
 // Mock vsts-task-tool-lib
 const toolPath = path.join('/', 'Python', '3.6.4', 'x64');
 taskRunner.registerMock('vsts-task-tool-lib/tool', {
     findLocalTool: () => toolPath
+});
+
+taskRunner.registerMock('./toolutil', {
+    prependPathSafe: (toolPath: string) => {
+        console.log('##vso[task.prependpath]' + toolPath);
+    }
 });
 
 taskRunner.run();


### PR DESCRIPTION
Right now you have to do this:

```yaml
- bash: echo "##vso[task.prependpath]$CONDA/bin"
  displayName: Add conda to PATH
```

Now you can do

```yaml
- task: UsePythonVersion@0
  inputs:
    versionSpec: anaconda
```

And [soon](https://github.com/Microsoft/azure-pipelines-yaml/blob/master/design/use-statement.md)

```yaml
- use: python
  version: anaconda
```