### PR TITLE
Restore fixed version numbers of DownloadPipelineArtifact and PublishPipelineArtifact

### DIFF
--- a/Tasks/DownloadPipelineArtifactV0/task.json
+++ b/Tasks/DownloadPipelineArtifactV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
+        "Minor": 139,
         "Patch": 0
     },
     "groups": [],

--- a/Tasks/DownloadPipelineArtifactV0/task.loc.json
+++ b/Tasks/DownloadPipelineArtifactV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
+    "Minor": 139,
     "Patch": 0
   },
   "groups": [],

--- a/Tasks/DownloadPipelineArtifactV1/task.json
+++ b/Tasks/DownloadPipelineArtifactV1/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 2
+        "Patch": 0
     },
     "groups": [],
     "demands": [],

--- a/Tasks/DownloadPipelineArtifactV1/task.loc.json
+++ b/Tasks/DownloadPipelineArtifactV1/task.loc.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 2
+    "Patch": 0
   },
   "groups": [],
   "demands": [],

--- a/Tasks/PublishPipelineArtifactV0/task.json
+++ b/Tasks/PublishPipelineArtifactV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
+        "Minor": 139,
         "Patch": 0
     },
     "groups": [],

--- a/Tasks/PublishPipelineArtifactV0/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
+    "Minor": 139,
     "Patch": 0
   },
   "groups": [],


### PR DESCRIPTION
Restore fixed version numbers of DownloadPipelineArtifact and PublishPipelineArtifact.
@jahsu-MSFT I wasn't able to add you as a reviewer, but your review is requested.  :)