### PR TITLE
Set bin directory correctly on Windows

### DIFF
--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -78,10 +78,7 @@ describe('UsePythonVersion L0 Suite', function () {
 
         testRunner.run();
 
-        const pypyDir = path.join('/', 'PyPy', '2.7.9', 'x64');
-        const pypyBinDir = task.getPlatform() === task.Platform.Windows
-            ? path.join(pypyDir, 'Scripts')
-            : path.join(pypyDir, 'bin');
+        const pypyBinDir = path.join('/', 'PyPy', '2.7.9', 'x64', 'bin');
 
         assert(didSetVariable(testRunner, 'pythonLocation', pypyBinDir));
         assert(didPrependPath(testRunner, pypyBinDir));
@@ -95,10 +92,7 @@ describe('UsePythonVersion L0 Suite', function () {
 
         testRunner.run();
 
-        const pypyDir = path.join('/', 'PyPy', '3.5.2', 'x64');
-        const pypyBinDir = task.getPlatform() === task.Platform.Windows
-            ? path.join(pypyDir, 'Scripts')
-            : path.join(pypyDir, 'bin');
+        const pypyBinDir = path.join('/', 'PyPy', '3.5.2', 'x64', 'bin');
 
         assert(didSetVariable(testRunner, 'pythonLocation', pypyBinDir));
         assert(didPrependPath(testRunner, pypyBinDir));

--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -78,9 +78,14 @@ describe('UsePythonVersion L0 Suite', function () {
 
         testRunner.run();
 
-        const pypyBinDir = path.join('/', 'PyPy', '2.7.9', 'x64', 'bin');
+        const pypyDir = path.join('/', 'PyPy', '2.7.9', 'x64');
+        const pypyBinDir = path.join(pypyDir, 'bin');
+        const pythonLocation = task.getPlatform() === task.Platform.Windows
+            ? pypyDir
+            : pypyBinDir;
 
-        assert(didSetVariable(testRunner, 'pythonLocation', pypyBinDir));
+        assert(didSetVariable(testRunner, 'pythonLocation', pythonLocation));
+        assert(didPrependPath(testRunner, pypyDir));
         assert(didPrependPath(testRunner, pypyBinDir));
         assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
         assert(testRunner.succeeded, 'task should have succeeded');
@@ -92,9 +97,14 @@ describe('UsePythonVersion L0 Suite', function () {
 
         testRunner.run();
 
-        const pypyBinDir = path.join('/', 'PyPy', '3.5.2', 'x64', 'bin');
+        const pypyDir = path.join('/', 'PyPy', '3.5.2', 'x64');
+        const pypyBinDir = path.join(pypyDir, 'bin');
+        const pythonLocation = task.getPlatform() === task.Platform.Windows
+            ? pypyDir
+            : pypyBinDir;
 
-        assert(didSetVariable(testRunner, 'pythonLocation', pypyBinDir));
+        assert(didSetVariable(testRunner, 'pythonLocation', pythonLocation));
+        assert(didPrependPath(testRunner, pypyDir));
         assert(didPrependPath(testRunner, pypyBinDir));
         assert.strictEqual(testRunner.stderr.length, 0, 'should not have written to stderr');
         assert(testRunner.succeeded, 'task should have succeeded');

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 150,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "instanceNameFormat": "Use Python $(versionSpec)",

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -68,12 +68,16 @@ function usePyPy(majorVersion: 2 | 3, parameters: TaskParameters, platform: Plat
         throw pypyNotFoundError(majorVersion);
     }
 
-    // For PyPy, the python executable is in the 'bin' directory, not the installation root.
-    // Also, Windows uses 'bin', not 'Scripts'.
+    // For PyPy, Windows uses 'bin', not 'Scripts'.
     const _binDir = path.join(installDir, 'bin');
-    task.setVariable('pythonLocation', _binDir);
+
+    // On Linux and macOS, the Python interpreter is in 'bin'.
+    // On Windows, it is in the installation root.
+    const pythonLocation = platform === Platform.Windows ? installDir : _binDir;
+    task.setVariable('pythonLocation', pythonLocation);
 
     if (parameters.addToPath) {
+        toolUtil.prependPathSafe(installDir);
         toolUtil.prependPathSafe(_binDir);
     }
 }

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -68,9 +68,10 @@ function usePyPy(majorVersion: 2 | 3, parameters: TaskParameters, platform: Plat
         throw pypyNotFoundError(majorVersion);
     }
 
-    // For PyPy, the python executable is in the bin dir
-    const _binDir = binDir(installDir, platform);
-    task.setVariable('pythonLocation', _binDir); 
+    // For PyPy, the python executable is in the 'bin' directory, not the installation root.
+    // Also, Windows uses 'bin', not 'Scripts'.
+    const _binDir = path.join(installDir, 'bin');
+    task.setVariable('pythonLocation', _binDir);
 
     if (parameters.addToPath) {
         toolUtil.prependPathSafe(_binDir);


### PR DESCRIPTION
Unlike CPython, which uses 'Scripts', PyPy uses 'bin' on Windows.

**Testing**
Ran https://dev.azure.com/brcrista/MyFirstProject/_build/results?buildId=787&_a=summary