### PR TITLE
Corrects missing parentheses in MSBuild parameter validation

### DIFF
--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 4
     },
     "demands": [
         "msbuild"
@@ -90,22 +90,14 @@
             "type": "string",
             "label": "Platform",
             "defaultValue": "",
-            "required": false,
-            "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-                "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
-            }
+            "required": false
         },
         {
             "name": "configuration",
             "type": "string",
             "label": "Configuration",
             "defaultValue": "",
-            "required": false,
-            "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-                "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
-            }
+            "required": false
         },
         {
             "name": "msbuildArguments",

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "msbuild"
@@ -92,7 +92,7 @@
             "defaultValue": "",
             "required": false,
             "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
                 "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
             }
         },
@@ -103,7 +103,7 @@
             "defaultValue": "",
             "required": false,
             "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
                 "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
             }
         },

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 4
+        "Patch": 1
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 4
+    "Patch": 1
   },
   "demands": [
     "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 1
+    "Patch": 4
   },
   "demands": [
     "msbuild"
@@ -90,22 +90,14 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.platform",
       "defaultValue": "",
-      "required": false,
-      "validation": {
-        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-        "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
-      }
+      "required": false
     },
     {
       "name": "configuration",
       "type": "string",
       "label": "ms-resource:loc.input.label.configuration",
       "defaultValue": "",
-      "required": false,
-      "validation": {
-        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-        "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
-      }
+      "required": false
     },
     {
       "name": "msbuildArguments",

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -92,7 +92,7 @@
       "defaultValue": "",
       "required": false,
       "validation": {
-        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
         "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
       }
     },
@@ -103,7 +103,7 @@
       "defaultValue": "",
       "required": false,
       "validation": {
-        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+        "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
         "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
       }
     },

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 4
+        "Patch": 1
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 4
     },
     "demands": [
         "msbuild",
@@ -66,11 +66,7 @@
             "label": "Platform",
             "helpMarkDown": "Specify the platform you want to build such as Win32, x86, x64 or any cpu.",
             "defaultValue": "",
-            "required": false,
-            "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-                "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
-            }
+            "required": false
         },
         {
             "name": "configuration",
@@ -78,11 +74,7 @@
             "label": "Configuration",
             "helpMarkDown": "Specify the configuration you want to build such as debug or release.",
             "defaultValue": "",
-            "required": false,
-            "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
-                "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
-            }
+            "required": false
         },
         {
             "name": "clean",

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "msbuild",
@@ -68,7 +68,7 @@
             "defaultValue": "",
             "required": false,
             "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
                 "message": "The following characters are forbidden in Platform: < > * | : \\ / & % \" . # ?"
             }
         },
@@ -80,7 +80,7 @@
             "defaultValue": "",
             "required": false,
             "validation": {
-                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]'",
+                "expression": "isMatch(value, '[<>*|:\\/&%\".#?]')",
                 "message": "The following characters are forbidden in Configuration: < > * | : \\ / & % \" . # ?"
             }
         },

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 160,
-    "Patch": 0
+    "Minor": 161,
+    "Patch": 4
   },
   "demands": [
     "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 4
+    "Patch": 1
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
The "isMatch" expression for the newly-added platform and configuration validation was missing a close-parenthesis.