### PR TITLE
Revert file copy feature added to PBA task

### DIFF
--- a/Tasks/PublishBuildArtifactsV1/package-lock.json
+++ b/Tasks/PublishBuildArtifactsV1/package-lock.json
@@ -25,13 +25,6 @@
         "semver": "5.5.0",
         "shelljs": "0.3.0",
         "uuid": "3.3.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
-        }
       }
     },
     "balanced-match": {
@@ -80,6 +73,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     }
   }
 }

--- a/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
@@ -51,7 +51,6 @@ async function run() {
         let pathtoPublish: string = tl.getPathInput('PathtoPublish', true, true);
         let artifactName: string = tl.getInput('ArtifactName', true);
         let artifactType: string = tl.getInput('ArtifactType', true);
-        const fileCopyOptions = tl.getInput('FileCopyOptions', false);
 
 
         let hostType = tl.getVariable('system.hostType');
@@ -101,10 +100,6 @@ async function run() {
                     let parentFolder = path.dirname(pathtoPublish);
                     let file = path.basename(pathtoPublish);
                     command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File '${file}'`
-                }
-
-                if (fileCopyOptions) {
-                    command += ` -FileCopyOptions '${fileCopyOptions}'`;
                 }
 
                 let powershell = new tr.ToolRunner('powershell.exe');

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 158,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/Tasks/PublishBuildArtifactsV1/task.loc.json
+++ b/Tasks/PublishBuildArtifactsV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 158,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",


### PR DESCRIPTION
The robocopy command that's executed throws some errors when ParallelCount is greater than one, due to changes in https://github.com/microsoft/azure-pipelines-tasks/pull/10820. Reverting the changes until I can investigate why this issue is happening.

Since this task is in 157, I will port these changes there as well.