### PR TITLE
Changes the default verbosityRestore to be a more default value

### DIFF
--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 165,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",
@@ -262,7 +262,7 @@
             "name": "verbosityRestore",
             "type": "pickList",
             "label": "Verbosity",
-            "defaultValue": "Detailed",
+            "defaultValue": "Normal",
             "helpMarkDown": "Specifies the amount of detail displayed in the output.",
             "required": "false",
             "groupName": "restoreAdvanced",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 165,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -262,7 +262,7 @@
       "name": "verbosityRestore",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.verbosityRestore",
-      "defaultValue": "Detailed",
+      "defaultValue": "Normal",
       "helpMarkDown": "ms-resource:loc.input.help.verbosityRestore",
       "required": "false",
       "groupName": "restoreAdvanced",


### PR DESCRIPTION
This proposed change reduces the level of noise in the output from `dotnet restore` as outlined in #12297 . I am unable to run the build or tests on my machine so I hope this does not conflict with any possible regression tests 🤞