### PR TITLE
AzurePolicyTask: Change instance name format string

### DIFF
--- a/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
@@ -2,7 +2,7 @@
   "loc.friendlyName": "Check Azure Policy Compliance",
   "loc.helpMarkDown": "",
   "loc.description": "Security and compliance assessment with Azure policies on resources that belong to the resource group and Azure subscription.",
-  "loc.instanceNameFormat": "Azure Policy compliance assessment for $(ConnectedServiceName):$(ResourceGroupName)",
+  "loc.instanceNameFormat": "Check Policy Compliance",
   "loc.input.label.ConnectedServiceName": "Azure subscription",
   "loc.input.help.ConnectedServiceName": "Select the Azure Resource Manager subscription to enforce the policies.",
   "loc.input.label.ResourceGroupName": "Resource group",

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -68,7 +68,7 @@
       "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{name}}}\" }"
     }
   ],
-  "instanceNameFormat": "Azure Policy compliance assessment for $(ConnectedServiceName):$(ResourceGroupName)",
+  "instanceNameFormat": "Check Policy Compliance",
   "execution": {
     "HttpRequestChain": {
       "Execute": [


### PR DESCRIPTION
Changing instanceNameFormat to a static string since ResourceGroupName is now an optional field and the ConnectedServiceName is a GUID that is not user friendly.