### PR TITLE
Bug : VsTest task with the "Test plan" option selected tries to run test in obj/ directories

### DIFF
--- a/Tasks/VsTestV2/distributedtest.ts
+++ b/Tasks/VsTestV2/distributedtest.ts
@@ -94,7 +94,7 @@ export class DistributedTest {
             console.log(tl.loc('UserProvidedSourceFilter', sourceFilter.toString()));
 
             if (this.inputDataContract.TestSelectionSettings.TestSelectionType.toLowerCase() !== 'testassemblies') {
-                sourceFilter = ['**\\*', '!**\\obj\\*'];
+                sourceFilter = ['**\\*', '!**\\obj\\**'];
             }
             const telemetryProps: { [key: string]: any; } = { MiniMatchLines: sourceFilter.length };
             telemetryProps.ExecutionFlow = 'Distributed';

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 164,
-        "Patch": 1
+        "Minor": 165,
+        "Patch": 0
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 164,
-    "Patch": 1
+    "Minor": 165,
+    "Patch": 0
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Fix : Updated minimatch expression to exclude obj and all sub directories