### PR TITLE
Not calling github APIs to validate version numer

### DIFF
--- a/Tasks/KubernetesV1/src/utilities.ts
+++ b/Tasks/KubernetesV1/src/utilities.ts
@@ -54,7 +54,12 @@ export async function getKubectlVersion(versionSpec: string, checkLatest: boolea
         else {
             // Do not check for validity of the version here,
             // We'll return proper error message when the download fails
-            return versionSpec;
+            if(!versionSpec.startsWith("v")) {
+                return "v".concat(versionSpec);
+            }
+            else{
+                return versionSpec;
+            }
         } 
      }
  

--- a/Tasks/KubernetesV1/src/utilities.ts
+++ b/Tasks/KubernetesV1/src/utilities.ts
@@ -47,9 +47,14 @@ export async function getKubectlVersion(versionSpec: string, checkLatest: boolea
             tl.warning(tl.loc("UsingLatestStableVersion"));
             return kubectlutility.getStableKubectlVersion();
         } 
+        else if ("v".concat(versionSpec) === kubectlutility.stableKubectlVersion) {
+            tl.debug(util.format("Using default versionSpec:%s.", versionSpec));
+            return kubectlutility.stableKubectlVersion;
+        }
         else {
-            let versions = await kubectlutility.getAvailableKubectlVersions();
-            return sanitizeVersionString(versions, versionSpec);
+            // Do not check for validity of the version here,
+            // We'll return proper error message when the download fails
+            return versionSpec;
         } 
      }
  

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 24
+        "Patch": 27
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 24
+    "Patch": 27
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
https://developercommunity.visualstudio.com/content/problem/479271/kubectl-apply-failing-with-responsebodyforeach-is.html

Kubectl download fails, as we validate the version before doing anything else. This validation makes multiple github API calls that fail with this message -
{"message":"API rate limit exceeded for **.**.**.**. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://developer.github.com/v3/#rate-limiting"}

Current task patch version on M149 is 26, so bumping it up to 27 here.