### PR TITLE
File Transforms - Tight substitute for system prefix variables

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureMysqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Azure Database for MySQL deployment",
-  "loc.helpMarkDown": "[More Information](https://aka.ms/mysqlazuredeployreadme)",
+  "loc.helpMarkDown": "[Learn more about this task](https://aka.ms/mysqlazuredeployreadme)",
   "loc.description": "Run your scripts and make changes to your Azure Database for MySQL",
   "loc.instanceNameFormat": "Execute Azure MySQL : $(TaskNameSelector)",
   "loc.group.displayName.target": "DB Details",

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 28
+        "Minor": 156,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 28
+    "Minor": 156,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 156,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 155,
+        "Minor": 156,
         "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 155,
+    "Minor": 156,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 156,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/Common/webdeployment-common-v2/Tests/L1JsonVarSub.ts
+++ b/Tasks/Common/webdeployment-common-v2/Tests/L1JsonVarSub.ts
@@ -11,7 +11,8 @@ var envVarObject = jsonSubUtil.createEnvTree([
     { name: 'user.profile.name.first', value: 'firstName', secret: false},
     { name: 'user.profile', value: 'replace_all', secret: false},
     { name: 'constructor.name', value: 'newConstructorName', secret: false},
-    { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false}
+    { name: 'constructor.valueOf', value: 'constructorNewValue', secret: false},
+    { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
 ]);
 
 var jsonObject = {
@@ -34,6 +35,9 @@ var jsonObject = {
     'constructor': {
         'name': 'myconstructorname',
         'valueOf': 'myconstructorvalue'
+    },
+    'systemsettings': {
+        'appurl': 'https://helloworld.visualstudio.com'
     }
 }
 // Method to be checked for JSON variable substitution
@@ -42,7 +46,9 @@ jsonSubUtil.substituteJsonVariable(jsonObject, envVarObject);
 if(typeof jsonObject['user.profile'] === 'object') {
     console.log('JSON - eliminating object variables validated');
 }
-if(jsonObject['data']['ConnectionString'] === 'database_connection' && jsonObject['data']['userName'] === 'db_admin') {
+if(jsonObject['data']['ConnectionString'] === 'database_connection'
+    && jsonObject['data']['userName'] === 'db_admin'
+    && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
     console.log('JSON - simple string change validated');
 }
 if(jsonObject['system']['debug'] === 'no_change') {

--- a/Tasks/Common/webdeployment-common-v2/Tests/L1JsonVarSubV2.ts
+++ b/Tasks/Common/webdeployment-common-v2/Tests/L1JsonVarSubV2.ts
@@ -16,7 +16,8 @@ var envVarObject = jsonSubUtil.createEnvTree([
     { name: 'profile.enabled', value: 'false', secret: false},
     { name: 'profile.version', value: '1173', secret: false},
     { name: 'profile.somefloat', value: '97.75', secret: false},
-    { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false}
+    { name: 'profile.preimum_level', value: '{"suaggar": "V4", "rok": "V5", "asranja": { "type" : "V6"}}', secret: false},
+    { name: 'systemsettings.appurl', value: 'https://dev.azure.com/helloworld', secret: false}
 ]);
 
 var jsonObject = {
@@ -52,13 +53,18 @@ var jsonObject = {
         "enabled": true,
         "version": 2,
         "somefloat": 2.3456
+    },
+    'systemsettings': {
+        'appurl': 'https://helloworld.visualstudio.com'
     }
 
 }
 // Method to be checked for JSON variable substitution
 jsonSubUtil.substituteJsonVariableV2(jsonObject, envVarObject);
 
-if(jsonObject['data']['ConnectionString'] === 'database_connection' && jsonObject['data']['userName'] === 'db_admin') {
+if(jsonObject['data']['ConnectionString'] === 'database_connection'
+    && jsonObject['data']['userName'] === 'db_admin'
+    && jsonObject['systemsettings']['appurl'] == 'https://dev.azure.com/helloworld') {
     console.log('JSON - simple string change validated');
 }
 if(jsonObject['system']['debug'] === 'no_change') {

--- a/Tasks/Common/webdeployment-common-v2/variableutility.ts
+++ b/Tasks/Common/webdeployment-common-v2/variableutility.ts
@@ -1,7 +1,7 @@
 import tl = require('azure-pipelines-task-lib');
 
 export function isPredefinedVariable(variable: string): boolean {
-    var predefinedVarPrefix = ['agent.', 'azure_http_user_agent', 'build.', 'common.', 'release.', 'system', 'tf_'];
+    var predefinedVarPrefix = ['agent.', 'azure_http_user_agent', 'build.', 'common.', 'release.', 'system.', 'tf_'];
     for(let varPrefix of predefinedVarPrefix) {
         if(variable.toLowerCase().startsWith(varPrefix)) {
             return true;

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -17,8 +17,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 153,
-        "Patch": 1
+        "Minor": 156,
+        "Patch": 0
     },
     "instanceNameFormat": "File Transform: $(Package)",
     "groups": [

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 153,
-    "Patch": 1
+    "Minor": 156,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "IIS web app deploy",
-  "loc.helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=866789)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=866789)",
   "loc.description": "Deploy a website or web application using Web Deploy",
   "loc.instanceNameFormat": "Deploy IIS Website/App: $(WebDeployPackage)",
   "loc.group.displayName.FileTransformsAndVariableSubstitution": "File Transforms & Variable Substitution Options",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 0,
-        "Patch": 58
+        "Minor": 156,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 0,
-    "Patch": 58
+    "Minor": 156,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "MySQL database deploy",
-  "loc.helpMarkDown": "[More Information](https://aka.ms/mysql-deployment-on-machine-group)",
+  "loc.helpMarkDown": "[Learn more about this task](https://aka.ms/mysql-deployment-on-machine-group)",
   "loc.description": "Run scripts and make changes to a MySQL Database",
   "loc.instanceNameFormat": "Deploy Using : $(TaskNameSelector)",
   "loc.input.label.TaskNameSelector": "Deploy MySql Using",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 1,
-        "Patch": 2
+        "Minor": 156,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.100.0",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 1,
-    "Patch": 2
+    "Minor": 156,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",


### PR DESCRIPTION
Fixes #10687

Ignore variables that are prefixed with `system.` and not `system` in variable substitution.