### PR TITLE
Users/eyma/appcenter distribute fix aliases

### DIFF
--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 150,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for multiple destinations.",
     "groups": [

--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -179,9 +179,7 @@
         {
             "name": "destinationGroupIds",
             "aliases": [
-                "destinationIds",
-                "distributionGroupId",
-                "destinationId"
+                "distributionGroupId"
             ],
             "type": "string",
             "defaultValue": "",
@@ -192,11 +190,6 @@
         },
         {
             "name": "destinationStoreId",
-            "aliases": [
-                "destinationIds",
-                "distributionGroupId",
-                "destinationId"
-            ],
             "type": "string",
             "label": "Destination ID",
             "helpMarkDown": "ID of the distribution store to deploy to.",


### PR DESCRIPTION
- Remove conflicting aliases from both distributionGroupIds and distributionStoreId that were causing issues with yaml build configuration
- Bump patch version of AppCenterDistributeV3