### PR TITLE
Fixed Node demands for GulpV0 and V1 tasks

### DIFF
--- a/Tasks/GulpV0/task.json
+++ b/Tasks/GulpV0/task.json
@@ -16,11 +16,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 0
     },
     "demands": [
-        "node.js"
+        "Node"
     ],
     "minimumAgentVersion": "1.91.0",
     "groups": [

--- a/Tasks/GulpV1/task.json
+++ b/Tasks/GulpV1/task.json
@@ -17,11 +17,11 @@
     "preview": true,
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 1
+        "Minor": 152,
+        "Patch": 0
     },
     "demands": [
-        "node.js"
+        "Node"
     ],
     "minimumAgentVersion": "1.91.0",
     "groups": [


### PR DESCRIPTION
Made demands consistent with agent capabilities from NodeTool as per [#10333](https://github.com/microsoft/azure-pipelines-tasks/issues/10333)