### PR TITLE
Fixed stable helm version download error

### DIFF
--- a/Tasks/Common/kubernetes-common-v2/helmutility.ts
+++ b/Tasks/Common/kubernetes-common-v2/helmutility.ts
@@ -32,12 +32,11 @@ export async function downloadHelm(version?: string): Promise<string> {
         const unzipedHelmPath = await toolLib.extractZip(helmDownloadPath);
         cachedToolpath = await toolLib.cacheDir(unzipedHelmPath, helmToolName, version);
     }
-
     const helmpath = findHelm(cachedToolpath);
     if (!helmpath) {
         throw new Error(tl.loc('HelmNotFoundInFolder', cachedToolpath));
     }
-
+    
     fs.chmodSync(helmpath, '777');
     return helmpath;
 }
@@ -69,7 +68,12 @@ export async function getStableHelmVersion(): Promise<string> {
     try {
         const downloadPath = await toolLib.downloadTool('https://api.github.com/repos/helm/helm/releases/latest');
         const response = JSON.parse(fs.readFileSync(downloadPath, 'utf8').toString().trim());
-        return response.body.tag_name;
+        if (!response.tag_name)
+        {
+            return stableHelmVersion;
+        }
+        
+        return response.tag_name;
     } catch (error) {
         tl.warning(tl.loc('HelmLatestNotKnown', helmLatestReleaseUrl, error, stableHelmVersion));
     }

--- a/Tasks/Common/kubernetes-common/helmutility.ts
+++ b/Tasks/Common/kubernetes-common/helmutility.ts
@@ -69,7 +69,12 @@ export async function getStableHelmVersion(): Promise<string> {
     try {
         const downloadPath = await toolLib.downloadTool('https://api.github.com/repos/helm/helm/releases/latest');
         const response = JSON.parse(fs.readFileSync(downloadPath, 'utf8').toString().trim());
-        return response.body.tag_name;
+        if (!response.tag_name)
+        {
+            return stableHelmVersion;
+        }
+        
+        return response.tag_name;
     } catch (error) {
         tl.warning(tl.loc('HelmLatestNotKnown', helmLatestReleaseUrl, error, stableHelmVersion));
     }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/HelmInstallerV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Helm tool installer",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=851275)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275)",
   "loc.description": "Install Helm and Kubernetes on an agent machine",
   "loc.instanceNameFormat": "Install Helm $(helmVersion)",
   "loc.group.displayName.prerequisite": "Prerequisite",

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 154,
+        "Minor": 155,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
-        "Patch": 1
+        "Minor": 154,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 154,
+    "Minor": 155,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
-    "Patch": 1
+    "Minor": 154,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 154,
-        "Patch": 2
+        "Minor": 155,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": true,
   "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 154,
-    "Patch": 2
+    "Minor": 155,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 155,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 155,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 155,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 155,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 155,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 155,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
while downloading from https://api.github.com/repos/helm/helm/releases/latest, the position of tag_name had changed. Put a check for tag_name, if tag_name cannot be extracted then returning stable version