### PR TITLE
AzurePolicyV0: Change summary URL

### DIFF
--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -96,7 +96,7 @@
             "EndpointId": "$(connectedServiceName)",
             "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
             "Method": "POST",
-            "Expression": "eq(count(root['value'][0].results.nonCompliantPolicies), 0)"
+            "Expression": "eq(root['value'][0].results.nonCompliantPolicies, 0)"
           }
         }
       ]

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 151,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": "true",
   "inputs": [
@@ -94,9 +94,9 @@
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
             "Method": "POST",
-            "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
+            "Expression": "eq(count(root['value'][0].results.nonCompliantPolicies), 0)"
           }
         }
       ]

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 151,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": "true",
   "inputs": [
@@ -96,9 +96,9 @@
         {
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
-            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
             "Method": "POST",
-            "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
+            "Expression": "eq(count(root['value'][0].results.nonCompliantPolicies), 0)"
           }
         }
       ]

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -98,7 +98,7 @@
             "EndpointId": "$(connectedServiceName)",
             "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
             "Method": "POST",
-            "Expression": "eq(count(root['value'][0].results.nonCompliantPolicies), 0)"
+            "Expression": "eq(root['value'][0].results.nonCompliantPolicies, 0)"
           }
         }
       ]


### PR DESCRIPTION
Changing the URL that is used to find out if evaluation was successful or not.

Existing URL retrieves all non-compliant resources, the new API returns the count of non-compliant resources and count of policies that were violated.

{
	"@odata.context": "....",
	"@odata.count": 1,
	"value": [
		{
			"@odata.id": null,
			"@odata.context": "....",
			"results": {
				"queryResultsUri": "...",
				"nonCompliantResources": 11714,
				"nonCompliantPolicies": 4
			},
			.....