### PR TITLE
AzurePolicyV0: Add summary URL just for logs, and using queryResults …

### DIFF
--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": "true",
   "inputs": [
@@ -95,8 +95,15 @@
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
             "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
+            "Method": "POST"
+          }
+        },
+        {
+          "RequestInputs": {
+            "EndpointId": "$(connectedServiceName)",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
             "Method": "POST",
-            "Expression": "eq(root['value'][0].results.nonCompliantPolicies, 0)"
+            "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
           }
         }
       ]

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": "true",
   "inputs": [
@@ -97,8 +97,15 @@
           "RequestInputs": {
             "EndpointId": "$(connectedServiceName)",
             "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/summarize?api-version=2018-04-04{{/if}}",
+            "Method": "POST"
+          }
+        },
+        {
+          "RequestInputs": {
+            "EndpointId": "$(connectedServiceName)",
+            "EndpointUrl": "{{#if ResourceGroupName}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/resourceGroups/$(ResourceGroupName)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{else}}$(endpoint.url)subscriptions/$(endpoint.subscriptionId)/providers/Microsoft.PolicyInsights/policyStates/latest/queryResults?api-version=2018-04-04&$filter=IsCompliant eq false{{/if}}",
             "Method": "POST",
-            "Expression": "eq(root['value'][0].results.nonCompliantPolicies, 0)"
+            "Expression": "or(and(eq(isNullOrEmpty(taskInputs['resources']), true), eq(count(jsonpath('value[*].resourceId')), 0)), and(eq(isNullOrEmpty(taskInputs['resources']), false), eq(count(intersect(split(taskInputs['resources'], ','), jsonpath('value[*].resourceId'))) ,0)))"
           }
         }
       ]


### PR DESCRIPTION
…for gate evaluation

Summary URL is now used only to display a small summary of the evaluation. The queryResults API is being used for the success/failure evaluation as was used earlier.