### PR TITLE
Choose parent's group id in maven download package task if current ar…

### DIFF
--- a/Tasks/DownloadPackageV1/packagebuilder.ts
+++ b/Tasks/DownloadPackageV1/packagebuilder.ts
@@ -136,7 +136,7 @@ export class PackageUrlsBuilder {
 
     private getMavenRouteParams(feedId: string, project: string, packageMetadata: any, fileMetadata: any): any {
         var fileName = fileMetadata.name;
-        var groupId = packageMetadata.protocolMetadata.data.groupId.replace(new RegExp("\\."), "/");
+        var groupId = packageMetadata.protocolMetadata.data.groupId || packageMetadata.protocolMetadata.data.parent.groupId;
         var artifactId = packageMetadata.protocolMetadata.data.artifactId;
         var version = packageMetadata.protocolMetadata.data.version;
 

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Adds support to download Maven, Python, Universal and Npm packages.",

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
…tifact doensn't have a groupid.