### PR TITLE
Adding telemetry data for PTR task

### DIFF
--- a/Tasks/PublishTestResultsV2/cieventlogger.ts
+++ b/Tasks/PublishTestResultsV2/cieventlogger.ts
@@ -2,6 +2,7 @@ import * as tl from 'vsts-task-lib/task';
 
 const area: string = 'TestExecution';
 const feature: string = 'PublishTestResultsTask';
+const consolidatedCiData: { [key: string]: any; } = <{ [key: string]: any; }>{};
 
 function getDefaultProps() {
     return {
@@ -13,8 +14,17 @@ function getDefaultProps() {
     };
 }
 
-export function publishEvent(properties: { [key: string]: any }): void {
+export function addToConsolidatedCi(key: string, value: any) {
+    consolidatedCiData[key] = value;
+}
+
+export function fireConsolidatedCi() {
+    publishEvent('publishTestResultsTaskConsolidatedCiEvent', consolidatedCiData);
+}
+
+export function publishEvent(subFeature: string, properties: { [key: string]: any }): void {
     try {
+        properties.subFeature = subFeature;
         _writeTelemetry(area, feature, Object.assign(getDefaultProps(), properties));
     } catch (err) {
         tl.debug('Unable to publish telemetry due to lower agent version.');

--- a/Tasks/PublishTestResultsV2/package-lock.json
+++ b/Tasks/PublishTestResultsV2/package-lock.json
@@ -24,7 +24,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -38,7 +38,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -72,11 +72,11 @@
       "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.5.1",
-        "semver": "5.5.1",
-        "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     }
   }

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as publishTestResultsTool from './publishtestresultstool';
 import * as tl from 'vsts-task-lib/task';
 import { publishEvent } from './cieventlogger';
+import * as ci from './cieventlogger';
 
 const MERGE_THRESHOLD = 100;
 const TESTRUN_SYSTEM = 'VSTS - PTR';
@@ -66,6 +67,8 @@ async function run() {
         tl.debug('publishRunAttachments: ' + publishRunAttachments);
         tl.debug('failTaskOnFailedTests: ' + failTaskOnFailedTests);
 
+        
+
         if (isNullOrWhitespace(searchFolder)) {
             searchFolder = tl.getVariable('System.DefaultWorkingDirectory');
         }
@@ -83,6 +86,12 @@ async function run() {
         const testResultsFilesCount = matchingTestResultsFiles ? matchingTestResultsFiles.length : 0;
 
         tl.debug(`Detected ${testResultsFilesCount} test result files`);
+
+        ci.addToConsolidatedCi('testRunner', testRunner);
+        ci.addToConsolidatedCi('failTaskOnFailedTests', failTaskOnFailedTests);
+        ci.addToConsolidatedCi('mergeResultsUserPreference', mergeResults);
+        ci.addToConsolidatedCi('testResultsFilesCount', testResultsFilesCount);   
+
         const forceMerge = testResultsFilesCount > MERGE_THRESHOLD;
         if (forceMerge) {
             tl.debug('Detected large number of test result files. Merged all of them into a single file and published a single test run to optimize for test result publish performance instead of publishing hundreds of test runs');
@@ -123,6 +132,7 @@ async function run() {
                 }
                 else if(exitCode == 40000){
                     // The exe returns with exit code: 40000 if there are test failures found and failTaskOnFailedTests is true
+                    ci.addToConsolidatedCi('failedTestsInRun', true);
                     tl.setResult(tl.TaskResult.Failed, tl.loc('ErrorFailTaskOnFailedTests'));
                 }
             } else {
@@ -136,14 +146,11 @@ async function run() {
                     TESTRUN_SYSTEM);
             }
         }
-
-        publishEvent({
-            'mergeResultsUserPreference': mergeResults,
-            'testResultsFilesCount': testResultsFilesCount
-        });
-
+        ci.fireConsolidatedCi();
         tl.setResult(tl.TaskResult.Succeeded, '');
     } catch (err) {
+
+        ci.fireConsolidatedCi();
         tl.setResult(tl.TaskResult.Failed, err);
     }
 }

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -67,9 +67,7 @@ export class TestResultsPublisher {
             fs.writeFileSync(responseFilePath, fileContent);
         } catch (ex) {
             // Log telemetry and return null path
-            publishEvent({
-                "exception": ex
-            });
+            publishEvent('publishTestResultsTaskEvent',{"exception": ex});
             tl.warning("Exception while writing to response file: " + ex);
             return null;
         }

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as tl from 'vsts-task-lib/task';
 import * as tr from 'vsts-task-lib/toolrunner';
 import { publishEvent } from './cieventlogger';
+import * as ci from './cieventlogger';
 let uuid = require('uuid');
 
 export class TestResultsPublisher {
@@ -67,7 +68,9 @@ export class TestResultsPublisher {
             fs.writeFileSync(responseFilePath, fileContent);
         } catch (ex) {
             // Log telemetry and return null path
-            publishEvent('publishTestResultsTaskEvent',{"exception": ex});
+            ci.addToConsolidatedCi('exception', ex);
+            ci.fireConsolidatedCi();
+
             tl.warning("Exception while writing to response file: " + ex);
             return null;
         }

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -69,8 +69,7 @@ export class TestResultsPublisher {
         } catch (ex) {
             // Log telemetry and return null path
             ci.addToConsolidatedCi('exception', ex);
-            ci.fireConsolidatedCi();
-
+            
             tl.warning("Exception while writing to response file: " + ex);
             return null;
         }

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 149,
-        "Patch": 2
+        "Minor": 150,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 149,
-    "Patch": 2
+    "Minor": 150,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Adding telemetry data for the task.
`
##[debug]Processed: ##vso[telemetry.publish area=TestExecution;feature=PublishTestResultsTask]{"builduri":"vstfs:///Build/Build/564","buildid":"564","osType":"Windows_NT","testRunner":"JUnit","failTaskOnFailedTests":"true","mergeResultsUserPreference":"false","config":null,"platform":null,"testResultsFilesCount":2,"failedTestsInRun":true,"subFeature":"publishTestResultsTaskConsolidatedCiEvent"}`