### PR TITLE
Updating CODEOWNERS for App Center Distribute

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,11 +7,11 @@ Tasks/AndroidSigningV3/*    @madhurig
 
 Tasks/ANTV1/*   @madhurig
 
-Tasks/AppCenterDistributeV1/*   @DennisPan    @keerthanakumar
+Tasks/AppCenterDistributeV1/*   @DennisPan    @turanuk
 
-Tasks/AppCenterDistributeV2/*   @DennisPan    @keerthanakumar
+Tasks/AppCenterDistributeV2/*   @DennisPan    @turanuk
 
-Tasks/AppCenterDistributeV3/*   @DennisPan    @keerthanakumar
+Tasks/AppCenterDistributeV3/*   @DennisPan    @turanuk
 
 Tasks/AppCenterTestV1/*   @owenniblock
 


### PR DESCRIPTION
Ownership change on the distribution side, updating PR reviewers to reflect that.