### PR TITLE
Use 32-bit version of 7zip if needed

### DIFF
--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -19,9 +19,13 @@ var xpUnzipLocation: string;
 // 7zip
 var xpSevenZipLocation: string;
 var winSevenZipLocation: string = path.join(__dirname, '7zip/7z.exe');
+var win32bitSevenZipLocation: string = path.join(__dirname, 'ia32/7zip/7z.exe');
 
 function getSevenZipLocation(): string {
     if (win) {
+        if (process.arch === 'ia32') {
+            return win32bitSevenZipLocation;
+        }
         return winSevenZipLocation;
     } else {
         if (typeof xpSevenZipLocation == "undefined") {

--- a/Tasks/ExtractFilesV1/make.json
+++ b/Tasks/ExtractFilesV1/make.json
@@ -4,6 +4,10 @@
             {
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
                 "dest": "./"
+            },
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip_ia32.zip",
+                "dest": "./ia32/"
             }
         ]
     }


### PR DESCRIPTION
The "ExtractFilesV1" task uses a 64-bit version of the 7z.exe binary which doesn't work on 32-bit systems and, more importantly, on Windows on ARM.
Let's use a 32-bit version of 7zip if the task is running under 32-bit version of Node.js.

_Somebody will have to create and upload an archive with 32-bit version of 7zip to the storage._
https://www.7-zip.org/download.html 