### PR TITLE
Update tasks owned by build to use new version of azure-pipelines-task-lib

### DIFF
--- a/Tasks/CMakeV1/cmaketask.ts
+++ b/Tasks/CMakeV1/cmaketask.ts
@@ -1,8 +1,8 @@
 
 
 import path = require('path');
-import tl = require('vsts-task-lib/task');
-import trm = require('vsts-task-lib/toolrunner');
+import tl = require('azure-pipelines-task-lib/task');
+import trm = require('azure-pipelines-task-lib/toolrunner');
 
 async function run() {
     try {   

--- a/Tasks/CMakeV1/package-lock.json
+++ b/Tasks/CMakeV1/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -23,32 +36,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -61,24 +48,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
-    },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "q": {
       "version": "1.5.1",
@@ -95,33 +64,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.9.20",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.9.20.tgz",
-      "integrity": "sha1-MbFJAXkbOyFytAiZDF4bzop57Zs=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/Tasks/CMakeV1/package.json
+++ b/Tasks/CMakeV1/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^0.9.20"
+    "azure-pipelines-task-lib": "^2.9.3"
   }
 }

--- a/Tasks/CMakeV1/task.json
+++ b/Tasks/CMakeV1/task.json
@@ -15,8 +15,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 151,
-        "Patch": 1
+        "Minor": 166,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "CMake $(cmakeArgs)",

--- a/Tasks/CMakeV1/task.loc.json
+++ b/Tasks/CMakeV1/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 151,
-    "Patch": 1
+    "Minor": 166,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/Common/MSBuildHelpers/msbuildhelpers.ts
+++ b/Tasks/Common/MSBuildHelpers/msbuildhelpers.ts
@@ -1,5 +1,4 @@
-import tl = require('vsts-task-lib/task');
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import tl = require('azure-pipelines-task-lib/task');
 
 /**
  * Finds the tool path for msbuild/xbuild based on specified msbuild version on Mac or Linux agent

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -55,19 +68,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "vsts-task-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-      "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-      "requires": {
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
-      }
     }
   }
 }

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^2.0.3-preview"
+    "azure-pipelines-task-lib": "^2.9.3"
   }
 }

--- a/Tasks/GruntV0/grunttask.ts
+++ b/Tasks/GruntV0/grunttask.ts
@@ -1,9 +1,11 @@
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
+import minimatch = require('minimatch');
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 var gruntFile = tl.getPathInput('gruntFile', true, true);
+tl.debug('check grunt file :' + gruntFile);
 var grunt = tl.which('grunt', false);
 var isCodeCoverageEnabled = tl.getBoolInput('enableCodeCoverage');
 var publishJUnitResults = tl.getBoolInput('publishJUnitResults');
@@ -15,33 +17,33 @@ tl.cd(cwd);
 tl.debug('check path : ' + grunt);
 if (!tl.exist(grunt)) {
 	tl.debug('not found global installed grunt-cli, try to find grunt-cli locally.');
-	var gt = tl.createToolRunner(tl.which('node', true));
+	var gt = tl.tool(tl.which('node', true));
 	var gtcli = tl.getInput('gruntCli', true);
 	gtcli = path.resolve(cwd, gtcli);
 	tl.debug('check path : ' + gtcli);
 	if (!tl.exist(gtcli)) {
 		tl.setResult(tl.TaskResult.Failed, tl.loc('GruntCliNotInstalled', gtcli));
 	}
-	gt.pathArg(gtcli);
+	gt.arg(gtcli);
 }
 else {
-	var gt = tl.createToolRunner(grunt);
+	var gt = tl.tool(grunt);
 }
 
 if (isCodeCoverageEnabled) {
-	var npm = tl.createToolRunner(tl.which('npm', true));
-	npm.argString('install istanbul');
+	var npm = tl.tool(tl.which('npm', true));
+	npm.line('install istanbul');
 	var testFramework = tl.getInput('testFramework', true);
 	var srcFiles = tl.getInput('srcFiles', false);
 	var testSrc = tl.getPathInput('testFiles', true, false);
-	var istanbul = tl.createToolRunner(tl.which('node', true));
+	var istanbul = tl.tool(tl.which('node', true));
 	istanbul.arg('./node_modules/istanbul/lib/cli.js');
-	istanbul.argString('cover --report cobertura --report html');
+	istanbul.line('cover --report cobertura --report html');
 	if (srcFiles) {
-		istanbul.argString('-i .' + path.sep + path.join(srcFiles));
+		istanbul.line('-i .' + path.sep + path.join(srcFiles));
 	}
 	if (testFramework.toLowerCase() == 'jasmine') {
-		istanbul.argString('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
+		istanbul.line('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
 	} else {
 		istanbul.arg('./node_modules/mocha/bin/_mocha');
 	}
@@ -52,9 +54,8 @@ if (isCodeCoverageEnabled) {
 
 // optional - no targets will concat nothing
 gt.arg(tl.getDelimitedInput('targets', ' ', false));
-gt.arg('--gruntfile');
-gt.pathArg(gruntFile);
-gt.argString(tl.getInput('arguments', false));
+gt.arg(['--gruntfile', gruntFile]);
+gt.line(tl.getInput('arguments', false));
 gt.exec().then(function (code) {
 	publishTestResults(publishJUnitResults, testResultsFiles);
 	if (isCodeCoverageEnabled) {
@@ -87,7 +88,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
             tl.debug('Pattern found in testResultsFiles parameter');
             var buildFolder = tl.getVariable('System.DefaultWorkingDirectory');
             var allFiles = tl.find(buildFolder);
-            var matchingTestResultsFiles = tl.match(allFiles, testResultsFiles, { matchBase: true });
+            var matchingTestResultsFiles = minimatch.match(allFiles, testResultsFiles, { matchBase: true });
         }
         else {
             tl.debug('No pattern found in testResultsFiles parameter');
@@ -99,7 +100,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
         }
         var tp = new tl.TestPublisher("JUnit");
         try {
-			tp.publish(matchingTestResultsFiles, true, "", "", "", true);
+			tp.publish(matchingTestResultsFiles, 'true', "", "", "", 'true');
 		} catch (error) {
 			tl.warning(error);
 		}

--- a/Tasks/GruntV0/package-lock.json
+++ b/Tasks/GruntV0/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -23,32 +36,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -57,23 +44,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "q": {
       "version": "1.5.1",
@@ -90,32 +64,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.7.4.tgz",
-      "integrity": "sha1-RJbh53GzHa/sdGd2p0NYoKEmNsI=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/Tasks/GruntV0/package.json
+++ b/Tasks/GruntV0/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^0.7.4"
+    "azure-pipelines-task-lib": "^2.9.3",
+    "minimatch": "^3.0.4"
   }
 }

--- a/Tasks/GruntV0/task.json
+++ b/Tasks/GruntV0/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [
         "node.js"

--- a/Tasks/GruntV0/task.loc.json
+++ b/Tasks/GruntV0/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [
     "node.js"

--- a/Tasks/GulpV0/gulptask.ts
+++ b/Tasks/GulpV0/gulptask.ts
@@ -1,11 +1,13 @@
 /// <reference path="typings/index.d.ts" />
 
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
+import minimatch = require('minimatch');
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 var gulpFile = tl.getPathInput('gulpFile', true, true);
+tl.debug('check gulp file :' + gulpFile);
 var gulp = tl.which('gulp', false);
 var isCodeCoverageEnabled = tl.getBoolInput('enableCodeCoverage');
 var publishJUnitResults = tl.getBoolInput('publishJUnitResults');
@@ -17,33 +19,33 @@ tl.cd(cwd);
 tl.debug('check path : ' + gulp);
 if (!tl.exist(gulp)) {
 	tl.debug('not found global installed gulp, try to find gulp locally.');
-	var gt = tl.createToolRunner(tl.which('node', true));
+	var gt = tl.tool(tl.which('node', true));
 	var gulpjs = tl.getInput('gulpjs', true);
 	gulpjs = path.resolve(cwd, gulpjs);
 	tl.debug('check path : ' + gulpjs);
 	if (!tl.exist(gulpjs)) {
 		tl.setResult(tl.TaskResult.Failed, tl.loc('GulpNotInstalled', gulpjs));
 	}
-	gt.pathArg(gulpjs);
+	gt.arg(gulpjs);
 }
 else {
-	var gt = tl.createToolRunner(gulp);
+	var gt = tl.tool(gulp);
 }
 
 if (isCodeCoverageEnabled) {
-	var npm = tl.createToolRunner(tl.which('npm', true));
-	npm.argString('install istanbul');
+	var npm = tl.tool(tl.which('npm', true));
+	npm.line('install istanbul');
 	var testFramework = tl.getInput('testFramework', true);
 	var srcFiles = tl.getInput('srcFiles', false);
 	var testSrc = tl.getPathInput('testFiles', true, false);
-	var istanbul = tl.createToolRunner(tl.which('node', true));
+	var istanbul = tl.tool(tl.which('node', true));
 	istanbul.arg('./node_modules/istanbul/lib/cli.js');
-	istanbul.argString('cover --report cobertura --report html');
+	istanbul.line('cover --report cobertura --report html');
 	if (srcFiles) {
-		istanbul.argString('-i .' + path.sep + path.join(srcFiles));
+		istanbul.line('-i .' + path.sep + path.join(srcFiles));
 	}
 	if (testFramework.toLowerCase() == 'jasmine') {
-		istanbul.argString('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
+		istanbul.line('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
 	} else {
 		istanbul.arg('./node_modules/mocha/bin/_mocha');
 	}
@@ -54,9 +56,8 @@ if (isCodeCoverageEnabled) {
 
 // optional - no targets will concat nothing
 gt.arg(tl.getDelimitedInput('targets', ' ', false));
-gt.arg('--gulpfile');
-gt.pathArg(gulpFile);
-gt.argString(tl.getInput('arguments', false));
+gt.arg(['--gulpfile', gulpFile]);
+gt.line(tl.getInput('arguments', false));
 gt.exec().then(function (code) {
 	publishTestResults(publishJUnitResults, testResultsFiles);
 	if (isCodeCoverageEnabled) {
@@ -89,7 +90,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
             tl.debug('Pattern found in testResultsFiles parameter');
             var buildFolder = tl.getVariable('System.DefaultWorkingDirectory');
             var allFiles = tl.find(buildFolder);
-            var matchingTestResultsFiles = tl.match(allFiles, testResultsFiles, { matchBase: true });
+            var matchingTestResultsFiles = minimatch.match(allFiles, testResultsFiles, { matchBase: true });
         }
         else {
             tl.debug('No pattern found in testResultsFiles parameter');
@@ -101,7 +102,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
         }
         var tp = new tl.TestPublisher("JUnit");
 		try {
-			tp.publish(matchingTestResultsFiles, true, "", "", "", true);
+			tp.publish(matchingTestResultsFiles, 'true', "", "", "", 'true');
 		} catch (error) {
 			tl.warning(error);
 		}

--- a/Tasks/GulpV0/package-lock.json
+++ b/Tasks/GulpV0/package-lock.json
@@ -3,6 +3,19 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -22,32 +35,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -56,23 +43,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "q": {
       "version": "1.5.1",
@@ -89,32 +63,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.7.4.tgz",
-      "integrity": "sha1-RJbh53GzHa/sdGd2p0NYoKEmNsI=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/Tasks/GulpV0/package.json
+++ b/Tasks/GulpV0/package.json
@@ -12,6 +12,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^0.7.4"
+    "azure-pipelines-task-lib": "^2.9.3",
+    "minimatch": "^3.0.4"
   }
 }

--- a/Tasks/GulpV0/task.json
+++ b/Tasks/GulpV0/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 151,
-        "Patch": 1
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [
         "node.js"

--- a/Tasks/GulpV0/task.loc.json
+++ b/Tasks/GulpV0/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 151,
-    "Patch": 1
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [
     "node.js"

--- a/Tasks/GulpV1/gulptask.ts
+++ b/Tasks/GulpV1/gulptask.ts
@@ -1,5 +1,6 @@
 import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
+import minimatch = require('minimatch');
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
 
@@ -8,6 +9,7 @@ tl.mkdirP(cwd);
 tl.cd(cwd);
 
 var gulpFile = tl.getPathInput('gulpFile', true, true);
+tl.debug('check gulp file :' + gulpFile);
 var isCodeCoverageEnabled = tl.getBoolInput('enableCodeCoverage');
 var publishJUnitResults = tl.getBoolInput('publishJUnitResults');
 var testResultsFiles = tl.getInput('testResultsFiles', publishJUnitResults);
@@ -21,29 +23,29 @@ if (gulpjs) {
     if (!tl.exist(gulpjs)) {
         tl.setResult(tl.TaskResult.Failed, tl.loc('GulpNotInstalled', gulpjs));
     }
-    var gt = tl.createToolRunner(tl.which('node', true));
-    gt.pathArg(gulpjs);
+    var gt = tl.tool(tl.which('node', true));
+    gt.arg(gulpjs);
 }
 else {
     tl.debug('gulpjs not set');
     var gulp = tl.which('gulp', true);
-    var gt = tl.createToolRunner(gulp);
+    var gt = tl.tool(gulp);
 }
 
 if (isCodeCoverageEnabled) {
-    var npm = tl.createToolRunner(tl.which('npm', true));
-    npm.argString('install istanbul');
+    var npm = tl.tool(tl.which('npm', true));
+    npm.line('install istanbul');
     var testFramework = tl.getInput('testFramework', true);
     var srcFiles = tl.getInput('srcFiles', false);
     var testSrc = tl.getPathInput('testFiles', true, false);
-    var istanbul = tl.createToolRunner(tl.which('node', true));
+    var istanbul = tl.tool(tl.which('node', true));
     istanbul.arg('./node_modules/istanbul/lib/cli.js');
-    istanbul.argString('cover --report cobertura --report html');
+    istanbul.line('cover --report cobertura --report html');
     if (srcFiles) {
-        istanbul.argString('-i .' + path.sep + path.join(srcFiles));
+        istanbul.line('-i .' + path.sep + path.join(srcFiles));
     }
     if (testFramework.toLowerCase() == 'jasmine') {
-        istanbul.argString('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
+        istanbul.line('./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=node_modules/jasmine/lib/examples/jasmine.json');
     } else {
         istanbul.arg('./node_modules/mocha/bin/_mocha');
     }
@@ -54,9 +56,8 @@ if (isCodeCoverageEnabled) {
 
 // optional - no targets will concat nothing
 gt.arg(tl.getDelimitedInput('targets', ' ', false));
-gt.arg('--gulpfile');
-gt.pathArg(gulpFile);
-gt.argString(tl.getInput('arguments', false));
+gt.arg(['--gulpfile', gulpFile]);
+gt.line(tl.getInput('arguments', false));
 gt.exec().then(function (code) {
     publishTestResults(publishJUnitResults, testResultsFiles);
     if (isCodeCoverageEnabled) {
@@ -89,7 +90,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
             tl.debug('Pattern found in testResultsFiles parameter');
             var buildFolder = tl.getVariable('System.DefaultWorkingDirectory');
             var allFiles = tl.find(buildFolder);
-            var matchingTestResultsFiles = tl.match(allFiles, testResultsFiles, { matchBase: true });
+            var matchingTestResultsFiles = minimatch.match(allFiles, testResultsFiles, { matchBase: true });
         }
         else {
             tl.debug('No pattern found in testResultsFiles parameter');
@@ -101,7 +102,7 @@ function publishTestResults(publishJUnitResults, testResultsFiles: string) {
         }
         var tp = new tl.TestPublisher("JUnit");
         try {
-            tp.publish(matchingTestResultsFiles, true, "", "", "", true);
+            tp.publish(matchingTestResultsFiles, 'true', "", "", "", 'true');
         } catch (error) {
             tl.warning(error);
         }

--- a/Tasks/GulpV1/package-lock.json
+++ b/Tasks/GulpV1/package-lock.json
@@ -13,6 +13,19 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
       "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -32,32 +45,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -66,23 +53,10 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "node-uuid": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "q": {
       "version": "1.5.1",
@@ -99,32 +73,10 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
-    "vso-node-api": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-0.6.1.tgz",
-      "integrity": "sha1-nT3Qao2uL/NoKvjyioRXOaC9ZIE=",
-      "requires": {
-        "q": "^1.0.1"
-      }
-    },
-    "vsts-task-lib": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-0.7.4.tgz",
-      "integrity": "sha1-RJbh53GzHa/sdGd2p0NYoKEmNsI=",
-      "requires": {
-        "glob": "^6.0.1",
-        "minimatch": "^3.0.0",
-        "node-uuid": "^1.4.7",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "vso-node-api": "^0.6.1"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/Tasks/GulpV1/package.json
+++ b/Tasks/GulpV1/package.json
@@ -12,7 +12,8 @@
   },
   "homepage": "https://github.com/microsoft/vsts-tasks#readme",
   "dependencies": {
-    "vsts-task-lib": "^0.7.4",
+    "azure-pipelines-task-lib": "^2.9.3",
+    "minimatch": "^3.0.4",
     "@types/node": "^6.0.101",
     "@types/q": "^1.0.7"
   }

--- a/Tasks/GulpV1/task.json
+++ b/Tasks/GulpV1/task.json
@@ -17,7 +17,7 @@
     "preview": true,
     "version": {
         "Major": 1,
-        "Minor": 158,
+        "Minor": 166,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/GulpV1/task.loc.json
+++ b/Tasks/GulpV1/task.loc.json
@@ -17,7 +17,7 @@
   "preview": true,
   "version": {
     "Major": 1,
-    "Minor": 158,
+    "Minor": 166,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "MSBuild",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?LinkID=613724)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=613724)",
   "loc.description": "Build with MSBuild",
   "loc.instanceNameFormat": "Build solution $(solution)",
   "loc.group.displayName.advanced": "Advanced",

--- a/Tasks/MSBuildV1/Tests/L0.ts
+++ b/Tasks/MSBuildV1/Tests/L0.ts
@@ -1,6 +1,6 @@
 import assert = require('assert');
 import path = require('path');
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 var psm = require('../../../Tests/lib/psRunner');
 var psr = null;
 

--- a/Tasks/MSBuildV1/Tests/L0MSBuildClean.ts
+++ b/Tasks/MSBuildV1/Tests/L0MSBuildClean.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
 let taskPath = path.join(__dirname, '..', 'msbuild.js');

--- a/Tasks/MSBuildV1/Tests/L0MSBuildDefaults.ts
+++ b/Tasks/MSBuildV1/Tests/L0MSBuildDefaults.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
 let taskPath = path.join(__dirname, '..', 'msbuild.js');

--- a/Tasks/MSBuildV1/Tests/L0MSBuildMultipleSolutions.ts
+++ b/Tasks/MSBuildV1/Tests/L0MSBuildMultipleSolutions.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
 let taskPath = path.join(__dirname, '..', 'msbuild.js');

--- a/Tasks/MSBuildV1/msbuild.ts
+++ b/Tasks/MSBuildV1/msbuild.ts
@@ -1,6 +1,6 @@
 import path = require('path');
-import tl = require('vsts-task-lib/task');
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import tl = require('azure-pipelines-task-lib/task');
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 import msbuildHelpers = require('msbuildhelpers/msbuildhelpers');
 
 async function run() {
@@ -38,7 +38,7 @@ async function run() {
             msbuildTool = tl.getInput('msbuildLocation');
         } 
 
-        let filesList: string[] = tl.findMatch(null, solution, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false }, { matchBase: true });
+        let filesList: string[] = tl.findMatch(null, solution, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false, allowBrokenSymbolicLinks: false }, { matchBase: true });
         for (let file of filesList) {
             if (clean) {
                 let cleanTool: ToolRunner = tl.tool(msbuildTool);

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -3,6 +3,19 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -38,7 +51,7 @@
     "msbuildhelpers": {
       "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz",
       "requires": {
-        "vsts-task-lib": "^2.0.3-preview"
+        "azure-pipelines-task-lib": "^2.9.3"
       }
     },
     "q": {
@@ -60,19 +73,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "vsts-task-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-      "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-      "requires": {
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
-      }
     }
   }
 }

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz",
-    "vsts-task-lib": "^2.0.3-preview"
+    "azure-pipelines-task-lib": "^2.9.3",
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz"
   }
 }

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 161,
-        "Patch": 3
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 161,
-    "Patch": 3
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [
     "msbuild"

--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -1,6 +1,6 @@
 import assert = require('assert');
 import path = require('path');
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('NodeTool Suite', function () {
     this.timeout(60000);

--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -5,6 +5,18 @@ import * as ttm from 'azure-pipelines-task-lib/mock-test';
 describe('NodeTool Suite', function () {
     this.timeout(60000);
 
+    function runValidations(validator: () => void, tr, done) {
+        try {
+            validator();
+            done();
+        }
+        catch (error) {
+            console.log("STDERR", tr.stderr);
+            console.log("STDOUT", tr.stdout);
+            done(error);
+        }
+    }
+
     it('Succeeds when the first download is available', (done: MochaDone) => {
         this.timeout(5000);
 
@@ -12,12 +24,11 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        console.log("STDERR", tr.stderr);
 
-        assert(tr.succeeded, 'NodeTool should have succeeded.');
-        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
-
-        done();
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
     });
 
     it('Succeeds when the second download is available', (done: MochaDone) => {
@@ -27,12 +38,11 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        console.log("STDERR", tr.stderr);
 
-        assert(tr.succeeded, 'NodeTool should have succeeded.');
-        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
-
-        done();
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
     });
 
     it('Succeeds when the third download is available', (done: MochaDone) => {
@@ -42,12 +52,11 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        console.log("STDERR", tr.stderr);
 
-        assert(tr.succeeded, 'NodeTool should have succeeded.');
-        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
-
-        done();
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
     });
 
     it('Removes "v" prefixes when evaluating latest version', (done: MochaDone) => {
@@ -57,12 +66,11 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
-        console.log("STDERR", tr.stderr);
 
-        assert(tr.succeeded, 'NodeTool should have succeeded.');
-        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
-
-        done();
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
     });
 
 });

--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -12,6 +12,7 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        console.log("STDERR", tr.stderr);
 
         assert(tr.succeeded, 'NodeTool should have succeeded.');
         assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
@@ -26,6 +27,7 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        console.log("STDERR", tr.stderr);
 
         assert(tr.succeeded, 'NodeTool should have succeeded.');
         assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
@@ -40,6 +42,7 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        console.log("STDERR", tr.stderr);
 
         assert(tr.succeeded, 'NodeTool should have succeeded.');
         assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
@@ -54,6 +57,7 @@ describe('NodeTool Suite', function () {
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         tr.run();
+        console.log("STDERR", tr.stderr);
 
         assert(tr.succeeded, 'NodeTool should have succeeded.');
         assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');

--- a/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import os = require('os');
 import path = require('path');
 
@@ -17,7 +17,7 @@ tmr.setAnswers(a);
 
 
 //Create assertAgent and getVariable mocks
-const tl = require('vsts-task-lib/mock-task');
+const tl = require('azure-pipelines-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
     if (variable.toLowerCase() == 'agent.tempdirectory') {
@@ -28,10 +28,10 @@ tlClone.getVariable = function(variable: string) {
 tlClone.assertAgent = function(variable: string) {
     return;
 };
-tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('vsts-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0FirstDownloadSuccess.ts
@@ -31,7 +31,7 @@ tlClone.assertAgent = function(variable: string) {
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0GetsLatestVersion.ts
+++ b/Tasks/NodeToolV0/Tests/L0GetsLatestVersion.ts
@@ -1,4 +1,4 @@
-import tmrm = require('vsts-task-lib/mock-run');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import assert = require('assert');
 import path = require('path');
 
@@ -9,7 +9,7 @@ tmr.setInput('versionSpec', '>=12.0.0');
 tmr.setInput('checkLatest', 'true');
 
 //Create tool-lib mock
-tmr.registerMock('vsts-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
     isExplicitVersion: function() {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0GetsLatestVersion.ts
+++ b/Tasks/NodeToolV0/Tests/L0GetsLatestVersion.ts
@@ -9,7 +9,7 @@ tmr.setInput('versionSpec', '>=12.0.0');
 tmr.setInput('checkLatest', 'true');
 
 //Create tool-lib mock
-tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
     isExplicitVersion: function() {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import os = require('os');
 import path = require('path');
 
@@ -17,7 +17,7 @@ tmr.setAnswers(a);
 
 
 //Create assertAgent and getVariable mocks
-const tl = require('vsts-task-lib/mock-task');
+const tl = require('azure-pipelines-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
     if (variable.toLowerCase() == 'agent.tempdirectory') {
@@ -28,10 +28,10 @@ tlClone.getVariable = function(variable: string) {
 tlClone.assertAgent = function(variable: string) {
     return;
 };
-tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('vsts-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0SecondDownloadSuccess.ts
@@ -31,7 +31,7 @@ tlClone.assertAgent = function(variable: string) {
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import os = require('os');
 import path = require('path');
 
@@ -17,7 +17,7 @@ tmr.setAnswers(a);
 
 
 //Create assertAgent and getVariable mocks
-const tl = require('vsts-task-lib/mock-task');
+const tl = require('azure-pipelines-task-lib/mock-task');
 const tlClone = Object.assign({}, tl);
 tlClone.getVariable = function(variable: string) {
     if (variable.toLowerCase() == 'agent.tempdirectory') {
@@ -28,10 +28,10 @@ tlClone.getVariable = function(variable: string) {
 tlClone.assertAgent = function(variable: string) {
     return;
 };
-tmr.registerMock('vsts-task-lib/mock-task', tlClone);
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('vsts-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
+++ b/Tasks/NodeToolV0/Tests/L0ThirdDownloadSuccess.ts
@@ -31,7 +31,7 @@ tlClone.assertAgent = function(variable: string) {
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
 //Create tool-lib mock
-tmr.registerMock('azure-pipelines-task-tool-lib/tool', {
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
     isExplicitVersion: function(versionSpec) {
         return false;
     },

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -1,5 +1,5 @@
-import * as taskLib from 'vsts-task-lib/task';
-import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as taskLib from 'azure-pipelines-task-lib/task';
+import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as restm from 'typed-rest-client/RestClient';
 import * as os from 'os';
 import * as path from 'path';

--- a/Tasks/NodeToolV0/package-lock.json
+++ b/Tasks/NodeToolV0/package-lock.json
@@ -32,6 +32,44 @@
         "@types/node": "*"
       }
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "azure-pipelines-tool-lib": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
+      "requires": {
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "azure-pipelines-task-lib": "^2.8.0",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "1.0.9",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -107,33 +145,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "vsts-task-lib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.4.0.tgz",
-      "integrity": "sha512-AqKNrYw6ebzlaV6o09TTWE9LxcywQPanPeocss8BUJXJFEMLRYr3ZyzzjM+lvvsgcYth74VXoHtkBonBpx//Tg==",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "vsts-task-tool-lib": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.9.0.tgz",
-      "integrity": "sha512-UjqceSJ0GLENtgDz2rXGcmR3Ehn3j7iNmbzzsnQlHNhR6gdkRlp5t9eAmMULmag1da6YAvZWVYBy37J5vQriWQ==",
-      "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.0.1",
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "1.0.7",
-        "uuid": "^3.0.1",
-        "vsts-task-lib": "2.4.0"
-      }
     }
   }
 }

--- a/Tasks/NodeToolV0/package.json
+++ b/Tasks/NodeToolV0/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^6.0.101",
     "@types/q": "^1.0.7",
     "typed-rest-client": "1.0.7",
-    "vsts-task-lib": "2.4.0",
-    "vsts-task-tool-lib": "0.9.0"
+    "azure-pipelines-task-lib": "^2.9.3",
+    "azure-pipelines-tool-lib": "^0.12.0"
   }
 }

--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 160,
+        "Minor": 166,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 160,
+    "Minor": 166,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 161,
-        "Patch": 3
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 161,
-    "Patch": 3
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [
     "msbuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 161,
-        "Patch": 2
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamariniOSV2/Tests/L0.ts
+++ b/Tasks/XamariniOSV2/Tests/L0.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import * as assert from 'assert';
-import * as ttm from 'vsts-task-lib/mock-test';
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('XamariniOS L0 Suite', function () {
     before(() => {

--- a/Tasks/XamariniOSV2/Tests/L0BuildToolLocation.ts
+++ b/Tasks/XamariniOSV2/Tests/L0BuildToolLocation.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0CleanBuild.ts
+++ b/Tasks/XamariniOSV2/Tests/L0CleanBuild.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0DefaultInputs.ts
+++ b/Tasks/XamariniOSV2/Tests/L0DefaultInputs.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0FallbackXbuild.ts
+++ b/Tasks/XamariniOSV2/Tests/L0FallbackXbuild.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MSBuildDefault.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MSBuildDefault.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MSBuildLocation.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MSBuildLocation.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MSBuildNotFound.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MSBuildNotFound.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MissingConfig.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MissingConfig.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MissingSolution.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MissingSolution.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0MultipleWildcardMatch.ts
+++ b/Tasks/XamariniOSV2/Tests/L0MultipleWildcardMatch.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0NoWildcardMatch.ts
+++ b/Tasks/XamariniOSV2/Tests/L0NoWildcardMatch.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0NuGetNotFound.ts
+++ b/Tasks/XamariniOSV2/Tests/L0NuGetNotFound.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0OneWildcardMatch.ts
+++ b/Tasks/XamariniOSV2/Tests/L0OneWildcardMatch.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0RunOnWindows.ts
+++ b/Tasks/XamariniOSV2/Tests/L0RunOnWindows.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0SignWithIds.ts
+++ b/Tasks/XamariniOSV2/Tests/L0SignWithIds.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0SkipNugetRestore.ts
+++ b/Tasks/XamariniOSV2/Tests/L0SkipNugetRestore.ts
@@ -1,6 +1,6 @@
 
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/Tests/L0ToolsNotFound.ts
+++ b/Tasks/XamariniOSV2/Tests/L0ToolsNotFound.ts
@@ -1,5 +1,5 @@
-import ma = require('vsts-task-lib/mock-answer');
-import tmrm = require('vsts-task-lib/mock-run');
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 import os = require('os');
 

--- a/Tasks/XamariniOSV2/ThirdPartyNotice.txt
+++ b/Tasks/XamariniOSV2/ThirdPartyNotice.txt
@@ -15,7 +15,7 @@ This Azure DevOps extension (XamariniOSV2) is based on or incorporates material 
 9.	semver (git+https://github.com/npm/node-semver.git)
 10.	shelljs (git://github.com/arturadib/shelljs.git)
 11.	uuid (git+https://github.com/kelektiv/node-uuid.git)
-12.	vsts-task-lib (git+https://github.com/Microsoft/vsts-task-lib.git)
+12.	azure-pipelines-task-lib (git+https://github.com/Microsoft/azure-pipelines-task-lib.git)
 
 
 %% @types/mocha NOTICES, INFORMATION, AND LICENSE BEGIN HERE
@@ -274,7 +274,7 @@ SOFTWARE.
 =========================================
 END OF uuid NOTICES, INFORMATION, AND LICENSE
 
-%% vsts-task-lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
+%% azure-pipelines-task-lib NOTICES, INFORMATION, AND LICENSE BEGIN HERE
 =========================================
 The MIT License (MIT)
 
@@ -298,5 +298,5 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 =========================================
-END OF vsts-task-lib NOTICES, INFORMATION, AND LICENSE
+END OF azure-pipelines-task-lib NOTICES, INFORMATION, AND LICENSE
 

--- a/Tasks/XamariniOSV2/make.json
+++ b/Tasks/XamariniOSV2/make.json
@@ -9,7 +9,7 @@
     "rm": [
          {
             "items": [
-                "node_modules/msbuildhelpers/node_modules/vsts-task-lib"
+                "node_modules/msbuildhelpers/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/XamariniOSV2/package-lock.json
+++ b/Tasks/XamariniOSV2/package-lock.json
@@ -9,6 +9,19 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.118.tgz",
       "integrity": "sha512-N33cKXGSqhOYaPiT4xUGsYlPPDwFtQM/6QxJxuMXA/7BcySW+lkn2yigWP7vfs4daiL/7NJNU6DMCqg5N4B+xQ=="
     },
+    "azure-pipelines-task-lib": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
+      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -44,7 +57,7 @@
     "msbuildhelpers": {
       "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz",
       "requires": {
-        "vsts-task-lib": "^2.0.3-preview"
+        "azure-pipelines-task-lib": "^2.9.3"
       }
     },
     "q": {

--- a/Tasks/XamariniOSV2/package-lock.json
+++ b/Tasks/XamariniOSV2/package-lock.json
@@ -79,19 +79,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-    },
-    "vsts-task-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-      "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-      "requires": {
-        "minimatch": "^3.0.0",
-        "mockery": "^1.7.0",
-        "q": "^1.1.2",
-        "semver": "^5.1.0",
-        "shelljs": "^0.3.0",
-        "uuid": "^3.0.1"
-      }
     }
   }
 }

--- a/Tasks/XamariniOSV2/package.json
+++ b/Tasks/XamariniOSV2/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/node": "^6.0.101",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz",
-    "vsts-task-lib": "^2.0.3-preview"
+    "azure-pipelines-task-lib": "^2.9.3",
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.0.0.tgz"
   }
 }

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 161,
-        "Patch": 2
+        "Minor": 166,
+        "Patch": 0
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",
     "demands": [

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 161,
-    "Patch": 2
+    "Minor": 166,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/XamariniOSV2/xamarinios.ts
+++ b/Tasks/XamariniOSV2/xamarinios.ts
@@ -1,16 +1,16 @@
 ﻿import path = require('path');
-import tl = require('vsts-task-lib/task');
+import tl = require('azure-pipelines-task-lib/task');
 import msbuildhelpers = require('msbuildhelpers/msbuildhelpers');
 import os = require('os');
 
-import { ToolRunner } from 'vsts-task-lib/toolrunner';
+import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 
 /**
  * Find all filenames starting from `rootDirectory` that match a wildcard pattern.
  * @param solutionPattern A filename pattern to evaluate, possibly containing wildcards.
  */
 function expandSolutionWildcardPatterns(solutionPattern: string): string {
-    const matchedSolutionFiles = tl.findMatch(null, solutionPattern, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false });
+    const matchedSolutionFiles = tl.findMatch(null, solutionPattern, { followSymbolicLinks: false, followSpecifiedSymbolicLink: false, allowBrokenSymbolicLinks: false });
     tl.debug(`Found ${matchedSolutionFiles ? matchedSolutionFiles.length : 0} solution files matching the pattern.`);
 
     if (matchedSolutionFiles && matchedSolutionFiles.length > 0) {


### PR DESCRIPTION
This is for [Bug 1670734: Tasks currently warning due to node security patch](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1670734/)

Tasks that were updated:
- CMakeV1
- MSBuildHelpers
- GruntV0
- GulpV0
- GulpV1
- MSBuildV1
- NodeToolV0

Tasks that depend on MSBuildHelpers and required version bump:
- XamariniOSV2 - also required updating to the new task lib version due to failing tests
- VSBuildV1
- XamarinAndroidV1