### PR TITLE
Added retry if fetching token for SPN auth fails with status code 403

### DIFF
--- a/Tasks/AzureResourceGroupDeploymentV2/task.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 152,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 152,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 4,
-        "Patch": 30
+        "Patch": 31
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 4,
-    "Patch": 30
+    "Patch": 31
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 34
+        "Patch": 35
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureVmssDeploymentV0/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 34
+    "Patch": 35
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/Common/azure-arm-rest/azure-arm-common.ts
+++ b/Tasks/Common/azure-arm-rest/azure-arm-common.ts
@@ -221,7 +221,7 @@ export class ApplicationTokenCredentials {
 
         let webRequestOptions: webClient.WebRequestOptions = {
             retriableErrorCodes: null,
-            retriableStatusCodes: [400, 408, 409, 500, 502, 503, 504],
+            retriableStatusCodes: [400, 403, 408, 409, 500, 502, 503, 504],
             retryCount: null,
             retryIntervalInSeconds: null
         };

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 151,
-        "Patch": 3
+        "Patch": 4
     },
     "satisfies": [
         "Java"

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 151,
-    "Patch": 3
+    "Patch": 4
   },
   "satisfies": [
     "Java"

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 155,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 155,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 0,
-        "Patch": 26
+        "Patch": 27
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 0,
-    "Patch": 26
+    "Patch": 27
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 13
+        "Patch": 14
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 13
+    "Patch": 14
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
Fixes #10860 

In case of newly created SPN, getting access token can fail with status code 403. This can happen due to SPN replication delay. 
Hence, we should add retry if failure status code is 403.