### PR TITLE
Resubmitting changes to resolve issue causing msbuild to call twice

### DIFF
--- a/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
@@ -32,9 +32,7 @@ function Invoke-BuildTools {
             if ($Clean) {
                 Invoke-MSBuild -ProjectFile $file -Targets Clean -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
             }
-
-            # If we cleaned and passed /t targets, we don't need to run them again
-            if (!$Clean -or -not $MSBuildArguments.Contains("/t")) {
+            else {
                 Invoke-MSBuild -ProjectFile $file -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
             }
         }

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
+        "Minor": 155,
         "Patch": 1
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
+    "Minor": 155,
     "Patch": 1
   },
   "demands": [

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 155,
+        "Patch": 1
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 155,
+    "Patch": 1
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 155,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 155,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "MSBuild",

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 151,
-        "Patch": 3
+        "Minor": 155,
+        "Patch": 1
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 151,
-    "Patch": 3
+    "Minor": 155,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
Resubmitting changes to resolve issue causing msbuild to call twice in some circumstances, since the PR got convoluted on merge to update.