### PR TITLE
Re-enable app service tests

### DIFF
--- a/Tasks/AzureFunctionAppContainerV1/Tests/L0.ts
+++ b/Tasks/AzureFunctionAppContainerV1/Tests/L0.ts
@@ -1,4 +1,4 @@
-/*import * as path from 'path';
+import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'vsts-task-lib/mock-test';
 import tl = require('vsts-task-lib');
@@ -59,4 +59,3 @@ describe('AzureFunctionOnContainerDeployment Suite', function() {
     });
 
 });
-*/

--- a/Tasks/AzureRmWebAppDeploymentV3/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/Tests/L0.ts
@@ -1,4 +1,3 @@
-/*
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'vsts-task-lib/mock-test';
@@ -124,5 +123,3 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 });
-
-*/

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
@@ -1,4 +1,3 @@
-/*
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'vsts-task-lib/mock-test';
@@ -367,4 +366,3 @@ describe('AzureRmWebAppDeployment Suite', function() {
     });
 
 });
-*/

--- a/Tasks/AzureWebAppContainerV1/Tests/L0.ts
+++ b/Tasks/AzureWebAppContainerV1/Tests/L0.ts
@@ -1,4 +1,3 @@
-/*
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'vsts-task-lib/mock-test';
@@ -60,4 +59,3 @@ describe('AzureWebAppDeployment Suite', function() {
     });
 
 });
-*/

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -21,8 +21,8 @@ steps:
   inputs:
     versionSpec: "8.x"
 
-- script: npm i -g npm@latest
-  displayName: Use npm version latest
+- script: npm i -g npm@6.9.0
+  displayName: Use npm version 6.9.0
 
 # npm install
 - script: npm install

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -21,6 +21,9 @@ steps:
   inputs:
     versionSpec: "8.x"
 
+- script: npm i -g npm@latest
+  displayName: Use npm version latest
+
 # npm install
 - script: npm install
   displayName: npm install


### PR DESCRIPTION
NPM 6.8.0 added a rule to ignore `core` files, that also ignored the folders named `core`. The recommendation from the thread is to move to 6.9.0 where they have added included core folders.