### PR TITLE
Period is a valid character for Configuration and Platform in MSBuild.

### DIFF
--- a/Tasks/Common/MSBuildHelpers/ArgumentFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/ArgumentFunctions.ps1
@@ -40,8 +40,8 @@ function Format-MSBuildArguments {
 
 function Test-MSBuildParam ([string]$msbuildParam, [string]$parameterName)
 {
-    if ($msBuildParam -match '[<>*|:\/&%".#?]')
+    if ($msBuildParam -match '[<>*|:\/&%"#?]')
     {
-        throw "The value of MSBuild parameter '$parameterName' ($msBuildParam) contains an invalid character. The value of $parameterName may not contain any of the following characters: < > * | : \ / & % `" . # ?"
+        throw "The value of MSBuild parameter '$parameterName' ($msBuildParam) contains an invalid character. The value of $parameterName may not contain any of the following characters: < > * | : \ / & % `" # ?"
     }
 }

--- a/Tasks/Common/MSBuildHelpers/Tests/Format-MSBuildArguments.RejectsInvalidCharacters.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Format-MSBuildArguments.RejectsInvalidCharacters.ps1
@@ -47,7 +47,7 @@ foreach ($acceptConfigurationCase in $acceptConfigurationCases)
 }
 
 # Arrange.
-$rejectCases = 'Release; /Logger:"\\networkshare\\NotActuallyALogger.dll', '<AngleBraces>', 'ASTER*SKS', 'AMPER&AND', 'PER%ENT', '"double quotes"', 'periods.', '#HASHTAGS', 'question marks?'
+$rejectCases = 'Release; /Logger:"\\networkshare\\NotActuallyALogger.dll', 'Angle<Braces', 'secarB>elgnA', 'ASTER*SKS', 'AMPER&AND', 'PER%ENT', '"double quotes"', '#HASHTAGS', 'question marks?'
 
 # Act.
 foreach ($rejectCase in $rejectCases)

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 160,
-    "Patch": 0
+    "Minor": 161,
+    "Patch": 1
   },
   "demands": [
     "MSBuild",

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 161,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 160,
-    "Patch": 0
+    "Minor": 161,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
- Period is a valid character for Configuration and Platform in MSBuild, so it was removed from the reject character set.
- Updated the tests in light of that fact.
- The remaining characters were manually tested in the Visual Studio interface to ensure that they are rejected when attempting to create a Configuration or Platform in Configuration Manager.