### PR TITLE
Updating agent bits in vstest task

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/8822112/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/8862105/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
This brings in the agent side changes required for TP/TS scenarios to work with TCM service enabled.