### PR TITLE
KubernetesV1: Updating from vsts-task-lib@2.0.5 to azure-pipelines-ta…

### DIFF
--- a/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Deploy to Kubernetes",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Kubernetes documentation](https://kubernetes.io/docs/home/)",
   "loc.description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running kubectl commands",
   "loc.instanceNameFormat": "kubectl $(command)",
   "loc.releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
-import tl = require('vsts-task-lib');
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import tl = require('azure-pipelines-task-lib');
 import * as shared from './TestShared';
 
 describe('Kubernetes Suite', function() {

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import * as shared from './TestShared';
 const querystring = require("querystring");

--- a/Tasks/KubernetesV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesV1/Tests/TestShared.ts
@@ -1,4 +1,4 @@
-import tl = require('vsts-task-lib');
+import tl = require('azure-pipelines-task-lib');
 
 export let TestEnvVars = {
     operatingSystem: "__operating_system__",

--- a/Tasks/KubernetesV1/ThirdPartyNotices.txt
+++ b/Tasks/KubernetesV1/ThirdPartyNotices.txt
@@ -1,4 +1,4 @@
-
+﻿
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
@@ -59,7 +59,7 @@ The Kubernetes task for Azure Pipelines or Team Foundation Server incorporates c
 45.	typed-rest-client  (https://github.com/Microsoft/typed-rest-client)
 46.	underscore (https://github.com/jashkenas/underscore)
 47.	vso-node-api (https://github.com/Microsoft/vsts-node-api)
-48.	VSTS-Task-Lib (https://github.com/Microsoft/vsts-task-lib)
+48.	Azure-Pipelines-Task-Lib (https://github.com/Microsoft/azure-pipelines-task-lib)
 49.	wrappy (https://github.com/npm/wrappy)
 50. xtend (https://github.com/Raynos/xtend)
 
@@ -1596,7 +1596,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 =========================================
 END OF vso-node-api NOTICES, INFORMATION, AND LICENSE
 
-%% VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+%% Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -1621,7 +1621,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 =========================================
-END OF VSTS-Task-Lib NOTICES, INFORMATION, AND LICENSE
+END OF Azure-Pipelines-Task-Lib NOTICES, INFORMATION, AND LICENSE
 
 %% wrappy NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================

--- a/Tasks/KubernetesV1/make.json
+++ b/Tasks/KubernetesV1/make.json
@@ -1,24 +1,24 @@
 {
 	"common": [{
-		"module": "../Common/docker-common",
+		"module": "../Common/docker-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
 	},
     {
-		"module": "../Common/utility-common",
+		"module": "../Common/utility-common-v2",
 		"type": "node",
 		"dest" : "./",
 		"compile" : true
 	},
 	{
-		"module": "../Common/azure-arm-rest",
+		"module": "../Common/azure-arm-rest-v2",
 		"type": "node",
 		"dest": "./",
 		"compile": true
 	},
 	{
-		"module": "../Common/kubernetes-common",
+		"module": "../Common/kubernetes-common-v2",
 		"type": "node",
 		"dest": "./",
 		"compile": true
@@ -27,11 +27,11 @@
 	"rm": [
         {
             "items": [
-                "node_modules/utility-common/node_modules/vsts-task-lib",
-				"node_modules/docker-common/node_modules/vsts-task-lib",
+                "node_modules/utility-common-v2/node_modules/azure-pipelines-task-lib",
+				"node_modules/docker-common-v2/node_modules/azure-pipelines-task-lib",
 				"node_modules/vsts-task-tool-lib/node_modules/vsts-task-lib",
-				"node_modules/azure-arm-rest/node_modules/vsts-task-lib",
-				"node_modules/kubernetes-common/node_modules/vsts-task-lib"
+				"node_modules/azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+				"node_modules/kubernetes-common-v2/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/KubernetesV1/npm-shrinkwrap.json
+++ b/Tasks/KubernetesV1/npm-shrinkwrap.json
@@ -11,18 +11,18 @@
       }
     },
     "@types/events": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
     },
     "@types/glob": {
       "version": "5.0.36",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
       "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
       "requires": {
-        "@types/events": "1.2.0",
+        "@types/events": "3.0.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "6.0.117"
+        "@types/node": "6.14.6"
       }
     },
     "@types/minimatch": {
@@ -36,14 +36,14 @@
       "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw=="
     },
     "@types/node": {
-      "version": "6.0.117",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.117.tgz",
-      "integrity": "sha512-sihk0SnN8PpiS5ihu5xJQ5ddnURNq4P+XPmW+nORlKkHy21CoZO/IVHK/Wq/l3G8fFW06Fkltgnqx229uPlnRg=="
+      "version": "6.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.6.tgz",
+      "integrity": "sha512-rFs9zCFtSHuseiNXxYxFlun8ibu+jtZPgRM+2ILCmeLiGeGLiIGxuOzD+cNyHegI1GD+da3R/cIbs9+xCLp13w=="
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -71,24 +71,41 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
-    "azure-arm-rest": {
-      "version": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
+    "azure-arm-rest-v2": {
+      "version": "file:../../_build/Tasks/Common/azure-arm-rest-v2-2.0.0.tgz",
       "requires": {
+        "@types/mocha": "2.2.48",
+        "@types/node": "6.0.68",
+        "@types/q": "1.0.7",
+        "azure-pipelines-task-lib": "2.8.0",
         "jsonwebtoken": "7.3.0",
         "q": "1.4.1",
-        "typed-rest-client": "0.12.0",
-        "vsts-task-lib": "2.0.5"
+        "typed-rest-client": "0.12.0"
       },
       "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
+        "@types/node": {
+          "version": "6.0.68",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.68.tgz",
+          "integrity": "sha1-DEO2uLlEX+uGoPvTRX4/S8WR5m0="
+        },
+        "@types/q": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@types/q/-/q-1.0.7.tgz",
+          "integrity": "sha512-0WS7XU7sXzQ7J1nbnMKKYdjrrFoO3YtZYgUzeV8JFXffPnHfvSJQleR70I8BOAsOm14i4dyaAZ3YzqIl1YhkXQ=="
         }
+      }
+    },
+    "azure-pipelines-task-lib": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
+      "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "1.7.0",
+        "q": "1.4.1",
+        "semver": "5.7.0",
+        "shelljs": "0.3.0",
+        "uuid": "3.3.2"
       }
     },
     "balanced-match": {
@@ -97,9 +114,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -122,40 +139,20 @@
       "requires": {
         "globby": "4.1.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "rimraf": "2.6.3"
       }
     },
-    "docker-common": {
-      "version": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
+    "docker-common-v2": {
+      "version": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "del": "2.2.0",
         "q": "1.4.1",
-        "vso-node-api": "6.0.1-preview",
-        "vsts-task-lib": "2.0.1-preview"
-      },
-      "dependencies": {
-        "node-uuid": {
-          "version": "1.4.8",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-        },
-        "vsts-task-lib": {
-          "version": "2.0.1-preview",
-          "resolved": "http://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.1-preview.tgz",
-          "integrity": "sha1-rfx4BRaPtJLVcD7eZIXOt4G2SrQ=",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "node-uuid": "1.4.8",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0"
-          }
-        }
+        "vso-node-api": "6.0.1-preview"
       }
     },
     "ecdsa-sig-formatter": {
@@ -226,17 +223,17 @@
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -297,27 +294,12 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "kubernetes-common": {
-      "version": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "kubernetes-common-v2": {
+      "version": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "js-yaml": "3.6.1",
-        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
-      },
-      "dependencies": {
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
-        }
       }
     },
     "lodash.once": {
@@ -330,7 +312,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "mockery": {
@@ -395,17 +377,17 @@
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "7.1.4"
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -423,9 +405,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -456,9 +438,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
-      "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
+      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -469,54 +451,32 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
-    "utility-common": {
-      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
+    "utility-common-v2": {
+      "version": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz",
       "requires": {
+        "azure-pipelines-task-lib": "2.8.0",
         "js-yaml": "3.6.1",
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "vso-node-api": "6.5.0",
-        "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       },
       "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        },
         "vso-node-api": {
           "version": "6.5.0",
-          "resolved": "http://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
           "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
           "requires": {
             "tunnel": "0.0.4",
             "typed-rest-client": "0.12.0",
             "underscore": "1.8.3"
           }
-        },
-        "vsts-task-lib": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-          "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
-          "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
-          }
         }
       }
     },
     "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "vso-node-api": {
       "version": "6.0.1-preview",
@@ -529,16 +489,16 @@
       }
     },
     "vsts-task-lib": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.5.tgz",
-      "integrity": "sha1-y9WrIy6rtxDJaXkFMYcmlZHA1RA=",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+      "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "1.7.0",
         "q": "1.4.1",
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "shelljs": "0.3.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       }
     },
     "vsts-task-tool-lib": {
@@ -546,29 +506,20 @@
       "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
-        "semver": "5.4.1",
+        "semver": "5.7.0",
         "semver-compare": "1.0.0",
         "typed-rest-client": "0.9.0",
-        "uuid": "3.2.1",
+        "uuid": "3.3.2",
         "vsts-task-lib": "2.0.4-preview"
       },
       "dependencies": {
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
-        "vsts-task-lib": {
-          "version": "2.0.4-preview",
-          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
-          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
           "requires": {
-            "minimatch": "3.0.4",
-            "mockery": "1.7.0",
-            "q": "1.4.1",
-            "semver": "5.4.1",
-            "shelljs": "0.3.0",
-            "uuid": "3.2.1"
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
           }
         }
       }

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -5,13 +5,13 @@
     "@types/mocha": "^2.2.5",
     "@types/node": "^6.0.101",
     "@types/q": "^1.5.0",
-    "azure-arm-rest": "file:../../_build/Tasks/Common/azure-arm-rest-1.0.2.tgz",
+    "azure-arm-rest-v2": "file:../../_build/Tasks/Common/azure-arm-rest-v2-2.0.0.tgz",
+    "azure-pipelines-task-lib": "2.8.0",
     "del": "2.2.0",
-    "docker-common": "file:../../_build/Tasks/Common/docker-common-1.0.0.tgz",
-    "kubernetes-common": "file:../../_build/Tasks/Common/kubernetes-common-1.0.0.tgz",
+    "docker-common-v2": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
+    "kubernetes-common-v2": "file:../../_build/Tasks/Common/kubernetes-common-v2-1.0.0.tgz",
     "moment": "2.21.0",
-    "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
-    "vsts-task-lib": "2.0.5",
+    "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz",
     "vsts-task-tool-lib": "0.4.0"
   }
 }

--- a/Tasks/KubernetesV1/src/clusterconnection.ts
+++ b/Tasks/KubernetesV1/src/clusterconnection.ts
@@ -3,8 +3,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as url from "url";
-import * as tl from "vsts-task-lib/task";
-import * as tr from "vsts-task-lib/toolrunner";
+import * as tl from "azure-pipelines-task-lib/task";
+import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as utils from "./utilities";
 import * as os from "os";
 import * as toolLib from 'vsts-task-tool-lib/tool';

--- a/Tasks/KubernetesV1/src/clusters/armkubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/armkubernetescluster.ts
@@ -1,9 +1,9 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
-import { AzureAksService } from 'azure-arm-rest/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-arm-rest/azure-arm-endpoint';
-import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest/azureModels';
+import tl = require('azure-pipelines-task-lib/task');
+import { AzureAksService } from 'azure-arm-rest-v2/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-arm-rest-v2/azureModels';
 
 // get kubeconfig file content
 async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceGroup: string, clusterName: string, useClusterAdmin?: boolean) : Promise<string> {

--- a/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/KubernetesV1/src/clusters/generickubernetescluster.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
-import kubectlutility = require("kubernetes-common/kubectlutility");
+import tl = require('azure-pipelines-task-lib/task');
+import kubectlutility = require("kubernetes-common-v2/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);

--- a/Tasks/KubernetesV1/src/kubernetes.ts
+++ b/Tasks/KubernetesV1/src/kubernetes.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 
 import ClusterConnection from "./clusterconnection";

--- a/Tasks/KubernetesV1/src/kubernetescommand.ts
+++ b/Tasks/KubernetesV1/src/kubernetescommand.ts
@@ -1,10 +1,10 @@
 "use strict";
 import * as del from "del";
 import * as fs from "fs";
-import * as tr from "vsts-task-lib/toolrunner";
-import trm = require('vsts-task-lib/toolrunner');
+import * as tr from "azure-pipelines-task-lib/toolrunner";
+import trm = require('azure-pipelines-task-lib/toolrunner');
 import * as path from "path";
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 import * as utils from "./utilities";
 import ClusterConnection from "./clusterconnection";
 

--- a/Tasks/KubernetesV1/src/kubernetesconfigmap.ts
+++ b/Tasks/KubernetesV1/src/kubernetesconfigmap.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
-import * as tr from "vsts-task-lib/toolrunner";
+import tl = require('azure-pipelines-task-lib/task');
+import * as tr from "azure-pipelines-task-lib/toolrunner";
 import path = require('path');
 import * as fs from "fs";
 import * as kubernetesCommand from "./kubernetescommand";

--- a/Tasks/KubernetesV1/src/kuberneteslogin.ts
+++ b/Tasks/KubernetesV1/src/kuberneteslogin.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import Q = require('q');
-import trm = require('vsts-task-lib/toolrunner');
+import trm = require('azure-pipelines-task-lib/toolrunner');
 import ClusterConnection from "./clusterconnection";
 
 export function run(connection: ClusterConnection, kubecommand: string, outputUpdate: (data: string) => any): any {

--- a/Tasks/KubernetesV1/src/kuberneteslogout.ts
+++ b/Tasks/KubernetesV1/src/kuberneteslogout.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import Q = require('q');
-import trm = require('vsts-task-lib/toolrunner');
+import trm = require('azure-pipelines-task-lib/toolrunner');
 import ClusterConnection from "./clusterconnection";
 
 export function run(connection: ClusterConnection, kubecommand: string, outputUpdate: (data: string) => any): any {

--- a/Tasks/KubernetesV1/src/kubernetessecret.ts
+++ b/Tasks/KubernetesV1/src/kubernetessecret.ts
@@ -1,15 +1,15 @@
 "use strict";
 
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import * as tr from "vsts-task-lib/toolrunner";
+import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as kubernetesCommand from "./kubernetescommand";
 import ClusterConnection from "./clusterconnection";
 
-import AuthenticationToken from "docker-common/registryauthenticationprovider/registryauthenticationtoken";
-import AuthenticationTokenProvider  from "docker-common/registryauthenticationprovider/authenticationtokenprovider";
-import ACRAuthenticationTokenProvider from "docker-common/registryauthenticationprovider/acrauthenticationtokenprovider";
-import { getDockerRegistryEndpointAuthenticationToken } from "docker-common/registryauthenticationprovider/registryauthenticationtoken";
+import AuthenticationToken from "docker-common-v2/registryauthenticationprovider/registryauthenticationtoken";
+import AuthenticationTokenProvider  from "docker-common-v2/registryauthenticationprovider/authenticationtokenprovider";
+import ACRAuthenticationTokenProvider from "docker-common-v2/registryauthenticationprovider/acrauthenticationtokenprovider";
+import { getDockerRegistryEndpointAuthenticationToken } from "docker-common-v2/registryauthenticationprovider/registryauthenticationtoken";
 
 export function run(connection: ClusterConnection, secret: string): any {
    

--- a/Tasks/KubernetesV1/src/utilities.ts
+++ b/Tasks/KubernetesV1/src/utilities.ts
@@ -3,13 +3,13 @@
 var https   = require('https');
 var fs      = require('fs');
 import * as path from "path";
-import * as tl from "vsts-task-lib/task";
+import * as tl from "azure-pipelines-task-lib/task";
 import * as os from "os";
 import * as util from "util";
 import * as toolLib from 'vsts-task-tool-lib/tool';
 
-import kubectlutility = require("kubernetes-common/kubectlutility");
-import downloadutility = require("utility-common/downloadutility");
+import kubectlutility = require("kubernetes-common-v2/kubectlutility");
+import downloadutility = require("utility-common-v2/downloadutility");
 
 export function getTempDirectory(): string {
     return tl.getVariable('agent.tempDirectory') || os.tmpdir();

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
…sk-lib@2.8.0

- Also moved KubernetesV1
	- from 'kubernetes-common' to 'kubernetes-common-v2'
	- from 'docker-common' to 'docker-common-v2'
	- from 'azure-arm-rest' to 'azure-arm-rest-v2'
	- from 'utility-common' to 'utility-common-v2'
- Bumped up patch version