### PR TITLE
Increase iOS temporary keychain unlock time to 6 hours

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -27,9 +27,9 @@ export async function installCertInTemporaryKeychain(keychainPath: string, keych
         createKeychainCommand.arg(['create-keychain', '-p', keychainPwd, keychainPath]);
         await createKeychainCommand.exec();
 
-        //update keychain settings
+        //update keychain settings, keep keychain unlocked for 6h = 21600 sec, which is the job timeout for paid hosted VMs
         let keychainSettingsCommand: ToolRunner = tl.tool(tl.which('security', true));
-        keychainSettingsCommand.arg(['set-keychain-settings', '-lut', '7200', keychainPath]);
+        keychainSettingsCommand.arg(['set-keychain-settings', '-lut', '21600', keychainPath]);
         await keychainSettingsCommand.exec();
     }
 

--- a/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
@@ -66,7 +66,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "keychain created"
         },
-        "/usr/bin/security set-keychain-settings -lut 7200 /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/security set-keychain-settings -lut 21600 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain settings"
         },

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
@@ -57,7 +57,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "keychain created"
         },
-        "/usr/bin/security set-keychain-settings -lut 7200 /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/security set-keychain-settings -lut 21600 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain settings"
         },

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
@@ -57,7 +57,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "keychain created"
         },
-        "/usr/bin/security set-keychain-settings -lut 7200 /build/temp/ios_signing_temp.keychain": {
+        "/usr/bin/security set-keychain-settings -lut 21600 /build/temp/ios_signing_temp.keychain": {
             "code": 0,
             "stdout": "keychain settings"
         },

--- a/Tasks/InstallAppleCertificateV2/package-lock.json
+++ b/Tasks/InstallAppleCertificateV2/package-lock.json
@@ -31,7 +31,7 @@
     "ios-signing-common": {
       "version": "file:../../_build/Tasks/Common/ios-signing-common-1.0.0.tgz",
       "requires": {
-        "vsts-task-lib": "2.0.6"
+        "vsts-task-lib": "^2.0.3-preview"
       }
     },
     "minimatch": {
@@ -99,7 +99,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "0.12.0",
+        "typed-rest-client": "^0.12.0",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 149,
+        "Minor": 150,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 149,
+    "Minor": 150,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 149,
+        "Minor": 150,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 149,
+    "Minor": 150,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 149,
+        "Minor": 150,
         "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were there solely to maintain compat with Xcode 7 have been removed. The task has better options to work with the Hosted macOS pool.",

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 149,
+    "Minor": 150,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tests-Legacy/L0/XcodeV5/responseSigningFile.json
+++ b/Tests-Legacy/L0/XcodeV5/responseSigningFile.json
@@ -47,7 +47,7 @@
       "code": 0,
       "stdout": "temporary keychain created"
     },
-    "/usr/bin/security set-keychain-settings -lut 7200 /user/build/_xcodetasktmp.keychain": {
+    "/usr/bin/security set-keychain-settings -lut 21600 /user/build/_xcodetasktmp.keychain": {
       "code": 0,
       "stdout": "set-keychain-settings on temporary keychain output"
     },


### PR DESCRIPTION
This matches the timeout of pipeline jobs on Hosted VMs for paid customers. 