### PR TITLE
Adding support for skipping effective POM generation (remix)

### DIFF
--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -2,6 +2,7 @@
 import Q = require('q');
 import os = require('os');
 import path = require('path');
+import fs = require('fs');
 
 import tl = require('vsts-task-lib/task');
 import {ToolRunner} from 'vsts-task-lib/toolrunner';
@@ -29,6 +30,7 @@ var publishJUnitResults: string = tl.getInput('publishJUnitResults');
 var testResultsFiles: string = tl.getInput('testResultsFiles', true);
 var ccTool = tl.getInput('codeCoverageTool');
 var authenticateFeed = tl.getBoolInput('mavenFeedAuthenticate', true);
+var skipEffectivePomGeneration = tl.getBoolInput("skipEffectivePom", true);
 var isCodeCoverageOpted = (typeof ccTool != "undefined" && ccTool && ccTool.toLowerCase() != 'none');
 var failIfCoverageEmptySetting: boolean = tl.getBoolInput('failIfCoverageEmpty');
 var codeCoverageFailed: boolean = false;
@@ -150,14 +152,23 @@ async function execBuild() {
         .then(function (code) {
             // Setup tool runner to execute Maven goals
             if (authenticateFeed) {
-                var mvnRun = tl.tool(mvnExec);
-                mvnRun.arg('-f');
-                mvnRun.arg(mavenPOMFile);
-                mvnRun.arg('help:effective-pom');
-                if(mavenOptions) {
-                    mvnRun.line(mavenOptions);
+                var repositories;
+
+                if (skipEffectivePomGeneration)
+                {
+                    var pomContents = fs.readFileSync(mavenPOMFile, "utf8");
+                    repositories = util.collectFeedRepositories(pomContents);
+                } else {
+                    var mvnRun = tl.tool(mvnExec);
+                    mvnRun.arg('-f');
+                    mvnRun.arg(mavenPOMFile);
+                    mvnRun.arg('help:effective-pom');
+                    if(mavenOptions) {
+                        mvnRun.line(mavenOptions);
+                    }
+                    repositories = util.collectFeedRepositoriesFromEffectivePom( mvnRun.execSync()['stdout']);
                 }
-                return util.collectFeedRepositoriesFromEffectivePom(mvnRun.execSync()['stdout'])
+                return repositories
                 .then(function (repositories) {
                     if (!repositories || !repositories.length) {
                         tl.debug('No built-in repositories were found in pom.xml');

--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -30,7 +30,7 @@ var publishJUnitResults: string = tl.getInput('publishJUnitResults');
 var testResultsFiles: string = tl.getInput('testResultsFiles', true);
 var ccTool = tl.getInput('codeCoverageTool');
 var authenticateFeed = tl.getBoolInput('mavenFeedAuthenticate', true);
-var skipEffectivePomGeneration = tl.getBoolInput("skipEffectivePom", true);
+var skipEffectivePomGeneration = tl.getBoolInput("skipEffectivePom", false);
 var isCodeCoverageOpted = (typeof ccTool != "undefined" && ccTool && ccTool.toLowerCase() != 'none');
 var failIfCoverageEmptySetting: boolean = tl.getBoolInput('failIfCoverageEmpty');
 var codeCoverageFailed: boolean = false;

--- a/Tasks/MavenV3/mavenutil.ts
+++ b/Tasks/MavenV3/mavenutil.ts
@@ -187,7 +187,7 @@ interface RepositoryInfo {
     id:string;
 }
 
-async function collectFeedRepositories(pomContents:string): Promise<any> {
+export async function collectFeedRepositories(pomContents:string): Promise<any> {
     return convertXmlStringToJson(pomContents).then(async function (pomJson) {
         let repos:RepositoryInfo[] = [];
         if (!pomJson) {

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -303,6 +303,18 @@
             "helpMarkDown": "Automatically authenticate Maven feeds from Azure Artifacts. If built-in Maven feeds are not in use, deselect this option for faster builds."
         },
         {
+            "name": "skipEffectivePom",
+            "aliases": [
+                "effectivePomSkip"
+            ],
+            "type": "boolean",
+            "label": "Skip generating effective POM while authenticating built-in feeds",
+            "required": true,
+            "defaultValue": "false",
+            "groupName": "advanced",
+            "helpMarkDown": "Authenticate built-in Maven feeds using the POM only, allowing parent POMs in Azure Artifacts/TFS [Package Management] feeds."
+        },
+        {
             "name": "sqAnalysisEnabled",
             "aliases": [
                 "sonarQubeRunAnalysis"

--- a/Tests-Legacy/L0/MavenV3/_suite.ts
+++ b/Tests-Legacy/L0/MavenV3/_suite.ts
@@ -635,7 +635,6 @@ describe('Maven Suite', function () {
     })
 
     it('run maven without authenticated feed and skip effectivePom', (done) => {
-
         setResponseFile('response.json');
 
         var tr = new trm.TaskRunner('MavenV3', true);
@@ -647,7 +646,7 @@ describe('Maven Suite', function () {
         tr.setInput('jdkVersion', 'default');
         tr.setInput('publishJUnitResults', 'true');
         tr.setInput('testResultsFiles', '**/TEST-*.xml');
-        tr.setInput('mavenFeedAuthenticate', 'true');
+        tr.setInput('mavenFeedAuthenticate', 'false');
         tr.setInput('skipEffectivePom', 'true');
 
         tr.run()
@@ -656,7 +655,7 @@ describe('Maven Suite', function () {
                 assert(tr.ran('/home/bin/maven/bin/mvn -f pom.xml package'), 'it should have run mvn -f pom.xml package');
                 assert(tr.invokedToolCount == 2, 'should have only run maven 2 times');
                 assert(tr.resultWasSet, 'task should have set a result');
-                assert(tr.stderr.length == 0, 'should not have written to stderr');
+                assert(tr.stderr.length == 0, 'should not have written to stderr:'+tr.stderr);
                 assert(tr.succeeded, 'task should have succeeded');
                 done();
             })

--- a/Tests-Legacy/L0/MavenV3/_suite.ts
+++ b/Tests-Legacy/L0/MavenV3/_suite.ts
@@ -634,6 +634,37 @@ describe('Maven Suite', function () {
             });
     })
 
+    it('run maven without authenticated feed and skip effectivePom', (done) => {
+
+        setResponseFile('response.json');
+
+        var tr = new trm.TaskRunner('MavenV3', true);
+        tr.setInput('mavenVersionSelection', 'Default');
+        tr.setInput('mavenPOMFile', 'pom.xml'); // Make that checkPath returns true for this filename in the response file
+        tr.setInput('options', '');
+        tr.setInput('goals', 'package');
+        tr.setInput('javaHomeSelection', 'JDKVersion');
+        tr.setInput('jdkVersion', 'default');
+        tr.setInput('publishJUnitResults', 'true');
+        tr.setInput('testResultsFiles', '**/TEST-*.xml');
+        tr.setInput('mavenFeedAuthenticate', 'true');
+        tr.setInput('skipEffectivePom', 'true');
+
+        tr.run()
+            .then(() => {
+                assert(tr.ran('/home/bin/maven/bin/mvn -version'), 'it should have run mvn -version');
+                assert(tr.ran('/home/bin/maven/bin/mvn -f pom.xml package'), 'it should have run mvn -f pom.xml package');
+                assert(tr.invokedToolCount == 2, 'should have only run maven 2 times');
+                assert(tr.resultWasSet, 'task should have set a result');
+                assert(tr.stderr.length == 0, 'should not have written to stderr');
+                assert(tr.succeeded, 'task should have succeeded');
+                done();
+            })
+            .fail((err) => {
+                done(err);
+            });
+    })
+
     it('run maven with feed settings and spaces', (done) => {
         setResponseFile('responseFeedWithSpaces.json');
 


### PR DESCRIPTION
This enables the task to work with a parent POM stored in
a Package Management feed
Added a new boolean setting to disable calling help:effective-pom during repository authentication, which prevents a parent-POM from being in a package management feed.

Ported from #8933 but added tests, fixed default, merged conflicts.