### PR TITLE
File better bugs

### DIFF
--- a/ci/file-bugs.js
+++ b/ci/file-bugs.js
@@ -101,33 +101,6 @@ function getIssuesByLabel(issues, issueType) {
     return labelMap;
 }
 
-function getProblem(bugs, staleBugs, untouchedBugs) {
-    let problem = '';
-
-    // Special case because we need commas
-    if (bugs > bugTolerance && staleBugs > staleBugTolerance && untouchedBugs > untouchedBugTolerance) {
-        return 'bugs, stale bugs, and untouched stale bugs';
-    }
-
-    if (bugs > bugTolerance) {
-        problem = 'bugs';
-    }
-    if (staleBugs > staleBugTolerance) {
-        if (problem) {
-            problem += ' and ';
-        }
-        problem += 'stale bugs';
-    }
-    if (untouchedBugs > untouchedBugTolerance) {
-        if (problem) {
-            problem += ' and ';
-        }
-        problem += 'untouched stale bugs';
-    }
-
-    return problem;
-}
-
 // Generates urls to view bugs by label for the bodies of the bugs
 function getIssueUrls(labels) {
     var urls = '';
@@ -219,9 +192,7 @@ async function fileBugs(bugsByLabel, staleBugsByLabel, untouchedBugsByLabel) {
             }
         }
 
-        const problem = getProblem(bugs, staleBugs, untouchedBugs);
-
-        if (problem) {
+        if (bugs > bugTolerance || staleBugs > staleBugTolerance || untouchedBugs > untouchedBugTolerance) {
             header(path);
             console.log('Bugs:', bugs);
             console.log('Stale bugs:', staleBugs);
@@ -231,7 +202,7 @@ async function fileBugs(bugsByLabel, staleBugsByLabel, untouchedBugsByLabel) {
             let bugTitle = `Too many bugs in https://github.com/microsoft/azure-pipelines-tasks`;
             // Format message as html so it renders correctly.
             let bugMessage = 
-`<div>The number of ${problem} assigned to the labels owned by this area path in https://github.com/microsoft/azure-pipelines-tasks has exceeded the number of allowable bugs.</div>
+`<div>The number of bugs, stale bugs, and/or untouched stale bugs assigned to the labels owned by this area path in https://github.com/microsoft/azure-pipelines-tasks has exceeded the allowable threshold.</div>
 <div><br></div>
 <div>Labels owned by this area: ${JSON.stringify(labels)}</div>
 <div><br></div>


### PR DESCRIPTION
This PR does the following:

1) Lowers the number of bugs required to file a bug from 100 to 50
2) Bumps the priority of bugs we file from 2 to 1 so they show up on scorecards
3) Adds an 'azure-pipelines-tasks' tag to the bugs we file
4) Makes it a little more clear why bugs are being filed (aka is it caused by bugs, stale bugs, or untouched bugs)
5) Fixes a bug in the linked issues (it was adding an 'Area: Release' tag to every link)