### PR TITLE
Docker login issue - Don't pass isSecret to true while setting DOCKER_CONFIG variable in Docker task login.

### DIFF
--- a/Tasks/Common/docker-common-v2/containerconnection.ts
+++ b/Tasks/Common/docker-common-v2/containerconnection.ts
@@ -117,7 +117,7 @@ export default class ContainerConnection {
     
     public setDockerConfigEnvVariable() {
         if (this.configurationDirPath && fs.existsSync(this.configurationDirPath)) {
-            tl.setVariable("DOCKER_CONFIG", this.configurationDirPath, true);
+            tl.setVariable("DOCKER_CONFIG", this.configurationDirPath);
         }
         else {
             tl.error(tl.loc('DockerRegistryNotFound'));

--- a/Tasks/Common/docker-common/containerconnection.ts
+++ b/Tasks/Common/docker-common/containerconnection.ts
@@ -117,7 +117,7 @@ export default class ContainerConnection {
     
     public setDockerConfigEnvVariable() {
         if (this.configurationDirPath && fs.existsSync(this.configurationDirPath)) {
-            tl.setVariable("DOCKER_CONFIG", this.configurationDirPath, true);
+            tl.setVariable("DOCKER_CONFIG", this.configurationDirPath);
         }
         else {
             tl.error(tl.loc('DockerRegistryNotFound'));

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 154,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 154,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 154,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 154,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 5
+        "Patch": 6
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 5
+    "Patch": 6
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 154,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 154,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 154,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 154,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Setting isSecret to true causes the variable to be not available as an environment variable in the sub-sequent tasks. Hence, don't set isSecret to true, so that docker commands run through script and through Docker task work correctly.

This was working with older version of task lib (vsts-task-lib) since the isSecret was not getting handled currently. Thus the variable was available as an environment variable to the subsequent tasks.