### PR TITLE
Fixes #12306 by attempting the download using the provided artifact path

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/de-de/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Erfolgreich in \"%s\" heruntergeladene Artefakte",
   "loc.messages.RetryingOperation": "Fehler in \"%s\", Vorgang wird wiederholt. Ausstehende Versuche: %s",
   "loc.messages.OperationFailed": "Fehler in \"%s\": %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Das Verzeichnis \"%s\" ist nicht vorhanden. Fallback auf das übergeordnete Verzeichnis: %s",
   "loc.messages.LatestBuildFound": "Gefundener aktueller Build: %s",
   "loc.messages.LatestBuildNotFound": "Aktueller Build wurde nicht gefunden.",
   "loc.messages.LatestBuildFromBranchNotFound": "Aktueller Build aus Branch \"%s\" nicht gefunden.",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
   "loc.messages.RetryingOperation": "Error: in %s, so retrying => retries pending  : %s",
   "loc.messages.OperationFailed": "Failed in %s with error: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
   "loc.messages.LatestBuildFound": "Latest build found:  %s",
   "loc.messages.LatestBuildNotFound": "Latest build not found",
   "loc.messages.LatestBuildFromBranchNotFound": "Latest build from branch %s not found",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/es-es/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Los artefactos se han descargado correctamente en %s",
   "loc.messages.RetryingOperation": "Error: en %s, por lo que se está reintentando => reintentos pendientes: %s",
   "loc.messages.OperationFailed": "Error en %s: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "El directorio \"%s\" no existe. Se usa el directorio primario: %s",
   "loc.messages.LatestBuildFound": "Última compilación encontrada: %s",
   "loc.messages.LatestBuildNotFound": "Última compilación no encontrada",
   "loc.messages.LatestBuildFromBranchNotFound": "No se encontró la última compilación de la rama %s",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/fr-fr/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Téléchargement réussi des artefacts sur %s",
   "loc.messages.RetryingOperation": "Erreur dans %s. Nouvelle tentative => nouvelles tentatives en attente : %s",
   "loc.messages.OperationFailed": "Échec dans %s. Erreur : %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Le répertoire '%s' n'existe pas. Retour au répertoire parent : %s",
   "loc.messages.LatestBuildFound": "Dernière build trouvée : %s",
   "loc.messages.LatestBuildNotFound": "Dernière build introuvable",
   "loc.messages.LatestBuildFromBranchNotFound": "Dernière build de la branche %s introuvable",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Gli artefatti sono stati scaricati in %s",
   "loc.messages.RetryingOperation": "Errore in %s. Verranno eseguiti nuovi tentativi => Tentativi in sospeso: %s",
   "loc.messages.OperationFailed": "Operazione non riuscita in %s. Errore: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "La directory '%s' non esiste. Verrà eseguito il fallback alla directory padre: '%s'",
   "loc.messages.LatestBuildFound": "Compilazione più recente trovata: %s",
   "loc.messages.LatestBuildNotFound": "Compilazione più recente non trovata",
   "loc.messages.LatestBuildFromBranchNotFound": "La compilazione più recente dal ramo %s non è stata trovata",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ja-jp/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "成果物が %s に正常にダウンロードされました",
   "loc.messages.RetryingOperation": "%s でエラーが発生したため、再試行します。保留中の再試行回数:  %s",
   "loc.messages.OperationFailed": "%s でエラー %s のために失敗しました",
-  "loc.messages.ArtifactNameDirectoryNotFound": "ディレクトリ '%s' が存在しません。親ディレクトリ: %s に戻ります",
   "loc.messages.LatestBuildFound": "最新のビルドが見つかりました。%s",
   "loc.messages.LatestBuildNotFound": "最新のビルドが見つかりません",
   "loc.messages.LatestBuildFromBranchNotFound": "ブランチ %s からの最新のビルドが見つかりませんでした",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "%s에 아티팩트를 다운로드했습니다.",
   "loc.messages.RetryingOperation": "%s에서 오류가 발생하여 다시 시도 중 => 다시 시도 보류 중: %s",
   "loc.messages.OperationFailed": "%s에서 실패했습니다(오류: %s).",
-  "loc.messages.ArtifactNameDirectoryNotFound": "디렉터리 '%s'이(가) 없습니다. 부모 디렉터리 %s(으)로 대체됩니다.",
   "loc.messages.LatestBuildFound": "최신 빌드가 발견됨: %s",
   "loc.messages.LatestBuildNotFound": "최신 빌드를 찾을 수 없습니다.",
   "loc.messages.LatestBuildFromBranchNotFound": "%s 분기에서 최신 빌드를 찾을 수 없습니다.",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "Артефакты успешно скачаны в %s",
   "loc.messages.RetryingOperation": "Ошибка в %s, выполняется повторная попытка => осталось повторных попыток: %s",
   "loc.messages.OperationFailed": "Сбой в %s с ошибкой: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Каталог \"%s\" не существует. Будет использоваться родительский каталог: %s",
   "loc.messages.LatestBuildFound": "Последняя найденная сборка: %s",
   "loc.messages.LatestBuildNotFound": "Последняя сборка не найдена",
   "loc.messages.LatestBuildFromBranchNotFound": "Последняя сборка из ветви %s не найдена",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功将项目下载到 %s",
   "loc.messages.RetryingOperation": "错误: 在 %s 中，正在重试 => 重试挂起: %s",
   "loc.messages.OperationFailed": "%s 中失败，出现错误: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "目录“%s”不存在。请回退到父级目录: %s",
   "loc.messages.LatestBuildFound": "找到最新生成: %s",
   "loc.messages.LatestBuildNotFound": "找不到最新生成",
   "loc.messages.LatestBuildFromBranchNotFound": "找不到分支 %s 中的最新生成",

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -44,7 +44,6 @@
   "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功將成品下載到 %s",
   "loc.messages.RetryingOperation": "錯誤: 在 %s，因此即將重試 => 暫止的重試次數: %s",
   "loc.messages.OperationFailed": "無法於 %s，錯誤: %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "目錄 '%s' 不存在。正在回復到父目錄: %s",
   "loc.messages.LatestBuildFound": "找到最新組建: %s",
   "loc.messages.LatestBuildNotFound": "找不到最新組建",
   "loc.messages.LatestBuildFromBranchNotFound": "找不到分支 %s 的最新組建",

--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -319,10 +319,6 @@ async function main(): Promise<void> {
                     let downloadUrl = artifact.resource.data;
                     let artifactName = artifact.name.replace('/', '\\');
                     let artifactLocation = path.join(downloadUrl, artifactName);
-                    if (!fs.existsSync(artifactLocation)) {
-                        console.log(tl.loc("ArtifactNameDirectoryNotFound", artifactLocation, downloadUrl));
-                        artifactLocation = downloadUrl;
-                    }
 
                     console.log(tl.loc("DownloadArtifacts", artifact.name, artifactLocation));
                     var fileShareProvider = new providers.FilesystemProvider(artifactLocation, artifactName);

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -249,7 +249,6 @@
         "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
         "RetryingOperation": "Error: in %s, so retrying => retries pending  : %s",
         "OperationFailed": "Failed in %s with error: %s",
-        "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s",
         "LatestBuildFound": "Latest build found:  %s",
         "LatestBuildNotFound": "Latest build not found",
         "LatestBuildFromBranchNotFound": "Latest build from branch %s not found",

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -249,7 +249,6 @@
     "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "OperationFailed": "ms-resource:loc.messages.OperationFailed",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound",
     "LatestBuildFound": "ms-resource:loc.messages.LatestBuildFound",
     "LatestBuildNotFound": "ms-resource:loc.messages.LatestBuildNotFound",
     "LatestBuildFromBranchNotFound": "ms-resource:loc.messages.LatestBuildFromBranchNotFound",

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/de-de/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Parallelisierungslimit",
   "loc.input.help.parallelizationLimit": "Anzahl von Dateien, die gleichzeitig heruntergeladen werden sollen",
   "loc.messages.DownloadArtifacts": "Artefakt \"%s\" wird von %s heruntergeladen.",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Erfolgreich in \"%s\" heruntergeladene Artefakte",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Das Verzeichnis \"%s\" ist nicht vorhanden. Fallback auf das übergeordnete Verzeichnis: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Erfolgreich in \"%s\" heruntergeladene Artefakte"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Parallelization limit",
   "loc.input.help.parallelizationLimit": "Number of files to download simultaneously",
   "loc.messages.DownloadArtifacts": "Downloading artifact %s from: %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/es-es/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Límite de paralelización",
   "loc.input.help.parallelizationLimit": "Número de archivos para descargar simultáneamente",
   "loc.messages.DownloadArtifacts": "Descargando el artefacto %s desde: %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Los artefactos se han descargado correctamente en %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "El directorio \"%s\" no existe. Se usa el directorio primario: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Los artefactos se han descargado correctamente en %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/fr-fr/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Limite de parallélisation",
   "loc.input.help.parallelizationLimit": "Nombre de fichiers à télécharger simultanément",
   "loc.messages.DownloadArtifacts": "Téléchargement de l'artefact %s à partir de %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Téléchargement réussi des artefacts sur %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Le répertoire '%s' n'existe pas. Retour au répertoire parent : %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Téléchargement réussi des artefacts sur %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Limite di parallelizzazione",
   "loc.input.help.parallelizationLimit": "Numero di file da scaricare contemporaneamente",
   "loc.messages.DownloadArtifacts": "Download dell'artefatto %s da %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Gli artefatti sono stati scaricati in %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "La directory '%s' non esiste. Verrà eseguito il fallback alla directory padre: '%s'"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Gli artefatti sono stati scaricati in %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ja-jp/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "並列処理の制限",
   "loc.input.help.parallelizationLimit": "同時にダウンロードするファイルの数",
   "loc.messages.DownloadArtifacts": "成果物 %s を %s からダウンロードしています",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "成果物が %s に正常にダウンロードされました",
-  "loc.messages.ArtifactNameDirectoryNotFound": "ディレクトリ '%s' が存在しません。親ディレクトリ: %s に戻ります"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "成果物が %s に正常にダウンロードされました"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "병렬 처리 제한",
   "loc.input.help.parallelizationLimit": "동시에 다운로드할 파일 수",
   "loc.messages.DownloadArtifacts": "%s 아티팩트를 %s에서 다운로드 중",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "%s에 아티팩트를 다운로드했습니다.",
-  "loc.messages.ArtifactNameDirectoryNotFound": "디렉터리 '%s'이(가) 없습니다. 부모 디렉터리 %s(으)로 대체됩니다."
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "%s에 아티팩트를 다운로드했습니다."
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "Предел параллелизма",
   "loc.input.help.parallelizationLimit": "Число одновременно скачиваемых файлов",
   "loc.messages.DownloadArtifacts": "Скачивается артефакт %s из: %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "Артефакты успешно скачаны в %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "Каталог \"%s\" не существует. Будет использоваться родительский каталог: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "Артефакты успешно скачаны в %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "并行化限制",
   "loc.input.help.parallelizationLimit": "要同时下载的文件数",
   "loc.messages.DownloadArtifacts": "正在从后列位置下载项目 %s: %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功将项目下载到 %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "目录“%s”不存在。请回退到父级目录: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功将项目下载到 %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DownloadFileshareArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -15,6 +15,5 @@
   "loc.input.label.parallelizationLimit": "平行處理的限制",
   "loc.input.help.parallelizationLimit": "要同時下載的檔案數目",
   "loc.messages.DownloadArtifacts": "正在從 %s 下載成品 %s",
-  "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功將成品下載到 %s",
-  "loc.messages.ArtifactNameDirectoryNotFound": "目錄 '%s' 不存在。正在回復到父目錄: %s"
+  "loc.messages.ArtifactsSuccessfullyDownloaded": "已成功將成品下載到 %s"
 }

--- a/Tasks/DownloadFileshareArtifactsV0/main.ts
+++ b/Tasks/DownloadFileshareArtifactsV0/main.ts
@@ -67,12 +67,7 @@ async function main(): Promise<void> {
         let artifactName = tl.getInput("artifactName", true);
         artifactName = artifactName.replace('/', '\\');
         let artifactLocation = path.join(downloadUrl, artifactName);
-
         console.log(tl.loc("DownloadArtifacts", artifactName, artifactLocation));
-        if (!fs.existsSync(artifactLocation)) {
-            console.log(tl.loc("ArtifactNameDirectoryNotFound", artifactLocation, downloadUrl));
-            artifactLocation = downloadUrl;
-        }
 
         let downloaderOptions = new engine.ArtifactEngineOptions();
         downloaderOptions.itemPattern = itemPattern;

--- a/Tasks/DownloadFileshareArtifactsV0/task.json
+++ b/Tasks/DownloadFileshareArtifactsV0/task.json
@@ -75,7 +75,6 @@
     },
     "messages": {
         "DownloadArtifacts": "Downloading artifact %s from: %s",
-        "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s",
-        "ArtifactNameDirectoryNotFound": "Directory '%s' does not exist. Falling back to parent directory: %s"
+        "ArtifactsSuccessfullyDownloaded": "Successfully downloaded artifacts to %s"
     }
 }

--- a/Tasks/DownloadFileshareArtifactsV0/task.loc.json
+++ b/Tasks/DownloadFileshareArtifactsV0/task.loc.json
@@ -75,7 +75,6 @@
   },
   "messages": {
     "DownloadArtifacts": "ms-resource:loc.messages.DownloadArtifacts",
-    "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded",
-    "ArtifactNameDirectoryNotFound": "ms-resource:loc.messages.ArtifactNameDirectoryNotFound"
+    "ArtifactsSuccessfullyDownloaded": "ms-resource:loc.messages.ArtifactsSuccessfullyDownloaded"
   }
 }


### PR DESCRIPTION
Removing the existence check for the artifact directory and change of artifact folder to parent directory should resolve the problems seen in #12306. It looks like the engine.ArtifactEngine.processItems() method will handle retry and failure, so no further changes should be necessary. It also looks to be a problem for DownloadBuildArtifactsV0, so updating here as well.