### PR TITLE
Improve Download GHR task

### DIFF
--- a/Tasks/DownloadGitHubReleaseV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadGitHubReleaseV0/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.itemPattern": "Minimatch pattern to filter files to be downloaded. To download all files within release use **",
   "loc.input.label.downloadPath": "Destination directory",
   "loc.input.help.downloadPath": "Path on the agent machine where the release assets will be downloaded",
-  "loc.messages.DownloadArtifacts": "Downloading assets of release %s from: %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded release assets to %s"
+  "loc.messages.DownloadArtifacts": "Downloading assets of release '%s' from: %s",
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded release assets to '%s'",
+  "loc.messages.InvalidRelease": "The release Id/Tag input '%s' is not valid",
+  "loc.messages.InvalidDefaultVersionType": "The DefaultVersionType input '%s' is not valid"
 }

--- a/Tasks/DownloadGitHubReleaseV0/package-lock.json
+++ b/Tasks/DownloadGitHubReleaseV0/package-lock.json
@@ -12,6 +12,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -162,7 +163,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "optional": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -173,6 +175,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -191,7 +194,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "optional": true
     },
     "minimatch": {
       "version": "3.0.2",
@@ -279,7 +283,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "optional": true
     },
     "right-align": {
       "version": "0.1.3",

--- a/Tasks/DownloadGitHubReleaseV0/task.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.json
@@ -10,8 +10,8 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 148,
-    "Patch": 2
+    "Minor": 149,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "Download GitHub Release",
@@ -90,7 +90,7 @@
       "target": "version",
       "endpointId": "$(connection)",
       "dataSourceName": "Releases",
-      "resultTemplate": "{ \"Value\" : \"{{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{id}}{{/equals}}\", \"DisplayValue\" : \" {{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{#if name}}{{name}}{{else}}{{id}}{{/if}}{{/equals}}\" }",
+      "resultTemplate": "{ \"Value\" : \"{{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{id}}{{/equals}}\", \"DisplayValue\" : \" {{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{#if name}}{{name}}{{else}}{{tag_name}}{{/if}}{{/equals}}{{#if prerelease}} (Pre-release){{/if}}\" }",
       "parameters": {
         "repositoryName": "$(userRepository)",
         "releaseByTagName": "$(defaultVersionType)"
@@ -114,7 +114,9 @@
     }
   },
   "messages": {
-    "DownloadArtifacts": "Downloading assets of release %s from: %s",
-    "ArtifactsSuccessfullyDownloaded": "Successfully downloaded release assets to %s"
+    "DownloadArtifacts": "Downloading assets of release '%s' from: %s",
+    "ArtifactsSuccessfullyDownloaded": "Successfully downloaded release assets to '%s'",
+    "InvalidRelease": "The release Id/Tag input '%s' is not valid",
+    "InvalidDefaultVersionType": "The DefaultVersionType input '%s' is not valid"
   }
 }

--- a/Tasks/DownloadGitHubReleaseV0/task.loc.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.loc.json
@@ -10,8 +10,8 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 148,
-    "Patch": 2
+    "Minor": 149,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -90,7 +90,7 @@
       "target": "version",
       "endpointId": "$(connection)",
       "dataSourceName": "Releases",
-      "resultTemplate": "{ \"Value\" : \"{{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{id}}{{/equals}}\", \"DisplayValue\" : \" {{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{#if name}}{{name}}{{else}}{{id}}{{/if}}{{/equals}}\" }",
+      "resultTemplate": "{ \"Value\" : \"{{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{id}}{{/equals}}\", \"DisplayValue\" : \" {{#equals defaultVersionType 'specificTag'}}{{tag_name}}{{else}}{{#if name}}{{name}}{{else}}{{tag_name}}{{/if}}{{/equals}}{{#if prerelease}} (Pre-release){{/if}}\" }",
       "parameters": {
         "repositoryName": "$(userRepository)",
         "releaseByTagName": "$(defaultVersionType)"
@@ -115,6 +115,8 @@
   },
   "messages": {
     "DownloadArtifacts": "ms-resource:loc.messages.DownloadArtifacts",
-    "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded"
+    "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
+    "InvalidRelease": "ms-resource:loc.messages.InvalidRelease",
+    "InvalidDefaultVersionType": "ms-resource:loc.messages.InvalidDefaultVersionType"
   }
 }


### PR DESCRIPTION
Show name/tag instead of release Id in task UI
Fail task if inputs are not valid
Improve task logs to show name/tag instead of Id of release being downloaded
Handle case when **defaultVersionType** input is null but **version** input is present
Show *Pre-release* in task UI for Pre-release versions