### PR TITLE
Fix ftp login issue

### DIFF
--- a/Tasks/FtpUploadV2/ftpuploadtask.ts
+++ b/Tasks/FtpUploadV2/ftpuploadtask.ts
@@ -261,8 +261,16 @@ async function run() {
         tl.warning(tl.loc("NoFilesFound"));
         return;
     }
-    
-    let ftpClient = await getFtpClient(ftpOptions);
+   
+    let ftpClient: ftp.Client;
+    try {
+        ftpClient = await getFtpClient(ftpOptions);
+    } catch (err) {
+        tl.error(err);
+        tl.setResult(tl.TaskResult.Failed, tl.loc("UploadFailed"));
+
+        return;
+    }
 
     let sleep = (milliseconds: number) => {
         return new Promise(resolve => setTimeout(resolve, milliseconds));

--- a/Tasks/FtpUploadV2/task.json
+++ b/Tasks/FtpUploadV2/task.json
@@ -18,8 +18,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 154,
+        "Patch": 0 
     },
     "instanceNameFormat": "FTP Upload: $(rootFolder)",
     "groups": [

--- a/Tasks/FtpUploadV2/task.loc.json
+++ b/Tasks/FtpUploadV2/task.loc.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 154,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [


### PR DESCRIPTION
If we throw in task, the task result is not set to "failed".  Must explicitly set the result.  This resulted in if the credentials were wrong and we couldn't login, we would still display the ftp task as succeeded.

Tested by uploading this fix to my personal account, verified wrong credentials would properly fail the task now.