### PR TITLE
Bumping up task minor versions to 154.

### DIFF
--- a/Tasks/DuffleInstallerV0/task.json
+++ b/Tasks/DuffleInstallerV0/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 2
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "groups": [],

--- a/Tasks/DuffleInstallerV0/task.loc.json
+++ b/Tasks/DuffleInstallerV0/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 2
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "groups": [],

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 153,
-        "Patch": 2
+        "Minor": 154,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 153,
-    "Patch": 2
+    "Minor": 154,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 3
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 3
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [


### PR DESCRIPTION
These tasks were moved to use the latest version of azure-pipelines-task-lib@2.8.0

Task affected:
- DuffleInstallerV0
- HelmDeployV0
- HelmInstallerV1
- KubectlInstallerV0