### PR TITLE
Making RG optional in check policy gate, and task friendly name changed.

### DIFF
--- a/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,8 +1,8 @@
 {
-  "loc.friendlyName": "Azure Policy Check Gate",
+  "loc.friendlyName": "Check Azure Policy Compliance",
   "loc.helpMarkDown": "",
   "loc.description": "Security and compliance assessment with Azure policies on resources that belong to the resource group and Azure subscription.",
-  "loc.instanceNameFormat": "Azure Policy compliance assessment for $(ResourceGroupName)",
+  "loc.instanceNameFormat": "Azure Policy compliance assessment for $(ConnectedServiceName):$(ResourceGroupName)",
   "loc.input.label.ConnectedServiceName": "Azure subscription",
   "loc.input.help.ConnectedServiceName": "Select the Azure Resource Manager subscription to enforce the policies.",
   "loc.input.label.ResourceGroupName": "Resource group",

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -1,7 +1,7 @@
 {
   "id": "8BA74703-E94F-4A35-814E-FC21F44578A2",
   "name": "AzurePolicyCheckGate",
-  "friendlyName": "Azure Policy Check Gate",
+  "friendlyName": "Check Azure Policy Compliance",
   "description": "Security and compliance assessment with Azure policies on resources that belong to the resource group and Azure subscription.",
   "helpUrl": "",
   "helpMarkDown": "",
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 3
   },
   "preview": "true",
   "inputs": [
@@ -34,7 +34,6 @@
       "name": "ResourceGroupName",
       "type": "pickList",
       "label": "Resource group",
-      "required": true,
       "helpMarkDown": "Provide name of a resource group.",
       "properties": {
         "EditableOptions": "True"
@@ -69,14 +68,14 @@
       "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
     }
   ],
-  "instanceNameFormat": "Azure Policy compliance assessment for $(ResourceGroupName)",
+  "instanceNameFormat": "Azure Policy compliance assessment for $(ConnectedServiceName):$(ResourceGroupName)",
   "execution": {
     "HttpRequestChain": {
       "Execute": [
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview{{/if}}",
             "Method": "POST"
           },
           "ExecutionOptions": {
@@ -95,7 +94,7 @@
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
             "Method": "POST",
             "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
           }

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 0,
-    "Patch": 3
+    "Minor": 151,
+    "Patch": 0
   },
   "preview": "true",
   "inputs": [

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 3
   },
   "preview": "true",
   "inputs": [
@@ -34,7 +34,6 @@
       "name": "ResourceGroupName",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.ResourceGroupName",
-      "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.ResourceGroupName",
       "properties": {
         "EditableOptions": "True"
@@ -76,7 +75,7 @@
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/triggerEvaluation?api-version=2018-07-01-preview{{/if}}",
             "Method": "POST"
           },
           "ExecutionOptions": {
@@ -97,7 +96,7 @@
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
             "Method": "POST",
             "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
           }

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -15,8 +15,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 0,
-    "Patch": 3
+    "Minor": 151,
+    "Patch": 0
   },
   "preview": "true",
   "inputs": [


### PR DESCRIPTION
1. Renaming the task (friendly name) to "Check Azure Policy Compliance"
2. Making the RG field optional, if the user wants to invoke the policy check across RGs in the subscription.

![image](https://user-images.githubusercontent.com/26896383/56124513-6e30c800-5f94-11e9-927a-c05ef8328e17.png)
