### PR TITLE
Passing mergeTestResutls as false for the VsTest1 task.

### DIFF
--- a/Tasks/VsTestV1/VSTest.ps1
+++ b/Tasks/VsTestV1/VSTest.ps1
@@ -264,7 +264,7 @@ finally
                             Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration -RunTitle $testRunTitle -PublishRunLevelAttachments $publishResultsOption
                         }
                         else {
-                            Write-Host "##vso[results.publish type=VSTest;publishRunAttachments=$publishResultsOption;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;runTitle=$testRunTitle;]"
+                            Write-Host "##vso[results.publish type=VSTest;publishRunAttachments=$publishResultsOption;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;runTitle=$testRunTitle;mergeResults=false;]"
                         }
                     }
                     else
@@ -277,7 +277,7 @@ finally
                             Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration -RunTitle $testRunTitle
                         }
                         else {
-                            Write-Host "##vso[results.publish type=VSTest;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;runTitle=$testRunTitle;]"
+                            Write-Host "##vso[results.publish type=VSTest;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;runTitle=$testRunTitle;mergeResults=false;]"
                         }
                     }
                 }
@@ -294,7 +294,7 @@ finally
                             Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration -PublishRunLevelAttachments $publishResultsOption
                         }
                         else {
-                            Write-Host "##vso[results.publish type=VSTest;publishRunAttachments=$publishResultsOption;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;]"
+                            Write-Host "##vso[results.publish type=VSTest;publishRunAttachments=$publishResultsOption;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;mergeResults=false;]"
                         }
                     }
                     else
@@ -307,7 +307,7 @@ finally
                             Publish-TestResults -Context $distributedTaskContext -TestResultsFiles $resultFiles -TestRunner "VSTest" -Platform $platform -Configuration $configuration
                         }
                         else {
-                            Write-Host "##vso[results.publish type=VSTest;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;]"
+                            Write-Host "##vso[results.publish type=VSTest;resultFiles=$resultFiles;platform=$platform;configuration=$configuration;testRunSystem=VSTest;mergeResults=false;]"
                         }
                     }
                 }

--- a/Tasks/VsTestV1/task.json
+++ b/Tasks/VsTestV1/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 93
+        "Patch": 94
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV1/task.loc.json
+++ b/Tasks/VsTestV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 93
+    "Patch": 94
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Default value of mergeTestResults is True and this actually archives the attachments as well.
Which causes the code coverage jobs to fail, as they will be looking for the .coverage files.
We actually pass the mergeTestResutls as false in VsTestV2 also, it was a miss from my side in previous change.