### PR TITLE
Publish Build Aritfacts: Allow custom robocopy options

### DIFF
--- a/Tasks/PublishBuildArtifactsV1/package-lock.json
+++ b/Tasks/PublishBuildArtifactsV1/package-lock.json
@@ -25,6 +25,13 @@
         "semver": "5.5.0",
         "shelljs": "0.3.0",
         "uuid": "3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+        }
       }
     },
     "balanced-match": {
@@ -73,11 +80,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-    },
-    "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     }
   }
 }

--- a/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
@@ -51,6 +51,7 @@ async function run() {
         let pathtoPublish: string = tl.getPathInput('PathtoPublish', true, true);
         let artifactName: string = tl.getInput('ArtifactName', true);
         let artifactType: string = tl.getInput('ArtifactType', true);
+        const fileCopyOptions = tl.getInput('FileCopyOptions', false);
 
 
         let hostType = tl.getVariable('system.hostType');
@@ -100,6 +101,10 @@ async function run() {
                     let parentFolder = path.dirname(pathtoPublish);
                     let file = path.basename(pathtoPublish);
                     command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File '${file}'`
+                }
+
+                if (fileCopyOptions) {
+                    command += ` -FileCopyOptions '${fileCopyOptions}'`;
                 }
 
                 let powershell = new tr.ToolRunner('powershell.exe');

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 158,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/Tasks/PublishBuildArtifactsV1/task.loc.json
+++ b/Tasks/PublishBuildArtifactsV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 158,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",


### PR DESCRIPTION
**Background**
Related PR: https://github.com/microsoft/azure-pipelines-tasks/pull/10820 which was reverted due to issues with how PowerShell treats space-separated arguments with the call (`&`) operator causing the task to fail when `ParallelCount > 1`

The solution to this is using an array for the call arguments, which are then each treated as separate arguments correctly. 

**Description**
`robocopy` is used for PublishBuildArtifact when copying an artifact's files to a file share (Artifact type FilePath).

This PR adds an optional input to for command line args passed through to `robocopy`

**Testing**
Tested uploading an artifact from a local agent to a file share on disk using the following YAML
```
- task: PublishBuildArtifacts@1
  inputs:
    PathtoPublish: 'Source/Timely.Main/bin/Release'
    ArtifactName: 'drop'
    publishLocation: 'FilePath'
    TargetPath: '\\localhost\c$\users\username\'
```
Scenarios Tested
- [x] No additional options
- [x] Parallel count > 1
- [x] Parallel count > 1 and 1 additonal file copy option
- [x] Parallel count > 1 and multiple additional file copy options
- [x] No parallel count and multiple additional file copy options
