### PR TITLE
Updating the agent version check in PTR task

### DIFF
--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -186,8 +186,8 @@ async function run() {
 function readAndPublishTestRunSummaryToEvidenceStore(testRunner: string) {
     try {
         const agentVersion = tl.getVariable('Agent.Version');
-        if(semver.lt(agentVersion, "2.162.1")) {
-            throw "Required agent version greater than or equal to 2.162.0";
+        if(semver.lt(agentVersion, "2.164.0")) {
+            throw "Required agent version greater than or equal to 2.164.0";
         }
 
         var tempPath = tl.getVariable('Agent.TempDirectory');

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 164,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 164,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
## Porting from PR #12213 

### Description
Publishing to Evidence store code didn't make it to the 2.163 and 2.162.1 version of the agent code. Hence that check in PTR task is invalid. Which is causing the pipelines to fail if they are using the agent version 2.162.1 - 2.163.*.

### Fix
I have update the agent version check in PTR and will quickly hot fix.

### ToDo
Need to follow up with Agent folks, why those changes didn't make it to the 2.162.1 - 2.163.* agent versions.