### PR TITLE
Invoking ImgDetails Post APi in buildPush DockerV2 task

### DIFF
--- a/Tasks/Common/docker-common/containerimageutils.ts
+++ b/Tasks/Common/docker-common/containerimageutils.ts
@@ -1,5 +1,6 @@
 "use strict";
 import * as tl from "vsts-task-lib/task";
+import * as fs from 'fs';
 
 export function hasRegistryComponent(imageName: string): boolean {
     var periodIndex = imageName.indexOf("."),
@@ -24,6 +25,11 @@ export function generateValidImageName(imageName: string): string {
     imageName = imageName.toLowerCase();
     imageName = imageName.replace(/ /g,"");
     return imageName;
+}
+
+export function getBaseImageNameFromDockerFileContent(dockerFilePath: string): string {
+    const dockerFileContent = fs.readFileSync(dockerFilePath, 'utf-8').toString();
+    return getBaseImageName(dockerFileContent);
 }
 
 export function getBaseImageName(contents: string): string {

--- a/Tasks/Common/docker-common/containerimageutils.ts
+++ b/Tasks/Common/docker-common/containerimageutils.ts
@@ -27,7 +27,7 @@ export function generateValidImageName(imageName: string): string {
     return imageName;
 }
 
-export function getBaseImageNameFromDockerFileContent(dockerFilePath: string): string {
+export function getBaseImageNameFromDockerFile(dockerFilePath: string): string {
     const dockerFileContent = fs.readFileSync(dockerFilePath, 'utf-8').toString();
     return getBaseImageName(dockerFileContent);
 }

--- a/Tasks/Common/docker-common/dockercommandutils.ts
+++ b/Tasks/Common/docker-common/dockercommandutils.ts
@@ -55,7 +55,7 @@ export function command(connection: ContainerConnection, dockerCommand: string, 
     });
 }
 
-export function push(connection: ContainerConnection, image: string, commandArguments: string, onCommandOut: (output) => any): any {
+export function push(connection: ContainerConnection, image: string, commandArguments: string, onCommandOut: (image, output) => any): any {
     var command = connection.createCommand();
     command.arg("push");
     command.arg(image);
@@ -69,7 +69,7 @@ export function push(connection: ContainerConnection, image: string, commandArgu
 
     return connection.execCommand(command).then(() => {
         // Return the std output of the command by calling the delegate
-        onCommandOut(output + "\n");
+        onCommandOut(image, output + "\n");
     });
 }
 

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/dockerpush.ts
+++ b/Tasks/DockerV2/dockerpush.ts
@@ -1,12 +1,17 @@
 "use strict";
 
 import * as tl from "vsts-task-lib/task";
+import * as fs from 'fs';
 import ContainerConnection from "docker-common/containerconnection";
 import * as dockerCommandUtils from "docker-common/dockercommandutils";
 import * as utils from "./utils";
+import { findDockerFile } from "docker-common/fileutils";
+import { WebRequest, WebResponse, sendRequest } from 'utility-common/restutilities';
+import { getBaseImageName, getResourceName, getBaseImageNameFromDockerFileContent } from "docker-common/containerimageutils";
+
 import Q = require('q');
 
-function pushMultipleImages(connection: ContainerConnection, imageNames: string[], tags: string[], commandArguments: string, onCommandOut: (output) => any): any {
+function pushMultipleImages(connection: ContainerConnection, imageNames: string[], tags: string[], commandArguments: string, onCommandOut: (image, output) => any): any {
     let promise: Q.Promise<void>;
     // create chained promise of push commands
     if (imageNames && imageNames.length > 0) {
@@ -14,6 +19,7 @@ function pushMultipleImages(connection: ContainerConnection, imageNames: string[
             if (tags && tags.length > 0) {
                 tags.forEach(tag => {
                     let imageNameWithTag = imageName + ":" + tag;
+                    tl.debug("Pushing ImageNameWithTag: " + imageNameWithTag);
                     if (promise) {
                         promise = promise.then(() => {
                             return dockerCommandUtils.push(connection, imageNameWithTag, commandArguments, onCommandOut)
@@ -25,6 +31,7 @@ function pushMultipleImages(connection: ContainerConnection, imageNames: string[
                 });
             }
             else {
+                tl.debug("Pushing ImageName: " + imageName);
                 if (promise) {
                     promise = promise.then(() => {
                         return dockerCommandUtils.push(connection, imageName, commandArguments, onCommandOut)
@@ -42,7 +49,7 @@ function pushMultipleImages(connection: ContainerConnection, imageNames: string[
 }
 
 export function run(connection: ContainerConnection, outputUpdate: (data: string) => any): any {
-    var commandArguments = tl.getInput("arguments", false); 
+    var commandArguments = tl.getInput("arguments", false);
 
     // get tags input
     let tags = tl.getDelimitedInput("tags", "\n");
@@ -62,10 +69,26 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         imageNames = connection.getQualifiedImageNamesFromConfig(repositoryName);
     }
 
+    const dockerfilepath = tl.getInput("dockerFile", true);
+    const dockerFile = findDockerFile(dockerfilepath);
+    if (!tl.exist(dockerFile)) {
+        throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
+    }
+
     // push all tags
     let output = "";
-    let promise = pushMultipleImages(connection, imageNames, tags, commandArguments, (commandOut) => output += commandOut);
-    
+    let outputImageName = "";
+    let digest = "";
+    let promise = pushMultipleImages(connection, imageNames, tags, commandArguments, (image, commandOutput) => {
+        output += commandOutput;
+        outputImageName = image;
+        digest = extractDigestFromOutput(commandOutput);
+        tl.debug("outputImageName: " + outputImageName + "\n" + "commandOutput: " + commandOutput + "\n" + "digest:" + digest);
+        publishToImageMetadataStore(connection, outputImageName, tags, digest, dockerFile).then((result) => {
+            tl.debug("ImageDetailsApiResponse: " + result);
+        });
+    });
+
     if (promise) {
         promise = promise.then(() => {
             let taskOutputPath = utils.writeTaskOutput("push", output);
@@ -79,3 +102,78 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
 
     return promise;
 }
+
+async function publishToImageMetadataStore(connection: ContainerConnection, imageName: string, tags: string[], digest: string, dockerFilePath: string): Promise<any> {
+    // Getting imageDetails
+    const imageUri = getResourceName(imageName, digest);
+    const baseImageName = getBaseImageNameFromDockerFileContent(dockerFilePath);
+    // ToDO:: Fix the getLayers code in dockerCommandUtils to handle the promise returned in history-> execCommand
+    const layers = [{ "directive": "", "arguments": "" }];
+    // const layers = dockerCommandUtils.getLayers(connection, imageName);
+
+    // Getting pipeline variables
+    const buildId = parseInt(tl.getVariable("Build.BuildId"));
+    const buildDefinitionName = tl.getVariable("Build.DefinitionName");
+    const buildVersion = tl.getVariable("Build.BuildNumber");
+    const buildDefinitionId = tl.getVariable("System.DefinitionId");
+
+    const requestUrl = tl.getVariable("System.TeamFoundationCollectionUri") + tl.getVariable("System.TeamProject") + "/_apis/deployment/imagedetails?api-version=5.0-preview.1";
+    const requestBody: string = JSON.stringify(
+        {
+            "imageName": imageUri,
+            "imageUri": imageUri,
+            "hash": digest,
+            "baseImageName": baseImageName,
+            "distance": 0,
+            "imageType": "",
+            "mediaType": "",
+            "tags": tags,
+            "layerInfo": layers,
+            "buildId": buildId,
+            "buildVersion": buildVersion,
+            "buildDefinitionName": buildDefinitionName,
+            "buildDefinitionId": buildDefinitionId
+        }
+    );
+
+    return sendRequestToImageStore(requestBody, requestUrl);
+}
+
+function extractDigestFromOutput(dockerPushCommandOutput: string): string {
+    const matchPatternForDigest = new RegExp(/sha256\:([\w]+)/);
+    const imageMatch = dockerPushCommandOutput.match(matchPatternForDigest);
+    if (imageMatch && imageMatch.length >= 1) {
+        return imageMatch[1];
+    }
+
+    return "";
+}
+
+async function sendRequestToImageStore(requestBody: string, requestUrl: string): Promise<any> {
+    const request = new WebRequest();
+    const accessToken: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
+    request.uri = requestUrl;
+    request.method = 'POST';
+    request.body = requestBody;
+    request.headers = {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + accessToken
+    };
+
+    tl.debug("requestUrl: " + requestUrl);
+    tl.debug("requestBody: " + requestBody);
+    tl.debug("accessToken: " + accessToken);
+
+    try {
+        tl.debug("Sending request for pushing image to Image meta data store");
+        const response = await sendRequest(request);
+        return response;
+    }
+    catch (error) {
+        tl.debug("Unable to push to Image Details Artifact Store, Error: " + error);
+    }
+
+    return Promise.resolve();
+}
+
+

--- a/Tasks/DockerV2/make.json
+++ b/Tasks/DockerV2/make.json
@@ -4,5 +4,11 @@
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
+	},
+	{
+		"module": "../Common/utility-common",
+		"type": "node",
+		"dest" : "./",
+		"compile" : true
 	}]
 }

--- a/Tasks/DockerV2/package-lock.json
+++ b/Tasks/DockerV2/package-lock.json
@@ -252,9 +252,14 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "shelljs": {
       "version": "0.3.0",
@@ -271,10 +276,71 @@
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
+    "typed-rest-client": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
+      "requires": {
+        "tunnel": "0.0.4",
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
+      }
+    },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "utility-common": {
+      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
+      "requires": {
+        "js-yaml": "3.6.1",
+        "semver": "^5.4.1",
+        "vso-node-api": "6.5.0",
+        "vsts-task-lib": "2.6.0",
+        "vsts-task-tool-lib": "0.4.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "vso-node-api": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+          "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "typed-rest-client": "^0.12.0",
+            "underscore": "1.8.3"
+          }
+        },
+        "vsts-task-lib": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+          "requires": {
+            "minimatch": "3.0.4",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
+          }
+        }
+      }
     },
     "vso-node-api": {
       "version": "6.0.1-preview",
@@ -297,6 +363,52 @@
         "q": "^1.1.2",
         "semver": "^5.1.0",
         "shelljs": "^0.3.0"
+      }
+    },
+    "vsts-task-tool-lib": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+      "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
+      "requires": {
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.9.0",
+        "uuid": "^3.0.1",
+        "vsts-task-lib": "2.0.4-preview"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "vsts-task-lib": {
+          "version": "2.0.4-preview",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+          "requires": {
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
+          }
+        }
       }
     },
     "wrappy": {

--- a/Tasks/DockerV2/package.json
+++ b/Tasks/DockerV2/package.json
@@ -6,6 +6,7 @@
     "del": "2.2.0",
     "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
     "esprima": "2.7.1",
-    "js-yaml": "3.6.1"
+    "js-yaml": "3.6.1",
+    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz"
   }
 }

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 150,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
When we run the DockerV2 task to build and push an image to a container registry, we will call the API -  [AddImageDetailsAsync](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FDeployment%2FClient%2FWebApi%2FGenerated%2FDeploymentHttpClient.cs&version=GBmaster&line=70&lineStyle=plain&lineEnd=70&lineStartColumn=27&lineEndColumn=47) to post the [image details as per Grafeas format ](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FDeployment%2FClient%2FWebApi%2FContracts%2FImageDetails.cs&version=GBmaster) to Deployment DB (tables Deployment.tbl_Note and Deployment.tbl_Occurrence).
This data will then be used to show the image details in the UI via [data providers](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FDeployment%2FService%2FPlugins%2FDataProviders&version=GBmaster)  