### PR TITLE
AzurePowerShellV5: Use LatestVersion by default for TargetAzurePs

### DIFF
--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -124,7 +124,7 @@
             ],
             "type": "radio",
             "label": "Azure PowerShell Version",
-            "defaultValue": "OtherVersion",
+            "defaultValue": "LatestVersion",
             "required": false,
             "options": {
                 "LatestVersion": "Latest installed version",


### PR DESCRIPTION
This makes usage of the task easier because the default task requires fewer manual changes to work, which is especially useful when experimenting and details do not matter.