### PR TITLE
FileTransform - make file type dropdown not editable

### DIFF
--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 1
+        "Patch": 2
     },
     "instanceNameFormat": "File Transform: $(Package)",
     "groups": [

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -66,7 +66,7 @@
                 "json": "JSON"
             },
             "properties": {
-                "EditableOptions": "True"
+                "EditableOptions": "False"
             },
             "groupName": "VariableSubstitution",
             "helpMarkDown": "Provide file format on which substitution has to be perfformed<br/>For XML, Variables defined in the build or release pipelines will be matched against the 'key' or 'name' entries in the appSettings, applicationSettings, and connectionStrings sections of any config file and parameters.xml. Variable Substitution is run after config transforms.<br/>To substitute JSON variables that are nested or hierarchical, specify them using JSONPath expressions. <br/> <br/> For example, to replace the value of ‘ConnectionString’ in the sample below, you need to define a variable as ‘Data.DefaultConnection.ConnectionString’ in the build or release pipeline (or release pipeline's environment). <br/> {<br/>&nbsp;&nbsp;\"Data\": {<br/>&nbsp;&nbsp;&nbsp;&nbsp;\"DefaultConnection\": {<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\"ConnectionString\": \"Server=(localdb)\\SQLEXPRESS;Database=MyDB;Trusted_Connection=True\"<br/>&nbsp;&nbsp;&nbsp;&nbsp;}<br/>&nbsp;&nbsp;}<br/> }<br/> Variable Substitution is run after configuration transforms. <br/><br/> Note: only custom variables defined in build/release pipelines are used in substitution. Default/system defined pipeline variables are excluded. <br/>Note: If same variables are defined in the release pipeline and in the stage, then the stage variables will supersede the release pipeline variables."

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -66,7 +66,7 @@
         "json": "JSON"
       },
       "properties": {
-        "EditableOptions": "True"
+        "EditableOptions": "False"
       },
       "groupName": "VariableSubstitution",
       "helpMarkDown": "ms-resource:loc.input.help.fileType"

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 1
+    "Patch": 2
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [


### PR DESCRIPTION
There is only a fixed list of supported types, so it doesn't make much sense to have it editable.