### PR TITLE
DuffleInstallerV0: Updating azure-pipelines-task-lib from v2.7.7 to v…

### DIFF
--- a/Tasks/Common/utility-common-v2/package-lock.json
+++ b/Tasks/Common/utility-common-v2/package-lock.json
@@ -12,15 +12,28 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -48,7 +61,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -128,12 +141,12 @@
         }
       }
     },
-    "azure-pipelines-task-lib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
-      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+    "vsts-task-lib": {
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+      "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
       "requires": {
-        "minimatch": "3.0.4",
+        "minimatch": "^3.0.0",
         "mockery": "^1.7.0",
         "q": "^1.1.2",
         "semver": "^5.1.0",
@@ -150,15 +163,15 @@
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^0.9.0",
         "uuid": "^3.0.1",
-        "azure-pipelines-task-lib": "2.8.0"
+        "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
         "azure-pipelines-task-lib": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
-          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
           "requires": {
-            "minimatch": "^3.0.0",
+            "minimatch": "3.0.4",
             "mockery": "^1.7.0",
             "q": "^1.1.2",
             "semver": "^5.1.0",

--- a/Tasks/DuffleInstallerV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DuffleInstallerV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Duffle tool installer",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275)",
   "loc.description": "Install a specified version of Duffle for installing and managing CNAB bundles",
   "loc.instanceNameFormat": "Install Duffle $(version)",
   "loc.input.label.version": "Version",

--- a/Tasks/DuffleInstallerV0/make.json
+++ b/Tasks/DuffleInstallerV0/make.json
@@ -1,7 +1,7 @@
 {
 	"common": [
     {
-		"module": "../Common/utility-common",
+		"module": "../Common/utility-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true

--- a/Tasks/DuffleInstallerV0/package-lock.json
+++ b/Tasks/DuffleInstallerV0/package-lock.json
@@ -34,9 +34,9 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "2.7.7",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.7.7.tgz",
-      "integrity": "sha512-4KBPheFTxTDqvaY0bjs9/Ab5yb2c/Y5u8gd54UGL2xhGbv2eoahOZPerAUY/vKsUDu2mjlP/JAWTlDv7dghdRQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -161,14 +161,13 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
-    "utility-common": {
-      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-      "integrity": "sha512-+LSl4ZiVLTR7ycYatVlMx8/ymQki31Ir5dWnFMXDFR9/Cfzs498t9WnUPp97DDz6U+7A+kllldPYOtWtKHevKg==",
+    "utility-common-v2": {
+      "version": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "js-yaml": "3.6.1",
         "semver": "^5.4.1",
         "vso-node-api": "6.5.0",
-        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       }
     },
@@ -188,11 +187,11 @@
       }
     },
     "vsts-task-lib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+      "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
       "requires": {
-        "minimatch": "3.0.4",
+        "minimatch": "^3.0.0",
         "mockery": "^1.7.0",
         "q": "^1.1.2",
         "semver": "^5.1.0",
@@ -219,19 +218,6 @@
           "requires": {
             "tunnel": "0.0.4",
             "underscore": "1.8.3"
-          }
-        },
-        "vsts-task-lib": {
-          "version": "2.0.4-preview",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
-          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
-          "requires": {
-            "minimatch": "^3.0.0",
-            "mockery": "^1.7.0",
-            "q": "^1.1.2",
-            "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
-            "uuid": "^3.0.1"
           }
         }
       }

--- a/Tasks/DuffleInstallerV0/package.json
+++ b/Tasks/DuffleInstallerV0/package.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-pipelines-task-lib": "2.7.7",
+    "azure-pipelines-task-lib": "2.8.0",
     "azure-pipelines-tool-lib": "0.11.0",
-    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz"
+    "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz"
   }
 }

--- a/Tasks/DuffleInstallerV0/src/duffleinstaller.ts
+++ b/Tasks/DuffleInstallerV0/src/duffleinstaller.ts
@@ -6,8 +6,8 @@ import fs = require('fs');
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as os from 'os';
 import * as util from 'util';
-import { WebRequest, sendRequest } from 'utility-common/restutilities';
-import { download } from 'utility-common/downloadutility';
+import { WebRequest, sendRequest } from 'utility-common-v2/restutilities';
+import { download } from 'utility-common-v2/downloadutility';
 
 const DuffleToolName = 'duffle';
 const DuffleLatestReleaseUrl = 'https://api.github.com/repos/deislabs/Duffle/releases/latest';

--- a/Tasks/DuffleInstallerV0/task.json
+++ b/Tasks/DuffleInstallerV0/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 0,
         "Minor": 153,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [],

--- a/Tasks/DuffleInstallerV0/task.loc.json
+++ b/Tasks/DuffleInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 0,
     "Minor": 153,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
…2.8.0

- Also moved DuffleInstallerV0 from using 'utility-common' to 'utility-common-v2'
- Bumped up patch version