### PR TITLE
Mask temporary keychain password.

### DIFF
--- a/Tasks/InstallAppleCertificateV2/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/preinstallcert.ts
@@ -64,6 +64,9 @@ async function run() {
             // generate a keychain password for the temporary keychain
             // overriding any value we may have read because keychainPassword is hidden in the designer for 'temp'.
             keychainPwd = Math.random().toString(36);
+
+            // tl.setSecret would work too, except it's not available in mock-task yet.
+            tl.setVariable('keychainPassword', keychainPwd, true);
         } else if (keychain === 'default') {
             keychainPath = await sign.getDefaultKeychainPath();
         } else if (keychain === 'custom') {

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 150,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 150,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [


### PR DESCRIPTION
`[command]/usr/bin/security create-keychain -p *** /Users/vsts/agent/2.148.2/work/_temp/ios_signing_temp.keychain`

Testing:
- [x] Unit tests pass
- [x] Uploaded and confirmed temporary password was masked.