### PR TITLE
addresses #11246

### DIFF
--- a/Tasks/GulpV1/gulptask.ts
+++ b/Tasks/GulpV1/gulptask.ts
@@ -3,13 +3,14 @@ import tl = require('vsts-task-lib/task');
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
+var cwd = tl.getPathInput('cwd', true, false);
+tl.mkdirP(cwd);
+tl.cd(cwd);
+
 var gulpFile = tl.getPathInput('gulpFile', true, true);
 var isCodeCoverageEnabled = tl.getBoolInput('enableCodeCoverage');
 var publishJUnitResults = tl.getBoolInput('publishJUnitResults');
 var testResultsFiles = tl.getInput('testResultsFiles', publishJUnitResults);
-var cwd = tl.getPathInput('cwd', true, false);
-tl.mkdirP(cwd);
-tl.cd(cwd);
 
 tl.debug('resolving either gulpjs or gulp');
 var gulpjs = tl.getInput('gulpjs', false);

--- a/Tasks/GulpV1/task.json
+++ b/Tasks/GulpV1/task.json
@@ -17,8 +17,8 @@
     "preview": true,
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 2
+        "Minor": 158,
+        "Patch": 0
     },
     "demands": [
         "node.js"
@@ -48,7 +48,7 @@
             "type": "filePath",
             "label": "gulp File Path",
             "defaultValue": "gulpfile.js",
-            "required": true,
+            "required": false,
             "helpMarkDown": "Relative path from repo root of the gulp file script file to run."
         },
         {

--- a/Tasks/GulpV1/task.loc.json
+++ b/Tasks/GulpV1/task.loc.json
@@ -17,8 +17,8 @@
   "preview": true,
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 2
+    "Minor": 158,
+    "Patch": 0
   },
   "demands": [
     "node.js"
@@ -48,7 +48,7 @@
       "type": "filePath",
       "label": "ms-resource:loc.input.label.gulpFile",
       "defaultValue": "gulpfile.js",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.gulpFile"
     },
     {


### PR DESCRIPTION
We should be setting the current working directory before we do things like check the existence of files.

`gulpFile` parameter has a default, so it shouldn't be considered required.