### PR TITLE
Bumping up DockerV2 patch version for fixing the addPipelineData mismatch

### DIFF
--- a/Tasks/DockerV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DockerV2/Strings/resources.resjson/en-US/resources.resjson
@@ -21,7 +21,7 @@
   "loc.input.label.arguments": "Arguments",
   "loc.input.help.arguments": "Docker command options. Ex:<br> For build command,<br>--build-arg HTTP_PROXY=http://10.20.30.2:1234 --quiet",
   "loc.input.label.addPipelineData": "Add Pipeline metadata to image(s)",
-  "loc.input.help.addPipelineData": "By default pipeline data like source branch name, build id are added which helps with traceability. For example you can inspect an image to find out which pipeline built the image. You can opt out of this default behavior by using this input.",
+  "loc.input.help.addPipelineData": "By default pipeline data like source branch name, build id are added which helps with trace-ability. For example you can inspect an image to find out which pipeline built the image. You can opt out of this default behavior by using this input.",
   "loc.messages.AddingNewAuthToExistingConfig": "Adding auth data for registry to Docker config file. Registry: %s.",
   "loc.messages.ConnectingToDockerHost": "DOCKER_HOST variable is set. Docker will try to connect to the Docker host: %s",
   "loc.messages.ContainerPatternFound": "Pattern found in Docker filepath parameter",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 154,
-        "Patch": 4
+        "Minor": 156,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 154,
-    "Patch": 4
+    "Minor": 156,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Change for addPipline data was 155.2: https://github.com/microsoft/azure-pipelines-tasks/commit/714e68f75c1e56ca699f6514700c5824cd231079#diff-5c26b05dad20b2a76322c20dac071e80

decreased the version to 154.3 : https://github.com/microsoft/azure-pipelines-tasks/commit/1671c9847fe756216a5509027338eca390c06e60#diff-5c26b05dad20b2a76322c20dac071e80


