### PR TITLE
Fixed help link for Azure Policy task

### DIFF
--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -3,7 +3,7 @@
     "name": "AzurePolicyCheckGate",
     "friendlyName": "Check Azure Policy compliance",
     "description": "Security and compliance assessment for Azure Policy",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/azure-policy-check-gate",
+    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/azure-policy",
     "helpMarkDown": "",
     "category": "Deploy",
     "visibility": [


### PR DESCRIPTION
There was some duplication and this task doc location was changed in https://github.com/MicrosoftDocs/azure-devops-docs-pr/pull/855

If we should change the name of the doc file for that task let me know and I can do that instead.