### PR TITLE
Update cobertura plugin

### DIFF
--- a/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
+++ b/Tasks/Common/codecoverage-tools/codecoverageconstants.ts
@@ -462,7 +462,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.saliman:gradle-cobertura-plugin:2.2.7'
+        classpath 'net.saliman:gradle-cobertura-plugin:2.6.0'
     }
 }
 `;


### PR DESCRIPTION
I experience an issue whereby selecting cobertura coverage causes the application to complain about the `apply plugin: 'java'` line from the cobertura gradle plugin.  This will need to be updated to a version which utilizes the gradle java plugin instead.