### PR TITLE
Add optional retry count input to DownloadSecureFile

### DIFF
--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/Common/securefiles-common/bump-task-version.ps1
+++ b/Tasks/Common/securefiles-common/bump-task-version.ps1
@@ -1,0 +1,37 @@
+# Bumps the version of all of the tasks that are technically modified when securefiles-common is changed.
+# Please validate the updated versions to confirm that nothing went horribly wrong.
+Param(
+[parameter(Mandatory=$true)]
+# The current sprint, find at https://whatsprintis.it/
+[int] $currentSprint,
+# The path to the Tasks folder
+[parameter()]
+[string] $taskRoot = (Join-Path $PSScriptRoot "..\..")
+)
+
+# Bump patch version and adjust sprint
+"AndroidSigningV2", "AndroidSigningV3", "DownloadSecureFileV1", "HelmDeployV0", "InstallAppleCertificateV2", "InstallAppleProvisioningProfileV1", "InstallSSHKeyV0" | % {
+    $taskLocation = Join-Path "$taskRoot/$_" "task.json"
+    $taskContent = Get-Content $taskLocation 
+    $task = $taskContent | ConvertFrom-Json
+    $v = $task.version
+    $newPatch = 0
+    if ($v.Minor -eq $currentSprint) {
+        $newPatch = $v.Patch + 1
+    }
+    Write-Output "${_}: $($v.Major).$($v.Minor).$($v.Patch) to $($v.Major).$currentSprint.$newPatch"
+    # Doing an awkward string replace to not interfere with any custom task.json formatting
+    $versionMatch = $taskContent | Select-String '"version":'
+    $versionLine = $versionMatch.LineNumber
+    $taskContent[$versionLine+1] = $taskContent[$versionLine+1].Replace(" $($v.Minor),", " $currentSprint,")
+    $taskContent[$versionLine+2] = $taskContent[$versionLine+2].Replace(" $($v.Patch)", " $newPatch")
+    $taskContent | Set-Content $taskLocation
+    
+    $taskLocLocation = Join-Path "$taskRoot/$_" "task.loc.json"
+    $taskLocContent = Get-Content $taskLocLocation 
+    $versionMatch = $taskLocContent | Select-String '"version":'
+    $versionLine = $versionMatch.LineNumber
+    $taskLocContent[$versionLine+1] = $taskLocContent[$versionLine+1].Replace(" $($v.Minor),", " $currentSprint,")
+    $taskLocContent[$versionLine+2] = $taskLocContent[$versionLine+2].Replace(" $($v.Patch)", " $newPatch")
+    $taskLocContent | Set-Content $taskLocLocation
+}

--- a/Tasks/Common/securefiles-common/securefiles-common-mock.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common-mock.ts
@@ -2,8 +2,14 @@ import * as tl from "azure-pipelines-task-lib/task";
 
 export class SecureFileHelpers {
 
-    constructor() {
+    constructor(retryCount?: number) {
         tl.debug('Mock SecureFileHelpers constructor');
+
+        if (retryCount) {
+            tl.debug('Mock SecureFileHelpers retry count set to: ' + retryCount);
+        } else {
+            tl.debug('Mock SecureFileHelpers retry count not set.');
+        }
     }
 
     async downloadSecureFile(secureFileId: string) {

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -7,15 +7,17 @@ import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBase
 export class SecureFileHelpers {
     serverConnection: WebApi;
 
-    constructor() {
+    constructor(retryCount?: number) {
         const serverUrl: string = tl.getVariable('System.TeamFoundationCollectionUri');
         const serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         const authHandler = getPersonalAccessTokenHandler(serverCreds);
 
+        const maxRetries = retryCount && retryCount >= 0 ? retryCount : 5; // Default to 5 if not specified
+        tl.debug('Secure file retry count set to: ' + maxRetries);
         const proxy = tl.getHttpProxyConfiguration();
         let options: IRequestOptions = {
             allowRetries: true,
-            maxRetries: 5
+            maxRetries: maxRetries
         };
 
         if (proxy) {

--- a/Tasks/Common/securefiles-common/securefiles-common.ts
+++ b/Tasks/Common/securefiles-common/securefiles-common.ts
@@ -17,7 +17,7 @@ export class SecureFileHelpers {
         const proxy = tl.getHttpProxyConfiguration();
         let options: IRequestOptions = {
             allowRetries: true,
-            maxRetries: maxRetries
+            maxRetries
         };
 
         if (proxy) {

--- a/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,8 +1,10 @@
 {
   "loc.friendlyName": "Download secure file",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=862069)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=862069)",
   "loc.description": "Download a secure file to a temporary location on the agent machine",
   "loc.instanceNameFormat": "Download secure file",
   "loc.input.label.secureFile": "Secure File",
-  "loc.input.help.secureFile": "Select the secure file to download to a temporary location on the agent. The file will be cleaned up after the pipeline runs."
+  "loc.input.help.secureFile": "Select the secure file to download to a temporary location on the agent. The file will be cleaned up after the pipeline runs.",
+  "loc.input.label.retryCount": "Retry Count",
+  "loc.input.help.retryCount": "Optional number of times to retry downloading a secure file if the download fails, defaults to five retries."
 }

--- a/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
@@ -6,5 +6,5 @@
   "loc.input.label.secureFile": "Secure File",
   "loc.input.help.secureFile": "Select the secure file to download to a temporary location on the agent. The file will be cleaned up after the pipeline runs.",
   "loc.input.label.retryCount": "Retry Count",
-  "loc.input.help.retryCount": "Optional number of times to retry downloading a secure file if the download fails, defaults to five retries."
+  "loc.input.help.retryCount": "Optional number of times to retry downloading a secure file if the download fails."
 }

--- a/Tasks/DownloadSecureFileV1/Tests/L0.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0.ts
@@ -10,7 +10,7 @@ describe('DownloadSecureFile Suite', function () {
     after(() => {
     });
 
-    it('Defaults: download secure file', (done: MochaDone) => {
+    it('Defaults: download secure file', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0SecureFile.js');
@@ -21,11 +21,9 @@ describe('DownloadSecureFile Suite', function () {
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Uses input retry count', (done: MochaDone) => {
+    it('Uses input retry count', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0ValidRetryCount.js');
@@ -36,11 +34,9 @@ describe('DownloadSecureFile Suite', function () {
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 7'), 'task should have used the input retry count of 7');
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Invalid retry count defaults to 5', (done: MochaDone) => {
+    it('Invalid retry count defaults to 5', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0InvalidRetryCount.js');
@@ -51,11 +47,9 @@ describe('DownloadSecureFile Suite', function () {
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 
-    it('Negative retry count defaults to 5', (done: MochaDone) => {
+    it('Negative retry count defaults to 5', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0NegativeRetryCount.js');
@@ -66,7 +60,5 @@ describe('DownloadSecureFile Suite', function () {
         assert(tr.stderr.length === 0, 'should not have written to stderr');
         assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
         assert(tr.succeeded, 'task should have succeeded');
-
-        done();
     });
 });

--- a/Tasks/DownloadSecureFileV1/Tests/L0.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0.ts
@@ -4,7 +4,6 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('DownloadSecureFile Suite', function () {
-    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
     before(() => {
     });
 
@@ -12,7 +11,7 @@ describe('DownloadSecureFile Suite', function () {
     });
 
     it('Defaults: download secure file', (done: MochaDone) => {
-        this.timeout(1000);
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0SecureFile.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -20,6 +19,52 @@ describe('DownloadSecureFile Suite', function () {
         tr.run();
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
+    it('Uses input retry count', (done: MochaDone) => {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        let tp: string = path.join(__dirname, 'L0ValidRetryCount.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 7'), 'task should have used the input retry count of 7');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
+    it('Invalid retry count defaults to 5', (done: MochaDone) => {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        let tp: string = path.join(__dirname, 'L0InvalidRetryCount.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
+    it('Negative retry count defaults to 5', (done: MochaDone) => {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        let tp: string = path.join(__dirname, 'L0NegativeRetryCount.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
         assert(tr.succeeded, 'task should have succeeded');
 
         done();

--- a/Tasks/DownloadSecureFileV1/Tests/L0InvalidRetryCount.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0InvalidRetryCount.ts
@@ -1,0 +1,38 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'predownloadsecurefile.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('secureFile', 'mySecureFileId');
+tr.setInput('retryCount', 'not a number');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "cp": "/bin/cp"
+    },
+    "checkPath": {
+        "/bin/cp": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/DownloadSecureFileV1/Tests/L0NegativeRetryCount.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0NegativeRetryCount.ts
@@ -1,0 +1,38 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'predownloadsecurefile.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('secureFile', 'mySecureFileId');
+tr.setInput('retryCount', '-1');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "cp": "/bin/cp"
+    },
+    "checkPath": {
+        "/bin/cp": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/DownloadSecureFileV1/Tests/L0ValidRetryCount.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0ValidRetryCount.ts
@@ -1,0 +1,38 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'predownloadsecurefile.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('secureFile', 'mySecureFileId');
+tr.setInput('retryCount', '7');
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['HOME'] = '/users/test';
+
+let secureFileHelperMock = require('securefiles-common/securefiles-common-mock');
+tr.registerMock('securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "cp": "/bin/cp"
+    },
+    "checkPath": {
+        "/bin/cp": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
+++ b/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
@@ -9,9 +9,13 @@ async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
+        let retryCount = parseInt(tl.getInput('retryCount'));
+        if (isNaN(retryCount) || retryCount < 0) {
+            retryCount = 5;
+        }
         // download decrypted contents
         secureFileId = tl.getInput('secureFile', true);
-        secureFileHelpers = new secureFilesCommon.SecureFileHelpers();
+        secureFileHelpers = new secureFilesCommon.SecureFileHelpers(retryCount);
         let secureFilePath: string = await secureFileHelpers.downloadSecureFile(secureFileId);
 
         if (tl.exist(secureFilePath)) {

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -31,6 +31,14 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "Select the secure file to download to a temporary location on the agent. The file will be cleaned up after the pipeline runs."
+        },
+        {
+            "name": "retryCount",
+            "type": "string",
+            "label": "Retry Count",
+            "defaultValue": "5",
+            "required": "false",
+            "helpMarkDown": "Optional number of times to retry downloading a secure file if the download fails, defaults to five retries."
         }
     ],
     "outputVariables": [

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -38,7 +38,7 @@
             "label": "Retry Count",
             "defaultValue": "5",
             "required": "false",
-            "helpMarkDown": "Optional number of times to retry downloading a secure file if the download fails, defaults to five retries."
+            "helpMarkDown": "Optional number of times to retry downloading a secure file if the download fails."
         }
     ],
     "outputVariables": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -31,6 +31,14 @@
       "defaultValue": "",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.secureFile"
+    },
+    {
+      "name": "retryCount",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.retryCount",
+      "defaultValue": "5",
+      "required": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.retryCount"
     }
   ],
   "outputVariables": [

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 155,
+        "Minor": 156,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 155,
+    "Minor": 156,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 153,
+        "Minor": 156,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 153,
+    "Minor": 156,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
Adds an optional input `retryCount` to the DownloadSecureFile, which will control the `maxRetryCount` passed into the server connection used to download the secure file.

Changes:
- Added `retryCount` task input
- Updated unit tests
- Bumped associated tasks that depend on `securefiles-common` 
  - AndroidSigningV2
  - AndroidSigningV3
  - DownloadSecureFileV1
  - HelmDeployV0
  - InstallAppleCertificateV2
  - InstallAppleProvisioningProfileV1
  - InstallSSHKeyV0

Testing:
- [x] Unit tests to verify `retryCount` input
- [x] Tested DownloadSecureFileV1 task and verified it worked as expected