### PR TITLE
Modify the base helm command to allow use with plugins

### DIFF
--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -44,6 +44,15 @@
     ],
     "inputs": [
         {
+            "name": "helmCommand",
+            "type": "string",
+            "label": "Helm command",
+            "defaultValue": "helm",
+            "required": false,
+            "helpMarkDown": "The command used to call helm. Defaults to 'helm'. Useful when wrapping or using plugins.",
+            "groupName": "cluster"
+        },
+        {
             "name": "connectionType",
             "type": "pickList",
             "label": "Connection Type",
@@ -403,7 +412,7 @@
             "resultTemplate": "{{{ #extractResource id resourcegroups}}}"
         }
     ],
-    "instanceNameFormat": "helm $(command)",
+    "instanceNameFormat": "$(command)",
     "showEnvironmentVariables": true,
     "prejobexecution": {
         "Node": {


### PR DESCRIPTION
This will allow you to override the `helm` command, in case you want to use something like [helm-secrets](https://github.com/futuresimple/helm-secrets). 

I figured I would do it by specifying the "helm" command as an input, defaulting it to "helm". It's relying on the inputs being in order. Is that the case? Could add a separate input group to ensure it's always first?