### PR TITLE
adding final step to delete files to remove parent folder if empty

### DIFF
--- a/Tasks/DeleteFilesV1/deletefiles.ts
+++ b/Tasks/DeleteFilesV1/deletefiles.ts
@@ -9,6 +9,8 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
 
     let sourceFolder: string = tl.getPathInput('SourceFolder', true, false);
 
+    const removeSourceFolder: boolean = tl.getBoolInput('RemoveSourceFolder', false);
+
     // Input that is used for backward compatibility with pre-sprint 95 symbol store artifacts.
     // Pre-95 symbol store artifacts were simply file path artifacts, so we need to make sure
     // not to delete the artifact share if it's a symbol store.
@@ -87,7 +89,7 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
 
     // if there wasn't an error, check if there's anything in the folder tree other than folders
     // if not, delete the root as well
-    if (!errorHappened) {
+    if (removeSourceFolder && !errorHappened) {
         foundPaths = tl.find(sourceFolder);
 
         if (foundPaths.every(x => tl.stats(x).isDirectory())) {

--- a/Tasks/DeleteFilesV1/deletefiles.ts
+++ b/Tasks/DeleteFilesV1/deletefiles.ts
@@ -28,7 +28,7 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
     }
 
     // find all files
-    let foundPaths = tl.find(sourceFolder);
+    let foundPaths: string[] = tl.find(sourceFolder);
 
     // short-circuit if not exists
     if (!foundPaths.length) {
@@ -82,6 +82,22 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
         catch (err) {
             tl.error(err);
             errorHappened = true;
+        }
+    }
+
+    // if there wasn't an error, check if there's anything in the folder tree other than folders
+    // if not, delete the root as well
+    if (!errorHappened) {
+        foundPaths = tl.find(sourceFolder);
+
+        if (foundPaths.every(x => tl.stats(x).isDirectory())) {
+            try {
+                tl.rmRF(sourceFolder);
+            }
+            catch (err) {
+                tl.error(err);
+                errorHappened = true;
+            }
         }
     }
 

--- a/Tasks/DeleteFilesV1/deletefiles.ts
+++ b/Tasks/DeleteFilesV1/deletefiles.ts
@@ -92,7 +92,7 @@ tl.setResourcePath(path.join(__dirname, 'task.json'));
     if (removeSourceFolder && !errorHappened) {
         foundPaths = tl.find(sourceFolder);
 
-        if (foundPaths.every(x => tl.stats(x).isDirectory())) {
+        if (foundPaths.length === 1) {
             try {
                 tl.rmRF(sourceFolder);
             }

--- a/Tasks/DeleteFilesV1/task.json
+++ b/Tasks/DeleteFilesV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 1,
-        "Patch": 9
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.92.0",
@@ -28,7 +28,7 @@
             "label": "Source Folder",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "The source folder that the deletion(s) will be run from.  Empty is the root of the repo.  Use [variables](https://go.microsoft.com/fwlink/?LinkID=550988) if files are not in the repo. Example: $(agent.builddirectory)"
+            "helpMarkDown": "The source folder that the deletion(s) will be run from. Empty is the root of the repo. Use [variables](https://go.microsoft.com/fwlink/?LinkID=550988) if files are not in the repo. Example: $(agent.builddirectory)"
         },
         {
             "name": "Contents",
@@ -37,6 +37,15 @@
             "defaultValue": "myFileShare",
             "required": true,
             "helpMarkDown": "File/folder paths to delete. Supports multiple lines of minimatch patterns. [More Information](https://go.microsoft.com/fwlink/?LinkID=722333)"
+        },
+        {
+            "name": "RemoveSourceFolder",
+            "type": "boolean",
+            "label": "Remove SourceFolder",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Attempt to remove the source folder as well."
+
         }
     ],
     "instanceNameFormat": "Delete files from $(SourceFolder)",

--- a/Tasks/DeleteFilesV1/task.loc.json
+++ b/Tasks/DeleteFilesV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 9
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.92.0",
@@ -37,6 +37,14 @@
       "defaultValue": "myFileShare",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.Contents"
+    },
+    {
+      "name": "RemoveSourceFolder",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.RemoveSourceFolder",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.RemoveSourceFolder"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
The `DeleteFiles` task used to leave the source folder around, but now the caller can specify they want to delete it, too.