### PR TITLE
Base URL to download Helm Client has changed to https://get.helm.sh

### DIFF
--- a/Tasks/Common/kubernetes-common-v2/helmutility.ts
+++ b/Tasks/Common/kubernetes-common-v2/helmutility.ts
@@ -9,7 +9,7 @@ import { getExecutableExtension } from './utility';
 
 const helmToolName = 'helm';
 const helmLatestReleaseUrl = 'https://api.github.com/repos/helm/helm/releases/latest';
-const stableHelmVersion = 'v2.9.1';
+const stableHelmVersion = 'v2.14.1';
 
 export async function getHelm(version?: string) {
     try {
@@ -52,13 +52,13 @@ function findHelm(rootFolder: string) {
 function getHelmDownloadURL(version: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-linux-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-linux-amd64.zip', version);
 
         case 'Darwin':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-darwin-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-darwin-amd64.zip', version);
 
         case 'Windows_NT':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-windows-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-windows-amd64.zip', version);
 
         default:
             throw Error('Unknown OS type');
@@ -67,7 +67,7 @@ function getHelmDownloadURL(version: string): string {
 
 export async function getStableHelmVersion(): Promise<string> {
     try {
-        const downloadPath = await toolLib.downloadTool('https://api.github.com/repos/helm/helm/releases/latest');
+        const downloadPath = await toolLib.downloadTool(helmLatestReleaseUrl);
         const response = JSON.parse(fs.readFileSync(downloadPath, 'utf8').toString().trim());
         return response.body.tag_name;
     } catch (error) {

--- a/Tasks/Common/kubernetes-common/helmutility.ts
+++ b/Tasks/Common/kubernetes-common/helmutility.ts
@@ -9,7 +9,7 @@ import { getExecutableExtension } from './utility';
 
 const helmToolName = 'helm';
 const helmLatestReleaseUrl = 'https://api.github.com/repos/helm/helm/releases/latest';
-const stableHelmVersion = 'v2.9.1';
+const stableHelmVersion = 'v2.14.1';
 
 export async function getHelm(version?: string) {
     try {
@@ -52,13 +52,13 @@ function findHelm(rootFolder: string) {
 function getHelmDownloadURL(version: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-linux-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-linux-amd64.zip', version);
 
         case 'Darwin':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-darwin-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-darwin-amd64.zip', version);
 
         case 'Windows_NT':
-            return util.format('https://storage.googleapis.com/kubernetes-helm/helm-%s-windows-amd64.zip', version);
+            return util.format('https://get.helm.sh/helm-%s-windows-amd64.zip', version);
 
         default:
             throw Error('Unknown OS type');
@@ -67,7 +67,7 @@ function getHelmDownloadURL(version: string): string {
 
 export async function getStableHelmVersion(): Promise<string> {
     try {
-        const downloadPath = await toolLib.downloadTool('https://api.github.com/repos/helm/helm/releases/latest');
+        const downloadPath = await toolLib.downloadTool(helmLatestReleaseUrl);
         const response = JSON.parse(fs.readFileSync(downloadPath, 'utf8').toString().trim());
         return response.body.tag_name;
     } catch (error) {

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV0/src/helminstaller.ts
+++ b/Tasks/HelmInstallerV0/src/helminstaller.ts
@@ -11,7 +11,7 @@ import { WebRequest, sendRequest } from "./webClient";
 const uuidV4 = require('uuid/v4');
 const helmToolName = "helm"
 const helmLatestReleaseUrl = "https://api.github.com/repos/helm/helm/releases/latest";
-const stableHelmVersion = "v2.9.1"
+const stableHelmVersion = "v2.14.1"
 
 export async function getHelmVersion(): Promise<string> {
     var checkLatestHelmVersion = tl.getBoolInput('checkLatestHelmVersion', false);
@@ -55,21 +55,21 @@ function findHelm(rootFolder: string) {
 function getHelmDownloadURL(version: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format("https://storage.googleapis.com/kubernetes-helm/helm-%s-linux-amd64.zip", version);
+            return util.format("https://get.helm.sh/helm-%s-linux-amd64.zip", version);
 
         case 'Darwin':
-            return util.format("https://storage.googleapis.com/kubernetes-helm/helm-%s-darwin-amd64.zip", version);
+            return util.format("https://get.helm.sh/helm-%s-darwin-amd64.zip", version);
 
         default:
         case 'Windows_NT':
-            return util.format("https://storage.googleapis.com/kubernetes-helm/helm-%s-windows-amd64.zip", version);
+            return util.format("https://get.helm.sh/helm-%s-windows-amd64.zip", version);
 
     }
 }
 
 async function getStableHelmVersion(): Promise<string> {
     var request = new WebRequest();
-    request.uri = "https://api.github.com/repos/helm/helm/releases/latest";
+    request.uri = helmLatestReleaseUrl;
     request.method = "GET";
 
     try {

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 2
+        "Minor": 154,
+        "Patch": 1
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 153,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "satisfies": [
@@ -35,7 +35,7 @@
             "type": "string",
             "required": true,
             "helpMarkDown": "Specify the version of Helm to install",
-            "defaultValue": "2.9.1"
+            "defaultValue": "2.14.1"
         },
         {
             "name": "checkLatestHelmVersion",

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 2
+    "Minor": 154,
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 153,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "satisfies": [
@@ -35,7 +35,7 @@
       "type": "string",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.helmVersion",
-      "defaultValue": "2.9.1"
+      "defaultValue": "2.14.1"
     },
     {
       "name": "checkLatestHelmVersion",

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 155,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 155,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "demands": [],

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 155,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 155,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 155,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 155,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
https://github.com/microsoft/azure-pipelines-tasks/issues/10727

And changed the `stableHelmVersion` to `v2.14.1`.