### PR TITLE
KubernetesManifestV0: Updating from vsts-task-lib@v2.6.0 to azure-pip…

### DIFF
--- a/Tasks/KubernetesManifestV0/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV0/Tests/L0.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
-import * as tl from 'vsts-task-lib';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import * as tl from 'azure-pipelines-task-lib';
 import * as shared from './TestShared';
 
 describe('Kubernetes Manifests Suite', function () {

--- a/Tasks/KubernetesManifestV0/Tests/TestSetup.ts
+++ b/Tasks/KubernetesManifestV0/Tests/TestSetup.ts
@@ -1,5 +1,5 @@
-import * as ma from 'vsts-task-lib/mock-answer';
-import * as tmrm from 'vsts-task-lib/mock-run';
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
 import * as path from 'path';
 
 import * as shared from './TestShared';
@@ -250,7 +250,7 @@ if (process.env[shared.TestEnvVars.arguments]) {
 }
 
 tr.setAnswers(<any>a);
-tr.registerMock('vsts-task-lib/toolrunner', require('vsts-task-lib/mock-toolrunner'));
+tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
 
 // Create mock for fs module
 import * as fs from 'fs';

--- a/Tasks/KubernetesManifestV0/ThirdPartyNotices.txt
+++ b/Tasks/KubernetesManifestV0/ThirdPartyNotices.txt
@@ -59,7 +59,7 @@ The Kubernetes task for Azure Pipelines or Team Foundation Server incorporates c
 45.	typed-rest-client  (https://github.com/Microsoft/typed-rest-client)
 46.	underscore (https://github.com/jashkenas/underscore)
 47.	vso-node-api (https://github.com/Microsoft/vsts-node-api)
-48.	VSTS-Task-Lib (https://github.com/Microsoft/vsts-task-lib)
+48.	Azure-Pipelines-Task-Lib (https://github.com/Microsoft/azure-pipelines-task-lib)
 49.	wrappy (https://github.com/npm/wrappy)
 50. xtend (https://github.com/Raynos/xtend)
 
@@ -1596,7 +1596,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF vso-node-api NOTICES, INFORMATION, AND LICENSE
 
-%% VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+%% Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -1621,7 +1621,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 =========================================
-END OF VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE
+END OF Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE
 
 %% wrappy NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================

--- a/Tasks/KubernetesManifestV0/make.json
+++ b/Tasks/KubernetesManifestV0/make.json
@@ -1,19 +1,13 @@
 {
 	"common": [
     {
-		"module": "../Common/utility-common",
-		"type": "node",
-		"dest" : "./",
-		"compile" : true
-    },
-    {
-		"module": "../Common/kubernetes-common",
+		"module": "../Common/kubernetes-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
 	},
 	{
-		"module": "../Common/docker-common",
+		"module": "../Common/docker-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
@@ -22,9 +16,8 @@
 	"rm": [
         {
             "items": [
-				"node_modules/kubernetes-common/node_modules/vsts-task-lib",
-				"node_modules/docker-common/node_modules/vsts-task-lib",
-                "node_modules/utility-common/node_modules/vsts-task-lib",
+				"node_modules/kubernetes-common-v2/node_modules/azure-pipelines-task-lib",
+				"node_modules/docker-common-v2/node_modules/azure-pipelines-task-lib",
 				"node_modules/vsts-task-tool-lib/node_modules/vsts-task-lib"
             ],
             "options": "-Rf"

--- a/Tasks/KubernetesManifestV0/package-lock.json
+++ b/Tasks/KubernetesManifestV0/package-lock.json
@@ -11,18 +11,18 @@
       }
     },
     "@types/events": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "5.0.36",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
       "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
       "requires": {
-        "@types/events": "1.2.0",
+        "@types/events": "3.0.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.117"
+        "@types/node": "6.14.6"
       }
     },
     "@types/minimatch": {
@@ -36,14 +36,14 @@
       "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
     },
     "@types/node": {
-      "version": "6.0.117",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.117.tgz",
-      "integrity": "sha512-sihk0SnN8PpiS5ihu5xJQ5ddnURNq4P+XPmW+nORlKkHy21CoZO/IVHK/Wq/l3G8fFW06Fkltgnqx229uPlnRg=="
+      "version": "6.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+      "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w=="
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -71,15 +71,28 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "1.7.0",
+        "q": "1.4.1",
+        "semver": "5.7.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -97,38 +110,47 @@
       "requires": {
         "globby": "4.1.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       }
     },
-    "docker-common": {
-      "version": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
+    "docker-common-v2": {
+      "version": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "del": "2.2.0",
         "q": "1.4.1",
-        "vso-node-api": "6.0.1-preview",
-        "vsts-task-lib": "2.0.1-preview"
+        "vso-node-api": "6.0.1-preview"
       },
       "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "vsts-task-lib": {
-          "version": "2.0.1-preview",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.1-preview.tgz",
-          "integrity": "sha1-rfx4BRaPtJLVcD7eZIXOt4G2SrQ=",
+        "azure-pipelines-task-lib": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "1.7.0",
-            "node-uuid": "1.4.8",
             "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0"
+            "semver": "5.7.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.3.2"
+          }
+        },
+        "del": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+          "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
+          "requires": {
+            "globby": "4.1.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.3"
           }
         }
       }
@@ -188,17 +210,17 @@
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -212,12 +234,39 @@
         "esprima": "2.7.3"
       }
     },
-    "kubernetes-common": {
-      "version": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "kubernetes-common-v2": {
+      "version": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "js-yaml": "3.6.1",
-        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
+      },
+      "dependencies": {
+        "azure-pipelines-task-lib": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+          "requires": {
+            "minimatch": "3.0.4",
+            "mockery": "1.7.0",
+            "q": "1.4.1",
+            "semver": "5.7.0",
+            "shelljs": "0.3.0",
+            "uuid": "3.3.2"
+          }
+        },
+        "vsts-task-tool-lib": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+          "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
+          "requires": {
+            "semver": "5.7.0",
+            "semver-compare": "1.0.0",
+            "typed-rest-client": "0.9.0",
+            "uuid": "3.3.2",
+            "vsts-task-lib": "2.0.4-preview"
+          }
+        }
       }
     },
     "minimatch": {
@@ -225,7 +274,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -285,17 +334,17 @@
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.4"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -308,9 +357,9 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -324,7 +373,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "tunnel": {
@@ -339,43 +388,19 @@
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
       }
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-    },
-    "utility-common": {
-      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-      "requires": {
-        "js-yaml": "3.6.1",
-        "semver": "5.4.1",
-        "vso-node-api": "6.5.0",
-        "vsts-task-lib": "2.6.0",
-        "vsts-task-tool-lib": "0.4.0"
-      },
-      "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        },
-        "vso-node-api": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-          "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-          "requires": {
-            "tunnel": "0.0.4",
-            "typed-rest-client": "0.12.0",
-            "underscore": "1.8.3"
-          }
-        }
-      }
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "uuid": {
       "version": "3.3.2",
@@ -389,18 +414,18 @@
       "requires": {
         "q": "1.4.1",
         "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "underscore": "1.9.1"
       }
     },
     "vsts-task-lib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+      "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
         "q": "1.4.1",
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "shelljs": "0.3.0",
         "uuid": "3.3.2"
       }
@@ -410,31 +435,11 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "0.9.0",
-        "uuid": "3.2.1",
+        "uuid": "3.3.2",
         "vsts-task-lib": "2.0.4-preview"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
-        "vsts-task-lib": {
-          "version": "2.0.4-preview",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
-          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
-        }
       }
     },
     "wrappy": {

--- a/Tasks/KubernetesManifestV0/package.json
+++ b/Tasks/KubernetesManifestV0/package.json
@@ -5,12 +5,11 @@
     "@types/mocha": "^2.2.5",
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
+    "azure-pipelines-task-lib": "2.8.0",
     "del": "2.2.0",
-    "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
-    "kubernetes-common": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "docker-common-v2": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
+    "kubernetes-common-v2": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
     "moment": "2.21.0",
-    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-    "vsts-task-lib": "2.6.0",
     "vsts-task-tool-lib": "0.4.0"
   }
 }

--- a/Tasks/KubernetesManifestV0/src/actions/bake.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/bake.ts
@@ -1,13 +1,13 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as  path from 'path';
 import * as fs from 'fs';
-import * as  helmutility from 'kubernetes-common/helmutility';
+import * as  helmutility from 'kubernetes-common-v2/helmutility';
 import * as uuidV4 from 'uuid/v4';
 
 import { getTempDirectory } from '../utils/FileHelper';
-import { Helm, NameValuePair } from 'kubernetes-common/helm-object-model';
+import { Helm, NameValuePair } from 'kubernetes-common-v2/helm-object-model';
 import * as TaskParameters from '../models/TaskInputParameters';
 
 class HelmRenderEngine {

--- a/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/createSecret.ts
@@ -1,10 +1,10 @@
 'use strict';
 
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
-import AuthenticationToken from 'docker-common/registryauthenticationprovider/registryauthenticationtoken';
-import { getDockerRegistryEndpointAuthenticationToken } from 'docker-common/registryauthenticationprovider/registryauthenticationtoken';
+import AuthenticationToken from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
+import { getDockerRegistryEndpointAuthenticationToken } from 'docker-common-v2/registryauthenticationprovider/registryauthenticationtoken';
 
 export async function createSecret(ignoreSslErrors?: boolean) {
     const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);

--- a/Tasks/KubernetesManifestV0/src/actions/delete.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/delete.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import * as tl from 'azure-pipelines-task-lib/task';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 

--- a/Tasks/KubernetesManifestV0/src/actions/deploy.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/deploy.ts
@@ -3,7 +3,7 @@
 import * as deploymentHelper from '../utils/DeploymentHelper';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 import * as utils from '../utils/utilities';
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 
 export async function deploy(ignoreSslErrors?: boolean) {
     const kubectlPath = await utils.getKubectl();

--- a/Tasks/KubernetesManifestV0/src/actions/patch.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/patch.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import * as tl from 'azure-pipelines-task-lib/task';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as constants from '../models/constants';
 import * as TaskParameters from '../models/TaskInputParameters';

--- a/Tasks/KubernetesManifestV0/src/actions/promote.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/promote.ts
@@ -1,12 +1,12 @@
 'use strict';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 
 import * as deploymentHelper from '../utils/DeploymentHelper';
 import * as canaryDeploymentHelper from '../utils/CanaryDeploymentHelper';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 
 export async function promote(ignoreSslErrors?: boolean) {
 

--- a/Tasks/KubernetesManifestV0/src/actions/reject.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/reject.ts
@@ -1,7 +1,7 @@
 'use strict';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as canaryDeploymentHelper from '../utils/CanaryDeploymentHelper';
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import * as utils from '../utils/utilities';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 

--- a/Tasks/KubernetesManifestV0/src/actions/scale.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/scale.ts
@@ -1,12 +1,12 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 
 import * as utils from '../utils/utilities';
 import * as constants from '../models/constants';
 import * as TaskInputParameters from '../models/TaskInputParameters';
 
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 
 export async function scale(ignoreSslErrors?: boolean) {
     const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);

--- a/Tasks/KubernetesManifestV0/src/connection.ts
+++ b/Tasks/KubernetesManifestV0/src/connection.ts
@@ -1,8 +1,8 @@
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as utils from './utils/FileHelper';
-import * as kubectlutility from 'kubernetes-common/kubectlutility';
+import * as kubectlutility from 'kubernetes-common-v2/kubectlutility';
 
 export class Connection {
     public ignoreSSLErrors: boolean;

--- a/Tasks/KubernetesManifestV0/src/models/TaskInputParameters.ts
+++ b/Tasks/KubernetesManifestV0/src/models/TaskInputParameters.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 
 export let namespace: string = tl.getInput('namespace', false);
 export const containers: string[] = tl.getDelimitedInput('containers', '\n');

--- a/Tasks/KubernetesManifestV0/src/models/constants.ts
+++ b/Tasks/KubernetesManifestV0/src/models/constants.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as utils from '../utils/utilities';
 
 export class KubernetesWorkload {

--- a/Tasks/KubernetesManifestV0/src/run.ts
+++ b/Tasks/KubernetesManifestV0/src/run.ts
@@ -1,5 +1,5 @@
 'use strict';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 
 import { deploy } from './actions/deploy';

--- a/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/CanaryDeploymentHelper.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
-import * as tl from 'vsts-task-lib/task';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 

--- a/Tasks/KubernetesManifestV0/src/utils/DeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/DeploymentHelper.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as yaml from 'js-yaml';
 import * as canaryDeploymentHelper from '../utils/CanaryDeploymentHelper';
 import * as KubernetesObjectUtility from '../utils/KubernetesObjectUtility';
@@ -11,8 +11,8 @@ import * as TaskInputParameters from '../models/TaskInputParameters';
 import * as models from '../models/constants';
 import * as fileHelper from '../utils/FileHelper';
 import * as utils from '../utils/utilities';
-import { IExecSyncResult } from 'vsts-task-lib/toolrunner';
-import { Kubectl, Resource } from 'kubernetes-common/kubectl-object-model';
+import { IExecSyncResult } from 'azure-pipelines-task-lib/toolrunner';
+import { Kubectl, Resource } from 'kubernetes-common-v2/kubectl-object-model';
 
 export function deploy(kubectl: Kubectl, manifestFilePaths: string[], deploymentStrategy: string) {
 

--- a/Tasks/KubernetesManifestV0/src/utils/FileHelper.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/FileHelper.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as os from 'os';
 
 export function getTempDirectory(): string {

--- a/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
@@ -1,8 +1,8 @@
 'use strict';
 import * as fs from 'fs';
-import * as tl from 'vsts-task-lib/task';
+import * as tl from 'azure-pipelines-task-lib/task';
 import * as yaml from 'js-yaml';
-import { Resource } from 'kubernetes-common/kubectl-object-model';
+import { Resource } from 'kubernetes-common-v2/kubectl-object-model';
 import { KubernetesWorkload, recognizedWorkloadTypes } from '../models/constants';
 import * as utils from '../utils/utilities';
 import { StringComparer } from '../utils/utilities';

--- a/Tasks/KubernetesManifestV0/src/utils/utilities.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/utilities.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import * as tl from 'vsts-task-lib/task';
-import { IExecSyncResult } from 'vsts-task-lib/toolrunner';
-import * as kubectlutility from 'kubernetes-common/kubectlutility';
-import { Kubectl } from 'kubernetes-common/kubectl-object-model';
+import * as tl from 'azure-pipelines-task-lib/task';
+import { IExecSyncResult } from 'azure-pipelines-task-lib/toolrunner';
+import * as kubectlutility from 'kubernetes-common-v2/kubectlutility';
+import { Kubectl } from 'kubernetes-common-v2/kubectl-object-model';
 import { pipelineAnnotations } from '../models/constants';
 
 export enum StringComparer {

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
…elines-task-lib@v2.8.0

- Also moved KubernetesManifestV0
	- from 'kubernetes-common' to 'kubernetes-common-v2'
	- from 'docker-common' to 'docker-common-v2'
- Removed dependency on 'utility-common' as it was unused.
- Bumped up patch version