### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/Tasks/PublishTestResultsV2/Tests/TestSetup.ts
+++ b/Tasks/PublishTestResultsV2/Tests/TestSetup.ts
@@ -45,7 +45,7 @@ tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-
 
 // Mock guid generator
 tr.registerMock('uuid', {
-    v1: function () {
+    v4: function () {
         return newUuid;
     }
 });

--- a/Tasks/PublishTestResultsV2/Tests/TestSetup.ts
+++ b/Tasks/PublishTestResultsV2/Tests/TestSetup.ts
@@ -44,10 +44,8 @@ tr.setAnswers(a);
 tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
 
 // Mock guid generator
-tr.registerMock('uuid', {
-    v4: function () {
-        return newUuid;
-    }
+tr.registerMock('uuid/v4', function () {
+    return newUuid;
 });
 
 // Create mock for getVariable

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -56,7 +56,7 @@ export class TestResultsPublisher {
         try {
             const agentTempDirectory = tl.getVariable('Agent.TempDirectory');
             // The response file is being created in agent temp directory so that it is automatically deleted after.
-            responseFilePath = path.join(agentTempDirectory, uuid.v1() + '.txt');
+            responseFilePath = path.join(agentTempDirectory, uuid.v4() + '.txt');
 
             // Adding quotes around matching file names
             matchingTestResultsFiles = this.modifyMatchingFileName(matchingTestResultsFiles);

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -5,7 +5,7 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from 'azure-pipelines-task-lib/toolrunner';
 import { publishEvent } from './cieventlogger';
 import * as ci from './cieventlogger';
-let uuid = require('uuid');
+import * as uuidV4 from 'uuid/v4';
 
 export class TestResultsPublisher {
     constructor(matchingTestResultsFiles: string[], mergeResults: string, failTaskOnFailedTests: string, platform: string, config: string,
@@ -56,7 +56,7 @@ export class TestResultsPublisher {
         try {
             const agentTempDirectory = tl.getVariable('Agent.TempDirectory');
             // The response file is being created in agent temp directory so that it is automatically deleted after.
-            responseFilePath = path.join(agentTempDirectory, uuid.v4() + '.txt');
+            responseFilePath = path.join(agentTempDirectory, uuidV4() + '.txt');
 
             // Adding quotes around matching file names
             matchingTestResultsFiles = this.modifyMatchingFileName(matchingTestResultsFiles);

--- a/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
@@ -204,14 +204,10 @@ tlClone.assertAgent = function(variable: string) {
 // Register the tl mock
 tr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
-const uuid = require('uuid');
 // Create a mock for the uuid module
-const uuidClone = Object.assign({}, uuid);
-uuidClone.v4 = function() {
+tr.registerMock('uuid/v4', function () {
     return process.env[testConstants.feedId];
-};
-
-tr.registerMock('uuid', uuidClone);
+});
 
 const fs = require('fs');
 // Create a mock for fs operations

--- a/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
@@ -207,7 +207,7 @@ tr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 const uuid = require('uuid');
 // Create a mock for the uuid module
 const uuidClone = Object.assign({}, uuid);
-uuidClone.v1 = function() {
+uuidClone.v4 = function() {
     return process.env[testConstants.feedId];
 };
 

--- a/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
@@ -22,7 +22,7 @@ export class NugetFeedInstaller {
             try {
                 if (!helpers.isNullEmptyOrUndefined(password)) {
                     tl.debug('Attempting to write feed details along with provided credentials to temporary config file.');
-                    tempConfigFilePath = helpers.GenerateTempFile(`${uuid.v1()}.config`);
+                    tempConfigFilePath = helpers.GenerateTempFile(`${uuid.v4()}.config`);
                     const feedId = uuid.v1();
                     this.prepareNugetConfigFile(packageSource, tempConfigFilePath, username, password, feedId);
                     packageSource = feedId;

--- a/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
@@ -23,7 +23,7 @@ export class NugetFeedInstaller {
                 if (!helpers.isNullEmptyOrUndefined(password)) {
                     tl.debug('Attempting to write feed details along with provided credentials to temporary config file.');
                     tempConfigFilePath = helpers.GenerateTempFile(`${uuid.v4()}.config`);
-                    const feedId = uuid.v1();
+                    const feedId = uuid.v4();
                     this.prepareNugetConfigFile(packageSource, tempConfigFilePath, username, password, feedId);
                     packageSource = feedId;
                     ci.addToConsolidatedCi('passwordProvided', 'true');

--- a/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
@@ -6,7 +6,7 @@ import * as perf from 'performance-now';
 import * as ci from './cieventlogger';
 import * as constants from './constants';
 import * as helpers from './helpers';
-import * as uuid from 'uuid';
+import * as uuidV4 from 'uuid/v4';
 import * as fs from 'fs';
 import { NugetPackageVersionHelper } from './nugetpackageversionhelper';
 import { NugetDownloadHelper } from './nugetdownloadhelper';
@@ -22,8 +22,8 @@ export class NugetFeedInstaller {
             try {
                 if (!helpers.isNullEmptyOrUndefined(password)) {
                     tl.debug('Attempting to write feed details along with provided credentials to temporary config file.');
-                    tempConfigFilePath = helpers.GenerateTempFile(`${uuid.v4()}.config`);
-                    const feedId = uuid.v4();
+                    tempConfigFilePath = helpers.GenerateTempFile(`${uuidV4()}.config`);
+                    const feedId = uuidV4();
                     this.prepareNugetConfigFile(packageSource, tempConfigFilePath, username, password, feedId);
                     packageSource = feedId;
                     ci.addToConsolidatedCi('passwordProvided', 'true');

--- a/Tasks/VsTestV2/distributedtest.ts
+++ b/Tasks/VsTestV2/distributedtest.ts
@@ -8,7 +8,7 @@ import * as os from 'os';
 import * as ci from './cieventlogger';
 import { TestSelectorInvoker } from './testselectorinvoker';
 import { writeFileSync } from 'fs';
-import * as uuid from 'uuid';
+import * as uuidV4 from 'uuid/v4';
 
 const testSelector = new TestSelectorInvoker();
 
@@ -64,7 +64,7 @@ export class DistributedTest {
         }
 
         // Invoke DtaExecutionHost with the input json file
-        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v4() + '.json');
+        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuidV4() + '.json');
         utils.Helper.removeEmptyNodes(this.inputDataContract);
 
         try {
@@ -114,7 +114,7 @@ export class DistributedTest {
                 throw new Error(tl.loc('noTestSourcesFound', sourceFilter.toString()));
             }
 
-            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v4() + '.src');
+            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuidV4() + '.src');
             fs.writeFileSync(tempFile, filesMatching.join(os.EOL));
             tl.debug('Test Sources file :' + tempFile);
             return tempFile;

--- a/Tasks/VsTestV2/distributedtest.ts
+++ b/Tasks/VsTestV2/distributedtest.ts
@@ -64,7 +64,7 @@ export class DistributedTest {
         }
 
         // Invoke DtaExecutionHost with the input json file
-        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v1() + '.json');
+        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v4() + '.json');
         utils.Helper.removeEmptyNodes(this.inputDataContract);
 
         try {
@@ -114,7 +114,7 @@ export class DistributedTest {
                 throw new Error(tl.loc('noTestSourcesFound', sourceFilter.toString()));
             }
 
-            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v1() + '.src');
+            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v4() + '.src');
             fs.writeFileSync(tempFile, filesMatching.join(os.EOL));
             tl.debug('Test Sources file :' + tempFile);
             return tempFile;

--- a/Tasks/VsTestV2/helpers.ts
+++ b/Tasks/VsTestV2/helpers.ts
@@ -8,7 +8,7 @@ import * as ci from './cieventlogger';
 import * as constants from './constants';
 
 const str = require('string');
-const uuid = require('uuid');
+const uuidV4 = require('uuid/v4');
 const xml2js = require('xml2js');
 const parser = new xml2js.Parser();
 const builder = new xml2js.Builder();
@@ -106,7 +106,7 @@ export class Helper {
 
     public static saveToFile(fileContents: string, extension: string): Q.Promise<string> {
         const defer = Q.defer<string>();
-        const tempFile = Helper.GenerateTempFile(uuid.v4() + extension);
+        const tempFile = Helper.GenerateTempFile(uuidV4() + extension);
         fs.writeFile(tempFile, fileContents, function (err) {
             if (err) {
                 defer.reject(err);

--- a/Tasks/VsTestV2/helpers.ts
+++ b/Tasks/VsTestV2/helpers.ts
@@ -106,7 +106,7 @@ export class Helper {
 
     public static saveToFile(fileContents: string, extension: string): Q.Promise<string> {
         const defer = Q.defer<string>();
-        const tempFile = Helper.GenerateTempFile(uuid.v1() + extension);
+        const tempFile = Helper.GenerateTempFile(uuid.v4() + extension);
         fs.writeFile(tempFile, fileContents, function (err) {
             if (err) {
                 defer.reject(err);

--- a/Tasks/VsTestV2/nondistributedtest.ts
+++ b/Tasks/VsTestV2/nondistributedtest.ts
@@ -61,7 +61,7 @@ export class NonDistributedTest {
         dtaExecutionHostTool = tl.tool(path.join(__dirname, 'Modules/DTAExecutionHost.exe'));
 
         // Invoke DtaExecutionHost with the input json file
-        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v1() + '.json');
+        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v4() + '.json');
         utils.Helper.removeEmptyNodes(this.inputDataContract);
 
         try {
@@ -129,7 +129,7 @@ export class NonDistributedTest {
                 throw new Error(tl.loc('noTestSourcesFound', this.sourceFilter.toString()));
             }
 
-            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v1() + '.src');
+            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v4() + '.src');
             fs.writeFileSync(tempFile, filesMatching.join(os.EOL));
             tl.debug('Test Sources file :' + tempFile);
             return tempFile;

--- a/Tasks/VsTestV2/nondistributedtest.ts
+++ b/Tasks/VsTestV2/nondistributedtest.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as utils from './helpers';
 import * as outStream from './outputstream';
 import * as os from 'os';
-import * as uuid from 'uuid';
+import * as uuidV4 from 'uuid/v4';
 import * as fs from 'fs';
 import * as process from 'process';
 import { InputDataContract } from './inputdatacontract';
@@ -61,7 +61,7 @@ export class NonDistributedTest {
         dtaExecutionHostTool = tl.tool(path.join(__dirname, 'Modules/DTAExecutionHost.exe'));
 
         // Invoke DtaExecutionHost with the input json file
-        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuid.v4() + '.json');
+        const inputFilePath = utils.Helper.GenerateTempFile('input_' + uuidV4() + '.json');
         utils.Helper.removeEmptyNodes(this.inputDataContract);
 
         try {
@@ -129,7 +129,7 @@ export class NonDistributedTest {
                 throw new Error(tl.loc('noTestSourcesFound', this.sourceFilter.toString()));
             }
 
-            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuid.v4() + '.src');
+            const tempFile = utils.Helper.GenerateTempFile('testSources_' + uuidV4() + '.src');
             fs.writeFileSync(tempFile, filesMatching.join(os.EOL));
             tl.debug('Test Sources file :' + tempFile);
             return tempFile;

--- a/Tasks/VsTestV2/taskinputparser.ts
+++ b/Tasks/VsTestV2/taskinputparser.ts
@@ -176,7 +176,7 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
         tl.warning(tl.loc('uitestsparallel'));
     }
 
-    testConfiguration.taskInstanceIdentifier = uuid.v1();
+    testConfiguration.taskInstanceIdentifier = uuid.v4();
 
     try {
         versionFinder.getVsTestRunnerDetails(testConfiguration);

--- a/Tasks/VsTestV2/taskinputparser.ts
+++ b/Tasks/VsTestV2/taskinputparser.ts
@@ -7,7 +7,7 @@ import * as constants from './constants';
 import * as ci from './cieventlogger';
 import * as versionFinder from './versionfinder';
 import { AreaCodes, ResultMessages } from './constants';
-import * as uuid from 'uuid';
+import * as uuidV4 from 'uuid/v4';
 const regedit = require('regedit');
 
 export function getvsTestConfigurations() {
@@ -16,10 +16,10 @@ export function getvsTestConfigurations() {
     vsTestConfiguration.isResponseFileRun = false;
     vsTestConfiguration.publishTestResultsInTiaMode = false;
     vsTestConfiguration.publishRunAttachments = tl.getInput('publishRunAttachments');
-    vsTestConfiguration.vstestDiagFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-    vsTestConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-    vsTestConfiguration.vstestArgsFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-    vsTestConfiguration.responseSupplementryFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    vsTestConfiguration.vstestDiagFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+    vsTestConfiguration.responseFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+    vsTestConfiguration.vstestArgsFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+    vsTestConfiguration.responseSupplementryFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
     vsTestConfiguration.responseFileSupported = vsTestConfiguration.vsTestVersionDetails.isResponseFileSupported() || utils.Helper.isToolsInstallerFlow(vsTestConfiguration);
     return vsTestConfiguration;
 }
@@ -176,7 +176,7 @@ function initTestConfigurations(testConfiguration: models.TestConfigurations) {
         tl.warning(tl.loc('uitestsparallel'));
     }
 
-    testConfiguration.taskInstanceIdentifier = uuid.v4();
+    testConfiguration.taskInstanceIdentifier = uuidV4();
 
     try {
         versionFinder.getVsTestRunnerDetails(testConfiguration);
@@ -329,9 +329,9 @@ function getTiaConfiguration(): models.TiaConfiguration {
     tiaConfiguration.fileLevel = tl.getVariable('tia.filelevel');
     tiaConfiguration.sourcesDir = tl.getVariable('build.sourcesdirectory');
     tiaConfiguration.tiaFilterPaths = tl.getVariable('TIA_IncludePathFilters');
-    tiaConfiguration.runIdFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-    tiaConfiguration.baseLineBuildIdFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-    tiaConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    tiaConfiguration.runIdFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+    tiaConfiguration.baseLineBuildIdFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+    tiaConfiguration.responseFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
 
     tiaConfiguration.useNewCollector = false;
 

--- a/Tasks/VsTestV2/taskinputparser.ts
+++ b/Tasks/VsTestV2/taskinputparser.ts
@@ -16,10 +16,10 @@ export function getvsTestConfigurations() {
     vsTestConfiguration.isResponseFileRun = false;
     vsTestConfiguration.publishTestResultsInTiaMode = false;
     vsTestConfiguration.publishRunAttachments = tl.getInput('publishRunAttachments');
-    vsTestConfiguration.vstestDiagFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-    vsTestConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-    vsTestConfiguration.vstestArgsFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-    vsTestConfiguration.responseSupplementryFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
+    vsTestConfiguration.vstestDiagFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    vsTestConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    vsTestConfiguration.vstestArgsFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    vsTestConfiguration.responseSupplementryFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
     vsTestConfiguration.responseFileSupported = vsTestConfiguration.vsTestVersionDetails.isResponseFileSupported() || utils.Helper.isToolsInstallerFlow(vsTestConfiguration);
     return vsTestConfiguration;
 }
@@ -329,9 +329,9 @@ function getTiaConfiguration(): models.TiaConfiguration {
     tiaConfiguration.fileLevel = tl.getVariable('tia.filelevel');
     tiaConfiguration.sourcesDir = tl.getVariable('build.sourcesdirectory');
     tiaConfiguration.tiaFilterPaths = tl.getVariable('TIA_IncludePathFilters');
-    tiaConfiguration.runIdFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-    tiaConfiguration.baseLineBuildIdFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-    tiaConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
+    tiaConfiguration.runIdFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    tiaConfiguration.baseLineBuildIdFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    tiaConfiguration.responseFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
 
     tiaConfiguration.useNewCollector = false;
 

--- a/Tasks/VsTestV2/vstest.ts
+++ b/Tasks/VsTestV2/vstest.ts
@@ -10,7 +10,7 @@ import * as ci from './cieventlogger';
 import * as testselectorinvoker from './testselectorinvoker';
 import { AreaCodes, ResultMessages } from './constants';
 import * as os from 'os';
-import * as uuid from 'uuid';
+import * as uuidV4 from 'uuid/v4';
 import * as fs from 'fs';
 import * as xml2js from 'xml2js';
 import * as process from 'process';
@@ -384,7 +384,7 @@ function getVstestTestsListInternal(vsVersion: number, testCaseFilter: string, o
 }
 
 function getVstestTestsList(vsVersion: number): string {
-    const tempFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+    const tempFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
     tl.debug('Discovered tests listed at: ' + tempFile);
     const argsArray: string[] = [];
 
@@ -433,8 +433,8 @@ async function runVStest(settingsFile: string, vsVersion: number): Promise<tl.Ta
     let testCaseFilterOutput = '';
     let listFile = '';
     if (tiaConfig.userMapFile) {
-        testCaseFilterFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
-        testCaseFilterOutput = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+        testCaseFilterFile = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
+        testCaseFilterOutput = utils.Helper.GenerateTempFile(uuidV4() + '.txt');
     }
 
     let testselector = new testselectorinvoker.TestSelectorInvoker();

--- a/Tasks/VsTestV2/vstest.ts
+++ b/Tasks/VsTestV2/vstest.ts
@@ -384,7 +384,7 @@ function getVstestTestsListInternal(vsVersion: number, testCaseFilter: string, o
 }
 
 function getVstestTestsList(vsVersion: number): string {
-    const tempFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
+    const tempFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
     tl.debug('Discovered tests listed at: ' + tempFile);
     const argsArray: string[] = [];
 
@@ -433,8 +433,8 @@ async function runVStest(settingsFile: string, vsVersion: number): Promise<tl.Ta
     let testCaseFilterOutput = '';
     let listFile = '';
     if (tiaConfig.userMapFile) {
-        testCaseFilterFile = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
-        testCaseFilterOutput = utils.Helper.GenerateTempFile(uuid.v1() + '.txt');
+        testCaseFilterFile = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
+        testCaseFilterOutput = utils.Helper.GenerateTempFile(uuid.v4() + '.txt');
     }
 
     let testselector = new testselectorinvoker.TestSelectorInvoker();

--- a/Tests-Legacy/L0/VsTestV1/_suite.ts
+++ b/Tests-Legacy/L0/VsTestV1/_suite.ts
@@ -10,7 +10,7 @@ import shell = require('shelljs');
 import uuid = require('node-uuid');
 var ps = shell.which('powershell.exe');
 var psr = null;
-const tmpFileName = path.join(os.tmpdir(), uuid.v4() + ".json");
+const tmpFileName = path.join(os.tmpdir(), uuid.v1() + ".json");
 const testDllPath = path.join(__dirname, "data", "testDlls");
 const sysVstestLocation = "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe";
 

--- a/Tests-Legacy/L0/VsTestV1/_suite.ts
+++ b/Tests-Legacy/L0/VsTestV1/_suite.ts
@@ -10,7 +10,7 @@ import shell = require('shelljs');
 import uuid = require('node-uuid');
 var ps = shell.which('powershell.exe');
 var psr = null;
-const tmpFileName = path.join(os.tmpdir(), uuid.v1() + ".json");
+const tmpFileName = path.join(os.tmpdir(), uuid.v4() + ".json");
 const testDllPath = path.join(__dirname, "data", "testDlls");
 const sysVstestLocation = "\\vs\\IDE\\CommonExtensions\\Microsoft\\TestWindow\\vstest.console.exe";
 


### PR DESCRIPTION
I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of this repository.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found several occurrences in the test suite where `v1` UUIDs were being used instead of `v4` UUIDs and I was wondering if any of these cases really require the semantically much more complex `v1` UUIDs or whether we could live equally well with purely random `v4` UUIDs? Please see my commit messages for more details.

I'd be really curious to understand the motivation for choosing `v1` over `v4` UUIDs in the first place, so any feedback on this would be highly appreciated!

@acesiddhu @ShreyasRmsft as far as I can tell from the git history it seems like you have introduced some usages of `v1` UUIDs so I'd be particularly interested in your feedback.