### PR TITLE
Correctly detect directories and files in GitHub Release task

### DIFF
--- a/Tasks/GitHubReleaseV0/operations/Utility.ts
+++ b/Tasks/GitHubReleaseV0/operations/Utility.ts
@@ -53,7 +53,7 @@ export class Utility {
 
     public static isPatternADirectory(assets: string[], pattern: string): boolean {
         if (assets && assets.length === 1 && pattern) {
-            if (path.resolve(assets[0]) === path.resolve(pattern)) {
+            if ((path.resolve(assets[0]) === path.resolve(pattern)) && tl.exist(path.resolve(pattern)) && tl.stats(path.resolve(pattern)).isDirectory()) {
                 tl.debug("Pattern is a directory " + pattern);
                 return true;
             }


### PR DESCRIPTION
If you specify a direct path to a file, it should just attach the file.

Given that the pattern is the same as the path in that case it currently fails.