### PR TITLE
Only substitute manifest image when there's a full match

### DIFF
--- a/Tasks/KubernetesManifestV0/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV0/Tests/L0.ts
@@ -1,8 +1,11 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as tl from 'azure-pipelines-task-lib';
 import * as shared from './TestShared';
+import * as utils from '../src/utils/utilities';
+import * as yaml from 'js-yaml';
 
 describe('Kubernetes Manifests Suite', function () {
     this.timeout(30000);
@@ -23,6 +26,7 @@ describe('Kubernetes Manifests Suite', function () {
         delete process.env[shared.TestEnvVars.isBaselineDeploymentPresent];
         delete process.env[shared.TestEnvVars.arguments];
         delete process.env[shared.TestEnvVars.namespace];
+        delete process.env[shared.TestEnvVars.containers];
         delete process.env.RemoveNamespaceFromEndpoint;
     });
 
@@ -50,6 +54,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.isStableDeploymentPresent] = 'true';
         process.env[shared.TestEnvVars.isCanaryDeploymentPresent] = 'false';
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'false';
+        process.env[shared.TestEnvVars.containers] = "nginx:1.2"
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stderr.indexOf('"nginx-deployment-canary" not found') != -1, 'Canary deployment is not present');
@@ -224,6 +229,27 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.patch] = 'somePatch';
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
+        done();
+    });
+
+    it('Run should successfully add container image tags', (done: MochaDone) => {
+        const testFile = path.join(__dirname, './manifests/', 'deployment-image-substitution.yaml');
+        const deploymentFile = fs.readFileSync(testFile).toString();
+
+        const bigNameEditFirst = utils.substituteImageNameInSpecFile(deploymentFile, 'nginx-init', 'nginx-init:42.1');
+        const smallNameEditSecond = utils.substituteImageNameInSpecFile(bigNameEditFirst, 'nginx', 'nginx:42');
+        const smallSecondYaml = yaml.load(smallNameEditSecond);
+
+        assert(smallSecondYaml.spec.template.spec.containers[0].image === 'nginx:42', 'nginx image not tagged correctly');
+        assert(smallSecondYaml.spec.template.spec.initContainers[0].image === 'nginx-init:42.1', 'nginx-init image not tagged correctly');
+
+        const smallNameEditFirst = utils.substituteImageNameInSpecFile(deploymentFile, 'nginx', 'nginx:42');
+        const bigNameEditSecond = utils.substituteImageNameInSpecFile(smallNameEditFirst, 'nginx-init', 'nginx-init:42.1');
+        const bigSecondYaml = yaml.load(bigNameEditSecond);
+
+        assert(bigSecondYaml.spec.template.spec.containers[0].image === 'nginx:42', 'nginx image not tagged correctly');
+        assert(bigSecondYaml.spec.template.spec.initContainers[0].image === 'nginx-init:42.1', 'nginx-init image not tagged correctly');
+
         done();
     });
 });

--- a/Tasks/KubernetesManifestV0/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV0/Tests/L0.ts
@@ -26,7 +26,6 @@ describe('Kubernetes Manifests Suite', function () {
         delete process.env[shared.TestEnvVars.isBaselineDeploymentPresent];
         delete process.env[shared.TestEnvVars.arguments];
         delete process.env[shared.TestEnvVars.namespace];
-        delete process.env[shared.TestEnvVars.containers];
         delete process.env.RemoveNamespaceFromEndpoint;
     });
 
@@ -54,7 +53,6 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.isStableDeploymentPresent] = 'true';
         process.env[shared.TestEnvVars.isCanaryDeploymentPresent] = 'false';
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'false';
-        process.env[shared.TestEnvVars.containers] = "nginx:1.2"
         tr.run();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stderr.indexOf('"nginx-deployment-canary" not found') != -1, 'Canary deployment is not present');

--- a/Tasks/KubernetesManifestV0/Tests/manifests/deployment-image-substitution.yaml
+++ b/Tasks/KubernetesManifestV0/Tests/manifests/deployment-image-substitution.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+      - name: edgecase
+        image: nginx-image:1.7.9
+      imagePullSecrets:
+      - name: key1
+      initContainers:
+      - name: nginx-init-container
+        image: nginx-init:0.1.0

--- a/Tasks/KubernetesManifestV0/package.json
+++ b/Tasks/KubernetesManifestV0/package.json
@@ -8,6 +8,7 @@
     "azure-pipelines-task-lib": "2.8.0",
     "del": "2.2.0",
     "docker-common-v2": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
+    "js-yaml": "3.6.1",
     "kubernetes-common-v2": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
     "moment": "2.21.0",
     "vsts-task-tool-lib": "0.4.0"

--- a/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
@@ -3,13 +3,14 @@
 import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
+import {StringComparer, isEqual} from '../utils/StringComparison';
 import AuthenticationToken from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
 import { getDockerRegistryEndpointAuthenticationToken } from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
 
 export async function createSecret(ignoreSslErrors?: boolean) {
     const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
     let result;
-    if (utils.isEqual(TaskInputParameters.secretType, 'dockerRegistry', utils.StringComparer.OrdinalIgnoreCase)) {
+    if (isEqual(TaskInputParameters.secretType, 'dockerRegistry', StringComparer.OrdinalIgnoreCase)) {
         const authProvider: AuthenticationToken = getDockerRegistryEndpointAuthenticationToken(TaskInputParameters.dockerRegistryEndpoint);
         result = kubectl.createDockerSecret(TaskInputParameters.secretName.trim(),
             authProvider.getLoginServerUrl(),

--- a/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
@@ -3,7 +3,7 @@
 import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
-import {StringComparer, isEqual} from '../utils/StringComparison';
+import { StringComparer, isEqual } from '../utils/StringComparison';
 import AuthenticationToken from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
 import { getDockerRegistryEndpointAuthenticationToken } from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
 

--- a/Tasks/KubernetesManifestV0/src/models/constants.ts
+++ b/Tasks/KubernetesManifestV0/src/models/constants.ts
@@ -14,7 +14,6 @@ export class KubernetesWorkload {
 export const recognizedWorkloadTypes: string[] = ['deployment', 'replicaset', 'daemonset', 'pod', 'statefulset'];
 export const recognizedWorkloadTypesWithRolloutStatus: string[] = ['deployment', 'daemonset', 'statefulset'];
 
-debugger;
 const isRelease = isEqual(tl.getVariable('SYSTEM_HOSTTYPE'), 'release', StringComparer.OrdinalIgnoreCase);
 const orgUrl = tl.getVariable('System.TeamFoundationCollectionUri');
 

--- a/Tasks/KubernetesManifestV0/src/models/constants.ts
+++ b/Tasks/KubernetesManifestV0/src/models/constants.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as tl from 'azure-pipelines-task-lib/task';
-import * as utils from '../utils/utilities';
+import {StringComparer, isEqual} from '../utils/StringComparison';
 
 export class KubernetesWorkload {
     public static Pod: string = 'Pod';
@@ -14,7 +14,8 @@ export class KubernetesWorkload {
 export const recognizedWorkloadTypes: string[] = ['deployment', 'replicaset', 'daemonset', 'pod', 'statefulset'];
 export const recognizedWorkloadTypesWithRolloutStatus: string[] = ['deployment', 'daemonset', 'statefulset'];
 
-const isRelease = utils.isEqual(tl.getVariable('SYSTEM_HOSTTYPE'), 'release', utils.StringComparer.OrdinalIgnoreCase);
+debugger;
+const isRelease = isEqual(tl.getVariable('SYSTEM_HOSTTYPE'), 'release', StringComparer.OrdinalIgnoreCase);
 const orgUrl = tl.getVariable('System.TeamFoundationCollectionUri');
 
 export let pipelineAnnotations: string[] = [];

--- a/Tasks/KubernetesManifestV0/src/models/constants.ts
+++ b/Tasks/KubernetesManifestV0/src/models/constants.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as tl from 'azure-pipelines-task-lib/task';
-import {StringComparer, isEqual} from '../utils/StringComparison';
+import { StringComparer, isEqual } from '../utils/StringComparison';
 
 export class KubernetesWorkload {
     public static Pod: string = 'Pod';

--- a/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
@@ -8,8 +8,8 @@ import * as yaml from 'js-yaml';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 import * as fileHelper from '../utils/FileHelper';
 import * as helper from './KubernetesObjectUtility';
-import {  KubernetesWorkload } from '../models/constants';
-import {StringComparer, isEqual} from '../utils/StringComparison';
+import { KubernetesWorkload } from '../models/constants';
+import { StringComparer, isEqual } from '../utils/StringComparison';
 import * as utils from './utilities';
 
 export const CANARY_DEPLOYMENT_STRATEGY = 'CANARY';

--- a/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
@@ -8,7 +8,8 @@ import * as yaml from 'js-yaml';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 import * as fileHelper from '../utils/FileHelper';
 import * as helper from './KubernetesObjectUtility';
-import { KubernetesWorkload } from '../models/constants';
+import {  KubernetesWorkload } from '../models/constants';
+import {StringComparer, isEqual} from '../utils/StringComparison';
 import * as utils from './utilities';
 
 export const CANARY_DEPLOYMENT_STRATEGY = 'CANARY';
@@ -182,8 +183,8 @@ function getNewCanaryObject(inputObject: any, replicas: number, type: string): o
     addCanaryLabelsAndAnnotations(newObject, type);
 
     // Updating no. of replicas
-    if (!utils.isEqual(newObject.kind, KubernetesWorkload.Pod, utils.StringComparer.OrdinalIgnoreCase) &&
-        !utils.isEqual(newObject.kind, KubernetesWorkload.DaemonSet, utils.StringComparer.OrdinalIgnoreCase)) {
+    if (!isEqual(newObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase) &&
+        !isEqual(newObject.kind, KubernetesWorkload.DaemonSet, StringComparer.OrdinalIgnoreCase)) {
         newObject.spec.replicas = replicas;
     }
 

--- a/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
@@ -4,8 +4,8 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as yaml from 'js-yaml';
 import { Resource } from 'kubernetes-common-v2/kubectl-object-model';
 import { KubernetesWorkload, recognizedWorkloadTypes } from '../models/constants';
+import {StringComparer, isEqual} from '../utils/StringComparison';
 import * as utils from '../utils/utilities';
-import { StringComparer } from '../utils/utilities';
 
 export function isDeploymentEntity(kind: string): boolean {
     if (!kind) {
@@ -13,7 +13,7 @@ export function isDeploymentEntity(kind: string): boolean {
     }
 
     return recognizedWorkloadTypes.some(function (elem) {
-        return utils.isEqual(elem, kind, utils.StringComparer.OrdinalIgnoreCase);
+        return isEqual(elem, kind, StringComparer.OrdinalIgnoreCase);
     });
 }
 
@@ -27,7 +27,7 @@ export function getReplicaCount(inputObject: any): any {
     }
 
     const kind = inputObject.kind;
-    if (!utils.isEqual(kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase) && !utils.isEqual(kind, KubernetesWorkload.DaemonSet, StringComparer.OrdinalIgnoreCase)) {
+    if (!isEqual(kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase) && !isEqual(kind, KubernetesWorkload.DaemonSet, StringComparer.OrdinalIgnoreCase)) {
         return inputObject.spec.replicas;
     }
 
@@ -173,7 +173,7 @@ export function updateSelectorLabels(inputObject: any, newLabels: Map<string, st
         return;
     }
 
-    if (utils.isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
+    if (isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
         return;
     }
 
@@ -205,7 +205,7 @@ export function getResources(filePaths: string[], filterResourceTypes: string[])
         const fileContents = fs.readFileSync(filePath);
         yaml.safeLoadAll(fileContents, function (inputObject) {
             const inputObjectKind = inputObject ? inputObject.kind : '';
-            if (filterResourceTypes.filter(type => utils.isEqual(inputObjectKind, type, StringComparer.OrdinalIgnoreCase)).length > 0) {
+            if (filterResourceTypes.filter(type => isEqual(inputObjectKind, type, StringComparer.OrdinalIgnoreCase)).length > 0) {
                 const resource = {
                     type: inputObject.kind,
                     name: inputObject.metadata.name
@@ -223,7 +223,7 @@ function getSpecLabels(inputObject: any) {
         return null;
     }
 
-    if (utils.isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
+    if (isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
         return inputObject.metadata.labels;
     }
     if (!!inputObject.spec && !!inputObject.spec.template && !!inputObject.spec.template.metadata) {
@@ -239,7 +239,7 @@ function getImagePullSecrets(inputObject: any) {
         return null;
     }
 
-    if (utils.isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
+    if (isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
         return inputObject.spec.imagePullSecrets;
     }
 
@@ -255,7 +255,7 @@ function setImagePullSecrets(inputObject: any, newImagePullSecrets: any) {
         return;
     }
 
-    if (utils.isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
+    if (isEqual(inputObject.kind, KubernetesWorkload.Pod, StringComparer.OrdinalIgnoreCase)) {
         inputObject.spec.imagePullSecrets = newImagePullSecrets;
         return;
     }

--- a/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
@@ -4,7 +4,7 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as yaml from 'js-yaml';
 import { Resource } from 'kubernetes-common-v2/kubectl-object-model';
 import { KubernetesWorkload, recognizedWorkloadTypes } from '../models/constants';
-import {StringComparer, isEqual} from '../utils/StringComparison';
+import { StringComparer, isEqual } from '../utils/StringComparison';
 import * as utils from '../utils/utilities';
 
 export function isDeploymentEntity(kind: string): boolean {

--- a/Tasks/KubernetesManifestV0/src/utils/StringComparison.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/StringComparison.ts
@@ -1,0 +1,25 @@
+export enum StringComparer {
+    Ordinal,
+    OrdinalIgnoreCase,
+}
+
+export function isEqual(str1: string, str2: string, stringComparer: StringComparer): boolean {
+
+    if (str1 == null && str2 == null) {
+        return true;
+    }
+
+    if (str1 == null) {
+        return false;
+    }
+
+    if (str2 == null) {
+        return false;
+    }
+
+    if (stringComparer == StringComparer.OrdinalIgnoreCase) {
+        return str1.toUpperCase() === str2.toUpperCase();
+    } else {
+        return str1 === str2;
+    }
+}

--- a/Tasks/KubernetesManifestV0/src/utils/utilities.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/utilities.ts
@@ -118,7 +118,7 @@ export function substituteImageNameInSpecFile(currentString: string, imageName: 
             const [currentImageName, currentImageTag] = line
                 .substring(imageKeyword[0].length) // consume the line from keyword onwards
                 .trim()
-                .replace(/[',"]/g, '') // reaplace allowed quotes with nothing
+                .replace(/[',"]/g, '') // replace allowed quotes with nothing
                 .split(':');
 
             if (currentImageName === imageName) {

--- a/Tasks/KubernetesManifestV0/src/utils/utilities.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/utilities.ts
@@ -6,10 +6,6 @@ import * as kubectlutility from 'kubernetes-common-v2/kubectlutility';
 import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import { pipelineAnnotations } from '../models/constants';
 
-export enum StringComparer {
-    Ordinal, OrdinalIgnoreCase
-}
-
 export function getManifestFiles(manifestFilePaths: string | string[]): string[] {
     if (!manifestFilePaths) {
         tl.debug('file input is not present');
@@ -111,51 +107,27 @@ export function annotateChildPods(kubectl: Kubectl, resourceType: string, resour
 */
 
 export function substituteImageNameInSpecFile(currentString: string, imageName: string, imageNameWithNewTag: string) {
-    const i = currentString.indexOf(imageName);
-    if (i < 0) {
+    if (currentString.indexOf(imageName) < 0) {
         tl.debug(`No occurence of replacement token: ${imageName} found`);
         return currentString;
     }
 
-    let newString = '';
-    currentString.split('\n')
-        .forEach((line) => {
-            if (line.indexOf(imageName) > 0 && line.toLocaleLowerCase().indexOf('image') > 0) {
-                const i = line.indexOf(imageName);
-                newString += line.substring(0, i);
-                const leftOverString = line.substring(i);
-                if (leftOverString.endsWith('"')) {
-                    newString += imageNameWithNewTag + '"' + '\n';
-                } else {
-                    newString += imageNameWithNewTag + '\n';
-                }
-            } else {
-                newString += line + '\n';
+    return currentString.split('\n').reduce((acc, line) => {
+        const imageKeyword = line.match(/^ *image:/);
+        if (imageKeyword) {
+            const [currentImageName, currentImageTag] = line
+                .substring(imageKeyword[0].length) // consume the line from keyword onwards
+                .trim()
+                .replace(/[',"]/g, '') // reaplace allowed quotes with nothing
+                .split(':');
+
+            if (currentImageName === imageName) {
+                return acc + `${imageKeyword[0]} ${imageNameWithNewTag}\n`;
             }
-        });
+        }
 
-    return newString;
-}
-
-export function isEqual(str1: string, str2: string, stringComparer: StringComparer): boolean {
-
-    if (str1 == null && str2 == null) {
-        return true;
-    }
-
-    if (str1 == null) {
-        return false;
-    }
-
-    if (str2 == null) {
-        return false;
-    }
-
-    if (stringComparer == StringComparer.OrdinalIgnoreCase) {
-        return str1.toUpperCase() === str2.toUpperCase();
-    } else {
-        return str1 === str2;
-    }
+        return acc + line + '\n';
+    }, '');
 }
 
 function createInlineArray(str: string | string[]): string {


### PR DESCRIPTION
While using this task, I encountered some strange behavior. Using a deployment file (snippet) like:

```yaml
    spec:
      containers:
      - name: nginx
         image: nginx:1.7.9
      - name: edgecase
         image: nginx-image:1.7.9
      initContainers:
      - name: nginx-init-container
         image: nginx-init:0.1.0 
```

And a containers element in my task definition like:
```yaml
- task: KubernetesManifest@0
   displayName: Deploy application
   inputs:
     action: deploy
     manifests: kubernetes/deployment.yaml
     containers: |
       nginx:42
       nginx-image:42.1
       nginx-init:42.1.2
```

I got the following output which is incorrect and potentially dangerous because of unexpected containers being deployed

```yaml
    spec:
      containers:
      - name: nginx
         image: nginx:42
      - name: edgecase
         image: nginx:42
      initContainers:
      - name: nginx-init-container
         image: nginx:42
```

This PR fixes that issue and only matches when there is a full match on the target image name. The solution is still doing raw string processing. Personally I would prefer using a Yaml lib (or even Kubernetes Yaml model) for parsing the incoming Yaml file but there are probably reasons for not doing this.

While writing test cases, I encountered runtime errors because of a circular import between `utilities.ts` and `constants.ts`. Because of that I moved the string equality utility to a separate file. This resolved the issue.

Note that I'm completely new to TypeScript (did some JS before) so please forgive possible style and convention mistakes.