### PR TITLE
[Port to m162]: Fixing CI failures for AzureFunctionOnKubernetesV0 and PublishPipelin…

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV0/package-lock.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/package-lock.json
@@ -367,9 +367,9 @@
       }
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "utility-common-v2": {
       "version": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz",

--- a/Tasks/AzureFunctionOnKubernetesV0/package.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
+    "@types/node": "12.12.7",
     "@types/q": "^1.5.0",
     "docker-common-v2": "file:../../_build/Tasks/Common/docker-common-v2-1.0.0.tgz",
     "js-yaml": "3.13.1",

--- a/Tasks/PublishPipelineMetadataV0/package.json
+++ b/Tasks/PublishPipelineMetadataV0/package.json
@@ -4,6 +4,7 @@
   "description": "Publish Pipeline Metadata to Evidence store",
   "main": "publishmetadata.js",
   "dependencies": {
+    "@types/node": "12.12.7",
     "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz"
   },
   "devDependencies": {},


### PR DESCRIPTION
Porting the fix to m162 to unblock m162 CI.