### PR TITLE
Add instructions on installing custom task

### DIFF
--- a/docs/pinToTaskVersion/New-TaskInstallScript.ps1
+++ b/docs/pinToTaskVersion/New-TaskInstallScript.ps1
@@ -1,0 +1,87 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CollectionUrl,
+    [Parameter(Mandatory = $true)]
+    [string]$taskDir)
+
+$ErrorActionPreference = 'Stop'
+
+function Install-Task {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CollectionUrl,
+
+        [Parameter(Mandatory = $true)]
+        $Task)
+
+    "Installing task '$($Task.Name)' version '$($Task.Version)'."
+    $url = "$($CollectionUrl.TrimEnd('/'))/_apis/distributedtask/tasks/$($Task.Id)/?overwrite=false&api-version=2.0"
+
+    # Format the content.
+    [byte[]]$bytes = [System.Convert]::FromBase64String($Task.Base64Zip)
+
+    # Send the HTTP request.
+    try {
+        Invoke-RestMethod -Uri $url -Method Put -Body $bytes -UseDefaultCredentials -ContentType 'application/octet-stream' -Headers @{
+            #'Authorization' = "Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$Pat")))"
+            'X-TFS-FedAuthRedirect' = 'Suppress'
+            'Content-Range' = "bytes 0-$($bytes.Length - 1)/$($bytes.Length)"
+        }
+    } catch {
+        $details = $null
+        try { $details = ConvertFrom-Json $_.ErrorDetails.Message }
+        catch { }
+
+        if ($details.TypeKey -eq 'TaskDefinitionExistsException') {
+            Write-Warning $details.Message
+        } else {
+            throw
+        }
+    }
+}
+
+# Validate the directory exists.
+if (!(Test-Path $taskDir -PathType Container)) {
+    throw "Directory does not exist: '$taskDir'."
+}
+
+# Resolve the directory info.
+$taskDir = Get-Item $taskDir
+
+# Deserialize the task.json.
+$manifest = Get-Item ([System.IO.Path]::Combine($taskDir, "task.json")) |
+    Get-Content -Encoding UTF8 |
+    Out-String |
+    ConvertFrom-Json
+
+# Get the zip bytes.
+$zipFile = "$($taskDir.TrimEnd('/', '\')).temp.zip"
+if ((Test-Path -LiteralPath $zipFile -PathType Leaf)) {
+    Remove-Item -LiteralPath $zipFile
+}
+
+try {
+    $items = Get-ChildItem -LiteralPath $taskDir |
+        ForEach-Object { $_.FullName }
+    Compress-Archive -Path $items -DestinationPath $zipFile
+    $base64Zip = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes((Get-Item -LiteralPath $zipFile).FullName))
+} finally {
+    if ((Test-Path -LiteralPath $zipFile -PathType Leaf)) {
+        Remove-Item -LiteralPath $zipFile
+    }
+}
+
+# Embed the task into the script.
+$id = "$($manifest.Id)"
+$name = "$($manifest.Name)"
+$version = "$($manifest.Version.Major).$($manifest.Version.Minor).$($manifest.Version.Patch)"
+$task = @{
+    Id = $id.Replace("'", "''")
+    Name = $name.Replace("'", "''")
+    Version = $version.Replace("'", "''")
+    Base64Zip = $base64Zip
+}
+
+Install-Task -CollectionUrl $CollectionUrl -Task $task

--- a/docs/pinToTaskVersion/pinToTaskVersion.md
+++ b/docs/pinToTaskVersion/pinToTaskVersion.md
@@ -1,0 +1,22 @@
+By default, our in the box tasks (those in this repo) automatically slide on minor and patch updates. Sometimes this behavior is undesirable (e.g. for Security/Compliance reasons), this behavior is undesirable.
+
+To avoid this behavior, we allow you to install a specific version of a task that you can pin to. Simply follow these steps.
+
+1. If you are not the TFS team project collection administrator, make sure that you have been added as an agent pool administrator at `All Pools` level. For more information, see [Agent pools](https://msdn.microsoft.com/library/vs/alm/build/agents/admin#agent-pools).
+
+2. Clone this repo and checkout the branch containing the version you want.
+
+3. On one your TFS Application Tiers, open a PowerShell console, and then change the current location to the root of this repo.
+
+4. To verify that your execution policy allows for the execution of installation scripts, run the following command line:
+
+```powershell
+Set-ExecutionPolicy Unrestricted -Scope Process -Force
+```
+
+5. From a TFS Application Tier, run the installation script against your TFS collection, as follows:
+
+```powershell
+$taskDir = Tasks\BashV3 # Replace BashV3 with the name of the task you would like to install.
+.docs\pinToTaskVersion\New-TaskInstallScript.ps1 -CollectionUrl http://myserver:8080/tfs/DefaultCollection -taskDir 
+```

--- a/docs/pinToTaskVersion/pinToTaskVersion.md
+++ b/docs/pinToTaskVersion/pinToTaskVersion.md
@@ -1,4 +1,4 @@
-By default, our in the box tasks (those in this repo) automatically slide on minor and patch updates. Sometimes this behavior is undesirable (e.g. for Security/Compliance reasons), this behavior is undesirable.
+By default, our in the box tasks (those in this repo) automatically slide on minor and patch updates. Sometimes this behavior is undesirable (e.g. for Security/Compliance reasons).
 
 To avoid this behavior, we allow you to install a specific version of a task that you can pin to. Simply follow these steps.
 
@@ -6,7 +6,7 @@ To avoid this behavior, we allow you to install a specific version of a task tha
 
 2. Clone this repo and checkout the branch containing the version you want.
 
-3. On one your TFS Application Tiers, open a PowerShell console, and then change the current location to the root of this repo.
+3. On one of your TFS Application Tiers, open a PowerShell console, and then change the current location to the root of this repo.
 
 4. To verify that your execution policy allows for the execution of installation scripts, run the following command line:
 
@@ -18,5 +18,5 @@ Set-ExecutionPolicy Unrestricted -Scope Process -Force
 
 ```powershell
 $taskDir = Tasks\BashV3 # Replace BashV3 with the name of the task you would like to install.
-.docs\pinToTaskVersion\New-TaskInstallScript.ps1 -CollectionUrl http://myserver:8080/tfs/DefaultCollection -taskDir 
+.docs\pinToTaskVersion\New-TaskInstallScript.ps1 -CollectionUrl http://myserver:8080/tfs/DefaultCollection -taskDir $taskDir
 ```


### PR DESCRIPTION
We end up exposing a form of this script any time a customer asks us to pin to a specific version in [releases](https://github.com/microsoft/azure-pipelines-tasks/releases). This should allow customers to self serve, and docs it for us if we ever need to do this for a customer