### PR TITLE
Add more retries to secure file tasks

### DIFF
--- a/Tasks/AndroidSigningV2/package-lock.json
+++ b/Tasks/AndroidSigningV2/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -62,7 +62,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -83,10 +83,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.14.4",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "semver": {

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "demands": [
         "JDK"

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "demands": [
     "JDK"

--- a/Tasks/AndroidSigningV3/package-lock.json
+++ b/Tasks/AndroidSigningV3/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -62,7 +62,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -83,10 +83,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "semver": {

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",
     "demands": [

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/Common/securefiles-common/package-lock.json
+++ b/Tasks/Common/securefiles-common/package-lock.json
@@ -42,11 +42,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -59,7 +59,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -73,7 +73,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as Q from 'q';
 import * as tl from 'azure-pipelines-task-lib/task';
 import { getPersonalAccessTokenHandler, WebApi } from 'azure-devops-node-api';
+import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBaseInterfaces";
 
 export class SecureFileHelpers {
     serverConnection: WebApi;
@@ -12,7 +13,14 @@ export class SecureFileHelpers {
         const authHandler = getPersonalAccessTokenHandler(serverCreds);
 
         const proxy = tl.getHttpProxyConfiguration();
-        const options = proxy ? { proxy, ignoreSslError: true } : undefined;
+        let options: IRequestOptions = {
+            allowRetries: true,
+            maxRetries: 5
+        }
+
+        if (proxy) {
+            options = {...options, proxy, ignoreSslError: true }
+        }
 
         this.serverConnection = new WebApi(serverUrl, authHandler, options);
     }

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -16,11 +16,11 @@ export class SecureFileHelpers {
         let options: IRequestOptions = {
             allowRetries: true,
             maxRetries: 5
-        }
+        };
 
         if (proxy) {
             options = {...options, proxy, ignoreSslError: true }
-        }
+        };
 
         this.serverConnection = new WebApi(serverUrl, authHandler, options);
     }

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -19,7 +19,7 @@ export class SecureFileHelpers {
         };
 
         if (proxy) {
-            options = {...options, proxy, ignoreSslError: true }
+            options = { ...options, proxy, ignoreSslError: true };
         };
 
         this.serverConnection = new WebApi(serverUrl, authHandler, options);

--- a/Tasks/DownloadSecureFileV1/package-lock.json
+++ b/Tasks/DownloadSecureFileV1/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -62,7 +62,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -83,10 +83,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "semver": {

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -17,7 +17,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "array-union": {
@@ -25,7 +25,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -61,12 +61,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.5.tgz",
           "integrity": "sha1-y9WrIy6rtxDJaXkFMYcmlZHA1RA=",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.4.1",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }
@@ -99,11 +99,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.4.1",
+        "semver": "5.4.1",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -116,7 +116,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -135,13 +135,13 @@
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
       "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
       "requires": {
-        "globby": "^4.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "4.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "ecdsa-sig-formatter": {
@@ -149,7 +149,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "esprima": {
@@ -167,11 +167,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globby": {
@@ -179,12 +179,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^6.0.1",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "6.0.4",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       }
     },
     "hoek": {
@@ -197,8 +197,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -216,7 +216,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -224,7 +224,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "isemail": {
@@ -237,10 +237,10 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
       "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
       "requires": {
-        "hoek": "2.x.x",
-        "isemail": "1.x.x",
-        "moment": "2.x.x",
-        "topo": "1.x.x"
+        "hoek": "2.16.3",
+        "isemail": "1.2.0",
+        "moment": "2.21.0",
+        "topo": "1.1.0"
       }
     },
     "js-yaml": {
@@ -248,8 +248,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "jsonwebtoken": {
@@ -257,11 +257,11 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz",
       "integrity": "sha1-hRGNanDj/M3xQ4n056HD+cip+7o=",
       "requires": {
-        "joi": "^6.10.1",
-        "jws": "^3.1.4",
-        "lodash.once": "^4.0.0",
-        "ms": "^0.7.1",
-        "xtend": "^4.0.1"
+        "joi": "6.10.1",
+        "jws": "3.2.2",
+        "lodash.once": "4.1.1",
+        "ms": "0.7.3",
+        "xtend": "4.0.1"
       }
     },
     "jwa": {
@@ -271,7 +271,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "jws": {
@@ -279,8 +279,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
+        "jwa": "1.4.1",
+        "safe-buffer": "5.1.2"
       }
     },
     "kubernetes-common": {
@@ -297,11 +297,11 @@
           "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
           "requires": {
             "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.4.1",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }
@@ -316,7 +316,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -344,7 +344,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "os": {
@@ -377,7 +377,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "q": {
@@ -390,7 +390,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
@@ -398,12 +398,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -416,10 +416,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       },
       "dependencies": {
         "@types/q": {
@@ -454,7 +454,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
       "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "tunnel": {
@@ -480,7 +480,7 @@
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
       "requires": {
         "js-yaml": "3.6.1",
-        "semver": "^5.4.1",
+        "semver": "5.4.1",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
@@ -492,11 +492,11 @@
           "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
           "requires": {
             "minimatch": "3.0.4",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.4.1",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }
@@ -512,7 +512,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
@@ -533,11 +533,11 @@
       "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.4.1",
+        "semver": "5.4.1",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "vsts-task-tool-lib": {
@@ -545,10 +545,10 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^0.9.0",
-        "uuid": "^3.0.1",
+        "semver": "5.4.1",
+        "semver-compare": "1.0.0",
+        "typed-rest-client": "0.9.0",
+        "uuid": "3.2.1",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
@@ -562,12 +562,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.4.1",
+            "shelljs": "0.3.0",
+            "uuid": "3.2.1"
           }
         }
       }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 152,
-        "Patch": 3
+        "Minor": 153,
+        "Patch": 0
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 152,
-    "Patch": 3
+    "Minor": 153,
+    "Patch": 0
   },
   "demands": [],
   "groups": [

--- a/Tasks/InstallAppleCertificateV2/package-lock.json
+++ b/Tasks/InstallAppleCertificateV2/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.6.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -60,7 +60,7 @@
     "ios-signing-common": {
       "version": "file:../../_build/Tasks/Common/ios-signing-common-1.0.0.tgz",
       "requires": {
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "minimatch": {
@@ -68,7 +68,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -89,10 +89,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "semver": {

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -60,7 +60,7 @@
     "ios-signing-common": {
       "version": "file:../../_build/Tasks/Common/ios-signing-common-1.0.0.tgz",
       "requires": {
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "minimatch": {
@@ -68,7 +68,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "mockery": {
@@ -89,10 +89,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       }
     },
     "semver": {

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/InstallSSHKeyV0/package-lock.json
+++ b/Tasks/InstallSSHKeyV0/package-lock.json
@@ -31,11 +31,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.5.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.2.1"
       }
     },
     "balanced-match": {
@@ -48,7 +48,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -62,7 +62,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -83,10 +83,10 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "^6.0.0",
-        "@types/q": "^1.5.2",
+        "@types/node": "6.0.117",
+        "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
-        "azure-pipelines-task-lib": "^2.8.0"
+        "azure-pipelines-task-lib": "2.8.0"
       },
       "dependencies": {
         "@types/q": {

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 153,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 153,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
Occasionally secure file downloads can fail with ECONNRESET issues and the expected behavior is to retry the download until it succeeds. I've tested these changes with a customer who experienced these issues frequently (they had multiple stages and jobs in a release pipeline downloading secure files) and confirmed that the issue is mitigated.

- Enabled up to 5 retries for secure file downloads
- Bumped all task versions that depended on `securefiles-common`