### PR TITLE
[CopyFilesOverSSHV0 and SshV0]: Bump ssh2 package version to 0.8.7

### DIFF
--- a/Tasks/CopyFilesOverSSHV0/package-lock.json
+++ b/Tasks/CopyFilesOverSSHV0/package-lock.json
@@ -136,17 +136,17 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "ssh2": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.2.tgz",
-      "integrity": "sha512-oaXu7faddvPFGavnLBkk0RFwLXvIzCPq6KqAC3ExlnFPAVIE1uo7pWHe9xmhNHXm+nIe7yg9qsssOm+ip2jijw==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.7.tgz",
+      "integrity": "sha512-/u1BO12kb0lDVxJXejWB9pxyF3/ncgRqI9vPCZuPzo05pdNDzqUeQRavScwSPsfMGK+5H/VRqp1IierIx0Bcxw==",
       "requires": {
-        "ssh2-streams": "~0.4.2"
+        "ssh2-streams": "~0.4.8"
       },
       "dependencies": {
         "ssh2-streams": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.2.tgz",
-          "integrity": "sha512-2rSj3oTIJnbAIzR3+XwIYef9wCOVrPQZNLL+fFPPjnPxf09tKkAbgrlYgh/1qynBTz65AUOS+s1zuko4M/GKCw==",
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.8.tgz",
+          "integrity": "sha512-auxXfgYySz2vYw7TMU7PK7vFI7EPvhvTH8/tZPgGaWocK4p/vwCMiV3icz9AEkb0R40kOKZtFtqYIxDJyJiytw==",
           "requires": {
             "asn1": "~0.2.0",
             "bcrypt-pbkdf": "^1.0.2",

--- a/Tasks/CopyFilesOverSSHV0/package.json
+++ b/Tasks/CopyFilesOverSSHV0/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft.com/vsts-tasks#readme",
   "dependencies": {
     "ssh2-sftp-client": "^5.1.2",
-    "ssh2": "^0.8.2",
+    "ssh2": "^0.8.7",
     "minimatch": "^3.0.4",
     "azure-pipelines-task-lib": "^2.9.3"
   }

--- a/Tasks/CopyFilesOverSSHV0/task.json
+++ b/Tasks/CopyFilesOverSSHV0/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 175,
-        "Patch": 1
+        "Minor": 177,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/SshV0/package-lock.json
+++ b/Tasks/SshV0/package-lock.json
@@ -166,21 +166,21 @@
     },
     "shelljs": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "ssh2": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.2.tgz",
-      "integrity": "sha512-oaXu7faddvPFGavnLBkk0RFwLXvIzCPq6KqAC3ExlnFPAVIE1uo7pWHe9xmhNHXm+nIe7yg9qsssOm+ip2jijw==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.7.tgz",
+      "integrity": "sha512-/u1BO12kb0lDVxJXejWB9pxyF3/ncgRqI9vPCZuPzo05pdNDzqUeQRavScwSPsfMGK+5H/VRqp1IierIx0Bcxw==",
       "requires": {
-        "ssh2-streams": "~0.4.2"
+        "ssh2-streams": "~0.4.8"
       },
       "dependencies": {
         "ssh2-streams": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.2.tgz",
-          "integrity": "sha512-2rSj3oTIJnbAIzR3+XwIYef9wCOVrPQZNLL+fFPPjnPxf09tKkAbgrlYgh/1qynBTz65AUOS+s1zuko4M/GKCw==",
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.8.tgz",
+          "integrity": "sha512-auxXfgYySz2vYw7TMU7PK7vFI7EPvhvTH8/tZPgGaWocK4p/vwCMiV3icz9AEkb0R40kOKZtFtqYIxDJyJiytw==",
           "requires": {
             "asn1": "~0.2.0",
             "bcrypt-pbkdf": "^1.0.2",

--- a/Tasks/SshV0/package.json
+++ b/Tasks/SshV0/package.json
@@ -5,7 +5,7 @@
     "@types/ssh2": "0.5.43",
     "@types/ssh2-sftp-client": "^5.2.0",
     "azure-pipelines-task-lib": "^2.9.3",
-    "ssh2": "0.8.2",
+    "ssh2": "0.8.7",
     "ssh2-sftp-client": "^5.1.2",
     "uuid": "^3.2.1"
   }

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 0,
         "Minor": 177,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**: CopyFilesOverSSHV0 and SshV0

**Description**: Update ssh2 dependency to 0.8.7 version which add support for keys ed25519

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #11443 #10642

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected