### PR TITLE
HelmDeployV0: Updating from vsts-task-lib@v2.4.0 to azure-pipelines-t…

### DIFF
--- a/Tasks/HelmDeployV0/ThirdPartyNotices.txt
+++ b/Tasks/HelmDeployV0/ThirdPartyNotices.txt
@@ -70,7 +70,7 @@ General Public License.
 47. typed-rest-client  (https://github.com/Microsoft/typed-rest-client)
 48.	underscore (https://github.com/jashkenas/underscore)
 49. vso-node-api (https://github.com/Microsoft/vsts-node-api)
-50.	VSTS-Task-Lib (https://github.com/Microsoft/vsts-task-lib)
+50.	Azure-Pipelines-Task-Lib (https://github.com/Microsoft/azure-pipelines-task-lib)
 51. vsts-task-tool-lib (git+https://github.com/microsoft/vsts-task-installer-lib.git)
 51.	wrappy (https://github.com/npm/wrappy)
 53. xtend (https://github.com/Raynos/xtend)
@@ -1608,7 +1608,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF vso-node-api NOTICES, INFORMATION, AND LICENSE
 
-%% VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+%% Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -1633,7 +1633,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 =========================================
-END OF VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE
+END OF Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE
 
 %% vsts-task-tool-lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================

--- a/Tasks/HelmDeployV0/make.json
+++ b/Tasks/HelmDeployV0/make.json
@@ -1,6 +1,6 @@
 {
 	"common": [{
-		"module": "../Common/azure-arm-rest",
+		"module": "../Common/azure-arm-rest-v2",
 		"type": "node",
 		"dest": "./",
 		"compile": true
@@ -12,13 +12,7 @@
         "compile": true
     },
     {
-		"module": "../Common/utility-common",
-		"type": "node",
-		"dest" : "./",
-		"compile" : true
-    },
-    {
-		"module": "../Common/kubernetes-common",
+		"module": "../Common/kubernetes-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
@@ -27,10 +21,9 @@
 	"rm": [
         {
             "items": [
-                "node_modules/utility-common/node_modules/vsts-task-lib",
-                "node_modules/kubernetes-common/node_modules/vsts-task-lib",
-                "node_modules/azure-arm-rest/node_modules/vsts-task-lib",
-                "node_modules/securefiles-common/node_modules/vsts-task-lib"
+                "node_modules/kubernetes-common-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/securefiles-common/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -2,15 +2,20 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
+    },
     "@types/node": {
-      "version": "6.0.117",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.117.tgz",
-      "integrity": "sha512-sihk0SnN8PpiS5ihu5xJQ5ddnURNq4P+XPmW+nORlKkHy21CoZO/IVHK/Wq/l3G8fFW06Fkltgnqx229uPlnRg=="
+      "version": "6.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+      "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w=="
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -38,35 +43,39 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "azure-arm-rest": {
-      "version": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
+    "azure-arm-rest-v2": {
+      "version": "file:../../_build/Tasks/Common/azure-arm-rest-v2-2.0.0.tgz",
       "requires": {
+        "@types/mocha": "2.2.48",
+        "@types/node": "6.0.68",
+        "@types/q": "1.0.7",
+        "azure-pipelines-task-lib": "2.8.0",
         "jsonwebtoken": "7.3.0",
         "q": "1.4.1",
-        "typed-rest-client": "0.12.0",
-        "vsts-task-lib": "2.0.5"
+        "typed-rest-client": "0.12.0"
       },
       "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
+        "@types/node": {
+          "version": "6.0.68",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.68.tgz",
+          "integrity": "sha1-DEO2uLlEX+uGoPvTRX4/S8WR5m0="
         },
-        "vsts-task-lib": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.5.tgz",
-          "integrity": "sha1-y9WrIy6rtxDJaXkFMYcmlZHA1RA=",
+        "@types/q": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.7.tgz",
+          "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "1.7.0",
             "q": "1.4.1",
-            "semver": "5.4.1",
+            "semver": "5.7.0",
             "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "uuid": "3.3.2"
           }
         }
       }
@@ -101,9 +110,9 @@
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
         "q": "1.4.1",
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       }
     },
     "balanced-match": {
@@ -137,11 +146,11 @@
       "requires": {
         "globby": "4.1.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       }
     },
     "ecdsa-sig-formatter": {
@@ -212,9 +221,9 @@
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
         "is-path-inside": "1.0.1"
       }
@@ -239,8 +248,15 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.21.0",
+        "moment": "2.24.0",
         "topo": "1.1.0"
+      },
+      "dependencies": {
+        "moment": {
+          "version": "2.24.0",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+        }
       }
     },
     "js-yaml": {
@@ -283,25 +299,46 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "kubernetes-common": {
-      "version": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "kubernetes-common-v2": {
+      "version": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "js-yaml": "3.6.1",
-        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       },
       "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+        "azure-pipelines-task-lib": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "1.7.0",
             "q": "1.4.1",
-            "semver": "5.4.1",
+            "semver": "5.7.0",
             "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "uuid": "3.3.2"
+          }
+        },
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        },
+        "vsts-task-tool-lib": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+          "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
+          "requires": {
+            "semver": "5.7.0",
+            "semver-compare": "1.0.0",
+            "typed-rest-client": "0.9.0",
+            "uuid": "3.3.2",
+            "vsts-task-lib": "2.0.4-preview"
           }
         }
       }
@@ -386,17 +423,17 @@
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.4"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -416,23 +453,41 @@
     "securefiles-common": {
       "version": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
       "requires": {
-        "@types/node": "6.0.117",
+        "@types/node": "6.14.6",
         "@types/q": "1.5.2",
         "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "2.8.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "6.14.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+          "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w=="
+        },
         "@types/q": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
           "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+          "requires": {
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.7.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.3.2"
+          }
         }
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -463,9 +518,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -476,68 +531,22 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
-    "utility-common": {
-      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-      "requires": {
-        "js-yaml": "3.6.1",
-        "semver": "5.4.1",
-        "vso-node-api": "6.5.0",
-        "vsts-task-lib": "2.6.0",
-        "vsts-task-tool-lib": "0.4.0"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
-        }
-      }
-    },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "0.12.0",
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        }
-      }
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vsts-task-lib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
-      "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+      "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
         "q": "1.4.1",
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       }
     },
     "vsts-task-tool-lib": {
@@ -545,29 +554,20 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "0.9.0",
-        "uuid": "3.2.1",
+        "uuid": "3.3.2",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
-        "vsts-task-lib": {
-          "version": "2.0.4-preview",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
-          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
           }
         }
       }

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -2,13 +2,12 @@
   "dependencies": {
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-arm-rest": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
+    "azure-arm-rest-v2": "file:../../_build/Tasks/Common/azure-arm-rest-v2-2.0.0.tgz",
+    "azure-pipelines-task-lib": "2.8.0",
     "del": "2.2.0",
-    "kubernetes-common": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "kubernetes-common-v2": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
     "moment": "2.21.0",
     "securefiles-common": "file:../../_build/Tasks/Common/securefiles-common-1.0.0.tgz",
-    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-    "vsts-task-lib": "2.4.0",
     "vsts-task-tool-lib": "0.4.0"
   }
 }

--- a/Tasks/HelmDeployV0/src/basecommand.ts
+++ b/Tasks/HelmDeployV0/src/basecommand.ts
@@ -1,9 +1,9 @@
 import path = require("path");
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import fs = require("fs");
 import util = require("util");
 import os = require("os");
-import tr = require('vsts-task-lib/toolrunner');
+import tr = require('azure-pipelines-task-lib/toolrunner');
 
 abstract class basecommand {
     private toolPath: string;

--- a/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
+++ b/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
@@ -1,9 +1,9 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
-import { AzureAksService } from 'azure-arm-rest/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-arm-rest/azure-arm-endpoint';
-import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest/azureModels';
+import tl = require('azure-pipelines-task-lib/task');
+import { AzureAksService } from 'azure-arm-rest-v2/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest-v2/azureModels';
 
 // get kubeconfig file content
 async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceGroup: string, clusterName: string) : Promise<string> {

--- a/Tasks/HelmDeployV0/src/clusters/generickubernetescluster.ts
+++ b/Tasks/HelmDeployV0/src/clusters/generickubernetescluster.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
-import kubectlutility = require("kubernetes-common/kubectlutility");
+import tl = require('azure-pipelines-task-lib/task');
+import kubectlutility = require("kubernetes-common-v2/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);

--- a/Tasks/HelmDeployV0/src/commoncommandoption.ts
+++ b/Tasks/HelmDeployV0/src/commoncommandoption.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./helmcli";
 
 export function addArguments(helmCli: helmcli) : void {

--- a/Tasks/HelmDeployV0/src/deletesecurefiles.ts
+++ b/Tasks/HelmDeployV0/src/deletesecurefiles.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import fs = require('fs');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 
 tl.setResourcePath(path.join(__dirname, '..' , 'task.json'));

--- a/Tasks/HelmDeployV0/src/helm.ts
+++ b/Tasks/HelmDeployV0/src/helm.ts
@@ -1,10 +1,10 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import { AzureAksService } from 'azure-arm-rest/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-arm-rest/azure-arm-endpoint';
-import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest/azureModels';
+import { AzureAksService } from 'azure-arm-rest-v2/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest-v2/azureModels';
 
 import helmcli from "./helmcli";
 import kubernetescli from "./kubernetescli"

--- a/Tasks/HelmDeployV0/src/helmcli.ts
+++ b/Tasks/HelmDeployV0/src/helmcli.ts
@@ -1,9 +1,9 @@
 import path = require("path");
-import tl = require("vsts-task-lib/task");
+import tl = require("azure-pipelines-task-lib/task");
 import fs = require("fs");
 import util = require("util");
 import os = require("os");
-import * as tr from "vsts-task-lib/toolrunner";
+import * as tr from "azure-pipelines-task-lib/toolrunner";
 import basecommand from "./basecommand"
 
 export default class helmcli extends basecommand {

--- a/Tasks/HelmDeployV0/src/helmcommands/helminit.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helminit.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./../helmcli";
 import {addTillerTlsSettings} from "./../tlssetting";
 

--- a/Tasks/HelmDeployV0/src/helmcommands/helminstall.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helminstall.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./../helmcli";
 import * as helmutil from "./../utils";
 import {addHelmTlsSettings} from "./../tlssetting";

--- a/Tasks/HelmDeployV0/src/helmcommands/helmpackage.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helmpackage.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./../helmcli";
 import * as helmutil from "./../utils";
 

--- a/Tasks/HelmDeployV0/src/helmcommands/helmupgrade.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helmupgrade.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./../helmcli";
 import * as helmutil from "./../utils";
 import {addHelmTlsSettings} from "./../tlssetting";

--- a/Tasks/HelmDeployV0/src/helmcommands/uinotimplementedcommands.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/uinotimplementedcommands.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./../helmcli";
 import {addHelmTlsSettings} from "./../tlssetting";
 

--- a/Tasks/HelmDeployV0/src/kubernetescli.ts
+++ b/Tasks/HelmDeployV0/src/kubernetescli.ts
@@ -1,4 +1,4 @@
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import fs = require("fs");
 import basecommand from "./basecommand"
 

--- a/Tasks/HelmDeployV0/src/tlssetting.ts
+++ b/Tasks/HelmDeployV0/src/tlssetting.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import helmcli from "./helmcli";
 
 export function addHelmTlsSettings(helmCli: helmcli) : void { 

--- a/Tasks/HelmDeployV0/src/utils.ts
+++ b/Tasks/HelmDeployV0/src/utils.ts
@@ -2,7 +2,7 @@
 
 var fs      = require('fs');
 import * as path from "path";
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 import * as os from "os";
 
 export function getTempDirectory(): string {

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 153,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 153,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV1/make.json
+++ b/Tasks/HelmInstallerV1/make.json
@@ -10,7 +10,6 @@
     "rm": [
         {
             "items": [
-                "node_modules/kubernetes-common/node_modules/vsts-task-lib",
                 "node_modules/kubernetes-common-v2/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"


### PR DESCRIPTION
…ask-lib@v2.8.0

- Also moved HelmDeployV0
	- from 'kubernetes-common' to 'kubernetes-common-v2'
	- from 'azure-arm-rest' to 'azure-arm-rest-v2'
- Removed dependency on 'utility-common' as it was unused.
- Bumped up patch version