### PR TITLE
Updated make-options.js with the new task publishPipelinemetadata

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -295,6 +295,8 @@ Tasks/PublishCodeCoverageResultsV2/*    @karanjitsingh @acesiddhu
 
 Tasks/PublishPipelineArtifactV0/*       @mihaif @jahsu-MSFT @fadnavistanmay @owenhuynMSFT @arunkm
 
+Tasks/PublishPipelineMetadataV0/*    @vithati @nidabas
+
 Tasks/PublishSymbolsV2/*    @arunkm @mihaif @jahsu-MSFT @fadnavistanmay @owenhuynMSFT
 
 Tasks/PublishTestResultsV1/*    @smalpani

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 160,
-        "Patch": 3
+        "Minor": 161,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 160,
-    "Patch": 3
+    "Minor": 161,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/PublishPipelineMetadataV0/task.json
+++ b/Tasks/PublishPipelineMetadataV0/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 160,
+        "Minor": 161,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/PublishPipelineMetadataV0/task.loc.json
+++ b/Tasks/PublishPipelineMetadataV0/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 160,
+    "Minor": 161,
     "Patch": 0
   },
   "preview": true,

--- a/make-options.json
+++ b/make-options.json
@@ -134,6 +134,7 @@
         "PublishCodeCoverageResultsV1",
         "PublishPipelineArtifactV0",
         "PublishPipelineArtifactV1",
+        "PublishPipelineMetadataV0",
         "PublishSymbolsV2",
         "PublishTestResultsV1",
         "PublishTestResultsV2",


### PR DESCRIPTION
Also updated docker task version which got missed in this PR -https://github.com/microsoft/azure-pipelines-tasks/pull/11634