### PR TITLE
Calling results.publishmetadatatoevidencestore agent command to publish metadata.

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/10925608/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/11040905/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -154,11 +154,9 @@ async function run() {
                     // The exe returns with exit code: 40000 if there are test failures found and failTaskOnFailedTests is true
                     ci.addToConsolidatedCi('failedTestsInRun', true);
                     tl.setResult(tl.TaskResult.Failed, tl.loc('ErrorFailTaskOnFailedTests'));
-                }
 
-                // Doing it only for test results published using TestResultPublisher tool.
-                // For other publishes, publishing to evidence store happens as part of results.publish command itself.
-                if (exitCode !== 20000) {
+                    // Doing it only for test results published using TestResultPublisher tool.
+                    // For other publishes, publishing to evidence store happens as part of results.publish command itself.
                     readAndPublishTestRunSummaryToEvidenceStore(testRunner);
                 }
             } else {
@@ -184,7 +182,7 @@ function readAndPublishTestRunSummaryToEvidenceStore(testRunner: string) {
     try {
         const agentVersion = tl.getVariable('Agent.Version');
         if(semver.lt(agentVersion, "2.162.0")) {
-            throw "Requried agent version greater than or equal to 2.162.0";
+            throw "Required agent version greater than or equal to 2.162.0";
         }
 
         var tempPath = tl.getVariable('Agent.TempDirectory');

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -149,12 +149,13 @@ async function run() {
                         testRunTitle,
                         publishRunAttachments,
                         TESTRUN_SYSTEM);
-                }
-                else if(exitCode == 40000){
+                } else if (exitCode === 40000) {
                     // The exe returns with exit code: 40000 if there are test failures found and failTaskOnFailedTests is true
                     ci.addToConsolidatedCi('failedTestsInRun', true);
                     tl.setResult(tl.TaskResult.Failed, tl.loc('ErrorFailTaskOnFailedTests'));
+                }
 
+                if (exitCode !== 20000) {
                     // Doing it only for test results published using TestResultPublisher tool.
                     // For other publishes, publishing to evidence store happens as part of results.publish command itself.
                     readAndPublishTestRunSummaryToEvidenceStore(testRunner);

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -182,7 +182,7 @@ async function run() {
 function readAndPublishTestRunSummaryToEvidenceStore(testRunner: string) {
     try {
         const agentVersion = tl.getVariable('Agent.Version');
-        if(semver.lt(agentVersion, "2.162.0")) {
+        if(semver.lt(agentVersion, "2.162.1")) {
             throw "Required agent version greater than or equal to 2.162.0";
         }
 

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -119,6 +119,7 @@ export class TestResultsPublisher {
         envVars = this.addToProcessEnvVars(envVars, 'jobname', tl.getVariable('System.JobName'));
         envVars = this.addToProcessEnvVars(envVars, 'jobattempt', tl.getVariable('System.JobAttempt'));
         envVars = this.addToProcessEnvVars(envVars, 'jobidentifier', tl.getVariable('System.JobIdentifier'));
+        envVars = this.addToProcessEnvVars(envVars, 'agenttempdirectory', tl.getVariable('Agent.TempDirectory'));
 
         // Setting proxy details
         envVars = this.addToProcessEnvVars(envVars, "proxyurl", tl.getVariable('agent.proxyurl'));

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 162,
-        "Patch": 1
+        "Minor": 163,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 161,
+        "Minor": 162,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 162,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 161,
+    "Minor": 162,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 162,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 162,
-    "Patch": 1
+    "Minor": 163,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
- calling command to publish to evidence store, command will be checked in agent 2.162.0.
- passing agent.tempdirectory to exe, so it create a runsummaryjson.