### PR TITLE
Revert "Add Proxy Support for NuGetToolGetter" - DO NOT MERGE

### DIFF
--- a/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
@@ -138,10 +138,7 @@ async function getLatestMatchVersionInfo(versionSpec: string): Promise<INuGetVer
     taskLib.debug('Querying versions list');
 
     let versionsUrl = 'https://dist.nuget.org/tools.json';
-    let proxyRequestOptions = {
-        proxy: taskLib.getHttpProxyConfiguration(versionsUrl)
-    };
-    let rest: restm.RestClient = new restm.RestClient('vsts-tasks/NuGetToolInstaller', undefined, undefined, proxyRequestOptions);
+    let rest: restm.RestClient = new restm.RestClient('vsts-tasks/NuGetToolInstaller');
 
     let nugetVersions: INuGetVersionInfo[] = (await rest.get<INuGetVersionInfo[]>(versionsUrl, GetRestClientOptions())).result;
     // x.stage is the string representation of the enum, NuGetReleaseStage.Value = number, NuGetReleaseStage[NuGetReleaseStage.Value] = string, NuGetReleaseStage[x.stage] = number

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -8,8 +8,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 143,
-        "Patch": 0
+        "Minor": 2,
+        "Patch": 39
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -8,8 +8,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 143,
-    "Patch": 0
+    "Minor": 2,
+    "Patch": 39
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Reverts Microsoft/azure-pipelines-tasks#9449

Trying to figure out why some tests are currently failing in some azure suites