### PR TITLE
Updating azure-pipelines-task-lib version from 2.7.7 to 2.8.0

### DIFF
--- a/Tasks/DockerInstallerV0/package-lock.json
+++ b/Tasks/DockerInstallerV0/package-lock.json
@@ -26,9 +26,9 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
@@ -45,7 +45,7 @@
       "requires": {
         "@types/semver": "5.5.0",
         "@types/uuid": "3.4.4",
-        "azure-pipelines-task-lib": "2.7.7",
+        "azure-pipelines-task-lib": "2.8.0",
         "semver": "5.6.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "1.0.9",

--- a/Tasks/DockerInstallerV0/package.json
+++ b/Tasks/DockerInstallerV0/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-pipelines-task-lib": "2.7.7",
+    "azure-pipelines-task-lib": "2.8.0",
     "azure-pipelines-tool-lib": "0.11.0"
   }
 }

--- a/Tasks/DockerInstallerV0/task.json
+++ b/Tasks/DockerInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/DockerInstallerV0/task.loc.json
+++ b/Tasks/DockerInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/DuffleInstallerV0/package-lock.json
+++ b/Tasks/DuffleInstallerV0/package-lock.json
@@ -22,7 +22,7 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.4.tgz",
       "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "requires": {
-        "@types/node": "*"
+        "@types/node": "6.14.4"
       }
     },
     "argparse": {
@@ -30,20 +30,20 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.7.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
       }
     },
     "azure-pipelines-tool-lib": {
@@ -51,13 +51,13 @@
       "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.11.0.tgz",
       "integrity": "sha512-Bg3usPtOs/YvM5V9dOEwxvsructz/BTsO5mVgLQ013kJsQN9DJrTjZMAgxxdaeW1H8KPHMz/40ix1T7XZ++VCw==",
       "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.0.1",
-        "azure-pipelines-task-lib": "^2.7.1",
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
+        "@types/semver": "5.5.0",
+        "@types/uuid": "3.4.4",
+        "azure-pipelines-task-lib": "2.8.0",
+        "semver": "5.7.0",
+        "semver-compare": "1.0.0",
         "typed-rest-client": "1.0.9",
-        "uuid": "^3.0.1"
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "typed-rest-client": {
@@ -81,7 +81,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -100,8 +100,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "argparse": "1.0.10",
+        "esprima": "2.7.3"
       }
     },
     "minimatch": {
@@ -109,7 +109,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -163,10 +163,9 @@
     },
     "utility-common": {
       "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-      "integrity": "sha512-+LSl4ZiVLTR7ycYatVlMx8/ymQki31Ir5dWnFMXDFR9/Cfzs498t9WnUPp97DDz6U+7A+kllldPYOtWtKHevKg==",
       "requires": {
         "js-yaml": "3.6.1",
-        "semver": "^5.4.1",
+        "semver": "5.7.0",
         "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
@@ -183,7 +182,7 @@
       "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
       "requires": {
         "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
+        "typed-rest-client": "0.12.0",
         "underscore": "1.8.3"
       }
     },
@@ -193,11 +192,11 @@
       "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
+        "mockery": "1.7.0",
+        "q": "1.5.1",
+        "semver": "5.7.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
       }
     },
     "vsts-task-tool-lib": {
@@ -205,10 +204,10 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^0.9.0",
-        "uuid": "^3.0.1",
+        "semver": "5.7.0",
+        "semver-compare": "1.0.0",
+        "typed-rest-client": "0.9.0",
+        "uuid": "3.3.2",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
@@ -226,12 +225,12 @@
           "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.5.1",
+            "semver": "5.7.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.3.2"
           }
         }
       }

--- a/Tasks/DuffleInstallerV0/package.json
+++ b/Tasks/DuffleInstallerV0/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-pipelines-task-lib": "2.7.7",
+    "azure-pipelines-task-lib": "2.8.0",
     "azure-pipelines-tool-lib": "0.11.0",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz"
   }

--- a/Tasks/DuffleInstallerV0/task.json
+++ b/Tasks/DuffleInstallerV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 153,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [],

--- a/Tasks/DuffleInstallerV0/task.loc.json
+++ b/Tasks/DuffleInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 153,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/HelmInstallerV1/package-lock.json
+++ b/Tasks/HelmInstallerV1/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
@@ -53,7 +53,7 @@
       "requires": {
         "@types/semver": "5.5.0",
         "@types/uuid": "3.4.4",
-        "azure-pipelines-task-lib": "2.7.7",
+        "azure-pipelines-task-lib": "2.8.0",
         "semver": "5.7.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "1.0.9",

--- a/Tasks/HelmInstallerV1/package.json
+++ b/Tasks/HelmInstallerV1/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-pipelines-task-lib": "2.7.7",
+    "azure-pipelines-task-lib": "2.8.0",
     "azure-pipelines-tool-lib": "0.11.0",
     "kubernetes-common": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz"
   }

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 153,
-        "Patch": 1
+        "Patch": 2
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 153,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": true,
   "demands": [],

--- a/Tasks/KubectlInstallerV0/package-lock.json
+++ b/Tasks/KubectlInstallerV0/package-lock.json
@@ -29,9 +29,9 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
@@ -48,7 +48,7 @@
       "requires": {
         "@types/semver": "5.5.0",
         "@types/uuid": "3.4.4",
-        "azure-pipelines-task-lib": "2.7.7",
+        "azure-pipelines-task-lib": "2.8.0",
         "semver": "5.7.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "1.0.9",

--- a/Tasks/KubectlInstallerV0/package.json
+++ b/Tasks/KubectlInstallerV0/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "azure-pipelines-task-lib": "2.7.7",
-    "azure-pipelines-tool-lib": "0.11.0"
+    "azure-pipelines-task-lib": "2.8.0",
+    "azure-pipelines-tool-lib": "0.11.0",
+    "kubernetes-common": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz"
   }
 }

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 153,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 153,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "satisfies": [


### PR DESCRIPTION
Tasks affected:
- DockerInstallerV0
- DuffleInstallerV0
- HelmInstallerV1
- KubectlInstallerV0