### PR TITLE
Update XCode task to respect teamId (#10312)

### DIFF
--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -240,7 +240,7 @@
             "required": false,
             "helpMarkDown": "(Optional, unless you are a member of multiple development teams.) Specify the 10-character development team ID.",
             "groupName": "sign",
-            "visibleRule": "signingOption = auto"
+            "visibleRule": "signingOption != nosign"
         },
         {
             "name": "destinationPlatformOption",

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -240,7 +240,7 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.teamId",
       "groupName": "sign",
-      "visibleRule": "signingOption = auto"
+      "visibleRule": "signingOption != nosign"
     },
     {
       "name": "destinationPlatformOption",

--- a/Tasks/XcodeV5/xcode.ts
+++ b/Tasks/XcodeV5/xcode.ts
@@ -214,7 +214,9 @@ async function run() {
         }
         else if (signingOption === 'auto') {
             xcode_codeSignStyle = 'CODE_SIGN_STYLE=Automatic';
+        }
 
+        if (signingOption !== 'nosign') {
             let teamId: string = tl.getInput('teamId');
             if (teamId) {
                 xcode_devTeam = 'DEVELOPMENT_TEAM=' + teamId;


### PR DESCRIPTION
Update Xcode task to respect teamId parameter except when 'nosign' is specified.

Per issue [#10312](https://github.com/microsoft/azure-pipelines-tasks/issues/10312) and abandoned [PR #10313](https://github.com/microsoft/azure-pipelines-tasks/pull/10313/files/1e70dadda6c9307ac34ab3bcc7d5b827f912e253#diff-8a30000fd1556b697ef95c23598aad64)

@hashtagchris 
@madhurig 