### PR TITLE
Fixed resources loading in MavenAuthenticateV0

### DIFF
--- a/Tasks/MavenAuthenticateV0/mavenauth.ts
+++ b/Tasks/MavenAuthenticateV0/mavenauth.ts
@@ -7,10 +7,13 @@ import { emitTelemetry } from 'artifacts-common/telemetry'
 const M2FolderName: string = ".m2";
 const SettingsXmlName: string = "settings.xml";
 
+
 async function run(): Promise<void> {
     let internalFeedServerElements: any[] = [];
     let externalServiceEndpointsServerElements: any[] = [];
     try {
+        tl.setResourcePath(path.join(__dirname, 'task.json'));
+
         internalFeedServerElements = util.getInternalFeedsServerElements("artifactsFeeds");
         externalServiceEndpointsServerElements = util.getExternalServiceEndpointsServerElements("mavenServiceConnections");
         const newServerElements = internalFeedServerElements.concat(externalServiceEndpointsServerElements);

--- a/Tasks/MavenAuthenticateV0/mavenutils.ts
+++ b/Tasks/MavenAuthenticateV0/mavenutils.ts
@@ -20,7 +20,7 @@ export function getInternalFeedsServerElements(input: string) {
         return serverElements;
     }
 
-    tl.debug(tl.loc("Info_GeneratingInteralFeeds", feeds.length));
+    tl.debug(tl.loc("Info_GeneratingInternalFeeds", feeds.length));
     for (let feed of feeds) {
         serverElements.push({
                 id: feed,

--- a/Tasks/MavenAuthenticateV0/task.json
+++ b/Tasks/MavenAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 157,
+        "Minor": 162,
         "Patch": 0
     },
     "runsOn": [


### PR DESCRIPTION
There was a typo in the usage of a resource name for an info message.

Warning messages that the resource name didn't exists was being added to the pipelines

Increased version to 162