### PR TITLE
Feature/app center distribute chunked symbol files

### DIFF
--- a/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterDistributeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "App Center distribute",
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
-  "loc.description": "Distribute app builds to testers and users via App Center",
+  "loc.description": "Distribute app builds to testers and users via Visual Studio App Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio App Center",
   "loc.releaseNotes": "Fix bug where feature branches were being truncated.",
   "loc.group.displayName.symbols": "Symbols",

--- a/Tasks/AppCenterDistributeV1/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0.ts
@@ -85,7 +85,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in the same foder', function () {
+    it('Positive path: multiple dSYMs in the same folder', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_1.js');
@@ -95,7 +95,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in parallel foders', function () {
+    it('Positive path: multiple dSYMs in parallel folders', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_2.js');

--- a/Tasks/AppCenterDistributeV1/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0.ts
@@ -186,7 +186,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: publish mandatory update)', function () {
+    it('Positive path: publish mandatory update', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0PublishMandatoryUpdate.js');

--- a/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
@@ -61,7 +61,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
@@ -61,7 +61,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
@@ -65,13 +65,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/bogus-container')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0OneIpaPass.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -59,13 +61,13 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
 //upload symbols
 nock('https://example.upload.test')
-    .put('/symbol_upload')
+    .put('/bogus-container')
     .reply(201, {
         status: 'success'
     });
@@ -115,6 +117,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
@@ -74,7 +74,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
@@ -78,13 +78,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -72,7 +74,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -128,6 +130,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_1.ts
@@ -74,7 +74,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -70,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -126,6 +128,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
@@ -76,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_2.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -70,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -126,6 +128,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
@@ -76,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_3.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -70,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -126,6 +128,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
@@ -76,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishCommitInfo_4.ts
@@ -72,7 +72,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -73,7 +73,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -71,7 +73,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -127,6 +129,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -73,7 +73,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0PublishMandatoryUpdate.ts
@@ -77,13 +77,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
@@ -63,7 +63,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
@@ -67,13 +67,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -61,7 +63,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -166,6 +168,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymIncludeParent.ts
@@ -63,7 +63,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -79,7 +79,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -79,7 +79,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -77,7 +79,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -202,6 +204,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -83,13 +83,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -85,13 +85,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -81,7 +81,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -81,7 +81,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -79,7 +81,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -212,6 +214,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
@@ -81,13 +81,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
@@ -77,7 +77,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
@@ -77,7 +77,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -75,7 +77,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -193,6 +195,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
@@ -88,13 +88,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
@@ -84,7 +84,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
@@ -2,7 +2,8 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
-import fs = require('fs');import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
 
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
@@ -2,7 +2,8 @@
 import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
-import fs = require('fs');
+import fs = require('fs');import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -83,7 +84,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -226,6 +227,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymMultipleDSYMs_tree.ts
@@ -84,7 +84,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -74,7 +76,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -190,7 +192,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
-tmr.registerMock('fs', fs);
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 
 tmr.run();
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
@@ -191,6 +191,7 @@ azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
 }
 
 tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
+tmr.registerMock('fs', fs);
 
 tmr.run();
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
@@ -76,7 +76,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
@@ -76,7 +76,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_multiple.ts
@@ -80,13 +80,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
@@ -75,7 +75,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
@@ -75,7 +75,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -73,7 +75,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
     });
 
@@ -184,6 +186,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV1/Tests/L0SymPDBs_single.ts
@@ -79,13 +79,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV1/Tests/package-lock.json
+++ b/Tasks/AppCenterDistributeV1/Tests/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-appcenterdistribute",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/AppCenterDistributeV1/Tests/package.json
+++ b/Tasks/AppCenterDistributeV1/Tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-appcenterdistribute",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Visual Studio App Center Upload Task",
   "main": "appcenterdistribute.js",
   "scripts": {

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -9,6 +9,7 @@ import { AzureBlobUploadHelper } from './azure-blob-upload-helper';
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import utils = require('./utils');
+import { inspect } from 'util';
 
 class UploadInfo {
     upload_id: string;
@@ -285,8 +286,7 @@ async function uploadSymbols(uploadUrl: string, file: string): Promise<void> {
         const azureBlobUploadHelper = new AzureBlobUploadHelper(tl.debug);
         await azureBlobUploadHelper.upload(uploadUrl, file);
     } catch (e) {
-        process.stdout.write(require('util').inspect(e));
-        
+        tl.error(inspect(e));
 
         throw e;
     }

--- a/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV1/appcenterdistribute.ts
@@ -5,6 +5,7 @@ import Q = require('q');
 import fs = require('fs');
 import os = require('os');
 
+import { AzureBlobUploadHelper } from './azure-blob-upload-helper';
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import utils = require('./utils');
@@ -276,27 +277,21 @@ function beginSymbolUpload(apiServer: string, apiVersion: string, appSlug: strin
     return defer.promise;
 }
 
-function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Q.Promise<void> {
+async function uploadSymbols(uploadUrl: string, file: string): Promise<void> {
     tl.debug("-- Uploading symbols...");
-    let defer = Q.defer<void>();
     tl.debug(`---- url: ${uploadUrl}`);
 
-    let stat = fs.statSync(file);
-    let headers = {
-        "x-ms-blob-type": "BlockBlob",
-        "Content-Length": stat.size,
-        "User-Agent": userAgent,
-        "internal-request-source": "VSTS"
-    };
+    try {
+        const azureBlobUploadHelper = new AzureBlobUploadHelper(tl.debug);
+        await azureBlobUploadHelper.upload(uploadUrl, file);
+    } catch (e) {
+        process.stdout.write(require('util').inspect(e));
+        
 
-    fs.createReadStream(file).pipe(request.put({ url: uploadUrl, headers: headers }, (err, res, body) => {
-        responseHandler(defer, err, res, body, () => {
-            tl.debug('-- Symbol uploaded.');
-            defer.resolve();
-        });
-    }));
+        throw e;
+    }
 
-    return defer.promise;
+    tl.debug('-- Symbol uploaded.');
 }
 
 function commitSymbols(apiServer: string, apiVersion: string, appSlug: string, symbol_upload_id: string, token: string, userAgent: string): Q.Promise<void> {
@@ -477,7 +472,7 @@ async function run() {
             let symbolsUploadInfo = await beginSymbolUpload(effectiveApiServer, effectiveApiVersion, appSlug, symbolsType, apiToken, userAgent);
 
             // upload symbols 
-            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile, userAgent);
+            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile);
 
             // Commit the symbols upload
             await commitSymbols(effectiveApiServer, effectiveApiVersion, appSlug, symbolsUploadInfo.symbol_upload_id, apiToken, userAgent);

--- a/Tasks/AppCenterDistributeV1/azure-blob-upload-helper.ts
+++ b/Tasks/AppCenterDistributeV1/azure-blob-upload-helper.ts
@@ -1,0 +1,50 @@
+import * as AzureStorage from "azure-storage";
+import * as Url from "url";
+
+import { inspect } from "util";
+
+export class AzureBlobUploadHelper {
+  constructor(private debug: Function) {}
+
+  public async upload(uploadUrl: string, zip: string): Promise<void> {
+    const urlObject = Url.parse(uploadUrl);
+    const blobService = this.getBlobService(urlObject);
+    const [container, blob] = this.getContainerAndBlob(urlObject);
+
+    await this.uploadBlockBlob(blobService, container, blob, zip);
+  }
+
+  private uploadBlockBlob(blobService: AzureStorage.BlobService, container: string, blob: string, file: string): Promise<void> {
+    return new Promise<void> ((resolve, reject) => {
+      blobService.createBlockBlobFromLocalFile(container, blob, file, {
+        contentSettings: {
+          contentType: "application/zip"
+        }
+      }, (error, result, response) => {
+        if (error) {
+          this.debug(`Failed to upload ZIP with symbols - ${inspect(error)}`);
+          reject(new Error("failed to upload ZIP with symbols"));
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  private getBlobService(urlObject: Url.Url): AzureStorage.BlobService {
+    const blobEndpoint = Url.format({
+      protocol: urlObject.protocol,
+      host: urlObject.host
+    });
+    const sharedAccessSignature = urlObject.query as string;
+
+    const connectionString = "BlobEndpoint=" + blobEndpoint + ";" + "SharedAccessSignature=" + sharedAccessSignature;
+
+    return new AzureStorage.BlobService(connectionString);
+  }
+
+  private getContainerAndBlob(urlObject: Url.Url): [string, string] {
+    const splitPathName = urlObject.pathname.split("/");
+    return [splitPathName[1], splitPathName[2]];
+  }
+}

--- a/Tasks/AppCenterDistributeV1/package-lock.json
+++ b/Tasks/AppCenterDistributeV1/package-lock.json
@@ -40,6 +40,31 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
+    "azure-storage": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "requires": {
+        "browserify-mime": "~1.2.9",
+        "extend": "^3.0.2",
+        "json-edm-parser": "0.1.2",
+        "md5.js": "1.3.4",
+        "readable-stream": "~2.0.0",
+        "request": "^2.86.0",
+        "underscore": "~1.8.3",
+        "uuid": "^3.0.0",
+        "validator": "~9.4.1",
+        "xml2js": "0.2.8",
+        "xmlbuilder": "^9.0.7"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -62,6 +87,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browserify-mime": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "caseless": {
       "version": "0.12.0",
@@ -180,6 +210,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -221,6 +260,14 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "json-edm-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+      "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+      "requires": {
+        "jsonparse": "~1.2.0"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -235,6 +282,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -265,6 +317,15 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
         "immediate": "~3.0.5"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mime-db": {
@@ -373,6 +434,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "sax": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -425,6 +491,11 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -434,6 +505,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "verror": {
       "version": "1.10.0",
@@ -464,6 +540,19 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
+    },
+    "xml2js": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+      "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+      "requires": {
+        "sax": "0.5.x"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/Tasks/AppCenterDistributeV1/package.json
+++ b/Tasks/AppCenterDistributeV1/package.json
@@ -17,8 +17,9 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks",
   "dependencies": {
-    "vsts-task-lib": "2.0.5",
+    "azure-storage": "^2.10.3",
     "jszip": "^3.1.2",
-    "request": "2.87.0"
+    "request": "2.87.0",
+    "vsts-task-lib": "2.0.5"
   }
 }

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 1
     },
     "releaseNotes": "Fix bug where feature branches were being truncated.",

--- a/Tasks/AppCenterDistributeV1/task.loc.json
+++ b/Tasks/AppCenterDistributeV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
+    "Minor": 152,
     "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AppCenterDistributeV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterDistributeV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "App Center distribute",
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
-  "loc.description": "Distribute app builds to testers and users via App Center",
+  "loc.description": "Distribute app builds to testers and users via Visual Studio App Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio App Center",
   "loc.releaseNotes": "Added support for multiple destinations.",
   "loc.group.displayName.symbols": "Symbols",

--- a/Tasks/AppCenterDistributeV2/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0.ts
@@ -85,7 +85,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in the same foder', function () {
+    it('Positive path: multiple dSYMs in the same folder', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_1.js');
@@ -95,7 +95,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in parallel foders', function () {
+    it('Positive path: multiple dSYMs in parallel folders', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_2.js');

--- a/Tasks/AppCenterDistributeV2/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0OneIpaPass.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -63,13 +65,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -115,6 +110,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -76,13 +78,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -128,6 +123,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -74,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -126,6 +121,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_3.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -74,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -126,6 +121,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishCommitInfo_4.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -74,13 +76,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -126,6 +121,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishMandatoryUpdate.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -75,13 +77,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -127,6 +122,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0PublishMultipleDestinations.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0PublishMultipleDestinations.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -79,13 +81,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -131,6 +126,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymIncludeParent.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -63,13 +65,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -166,6 +161,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -79,13 +81,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -202,6 +197,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -81,13 +83,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -212,6 +207,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -77,13 +79,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -193,6 +188,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymMultipleDSYMs_tree.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -85,13 +87,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -226,6 +221,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymPDBs_multiple.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -76,13 +78,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -190,6 +185,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV2/Tests/L0SymPDBs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -75,13 +77,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -184,6 +179,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV2/Tests/package-lock.json
+++ b/Tasks/AppCenterDistributeV2/Tests/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-appcenterdistribute",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/AppCenterDistributeV2/Tests/package.json
+++ b/Tasks/AppCenterDistributeV2/Tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-appcenterdistribute",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Visual Studio App Center Upload Task",
   "main": "appcenterdistribute.js",
   "scripts": {

--- a/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
@@ -8,6 +8,8 @@ import os = require('os');
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import utils = require('./utils');
+import { AzureBlobUploadHelper } from './azure-blob-upload-helper';
+import { inspect } from 'util';
 
 class UploadInfo {
     upload_id: string;
@@ -272,27 +274,20 @@ function beginSymbolUpload(apiServer: string, apiVersion: string, appSlug: strin
     return defer.promise;
 }
 
-function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Q.Promise<void> {
+async function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Promise<Q.Promise<void>> {
     tl.debug("-- Uploading symbols...");
-    let defer = Q.defer<void>();
     tl.debug(`---- url: ${uploadUrl}`);
 
-    let stat = fs.statSync(file);
-    let headers = {
-        "x-ms-blob-type": "BlockBlob",
-        "Content-Length": stat.size,
-        "User-Agent": userAgent,
-        "internal-request-source": "VSTS"
-    };
+    try {
+        const azureBlobUploadHelper = new AzureBlobUploadHelper(tl.debug);
+        await azureBlobUploadHelper.upload(uploadUrl, file);
+    } catch (e) {
+        tl.error(inspect(e));
 
-    fs.createReadStream(file).pipe(request.put({ url: uploadUrl, headers: headers }, (err, res, body) => {
-        responseHandler(defer, err, res, body, () => {
-            tl.debug('-- Symbol uploaded.');
-            defer.resolve();
-        });
-    }));
+        throw e;
+    }
 
-    return defer.promise;
+    tl.debug('-- Symbol uploaded.');
 }
 
 function commitSymbols(apiServer: string, apiVersion: string, appSlug: string, symbol_upload_id: string, token: string, userAgent: string): Q.Promise<void> {

--- a/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
@@ -274,7 +274,7 @@ function beginSymbolUpload(apiServer: string, apiVersion: string, appSlug: strin
     return defer.promise;
 }
 
-async function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Promise<Q.Promise<void>> {
+async function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Promise<void> {
     tl.debug("-- Uploading symbols...");
     tl.debug(`---- url: ${uploadUrl}`);
 

--- a/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV2/appcenterdistribute.ts
@@ -274,7 +274,7 @@ function beginSymbolUpload(apiServer: string, apiVersion: string, appSlug: strin
     return defer.promise;
 }
 
-async function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Promise<void> {
+async function uploadSymbols(uploadUrl: string, file: string): Promise<void> {
     tl.debug("-- Uploading symbols...");
     tl.debug(`---- url: ${uploadUrl}`);
 
@@ -472,7 +472,7 @@ async function run() {
             let symbolsUploadInfo = await beginSymbolUpload(effectiveApiServer, effectiveApiVersion, appSlug, symbolsType, apiToken, userAgent);
 
             // upload symbols
-            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile, userAgent);
+            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile);
 
             // Commit the symbols upload
             await commitSymbols(effectiveApiServer, effectiveApiVersion, appSlug, symbolsUploadInfo.symbol_upload_id, apiToken, userAgent);

--- a/Tasks/AppCenterDistributeV2/azure-blob-upload-helper.ts
+++ b/Tasks/AppCenterDistributeV2/azure-blob-upload-helper.ts
@@ -1,0 +1,50 @@
+import * as AzureStorage from "azure-storage";
+import * as Url from "url";
+
+import { inspect } from "util";
+
+export class AzureBlobUploadHelper {
+  constructor(private debug: Function) {}
+
+  public async upload(uploadUrl: string, zip: string): Promise<void> {
+    const urlObject = Url.parse(uploadUrl);
+    const blobService = this.getBlobService(urlObject);
+    const [container, blob] = this.getContainerAndBlob(urlObject);
+
+    await this.uploadBlockBlob(blobService, container, blob, zip);
+  }
+
+  private uploadBlockBlob(blobService: AzureStorage.BlobService, container: string, blob: string, file: string): Promise<void> {
+    return new Promise<void> ((resolve, reject) => {
+      blobService.createBlockBlobFromLocalFile(container, blob, file, {
+        contentSettings: {
+          contentType: "application/zip"
+        }
+      }, (error, result, response) => {
+        if (error) {
+          this.debug(`Failed to upload ZIP with symbols - ${inspect(error)}`);
+          reject(new Error("failed to upload ZIP with symbols"));
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  private getBlobService(urlObject: Url.Url): AzureStorage.BlobService {
+    const blobEndpoint = Url.format({
+      protocol: urlObject.protocol,
+      host: urlObject.host
+    });
+    const sharedAccessSignature = urlObject.query as string;
+
+    const connectionString = "BlobEndpoint=" + blobEndpoint + ";" + "SharedAccessSignature=" + sharedAccessSignature;
+
+    return new AzureStorage.BlobService(connectionString);
+  }
+
+  private getContainerAndBlob(urlObject: Url.Url): [string, string] {
+    const splitPathName = urlObject.pathname.split("/");
+    return [splitPathName[1], splitPathName[2]];
+  }
+}

--- a/Tasks/AppCenterDistributeV2/package-lock.json
+++ b/Tasks/AppCenterDistributeV2/package-lock.json
@@ -40,6 +40,31 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
+    "azure-storage": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "requires": {
+        "browserify-mime": "~1.2.9",
+        "extend": "^3.0.2",
+        "json-edm-parser": "0.1.2",
+        "md5.js": "1.3.4",
+        "readable-stream": "~2.0.0",
+        "request": "^2.86.0",
+        "underscore": "~1.8.3",
+        "uuid": "^3.0.0",
+        "validator": "~9.4.1",
+        "xml2js": "0.2.8",
+        "xmlbuilder": "^9.0.7"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -62,6 +87,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browserify-mime": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "caseless": {
       "version": "0.12.0",
@@ -180,6 +210,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -221,6 +260,14 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "json-edm-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+      "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+      "requires": {
+        "jsonparse": "~1.2.0"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -235,6 +282,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -265,6 +317,15 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
         "immediate": "~3.0.5"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mime-db": {
@@ -373,6 +434,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "sax": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -425,6 +491,11 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -434,6 +505,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "verror": {
       "version": "1.10.0",
@@ -464,6 +540,19 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
+    },
+    "xml2js": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+      "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+      "requires": {
+        "sax": "0.5.x"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/Tasks/AppCenterDistributeV2/package.json
+++ b/Tasks/AppCenterDistributeV2/package.json
@@ -17,8 +17,9 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks",
   "dependencies": {
-    "vsts-task-lib": "2.0.5",
+    "azure-storage": "^2.10.3",
     "jszip": "^3.1.2",
-    "request": "2.87.0"
+    "request": "2.87.0",
+    "vsts-task-lib": "2.0.5"
   }
 }

--- a/Tasks/AppCenterDistributeV2/task.json
+++ b/Tasks/AppCenterDistributeV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 1
     },
     "releaseNotes": "Added support for multiple destinations.",

--- a/Tasks/AppCenterDistributeV2/task.loc.json
+++ b/Tasks/AppCenterDistributeV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 151,
+    "Minor": 152,
     "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AppCenterDistributeV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AppCenterDistributeV3/Strings/resources.resjson/en-US/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "App Center distribute",
   "loc.helpMarkDown": "For help with this task, visit the Visual Studio App Center [support site](https://aka.ms/appcentersupport/).",
-  "loc.description": "Distribute app builds to testers and users via App Center",
+  "loc.description": "Distribute app builds to testers and users via Visual Studio App Center",
   "loc.instanceNameFormat": "Deploy $(app) to Visual Studio App Center",
   "loc.releaseNotes": "Added support for multiple destinations.",
   "loc.group.displayName.symbols": "Symbols",

--- a/Tasks/AppCenterDistributeV3/Tests/L0.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0.ts
@@ -131,7 +131,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in the same foder', function () {
+    it('Positive path: multiple dSYMs in the same folder', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_1.js');
@@ -141,7 +141,7 @@ describe('AppCenterDistribute L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Positive path: multiple dSYMs in parallel foders', function () {
+    it('Positive path: multiple dSYMs in parallel folders', function () {
         this.timeout(4000);
 
         let tp = path.join(__dirname, 'L0SymMultipleDSYMs_flat_2.js');

--- a/Tasks/AppCenterDistributeV3/Tests/L0NoSymbolsFails.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0NoSymbolsFails.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 
 var nock = require('nock');
@@ -35,6 +37,13 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/test/path/to/symbols.dSYM": false
     }
 };
+
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.setAnswers(a);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
@@ -66,7 +66,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
+        upload_url: 'https://example.upload.test/symbol_uploads',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -64,15 +66,8 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_upload',
+        upload_url: 'https://example.upload.test/bogus-container/bogus-blob',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -120,6 +115,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0OneIpaPass.ts
@@ -66,7 +66,7 @@ nock('https://example.test')
     })
     .reply(201, {
         symbol_upload_id: 100,
-        upload_url: 'https://example.upload.test/symbol_uploads',
+        upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
     });
 

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_1.ts
@@ -83,13 +83,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_1.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -133,6 +135,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_2.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -79,13 +81,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -131,6 +126,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_3.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_3.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -79,13 +81,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -131,6 +126,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_4.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishCommitInfo_4.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -79,13 +81,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -131,6 +126,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishMandatoryUpdate.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -132,6 +134,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishMandatoryUpdate.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishMandatoryUpdate.ts
@@ -82,13 +82,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishMultipleDestinations.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishMultipleDestinations.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -84,13 +86,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -136,6 +131,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishSilentUpdate.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishSilentUpdate.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Stats = require('fs').Stats
 
@@ -82,13 +84,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {
@@ -134,6 +129,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishStore.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishStore.ts
@@ -70,13 +70,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV3/Tests/L0PublishStoreIgnoreSilent.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0PublishStoreIgnoreSilent.ts
@@ -71,13 +71,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol
 nock('https://example.test')
     .patch("/v0.1/apps/testuser/testapp/symbol_uploads/100", {

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymIncludeParent.ts
@@ -72,13 +72,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymIncludeParent.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymIncludeParent.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -171,6 +173,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -88,13 +88,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_1.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_1.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -207,6 +209,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_2.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_flat_2.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -86,13 +88,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -217,6 +212,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -198,6 +200,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_single.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_single.ts
@@ -86,13 +86,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_tree.ts
@@ -94,13 +94,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_tree.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymMultipleDSYMs_tree.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -231,6 +233,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_multiple.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_multiple.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -81,13 +83,6 @@ nock('https://example.test')
         symbol_upload_id: 100,
         upload_url: 'https://example.upload.test/symbol_upload',
         expiration_date: 1234567
-    });
-
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
     });
 
 //finishing symbol upload, commit the symbol 
@@ -195,6 +190,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_single.ts
@@ -3,6 +3,8 @@ import ma = require('vsts-task-lib/mock-answer');
 import tmrm = require('vsts-task-lib/mock-run');
 import path = require('path');
 import fs = require('fs');
+import azureBlobUploadHelper = require('../azure-blob-upload-helper');
+
 var Readable = require('stream').Readable
 var Writable = require('stream').Writable
 var Stats = require('fs').Stats
@@ -189,6 +191,12 @@ fs.statSync = (s: string) => {
 
     return stat;
 }
+
+azureBlobUploadHelper.AzureBlobUploadHelper.prototype.upload = async () => {
+    return Promise.resolve();
+}
+
+tmr.registerMock('azure-blob-upload-helper', azureBlobUploadHelper);
 tmr.registerMock('fs', fs);
 
 tmr.run();

--- a/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_single.ts
+++ b/Tasks/AppCenterDistributeV3/Tests/L0SymPDBs_single.ts
@@ -84,13 +84,6 @@ nock('https://example.test')
         expiration_date: 1234567
     });
 
-//upload symbols
-nock('https://example.upload.test')
-    .put('/symbol_upload')
-    .reply(201, {
-        status: 'success'
-    });
-
 //finishing symbol upload, commit the symbol 
 nock('https://example.test')
     .patch('/v0.1/apps/testuser/testapp/symbol_uploads/100', {

--- a/Tasks/AppCenterDistributeV3/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV3/appcenterdistribute.ts
@@ -5,9 +5,11 @@ import Q = require('q');
 import fs = require('fs');
 import os = require('os');
 
+import { AzureBlobUploadHelper } from './azure-blob-upload-helper';
 import { ToolRunner } from 'vsts-task-lib/toolrunner';
 
 import utils = require('./utils');
+import { inspect } from 'util';
 
 class UploadInfo {
     upload_id: string;
@@ -317,27 +319,20 @@ function beginSymbolUpload(apiServer: string, apiVersion: string, appSlug: strin
     return defer.promise;
 }
 
-function uploadSymbols(uploadUrl: string, file: string, userAgent: string): Q.Promise<void> {
+async function uploadSymbols(uploadUrl: string, file: string): Promise<void> {
     tl.debug("-- Uploading symbols...");
-    let defer = Q.defer<void>();
     tl.debug(`---- url: ${uploadUrl}`);
 
-    let stat = fs.statSync(file);
-    let headers = {
-        "x-ms-blob-type": "BlockBlob",
-        "Content-Length": stat.size,
-        "User-Agent": userAgent,
-        "internal-request-source": "VSTS"
-    };
+    try {
+        const azureBlobUploadHelper = new AzureBlobUploadHelper(tl.debug);
+        await azureBlobUploadHelper.upload(uploadUrl, file);
+    } catch (e) {
+        tl.error(inspect(e));
 
-    fs.createReadStream(file).pipe(request.put({ url: uploadUrl, headers: headers }, (err, res, body) => {
-        responseHandler(defer, err, res, body, () => {
-            tl.debug('-- Symbol uploaded.');
-            defer.resolve();
-        });
-    }));
+        throw e;
+    }
 
-    return defer.promise;
+    tl.debug('-- Symbol uploaded.');
 }
 
 function commitSymbols(apiServer: string, apiVersion: string, appSlug: string, symbol_upload_id: string, token: string, userAgent: string): Q.Promise<void> {
@@ -534,7 +529,7 @@ async function run() {
             let symbolsUploadInfo = await beginSymbolUpload(effectiveApiServer, effectiveApiVersion, appSlug, symbolsType, apiToken, userAgent);
 
             // upload symbols
-            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile, userAgent);
+            await uploadSymbols(symbolsUploadInfo.upload_url, symbolsFile);
 
             // Commit the symbols upload
             await commitSymbols(effectiveApiServer, effectiveApiVersion, appSlug, symbolsUploadInfo.symbol_upload_id, apiToken, userAgent);

--- a/Tasks/AppCenterDistributeV3/azure-blob-upload-helper.ts
+++ b/Tasks/AppCenterDistributeV3/azure-blob-upload-helper.ts
@@ -1,0 +1,50 @@
+import * as AzureStorage from "azure-storage";
+import * as Url from "url";
+
+import { inspect } from "util";
+
+export class AzureBlobUploadHelper {
+  constructor(private debug: Function) {}
+
+  public async upload(uploadUrl: string, zip: string): Promise<void> {
+    const urlObject = Url.parse(uploadUrl);
+    const blobService = this.getBlobService(urlObject);
+    const [container, blob] = this.getContainerAndBlob(urlObject);
+
+    await this.uploadBlockBlob(blobService, container, blob, zip);
+  }
+
+  private uploadBlockBlob(blobService: AzureStorage.BlobService, container: string, blob: string, file: string): Promise<void> {
+    return new Promise<void> ((resolve, reject) => {
+      blobService.createBlockBlobFromLocalFile(container, blob, file, {
+        contentSettings: {
+          contentType: "application/zip"
+        }
+      }, (error, result, response) => {
+        if (error) {
+          this.debug(`Failed to upload ZIP with symbols - ${inspect(error)}`);
+          reject(new Error("failed to upload ZIP with symbols"));
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  private getBlobService(urlObject: Url.Url): AzureStorage.BlobService {
+    const blobEndpoint = Url.format({
+      protocol: urlObject.protocol,
+      host: urlObject.host
+    });
+    const sharedAccessSignature = urlObject.query as string;
+
+    const connectionString = "BlobEndpoint=" + blobEndpoint + ";" + "SharedAccessSignature=" + sharedAccessSignature;
+
+    return new AzureStorage.BlobService(connectionString);
+  }
+
+  private getContainerAndBlob(urlObject: Url.Url): [string, string] {
+    const splitPathName = urlObject.pathname.split("/");
+    return [splitPathName[1], splitPathName[2]];
+  }
+}

--- a/Tasks/AppCenterDistributeV3/package-lock.json
+++ b/Tasks/AppCenterDistributeV3/package-lock.json
@@ -40,6 +40,31 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
+    "azure-storage": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
+      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "requires": {
+        "browserify-mime": "~1.2.9",
+        "extend": "^3.0.2",
+        "json-edm-parser": "0.1.2",
+        "md5.js": "1.3.4",
+        "readable-stream": "~2.0.0",
+        "request": "^2.86.0",
+        "underscore": "~1.8.3",
+        "uuid": "^3.0.0",
+        "validator": "~9.4.1",
+        "xml2js": "0.2.8",
+        "xmlbuilder": "^9.0.7"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -62,6 +87,11 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browserify-mime": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "caseless": {
       "version": "0.12.0",
@@ -180,6 +210,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -221,6 +260,14 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "json-edm-parser": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
+      "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+      "requires": {
+        "jsonparse": "~1.2.0"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -235,6 +282,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonparse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -265,6 +317,15 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
         "immediate": "~3.0.5"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mime-db": {
@@ -373,6 +434,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "sax": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -425,6 +491,11 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
+    "underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -434,6 +505,11 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "verror": {
       "version": "1.10.0",
@@ -464,6 +540,19 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
+    },
+    "xml2js": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+      "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+      "requires": {
+        "sax": "0.5.x"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/Tasks/AppCenterDistributeV3/package.json
+++ b/Tasks/AppCenterDistributeV3/package.json
@@ -17,8 +17,9 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks",
   "dependencies": {
-    "vsts-task-lib": "2.0.5",
+    "azure-storage": "^2.10.3",
     "jszip": "^3.1.2",
-    "request": "2.87.0"
+    "request": "2.87.0",
+    "vsts-task-lib": "2.0.5"
   }
 }

--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 151,
+        "Minor": 152,
         "Patch": 1
     },
     "releaseNotes": "Added support for multiple destinations.",

--- a/Tasks/AppCenterDistributeV3/task.loc.json
+++ b/Tasks/AppCenterDistributeV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 151,
+    "Minor": 152,
     "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
In this PR, we are updating all versions of the App Center distribute tasks.

Earlier versions of these tasks have an issue with uploading larger (> 256mb) symbol files. Because we are uploading files directly to Azure Blob Storage, symbol files larger than 256mb will be rejected by Azure.

The changes in this PR leverage the Azure storage SDK to automatically chunk file uploads if the file are too large. We [borrowed a helper class from the App Center CLI](https://github.com/microsoft/appcenter-cli/blob/master/src/commands/crashes/lib/azure-blob-upload-helper.ts) which takes care of uploading and updated the tests accordingly.