### PR TITLE
[KubManifestV0] Ignore SSL errors conditonally

### DIFF
--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -105,7 +105,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "vso-node-api": {
       "version": "6.5.0",

--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -105,7 +105,7 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
     },
     "vso-node-api": {
       "version": "6.5.0",

--- a/Tasks/KubernetesManifestV0/src/actions/bake.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/bake.ts
@@ -9,7 +9,7 @@ import { Helm, NameValuePair } from "utility-common/helm-object-model";
 
 const uuidV4 = require('uuid/v4');
 
-export async function bake() {
+export async function bake(ignoreSslErrors?: boolean) {
     let renderType = tl.getInput("renderType", true);
     switch (renderType) {
         case "helm2":

--- a/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
@@ -7,7 +7,7 @@ import * as TaskInputParameters from '../models/TaskInputParameters';
 import AuthenticationToken from "docker-common/registryauthenticationprovider/registryauthenticationtoken";
 import { getDockerRegistryEndpointAuthenticationToken } from "docker-common/registryauthenticationprovider/registryauthenticationtoken";
 
-export async function createSecret() {
+export async function createSecret(ignoreSslErrors?: boolean) {
     let args = "";
     if (utils.isEqual(TaskInputParameters.secretType, "dockerRegistry", utils.StringComparer.OrdinalIgnoreCase)) {
         args = getDockerRegistrySecretArgs();
@@ -16,7 +16,7 @@ export async function createSecret() {
         args = getGenericSecretArgs();
     }
 
-    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace);
+    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
     var result = kubectl.createSecret(args, true, TaskInputParameters.secretName.trim());
     utils.checkForErrors([result]);
 }

--- a/Tasks/KubernetesManifestV0/src/actions/delete.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/delete.ts
@@ -5,14 +5,14 @@ import { Kubectl } from "kubernetes-common/kubectl-object-model";
 import * as utils from "../utils/utilities";
 import * as TaskInputParameters from '../models/TaskInputParameters';
 
-export async function deleteResources() {
+export async function deleteResources(ignoreSslErrors?: boolean) {
     let args = TaskInputParameters.args;
 
     if (args == null || args.length == 0) {
         throw (tl.loc("ArgumentsInputNotSupplied"));
     }
 
-    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace);
+    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
     var result = kubectl.delete(args);
     utils.checkForErrors([result]);
 }

--- a/Tasks/KubernetesManifestV0/src/actions/deploy.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/deploy.ts
@@ -5,8 +5,8 @@ import * as TaskInputParameters from '../models/TaskInputParameters';
 import * as utils from "../utils/utilities";
 import { Kubectl } from "kubernetes-common/kubectl-object-model";
 
-export async function deploy() {
+export async function deploy(ignoreSslErrors?: boolean) {
     var kubectlPath = await utils.getKubectl();
-    let kubectl = new Kubectl(kubectlPath, TaskInputParameters.namespace);
+    let kubectl = new Kubectl(kubectlPath, TaskInputParameters.namespace, ignoreSslErrors);
     deploymentHelper.deploy(kubectl, TaskInputParameters.manifests, TaskInputParameters.deploymentStrategy);
 }

--- a/Tasks/KubernetesManifestV0/src/actions/patch.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/patch.ts
@@ -5,8 +5,8 @@ import { Kubectl } from "kubernetes-common/kubectl-object-model";
 import * as utils from "../utils/utilities";
 import * as constants from "../models/constants";
 
-export async function patch() {
-    let kubectl = new Kubectl(await utils.getKubectl(), tl.getInput("namespace", false));
+export async function patch(ignoreSslErrors?: boolean) {
+    let kubectl = new Kubectl(await utils.getKubectl(), tl.getInput("namespace", false), ignoreSslErrors);
     let kind = tl.getInput("kind", false).toLowerCase();
     let name = tl.getInput("name", false);
     let filePath = tl.getInput("resourceFileToPatch", false);

--- a/Tasks/KubernetesManifestV0/src/actions/promote.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/promote.ts
@@ -6,9 +6,9 @@ import { Kubectl } from "kubernetes-common/kubectl-object-model";
 import * as utils from "../utils/utilities";
 import * as TaskInputParameters from '../models/TaskInputParameters';
 
-export async function promote() {
+export async function promote(ignoreSslErrors?: boolean) {
 
-    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace);
+    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
 
     if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
         // Deploy input manifests

--- a/Tasks/KubernetesManifestV0/src/actions/reject.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/reject.ts
@@ -5,9 +5,9 @@ import { Kubectl } from "kubernetes-common/kubectl-object-model";
 import * as utils from "../utils/utilities";
 import * as TaskInputParameters from '../models/TaskInputParameters';
 
-export async function reject() {
+export async function reject(ignoreSslErrors?: boolean) {
 
-    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace);
+    let kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
 
     if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
         tl.debug("Deployment strategy selected is Canary. Deleting baseline and canary workloads.");

--- a/Tasks/KubernetesManifestV0/src/actions/scale.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/scale.ts
@@ -5,8 +5,8 @@ import { Kubectl } from "kubernetes-common/kubectl-object-model";
 import * as utils from "../utils/utilities";
 import * as constants from "../models/constants";
 
-export async function scale() {
-    let kubectl = new Kubectl(await utils.getKubectl(), tl.getInput("namespace", false));
+export async function scale(ignoreSslErrors?: boolean) {
+    let kubectl = new Kubectl(await utils.getKubectl(), tl.getInput("namespace", false), ignoreSslErrors);
     let kind = tl.getInput("kind", true).toLowerCase();
     let replicas = tl.getInput("replicas", true);
     let name = tl.getInput("name", true);

--- a/Tasks/KubernetesManifestV0/src/connection.ts
+++ b/Tasks/KubernetesManifestV0/src/connection.ts
@@ -5,7 +5,8 @@ import * as utils from "./utils/FileHelper";
 import kubectlutility = require("utility-common/kubectlutility");
 
 export class Connection {
-
+    public ignoreSSLErrors: boolean;
+    
     public open() {
         let kubeconfig: string, kubeconfigFile: string;
         let kubernetesServiceConnection = tl.getInput("kubernetesServiceConnection", true);
@@ -22,6 +23,7 @@ export class Connection {
         kubeconfigFile = path.join(utils.getNewUserDirPath(), "config");
         fs.writeFileSync(kubeconfigFile, kubeconfig);
         tl.setVariable("KUBECONFIG", kubeconfigFile);
+        this.ignoreSSLErrors = tl.getEndpointDataParameter(kubernetesServiceConnection, 'acceptUntrustedCerts', true) === "true";
     }
 
     public close() {

--- a/Tasks/KubernetesManifestV0/src/run.ts
+++ b/Tasks/KubernetesManifestV0/src/run.ts
@@ -46,8 +46,8 @@ function run(): Promise<void> {
             tl.setResult(tl.TaskResult.Failed, 'Not a supported action, choose from "bake", "deploy", "patch", "scale", "delete", "promote", "reject"');
             process.exit(1);
     }
-    connection.open()
-    return action_func()
+    connection.open();
+    return action_func(connection.ignoreSSLErrors)
         .then(() => connection.close())
         .catch((error) => {
             connection.close()

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 150,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 150,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
Adding an `--insecure-skip-tls-verify` argument to CLI when the kubernetes endpoint has `allowUntrustedCertificates` enabled.