### PR TITLE
Updated image size calculation in docker v2 task

### DIFF
--- a/Tasks/Common/docker-common/dockercommandutils.ts
+++ b/Tasks/Common/docker-common/dockercommandutils.ts
@@ -5,6 +5,8 @@ import * as Q from "q";
 import ContainerConnection from "./containerconnection";
 import * as pipelineUtils from "./pipelineutils";
 
+const matchPatternForSize = new RegExp(/[\d\.]+/);
+
 export function build(connection: ContainerConnection, dockerFile: string, context: string, commandArguments: string, labelArguments: string[], tagArguments: string[], onCommandOut: (output) => any): any {
     var command = connection.createCommand();
 
@@ -89,6 +91,38 @@ export async function getLayers(connection: ContainerConnection, imageId: string
     return layers.reverse();
 }
 
+export function getImageSize(layers: { [key: string]: string }[]): string {
+    let imageSize = 0;
+    for (const layer of layers) {
+        for (let key in layer) {
+            if (key.toLowerCase() === "size") {
+                const layerSize = extractSizeInBytes(layer[key]);
+                imageSize += layerSize;
+            }
+        }
+    }
+
+    return imageSize.toString() + "B";
+}
+
+function extractSizeInBytes(size: string): number {
+    const sizeStringValue = size.match(matchPatternForSize);
+    if (sizeStringValue && sizeStringValue.length > 0) {
+        const sizeIntValue = parseFloat(sizeStringValue[0]);
+        const sizeUnit = size.substring(sizeIntValue.toString().length);
+        switch (sizeUnit.toLowerCase()) {
+            case "b": return sizeIntValue;
+            case "kb": return sizeIntValue * 1000;
+            case "mb": return sizeIntValue * 1000 * 1000;
+            case "gb": return sizeIntValue * 1000 * 1000 * 1000;
+            case "tb": return sizeIntValue * 1000 * 1000 * 1000 * 1000;
+            case "pb": return sizeIntValue * 1000 * 1000 * 1000 * 1000 * 1000;
+        }
+    }
+
+    return 0;
+}
+
 function parseHistory(input: string) {
     const NOP = '#(nop)';
     let directive = "UNSPECIFIED";
@@ -103,7 +137,7 @@ function parseHistory(input: string) {
     }
     else {
         directive = 'RUN';
-        argument = input.substring(indexCreatedBy + createdByMatch.length, input.length -1);
+        argument = input.substring(indexCreatedBy + createdByMatch.length, input.length - 1);
     }
 
     let createdAt: string = "";
@@ -111,13 +145,13 @@ function parseHistory(input: string) {
     const createdAtMatch = "createdAt:";
     const layerSizeMatch = "; layerSize:";
     const indexCreatedAt = input.indexOf(createdAtMatch);
-    const indexLayerSize = input.indexOf(layerSizeMatch);    
+    const indexLayerSize = input.indexOf(layerSizeMatch);
     if (indexCreatedAt >= 0 && indexLayerSize >= 0) {
         createdAt = input.substring(indexCreatedAt + createdAtMatch.length, indexLayerSize);
         layerSize = input.substring(indexLayerSize + layerSizeMatch.length, indexCreatedBy);
     }
 
-    return { "directive": directive, "arguments": argument, "createdOn" : createdAt, "size": layerSize };
+    return { "directive": directive, "arguments": argument, "createdOn": createdAt, "size": layerSize };
 }
 
 async function getHistory(connection: ContainerConnection, image: string): Promise<string> {

--- a/Tasks/Common/docker-common/dockercommandutils.ts
+++ b/Tasks/Common/docker-common/dockercommandutils.ts
@@ -105,18 +105,18 @@ export function getImageSize(layers: { [key: string]: string }[]): string {
     return imageSize.toString() + "B";
 }
 
-function extractSizeInBytes(size: string): number {
+export function extractSizeInBytes(size: string): number {
     const sizeStringValue = size.match(matchPatternForSize);
     if (sizeStringValue && sizeStringValue.length > 0) {
         const sizeIntValue = parseFloat(sizeStringValue[0]);
         const sizeUnit = size.substring(sizeIntValue.toString().length);
         switch (sizeUnit.toLowerCase()) {
             case "b": return sizeIntValue;
-            case "kb": return sizeIntValue * 1000;
-            case "mb": return sizeIntValue * 1000 * 1000;
-            case "gb": return sizeIntValue * 1000 * 1000 * 1000;
-            case "tb": return sizeIntValue * 1000 * 1000 * 1000 * 1000;
-            case "pb": return sizeIntValue * 1000 * 1000 * 1000 * 1000 * 1000;
+            case "kb": return sizeIntValue * 1024;
+            case "mb": return sizeIntValue * 1024 * 1024;
+            case "gb": return sizeIntValue * 1024 * 1024 * 1024;
+            case "tb": return sizeIntValue * 1024 * 1024 * 1024 * 1024;
+            case "pb": return sizeIntValue * 1024 * 1024 * 1024 * 1024 * 1024;
         }
     }
 

--- a/Tasks/Common/docker-common/pipelineutils.ts
+++ b/Tasks/Common/docker-common/pipelineutils.ts
@@ -32,14 +32,12 @@ function addBuildLabels(hostName: string, labels: string[]): void {
     addLabel(hostName, "build.definitionname", "BUILD_DEFINITIONNAME", labels);
     addLabel(hostName, "build.buildnumber", "BUILD_BUILDNUMBER", labels);
     addLabel(hostName, "build.builduri", "BUILD_BUILDURI", labels);
-    addLabel(hostName, "build.requestedfor", "BUILD_REQUESTEDFOR", labels);
 }
 
 function addReleaseLabels(hostName: string, labels: string[]): void {    
     addLabel(hostName, "release.definitionname", "RELEASE_DEFINITIONNAME", labels);
     addLabel(hostName, "release.releaseid", "RELEASE_RELEASEID", labels);
     addLabel(hostName, "release.releaseweburl", "RELEASE_RELEASEWEBURL", labels);
-    addLabel(hostName, "release.deployment.requestedfor", "RELEASE_DEPLOYMENT_REQUESTEDFOR", labels);
 }
 
 function getReverseDNSName(): string {

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
+    "Minor": 152,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/Tests/L0.ts
+++ b/Tasks/DockerV2/Tests/L0.ts
@@ -1,0 +1,65 @@
+import * as assert from "assert";
+import * as tl from "vsts-task-lib/task";
+import * as dockerCommandUtils from "docker-common/dockercommandutils";
+
+describe("DockerV2 Suite", function () {
+    this.timeout(10000);
+
+    if (!tl.osType().match(/^Win/)) {
+        return;
+    }
+
+    before((done) => {
+        done();
+    });
+
+    it("extractSizeInBytes should return correctly", (done: MochaDone) => {
+        console.log("TestCaseName: extractSizeInBytes should return correctly");
+
+        console.log("\n");
+
+        const bitSize = "24.01B";
+        const kbSize = "8.999KB";
+        const mbSize = "23mb";
+        const gbSize = "1.23GB";
+        const tbSize = "1tb";
+
+        let extractedSizeInBytes = dockerCommandUtils.extractSizeInBytes(bitSize);
+        assert.equal(extractedSizeInBytes, 24.01, "extractSizeInBytes should return correctly for input in bytes");
+
+        extractedSizeInBytes = dockerCommandUtils.extractSizeInBytes(kbSize);
+        assert.equal(extractedSizeInBytes, (8.999 * 1024), "extractSizeInBytes should return correctly for input in kilobytes");
+
+        extractedSizeInBytes = dockerCommandUtils.extractSizeInBytes(mbSize);
+        assert.equal(extractedSizeInBytes, (23 * 1024 * 1024), "extractSizeInBytes should return correctly for input in megabytes");
+
+        extractedSizeInBytes = dockerCommandUtils.extractSizeInBytes(gbSize);
+        assert.equal(extractedSizeInBytes, (1.23 * 1024 * 1024 * 1024), "extractSizeInBytes should return correctly for input in gigabytes");
+
+        extractedSizeInBytes = dockerCommandUtils.extractSizeInBytes(tbSize);
+        assert.equal(extractedSizeInBytes, (1 * 1024 * 1024 * 1024 * 1024), "extractSizeInBytes should return correctly for input in terabytes");
+
+        done();
+    });
+
+    it("getImageSize should return correctly for given layers", (done: MochaDone) => {
+        console.log("TestCaseName: getImageSize should return correctly for given layers");
+
+        console.log("\n");
+
+        let layers: { [key: string]: string }[] = [];
+        layers.push({ "directive": "dir1", "args": "args1", "createdOn": "10may", "size": "24.32kb" });
+        layers.push({ "directive": "dir2", "args": "args2", "createdOn": "10may", "size": "0B" });
+        layers.push({ "directive": "dir3", "args": "args3", "createdOn": "10may", "size": "7b" });
+        layers.push({ "directive": "dir4", "args": "args4", "createdOn": "10may", "size": "7.77GB" });
+        layers.push({ "directive": "dir5", "args": "args5", "createdOn": "10may", "size": "88.9MB" });
+
+        const expectedSize = (24.32 * 1024) + (7) + (7.77 * 1024 * 1024 * 1024) + (88.9 * 1024 * 1024);
+        const expectedSizeString = expectedSize.toString() + "B";
+
+        const actualImageSize = dockerCommandUtils.getImageSize(layers);
+        assert.equal(actualImageSize.indexOf(expectedSizeString), 0, "getImageSize should return correctly for given layers");
+        assert.equal(actualImageSize.length, expectedSizeString.length, "getImageSize should return correctly for given layers");
+        done();
+    });
+});

--- a/Tasks/DockerV2/dockerpush.ts
+++ b/Tasks/DockerV2/dockerpush.ts
@@ -85,11 +85,9 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     let promise = pushMultipleImages(connection, imageNames, tags, commandArguments, (image, commandOutput) => {
         output += commandOutput;
         outputImageName = image;
-        let extractedResult = extractDigestAndSizeFromOutput(commandOutput, matchPatternForDigestAndSize);
-        digest = extractedResult[0];
-        imageSize = extractedResult[1];
+        let digest = extractDigestFromOutput(commandOutput, matchPatternForDigestAndSize);
         tl.debug("outputImageName: " + outputImageName + "\n" + "commandOutput: " + commandOutput + "\n" + "digest:" + digest + "imageSize:" + imageSize);
-        publishToImageMetadataStore(connection, outputImageName, tags, digest, dockerFile, imageSize).then((result) => {
+        publishToImageMetadataStore(connection, outputImageName, tags, digest, dockerFile).then((result) => {
             tl.debug("ImageDetailsApiResponse: " + result);
         }, (error) => {
             tl.warning("publishToImageMetadataStore failed with error: " + error);
@@ -110,11 +108,12 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     return promise;
 }
 
-async function publishToImageMetadataStore(connection: ContainerConnection, imageName: string, tags: string[], digest: string, dockerFilePath: string, imageSize: string): Promise<any> {
+async function publishToImageMetadataStore(connection: ContainerConnection, imageName: string, tags: string[], digest: string, dockerFilePath: string): Promise<any> {
     // Getting imageDetails
     const imageUri = getResourceName(imageName, digest);
     const baseImageName = getBaseImageNameFromDockerFile(dockerFilePath);
     const layers = await dockerCommandUtils.getLayers(connection, imageName);
+    const imageSize = dockerCommandUtils.getImageSize(layers);
 
     // Getting pipeline variables
     const build = "build";
@@ -149,7 +148,7 @@ async function publishToImageMetadataStore(connection: ContainerConnection, imag
     return sendRequestToImageStore(requestBody, requestUrl);
 }
 
-function extractDigestAndSizeFromOutput(dockerPushCommandOutput: string, matchPattern: RegExp): string[] {
+function extractDigestFromOutput(dockerPushCommandOutput: string, matchPattern: RegExp): string {
     // SampleCommandOutput : The push refers to repository [xyz.azurecr.io/acr-helloworld]
     // 3b7670606102: Pushed 
     // e2af85e4b310: Pushed ce8609e9fdad: Layer already exists
@@ -159,17 +158,11 @@ function extractDigestAndSizeFromOutput(dockerPushCommandOutput: string, matchPa
     // Below regex will extract part after sha256, so expected return value will be 5e3c9cf1692e129744fe7db8315f05485c6bb2f3b9f6c5096ebaae5d5bfbbe60
     const imageMatch = dockerPushCommandOutput.match(matchPattern);
     let digest = "";
-    let size = "";
-    if (imageMatch) {
-        if (imageMatch.length >= 1) {
-            digest = imageMatch[1];
-        }
-        if (imageMatch.length >= 3) {
-            size = imageMatch[3];
-        }
+    if (imageMatch && imageMatch.length >= 1) {
+        digest = imageMatch[1];
     }
 
-    return [digest, size];
+    return digest;
 }
 
 async function sendRequestToImageStore(requestBody: string, requestUrl: string): Promise<any> {

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,8 +14,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
-        "Patch": 7
+        "Minor": 152,
+        "Patch": 0
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
-    "Patch": 7
+    "Minor": 152,
+    "Patch": 0
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 152,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 152,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
We were extracting image size from docker push output, which is not correct as it is the image manifest size and does not always represent the exact image size. (Reference doc [link](https://docs.docker.com/registry/spec/manifest-v2-2/#/manifest-list-field-descriptions))
Added changes to compute the image size as sum of the its' layers' size.
Also removed the RequestedFor label from the default image labels, as we don't want to expose user name in UI 
Pod for testing- http://nidabas-desk/DefaultCollection/p1/_serviceEndpoints/ed2bc004-c695-4955-b8b5-b4488b89cad8/kubernetesSummary?namespace=default
![image](https://user-images.githubusercontent.com/12389221/57507843-8be81780-731d-11e9-8be7-d2e76e90dd8e.png)
