### PR TITLE
Made Advanced section visible on kubectl login command KubernetesV1 task

### DIFF
--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 151,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -46,7 +46,7 @@
             "name": "advanced",
             "displayName": "Advanced",
             "isExpanded": false,
-            "visibleRule": "command != login && command != logout"
+            "visibleRule": "command != logout"
         },
         {
             "name": "output",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -45,8 +45,7 @@
         {
             "name": "advanced",
             "displayName": "Advanced",
-            "isExpanded": false,
-            "visibleRule": "command != logout"
+            "isExpanded": false
         },
         {
             "name": "output",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -45,8 +45,7 @@
     {
       "name": "advanced",
       "displayName": "ms-resource:loc.group.displayName.advanced",
-      "isExpanded": false,
-      "visibleRule": "command != logout"
+      "isExpanded": false
     },
     {
       "name": "output",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 151,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -46,7 +46,7 @@
       "name": "advanced",
       "displayName": "ms-resource:loc.group.displayName.advanced",
       "isExpanded": false,
-      "visibleRule": "command != login && command != logout"
+      "visibleRule": "command != logout"
     },
     {
       "name": "output",


### PR DESCRIPTION
The login command task was downloading kubectl even though version spec  was not set to visible when command was login.
