### PR TITLE
Fixing CI failures for AzureFunctionOnKubernetesV0 and PublishPipelineMetadataV0 tasks

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV0/package-lock.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/package-lock.json
@@ -25,6 +25,13 @@
       "integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
       "requires": {
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
+          "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ=="
+        }
       }
     },
     "argparse": {

--- a/Tasks/AzureFunctionOnKubernetesV0/package.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
+    "@types/node": "12.12.7",
     "@types/q": "^1.5.0",
     "docker-common-v2": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
     "js-yaml": "3.13.1",

--- a/Tasks/PublishPipelineMetadataV0/package.json
+++ b/Tasks/PublishPipelineMetadataV0/package.json
@@ -4,6 +4,7 @@
   "description": "Publish Pipeline Metadata to Evidence store",
   "main": "publishmetadata.js",
   "dependencies": {
+    "@types/node": "12.12.7",
     "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz"
   },
   "devDependencies": {},


### PR DESCRIPTION
Explicitly specifying @types/node version in package.json. It seems that a higher version dependency is causing the build failures.