### PR TITLE
Properly clean up Azure Powershell temp files

### DIFF
--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 4,
         "Minor": 154,
-        "Patch": 4
+        "Patch": 5
     },
     "preview": true,
     "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 4,
     "Minor": 154,
-    "Patch": 4
+    "Patch": 5
   },
   "preview": true,
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
This change fixes a bug where the PowerShell file that is executed is not properly cleaned up. It is likely that the file will contain sensitive information and thus should be properly cleaned. 

The new approach adds a ```finally``` block at the end of execution then checks to ensure that the file has been created and if it was created then it will go ahead and delete the file synchronously.  

Execution of ```node make.js test --task AzurePowerShellV4``` was successful.

This change is in relation to #10941
