### PR TITLE
Add option for xcpretty arguments and test run name in Xcode Task

### DIFF
--- a/Tasks/XcodeV5/postxcode.ts
+++ b/Tasks/XcodeV5/postxcode.ts
@@ -49,7 +49,8 @@ async function run() {
                         } else {
                             const TESTRUN_SYSTEM = "VSTS - xcode";
                             const tp = new tl.TestPublisher("JUnit");
-                            tp.publish(matchingTestResultsFiles, false, "", "", "", true, TESTRUN_SYSTEM);
+                            const testRunTitle = tl.getInput('testRunTitle')
+                            tp.publish(matchingTestResultsFiles, false, "", "", testRunTitle, true, TESTRUN_SYSTEM);
                         }
                     }
                 }

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -331,6 +331,15 @@
             "groupName": "advanced"
         },
         {
+            "name": "xcprettyArgs",
+            "type": "string",
+            "label": "xcpretty Arguments",
+            "required": false,
+            "helpMarkDown": "Additional arguments to pass to xcpretty",
+            "groupName": "advanced",
+            "visibleRule": "useXcpretty == true"
+        },
+        {
             "name": "publishJUnitResults",
             "type": "boolean",
             "label": "Publish test results to Azure Pipelines",
@@ -338,6 +347,15 @@
             "defaultValue": false,
             "groupName": "advanced",
             "helpMarkDown": "Specify whether to publish JUnit test results to Azure Pipelines. This requires xcpretty to be enabled to generate JUnit test results."
+        },
+        {
+            "name": "testRunTitle",
+            "type": "string",
+            "label": "Test Run Title",
+            "required": false,
+            "groupName": "advanced",
+            "helpMarkDown": "Title of the test run when publishing JUnit test results to Azure Pipelines.",
+            "visibleRule": "publishJUnitResults == true"
         }
     ],
     "execution": {

--- a/Tasks/XcodeV5/xcode.ts
+++ b/Tasks/XcodeV5/xcode.ts
@@ -239,6 +239,10 @@ async function run() {
             let xcPrettyPath: string = tl.which('xcpretty', true);
             let xcPrettyTool: ToolRunner = tl.tool(xcPrettyPath);
             xcPrettyTool.arg(['-r', 'junit', '--no-color']);
+            let xcPrettyArgs: string = tl.getInput('xcprettyArgs');
+            if (xcPrettyArgs) {
+                xcPrettyTool.line(xcPrettyArgs);
+            }
 
             const logFile: string = utils.getUniqueLogFileName('xcodebuild');
             xcb.pipeExecOutputToTool(xcPrettyTool, logFile);
@@ -311,6 +315,10 @@ async function run() {
             if (useXcpretty) {
                 let xcPrettyTool: ToolRunner = tl.tool(tl.which('xcpretty', true));
                 xcPrettyTool.arg('--no-color');
+                let xcPrettyArgs: string = tl.getInput('xcprettyArgs');
+                if (xcPrettyArgs) {
+                    xcPrettyTool.line(xcPrettyArgs);
+                }
                 const logFile: string = utils.getUniqueLogFileName('xcodebuild_archive');
                 xcodeArchive.pipeExecOutputToTool(xcPrettyTool, logFile);
                 utils.setTaskState('XCODEBUILD_ARCHIVE_LOG', logFile);
@@ -460,6 +468,10 @@ async function run() {
                     if (useXcpretty) {
                         let xcPrettyTool: ToolRunner = tl.tool(tl.which('xcpretty', true));
                         xcPrettyTool.arg('--no-color');
+                        let xcPrettyArgs: string = tl.getInput('xcprettyArgs');
+                        if (xcPrettyArgs) {
+                            xcPrettyTool.line(xcPrettyArgs);
+                        }
                         const logFile: string = utils.getUniqueLogFileName('xcodebuild_export');
                         xcodeExport.pipeExecOutputToTool(xcPrettyTool, logFile);
                         utils.setTaskState('XCODEBUILD_EXPORT_LOG', logFile);


### PR DESCRIPTION
Adds two optional inputs to the Xcode task.

* Setting the name of the test run when publishing the test results.
* Pass additional parameters to xcpretty

The reasons behind needing these changes:

* Currently the test run name is `JUnit_TestResults_XXX` this isn't helpful if you have multiple tests in the same build. At Tesco we have a nightly build that runs all the tests on iOS 12 and 11 each. Atm it's hard to distinguish which one is which. So it would be good to provide a custom name to disambiguate.
* it would be good to use a customer formatter (specifically https://github.com/Jon889/xcpretty-azure-pipelines-formatter) so that the output is a little friendlier for Azure Pipelines.

I tried to add tests for these new inputs, but couldn't quite work out how to do it.

Also the contribute doc mentions adding a label and assigning a reviewer, but that doesn't seem to be possible.