### PR TITLE
Third draft of changes to remove additional call of msbuild action

### DIFF
--- a/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
@@ -32,9 +32,7 @@ function Invoke-BuildTools {
             if ($Clean) {
                 Invoke-MSBuild -ProjectFile $file -Targets Clean -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
             }
-
-            # If we cleaned and passed /t targets, we don't need to run them again
-            if (!$Clean -or -not $MSBuildArguments.Contains("/t")) {
+            else {
                 Invoke-MSBuild -ProjectFile $file -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
             }
         }

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 1
+        "Minor": 158,
+        "Patch": 0
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 1
+    "Minor": 158,
+    "Patch": 0
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 158,
+        "Patch": 0
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 158,
+    "Patch": 0
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 155,
+        "Minor": 158,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 155,
+    "Minor": 158,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 151,
-        "Patch": 3
+        "Minor": 158,
+        "Patch": 0
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 151,
-    "Patch": 3
+    "Minor": 158,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
Third draft of changes to remove additional call of msbuild action depending upon provided arguments. This is to resolve the issues reported in this feedback item: https://developercommunity.visualstudio.com/content/problem/561551/visual-studio-build-11510-the-process-cannot-acces.html 