### PR TITLE
Make Kubernetes Service Connection as the default type

### DIFF
--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -60,7 +60,7 @@
             "name": "connectionType",
             "type": "pickList",
             "label": "Service connection type",
-            "defaultValue": "Azure Resource Manager",
+            "defaultValue": "Kubernetes Service Connection",
             "required": true,
             "options": {
                 "Azure Resource Manager": "Azure Resource Manager",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -60,7 +60,7 @@
       "name": "connectionType",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.connectionType",
-      "defaultValue": "Azure Resource Manager",
+      "defaultValue": "Kubernetes Service Connection",
       "required": true,
       "options": {
         "Azure Resource Manager": "Azure Resource Manager",


### PR DESCRIPTION
Make Kubernetes the default service connection type for KubernetesV1 task.
So that when connectionType is not specified in the YAML, it defaults to Kubernetes.