### PR TITLE
Calling results.publishmetadatatoevidencestore agent command to publish metadata

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/11023201/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/11102251/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -1,4 +1,6 @@
 import * as path from 'path';
+import * as fs from 'fs';
+import  * as semver from "semver"
 import * as publishTestResultsTool from './publishtestresultstool';
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from 'azure-pipelines-task-lib/toolrunner';
@@ -147,11 +149,16 @@ async function run() {
                         testRunTitle,
                         publishRunAttachments,
                         TESTRUN_SYSTEM);
-                }
-                else if(exitCode == 40000){
+                } else if (exitCode === 40000) {
                     // The exe returns with exit code: 40000 if there are test failures found and failTaskOnFailedTests is true
                     ci.addToConsolidatedCi('failedTestsInRun', true);
                     tl.setResult(tl.TaskResult.Failed, tl.loc('ErrorFailTaskOnFailedTests'));
+                }
+
+                if (exitCode !== 20000) {
+                    // Doing it only for test results published using TestResultPublisher tool.
+                    // For other publishes, publishing to evidence store happens as part of results.publish command itself.
+                    readAndPublishTestRunSummaryToEvidenceStore(testRunner);
                 }
             } else {
                 publish(testRunner, matchingTestResultsFiles,
@@ -165,11 +172,37 @@ async function run() {
             }
         }
         tl.setResult(tl.TaskResult.Succeeded, '');
-    } catch (err) {       
+    } catch (err) {
         tl.setResult(tl.TaskResult.Failed, err);
     } finally {
         ci.fireConsolidatedCi();
     }
+}
+
+function readAndPublishTestRunSummaryToEvidenceStore(testRunner: string) {
+    try {
+        const agentVersion = tl.getVariable('Agent.Version');
+        if(semver.lt(agentVersion, "2.162.1")) {
+            throw "Required agent version greater than or equal to 2.162.0";
+        }
+
+        var tempPath = tl.getVariable('Agent.TempDirectory');
+        var testRunSummaryPath = path.join(tempPath, "PTR_TEST_RUNSUMMARY.json");
+
+        var testRunSummary = fs.readFileSync(testRunSummaryPath, 'utf-8');
+    
+        var properties = <{ [key: string]: string }>{};
+    
+        properties['name'] = "PublishTestResults";
+        properties['testrunner'] = testRunner;
+        properties['testrunsummary'] = testRunSummary;
+        properties['description'] = "Test Results published from Publish Test Results tool";
+
+        tl.command('results.publishtoevidencestore', properties, '');
+    } catch (error) {
+        tl.debug(`Unable to publish the test run summary to evidencestore, error details:${error}`);
+    }
+
 }
 
 run();

--- a/Tasks/PublishTestResultsV2/publishtestresultstool.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresultstool.ts
@@ -119,6 +119,7 @@ export class TestResultsPublisher {
         envVars = this.addToProcessEnvVars(envVars, 'jobname', tl.getVariable('System.JobName'));
         envVars = this.addToProcessEnvVars(envVars, 'jobattempt', tl.getVariable('System.JobAttempt'));
         envVars = this.addToProcessEnvVars(envVars, 'jobidentifier', tl.getVariable('System.JobIdentifier'));
+        envVars = this.addToProcessEnvVars(envVars, 'agenttempdirectory', tl.getVariable('Agent.TempDirectory'));
 
         // Setting proxy details
         envVars = this.addToProcessEnvVars(envVars, "proxyurl", tl.getVariable('agent.proxyurl'));

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 162,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 162,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
- updated the task version
- updated the make.json with the right PTR library version.