### PR TITLE
[m160][DotNetCoreCLIV2]handling semver v2 runtime preview versions (#11610)

### DIFF
--- a/Tasks/UseDotNetV2/models.ts
+++ b/Tasks/UseDotNetV2/models.ts
@@ -121,13 +121,13 @@ export class VersionParts {
         try {
             let parts = version.split('.');
             // validate version
-            if ((parts.length != 3) || // check if the version has 3 parts
+            if ((parts.length < 3) || // check if the version has at least 3 parts
                 !parts[0] || // The major version must always be set
                 !parts[1] || // The minor version must always be set
                 !parts[2] || // The patch version must always be set
                 Number.isNaN(Number.parseInt(parts[0])) || // the major version number must be a number
                 Number.isNaN(Number.parseInt(parts[1])) || // the minor version number must be a number
-                Number.isNaN(Number.parseInt(parts[2].split('-')[0])) // the patch version number must be a number. (the patch version can have a '-' because of version numbers like: 1.0.0-beta-50)
+                Number.isNaN(Number.parseInt(parts[2].split(/\-|\+/)[0])) // the patch version number must be a number. (the patch version can have a '-', or a '+' because of version numbers like: 1.0.0-beta-50)
             ) {
                 throw tl.loc("OnlyExplicitVersionAllowed", version);
             }
@@ -149,16 +149,22 @@ export class VersionParts {
         try {
             let parts = version.split('.');
             // validate version
-            if ((parts.length < 2 || parts.length > 3) || // check if the version has 2 or 3 parts
+            if (parts.length < 2 || // check if the version has at least 3 parts
                 (parts[1] == "x" && parts.length > 2) ||  // a version number like `1.x` must have only major and minor version
                 (parts[1] != "x" && parts.length <= 2) ||  // a version number like `1.1` must have a patch version
                 !parts[0] || // The major version must always be set
                 !parts[1] || // The minor version must always be set
                 (parts.length == 3 && !parts[2]) || // a version number like `1.1.` is invalid because the patch version is missing
                 Number.isNaN(Number.parseInt(parts[0])) || // the major version number must be a number
-                ( // The next lines check the minor version
-                    Number.isNaN(Number.parseInt(parts[1])) &&  // the minor version number must be a number
-                    parts[1] != "x" // the minor version can't be `x`
+                (
+                    parts[1] != "x" && // if the minor version is not `x`
+                    (
+                        Number.isNaN(Number.parseInt(parts[1])) || // the minor version number must be a number
+                        (
+                            parts.length > 2 && parts[2] != "x" && // if the patch is not `x`, then its an explicit version
+                            !semver.valid(version) // validate the explicit version
+                        )
+                    )
                 )
             ) {
                 throw tl.loc("VersionNumberHasTheWrongFormat", version);

--- a/Tasks/UseDotNetV2/package-lock.json
+++ b/Tasks/UseDotNetV2/package-lock.json
@@ -333,9 +333,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "semver": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-      "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/Tasks/UseDotNetV2/package.json
+++ b/Tasks/UseDotNetV2/package.json
@@ -29,7 +29,7 @@
     "azure-pipelines-task-lib": "3.0.0-preview",
     "azure-pipelines-tool-lib": "0.11.0",
     "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
-    "semver": "6.0.0",
+    "semver": "6.3.0",
     "typed-rest-client": "0.11.0",
     "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz"
   }

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 23
+        "Patch": 24
     },
    "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 23
+    "Patch": 24
   },
   "satisfies": [
     "DotNetCore"


### PR DESCRIPTION
* updating semver version to ^6.3.0 to use semverv2

* hanlde v2 runtime preview versions

* Update models.ts

* review comment, some more fix

* formatting messages

* making semver version explicit