### PR TITLE
Fixing the maxof mustache template function in Jenkins download task.

### DIFF
--- a/Tasks/JenkinsDownloadArtifactsV1/ArtifactDetails/JenkinsRestClient.ts
+++ b/Tasks/JenkinsDownloadArtifactsV1/ArtifactDetails/JenkinsRestClient.ts
@@ -161,22 +161,19 @@ export class JenkinsRestClient {
 
             let result = null;
             if (!!array && !!property) {
-                let maxValue: number = parseInt(GetJsonProperty(array[0], property));
+                let maxValue: number = 0;
+                result = array[0]; //consider first as result until we figure out if there are any other max available
 
-                if (!isNaN(maxValue)) {
-                    result = array[0]; //consider first as result until we figure out if there are any other max available
-
-                    for(let i = 1; i < array.length; i++) {
-                        let value: number = parseInt(GetJsonProperty(array[i], property));
-                        tl.debug(`#selectMaxOf comparing values ${maxValue} and ${value}`);
-                        if (!isNaN(value) && value > maxValue) {
-                            result = array[i];
-                            maxValue = value;
-                        }                        
-                    }
-
-                    tl.debug(`Found maxvalue ${maxValue}`);
+                for(let i = 0; i < array.length; i++) {
+                    let value: number = parseInt(GetJsonProperty(array[i], property));
+                    tl.debug(`#selectMaxOf comparing values ${maxValue} and ${value}`);
+                    if (!isNaN(value) && value > maxValue) {
+                        result = array[i];
+                        maxValue = value;
+                    }                        
                 }
+
+                tl.debug(`Found maxvalue ${maxValue}`);
             }
 
             return result;

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -18,7 +18,7 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 154,
+        "Minor": 155,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 154,
+    "Minor": 155,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
The first object may have null values, which was causing the whole evaluation to fail.
If the first object don't have the required property, we should ignore and move on to the next object.