### PR TITLE
Fix errors of python dependency

### DIFF
--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 6
+    "Patch": 7
   },
   "preview": true,
   "instanceNameFormat": "Azure IoT Edge - $(action)",

--- a/Tasks/AzureIoTEdgeV2/util.ts
+++ b/Tasks/AzureIoTEdgeV2/util.ts
@@ -89,6 +89,7 @@ export default class Util {
       cmds = [
         { path: `sudo`, arg: `apt-get update`, execOption: Constants.execSyncSilentOption },
         { path: `sudo`, arg: `apt-get install -y python-setuptools`, execOption: Constants.execSyncSilentOption },
+        { path: `sudo`, arg: `pip install --upgrade cryptography`, execOption: Constants.execSyncSilentOption},
         { path: `sudo`, arg: `pip install ${Constants.iotedgedev}==${version}`, execOption: Constants.execSyncSilentOption },
       ]
     } else if (tl.osType() === Constants.osTypeWindows) {


### PR DESCRIPTION
The task would fail due to issue [https://github.com/microsoft/azure-pipelines-image-generation/issues/978](https://github.com/microsoft/azure-pipelines-image-generation/issues/978)
This change tries to add the workaround to the task to avoid task failures caused by the pre-installed packages.