### PR TITLE
[Port to releases/m152]: Fixing Docker task issues - Dockerfile in push command, and lowercasing of image names.

### DIFF
--- a/Tasks/Common/docker-common/containerconnection.ts
+++ b/Tasks/Common/docker-common/containerconnection.ts
@@ -62,22 +62,26 @@ export default class ContainerConnection {
         return imageName;
     }
 
-    public getQualifiedImageName(repository: string): string {
+    public getQualifiedImageName(repository: string, enforceDockerNamingConvention?: boolean): string {
         let imageName = repository ? repository : "";
         if (repository && this.registryAuth) {
             imageName = this.prefixRegistryIfRequired(this.registryAuth["registry"], repository);
         }
 
-        return imageName;
+        return enforceDockerNamingConvention ? imageUtils.generateValidImageName(imageName) : imageName;
     }
 
-    public getQualifiedImageNamesFromConfig(repository: string) {
+    public getQualifiedImageNamesFromConfig(repository: string, enforceDockerNamingConvention?: boolean) {
         let imageNames: string[] = [];
         if (repository) {
             let regUrls = this.getRegistryUrlsFromDockerConfig();
             if (regUrls && regUrls.length > 0) {
                 regUrls.forEach(regUrl => {
                     let imageName = this.prefixRegistryIfRequired(regUrl, repository);
+                    if (enforceDockerNamingConvention) {
+                        imageName = imageUtils.generateValidImageName(imageName);
+                    }
+                    
                     imageNames.push(imageName);
                 });
             }

--- a/Tasks/Common/docker-common/fileutils.ts
+++ b/Tasks/Common/docker-common/fileutils.ts
@@ -24,7 +24,7 @@ export function writeFileSync(filePath: string, data: string): number {
     }
 }
 
-export function findDockerFile(dockerfilepath : string) : string {
+export function findDockerFile(dockerfilepath: string) : string {
     if (dockerfilepath.indexOf('*') >= 0 || dockerfilepath.indexOf('?') >= 0) {
         tl.debug(tl.loc('ContainerPatternFound'));
         let workingDirectory = tl.getVariable('System.DefaultWorkingDirectory');

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
+    "Minor": 152,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -15,7 +15,7 @@ function useDefaultBuildContext(buildContext: string): boolean {
     return buildContext === defaultPath;
 }
 
-export function run(connection: ContainerConnection, outputUpdate: (data: string) => any, ignoreArguments?: boolean): any {
+export function run(connection: ContainerConnection, outputUpdate: (data: string) => any, isBuildAndPushCommand?: boolean): any {
     // find dockerfile path
     let dockerfilepath = tl.getInput("Dockerfile", true);
     let dockerFile = fileUtils.findDockerFile(dockerfilepath);
@@ -25,7 +25,8 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     }
 
     // get command arguments
-    let commandArguments = ignoreArguments ? "" : tl.getInput("arguments", false);
+    // ignore the arguments input if the command is buildAndPush, as it is ambiguous
+    let commandArguments = isBuildAndPushCommand ? "" : tl.getInput("arguments", false);
     
     // get qualified image names by combining container registry(s) and repository
     let repositoryName = tl.getInput("repository");
@@ -33,13 +34,13 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     // if container registry is provided, use that
     // else, use the currently logged in registries
     if (tl.getInput("containerRegistry")) {
-        let imageName = connection.getQualifiedImageName(repositoryName);
+        let imageName = connection.getQualifiedImageName(repositoryName, true);
         if (imageName) {
             imageNames.push(imageName);
         }
     }
     else {
-        imageNames = connection.getQualifiedImageNamesFromConfig(repositoryName);
+        imageNames = connection.getQualifiedImageNamesFromConfig(repositoryName, true);
     }
 
     // get label arguments

--- a/Tasks/DockerV2/dockerpush.ts
+++ b/Tasks/DockerV2/dockerpush.ts
@@ -50,31 +50,38 @@ function pushMultipleImages(connection: ContainerConnection, imageNames: string[
     return promise;
 }
 
-export function run(connection: ContainerConnection, outputUpdate: (data: string) => any, ignoreArguments?: boolean): any {
-    let commandArguments = ignoreArguments ? "" : tl.getInput("arguments");
+export function run(connection: ContainerConnection, outputUpdate: (data: string) => any, isBuildAndPushCommand?: boolean): any {
+    // ignore the arguments input if the command is buildAndPush, as it is ambiguous
+    let commandArguments = isBuildAndPushCommand ? "" : tl.getInput("arguments");
 
     // get tags input
     let tags = tl.getDelimitedInput("tags", "\n");
 
-    // get qualified image name from the containerRegistry input
+    // get repository input
     let repositoryName = tl.getInput("repository");
     let imageNames: string[] = [];
     // if container registry is provided, use that
     // else, use the currently logged in registries
     if (tl.getInput("containerRegistry")) {
-        let imageName = connection.getQualifiedImageName(repositoryName);
+        let imageName = connection.getQualifiedImageName(repositoryName, true);
         if (imageName) {
             imageNames.push(imageName);
         }
     }
     else {
-        imageNames = connection.getQualifiedImageNamesFromConfig(repositoryName);
+        imageNames = connection.getQualifiedImageNamesFromConfig(repositoryName, true);
     }
 
     const dockerfilepath = tl.getInput("dockerFile", true);
-    const dockerFile = findDockerFile(dockerfilepath);
-    if (!tl.exist(dockerFile)) {
-        throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
+    let dockerFile = "";
+    if (isBuildAndPushCommand) {
+        // For buildAndPush command, to find out the base image name, we can use the
+        // Dockerfile returned by findDockerfile as we are sure that this is used
+        // for building.
+        dockerFile = findDockerFile(dockerfilepath);
+        if (!tl.exist(dockerFile)) {
+            throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
+        }
     }
 
     // push all tags
@@ -90,7 +97,7 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         imageSize = extractedResult[1];
         tl.debug("outputImageName: " + outputImageName + "\n" + "commandOutput: " + commandOutput + "\n" + "digest:" + digest + "imageSize:" + imageSize);
         publishToImageMetadataStore(connection, outputImageName, tags, digest, dockerFile, imageSize).then((result) => {
-            tl.debug("ImageDetailsApiResponse: " + result);
+            tl.debug("ImageDetailsApiResponse: " + JSON.stringify(result));
         }, (error) => {
             tl.warning("publishToImageMetadataStore failed with error: " + error);
         });
@@ -113,7 +120,7 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
 async function publishToImageMetadataStore(connection: ContainerConnection, imageName: string, tags: string[], digest: string, dockerFilePath: string, imageSize: string): Promise<any> {
     // Getting imageDetails
     const imageUri = getResourceName(imageName, digest);
-    const baseImageName = getBaseImageNameFromDockerFile(dockerFilePath);
+    const baseImageName = dockerFilePath ? getBaseImageNameFromDockerFile(dockerFilePath) : "NA";
     const layers = await dockerCommandUtils.getLayers(connection, imageName);
 
     // Getting pipeline variables

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 152,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 152,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 152,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 152,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Porting the following changes to releases/m152:
- Docker push should not depend on Dockerfile. Determine base image name from Dockerfile if the command is buildAndPush, else set it as NA. We will be working on finding a way to determine the base image name, so that we can do it for docker push as well. This fix is to unblock the docker push command. (issue #10148)
- Use Docker naming conventions for image names, i.e., change to lowercase and remove spaces. (issue #10415)