### PR TITLE
Fix parsing commonName containing slashes

### DIFF
--- a/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0CertificateValidForABriefTime.ts
@@ -54,9 +54,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/build/temp/ios_signing_temp.keychain": false
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=${toOpensslString(notBefore)}\nnotAfter=${toOpensslString(notAfter)}\n`
+            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=${toOpensslString(notBefore)}\nnotAfter=${toOpensslString(notAfter)}\n`
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0FailOnExpiredCertificate.ts
@@ -41,9 +41,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/bin/openssl": true
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2017 GMT\nnotAfter=${toOpensslString(expiredDate)}\n`
+            "stdout": `MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=Nov 13 03:37:42 2017 GMT\nnotAfter=${toOpensslString(expiredDate)}\n`
         }
     }
 };

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallCertWithEmptyPassword.ts
@@ -45,9 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/build/temp/ios_signing_temp.keychain": false
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass: | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass: | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass: -passout pass:115 | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychain.ts
@@ -41,9 +41,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/lib/login.keychain": true
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallTempKeychain.ts
@@ -45,9 +45,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/build/temp/ios_signing_temp.keychain": false
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,

--- a/Tasks/InstallAppleCertificateV2/Tests/L0UserSupplyCN.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0UserSupplyCN.ts
@@ -42,9 +42,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "/usr/lib/login.keychain": true
     },
     "exec": {
-        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -dates": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd | /usr/bin/openssl x509 -noout -fingerprint -subject -nameopt multiline -dates": {
             "code": 0,
-            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject= /UID=ZD34QB2EFN/CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)/OU=A9M46DL4GH/O=Madhuri Gummalla/C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=\n    userId                    = ZD34QB2EFN\n    commonName                = iPhone Developer: Madhuri Gummalla (HE432Y3E2Q)\n    organizationalUnitName    = A9M46DL4GH\n    organizationName          = Madhuri Gummalla\n    countryName               = US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
         },
         "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd | /usr/bin/grep friendlyName": {
             "code": 0,


### PR DESCRIPTION
I've encountered errors when trying to build an iOS app in AppCenter, when using a certificate containing a slash in commonName (example: `subject=/UID=XXXXXXXXXX/CN=iPhone Distribution: Some Danish Company A/S (YYYYYYYYYY)/OU=YYYYYYYYYY/O=Some Danish Company A/S/C=US`.

This happens because of incorrect parsing of openssl command output (`value.match(/\/CN=([^/]+)/);`) that does not expect slashes in the name.
This commit adds `-nameopt multiline` option to openssl, so that it splits subject into multiple lines, making it possible to distinguish slashes that are part of the name from path separators.