### PR TITLE
Fixed documentation error in KubernetesV0 and V1 tasks

### DIFF
--- a/Tasks/KubernetesV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesV0/Strings/resources.resjson/en-US/resources.resjson
@@ -49,7 +49,7 @@
   "loc.input.label.versionOrLocation": "Kubectl",
   "loc.input.help.versionOrLocation": "kubectl is a command line interface for running commands against Kubernetes clusters.",
   "loc.input.label.versionSpec": "Version spec",
-  "loc.input.help.versionSpec": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0, >=6.10.0",
+  "loc.input.help.versionSpec": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0",
   "loc.input.label.checkLatest": "Check for latest version",
   "loc.input.help.checkLatest": "Always checks online for the latest available version (stable.txt) that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
   "loc.input.label.specifyLocation": "Path to Kubectl",

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 151,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",
@@ -272,7 +272,7 @@
             "type": "string",
             "label": "Version spec",
             "defaultValue": "1.7.0",
-            "helpMarkDown": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0, >=6.10.0",
+            "helpMarkDown": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0",
             "groupName": "advanced",
             "visibleRule": "versionOrLocation = version"
         },

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 151,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
@@ -65,7 +65,7 @@
   "loc.input.label.versionOrLocation": "Kubectl",
   "loc.input.help.versionOrLocation": "kubectl is a command line interface for running commands against Kubernetes clusters.",
   "loc.input.label.versionSpec": "Version spec",
-  "loc.input.help.versionSpec": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0, >=6.10.0",
+  "loc.input.help.versionSpec": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0",
   "loc.input.label.checkLatest": "Check for latest version",
   "loc.input.help.checkLatest": "Always checks online for the latest available version (stable.txt) that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
   "loc.input.label.specifyLocation": "Path to kubectl",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 151,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -368,7 +368,7 @@
             "type": "string",
             "label": "Version spec",
             "defaultValue": "1.13.2",
-            "helpMarkDown": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0, >=6.10.0",
+            "helpMarkDown": "Version Spec of version to get.  Examples: 1.7.0, 1.x.0, 4.x.0, 6.10.0",
             "groupName": "advanced",
             "visibleRule": "versionOrLocation = version"
         },

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 151,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Error in kubernetes versionspec field tooltip. We don't support '>=' in version spec