### PR TITLE
Fixes case where MSBuild may ignore build errors when clean

### DIFF
--- a/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
@@ -34,7 +34,7 @@ function Invoke-BuildTools {
             }
 
             # If we cleaned and passed /t targets, we don't need to run them again
-            if (!$Clean -or -not $MSBuildArguments.Contains("/t")) {
+            if (!$Clean -or $MSBuildArguments -notmatch "[/-]t(arget)?:\S+") {
                 if ($CreateLogFile) {
                     $splat["LogFile"] = "$file.log"
                 }

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 161,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "MSBuild",

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 161,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 161,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
MSBuild (the command-line application) will accept an arbitrary number of "build target" switch values; these are ultimately concatenated into a single list. "Clean" is a special build target which, if specified, takes no action except removing previous build artifacts. Then, after removing "Clean" from the set, if there are no specific build targets provided, a default set is used (whether that's drawn from the solution or simply "all targets" is immaterial for now).

The MSBuildV1 task has two inputs with a strange interaction, given the above: "Clean" and "Additional MSBuild Parameters". When "Clean" (the MSBuildV1 parameter) is active, MSBuildV1 inserts a second run of MSBuild, adding the build target switch with "Clean" as the value, and all other parameters as given, before the requested run of MSBuild. However, the "Additional MSBuild Parameters" string given by the user may contain a build targets switch-- in this case, the initial run of MSBuild with "Clean" appended will also build the user's specified targets. The second run of MSBuild duplicates the effort of the first.

The previous strategy to prevent the second run involved simply checking the user's input string for /t, which is one form of the "build targets" switch. However, /t is also a valid string for certain input parameters, such as file paths. This would result in only the clean build being run, and the pipeline would succeed even if it ought to have failed, because the build of the targets that would fail to build would never be run.

This PR corrects the problem by examining the user's input string more specifically for a valid use of the "build targets" switch, which must meet the following format:
- Begins with forward slash or hyphen
- Followed by either "t" or "target"
- Followed by a colon
- And at least one non-whitespace character

Though it is still possible to fool the string check, I believe this approach should reduce the number of cases in which the same error occurs to as near zero as makes no difference.