### PR TITLE
Updating buildOptions metadata as per grafeas spec

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV0/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 160,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [

--- a/Tasks/AzureFunctionOnKubernetesV0/task.loc.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 160,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tasks/Common/docker-common-v2/dockercommandutils.ts
+++ b/Tasks/Common/docker-common-v2/dockercommandutils.ts
@@ -113,11 +113,21 @@ export function getPipelineLogsUrl(): string {
     return pipelineUrl;
 }
 
-export function getBuildAndPushArguments(dockerFile: string, labelArguments: string[], tagArguments: string[]): Object {
+export function getBuildAndPushArguments(dockerFile: string, labelArguments: string[], tagArguments: string[]): { [key: string]: string } {
+    let labelArgumentsString = "";
+    let tagArgumentsString = "";
+    if (labelArguments && labelArguments.length > 0) {
+        labelArgumentsString = labelArguments.join(", ");
+    }
+
+    if (tagArguments && tagArguments.length > 0) {
+        tagArgumentsString = tagArguments.join(", ");
+    }
+
     let buildArguments = {
         "dockerFilePath": dockerFile,
-        "labels": labelArguments,
-        "tags": tagArguments,
+        "labels": labelArgumentsString,
+        "tags": tagArgumentsString,
         "context": getBuildContext(dockerFile)
     };
 

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 3
+        "Patch": 4
     },
     "preview": true,
     "demands": [],

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "demands": [],

--- a/Tasks/ContainerStructureTestV0/testresultspublisher.ts
+++ b/Tasks/ContainerStructureTestV0/testresultspublisher.ts
@@ -118,10 +118,6 @@ export class TestResultPublisher {
         return resultFilePath;
     }
 
-    private getAttestationName(): string {
-        return `projects/${tl.getVariable("System.TeamProject")}/notes/${uuid.v1()}`
-    }
-
     private getTestTabUrl(): string {
       var pipeLineUrl = dockerCommandUtils.getPipelineLogsUrl();
       var testTabUrl = "";
@@ -173,7 +169,7 @@ export class TestResultPublisher {
           };
 
           return {
-            name: this.getAttestationName(),
+            name: uuid.v1(),
             description: "Test Results from Container structure test",
             resourceUri:[resourceUri],
             kind: "ATTESTATION",

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 160,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 160,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 160,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 160,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 160,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 160,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 160,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 160,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
1. Updated buildOptions as a map from string to string.
2. Sending noteName from test task as Id only without project details, as the handling is to be done on output on server side