### PR TITLE
Swallow exceptions encountered in getHistory for DockerV2 task

### DIFF
--- a/Tasks/Common/docker-common/dockercommandutils.ts
+++ b/Tasks/Common/docker-common/dockercommandutils.ts
@@ -83,6 +83,10 @@ export function getCommandArguments(args: string): string {
 export async function getLayers(connection: ContainerConnection, imageId: string): Promise<any> {
     var layers = [];
     var history = await getHistory(connection, imageId);
+    if (!history) {
+        return null;
+    }
+    
     var lines = history.split(/[\r?\n]/);
 
     lines.forEach(line => {
@@ -178,8 +182,11 @@ async function getHistory(connection: ContainerConnection, image: string): Promi
         });
     }
     catch (e) {
-        defer.reject(e);
-        console.log(e);
+        // Swallow any exceptions encountered in executing command
+        // such as --format flag not supported in old docker cli versions
+        output = null;
+        defer.resolve();
+        tl.warning(e);
     }
 
     await defer.promise;

--- a/Tasks/Common/docker-common/dockercommandutils.ts
+++ b/Tasks/Common/docker-common/dockercommandutils.ts
@@ -186,7 +186,7 @@ async function getHistory(connection: ContainerConnection, image: string): Promi
         // such as --format flag not supported in old docker cli versions
         output = null;
         defer.resolve();
-        tl.warning(e);
+        tl.warning("Not publishing to image meta data store as get history failed with error " + e);
     }
 
     await defer.promise;

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/dockerpush.ts
+++ b/Tasks/DockerV2/dockerpush.ts
@@ -124,6 +124,10 @@ async function publishToImageMetadataStore(connection: ContainerConnection, imag
     const imageUri = getResourceName(imageName, digest);
     const baseImageName = dockerFilePath ? getBaseImageNameFromDockerFile(dockerFilePath) : "NA";
     const layers = await dockerCommandUtils.getLayers(connection, imageName);
+    if (!layers) {
+        return null;
+    }
+    
     const imageSize = dockerCommandUtils.getImageSize(layers);
 
     // Getting pipeline variables

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 4
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 4
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
--format flag is not supported in old docker CLI versions, so if the history output could not be resolved, then we do not want to throw error. We will not invoke publishImageDetails API, and let the docker push task complete
Associated issue- https://github.com/microsoft/azure-pipelines-tasks/issues/10423