### PR TITLE
Update helpUrl of container tasks to a redirection link

### DIFF
--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -3,7 +3,7 @@
     "name": "DockerCompose",
     "friendlyName": "Docker Compose",
     "description": "Build, push or run multi-container Docker applications. Task can be used with Docker or Azure Container registry.",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/docker-compose",
+    "helpUrl": "https://aka.ms/azpipes-docker-compose-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=848006) or [see the Docker Compose documentation](https://docs.docker.com/)",
     "category": "Build",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 160,
-        "Patch": 4
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -3,7 +3,7 @@
   "name": "DockerCompose",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/docker-compose",
+  "helpUrl": "https://aka.ms/azpipes-docker-compose-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
   "visibility": [
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 160,
-    "Patch": 4
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerInstallerV0/task.json
+++ b/Tasks/DockerInstallerV0/task.json
@@ -3,7 +3,7 @@
     "name": "DockerInstaller",
     "friendlyName": "Docker CLI installer",
     "description": "Install Docker CLI on agent machine.",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/docker-installer",
+    "helpUrl": "https://aka.ms/azpipes-docker-installer-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Tool",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 1,
-        "Patch": 4
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/DockerInstallerV0/task.loc.json
+++ b/Tasks/DockerInstallerV0/task.loc.json
@@ -3,7 +3,7 @@
   "name": "DockerInstaller",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/docker-installer",
+  "helpUrl": "https://aka.ms/azpipes-docker-installer-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Tool",
   "visibility": [
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 1,
-    "Patch": 4
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -3,7 +3,7 @@
     "name": "Docker",
     "friendlyName": "Docker",
     "description": "Build or push Docker images, login or logout, or run a Docker command",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/docker",
+    "helpUrl": "https://aka.ms/azpipes-docker-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=848006) or [see the Docker documentation](https://docs.docker.com/)",
     "category": "Build",
     "visibility": [
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 165,
+        "Minor": 166,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -3,7 +3,7 @@
   "name": "Docker",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/docker",
+  "helpUrl": "https://aka.ms/azpipes-docker-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
   "visibility": [
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 165,
+    "Minor": 166,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -3,7 +3,7 @@
     "name": "HelmDeploy",
     "friendlyName": "Package and deploy Helm charts",
     "description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running helm commands",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/helm-deploy",
+    "helpUrl": "https://aka.ms/azpipes-helm-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Helm documentation](https://helm.sh/docs/)",
     "category": "Deploy",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 165,
-        "Patch": 1
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "groups": [{

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -3,7 +3,7 @@
   "name": "HelmDeploy",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/helm-deploy",
+  "helpUrl": "https://aka.ms/azpipes-helm-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
@@ -13,11 +13,12 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 165,
-    "Patch": 1
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
-  "groups": [{
+  "groups": [
+    {
       "name": "cluster",
       "displayName": "ms-resource:loc.group.displayName.cluster",
       "isExpanded": true,
@@ -41,7 +42,8 @@
       "visibleRule": "command != login && command != logout && command != package"
     }
   ],
-  "inputs": [{
+  "inputs": [
+    {
       "name": "connectionType",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.connectionType",

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -3,7 +3,7 @@
     "name": "HelmInstaller",
     "friendlyName": "Helm tool installer",
     "description": "Install Helm on an agent machine",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/helm-installer",
+    "helpUrl": "https://aka.ms/azpipes-helm-installer-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275)",
     "category": "Tool",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 165,
-        "Patch": 1
+        "Minor": 166,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -3,7 +3,7 @@
   "name": "HelmInstaller",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/tool/helm-installer",
+  "helpUrl": "https://aka.ms/azpipes-helm-installer-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Tool",
   "visibility": [
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 165,
-    "Patch": 1
+    "Minor": 166,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],
@@ -22,13 +22,15 @@
     "Helm"
   ],
   "groups": [],
-  "inputs": [{
-    "name": "helmVersionToInstall",
-    "label": "ms-resource:loc.input.label.helmVersionToInstall",
-    "type": "string",
-    "helpMarkDown": "ms-resource:loc.input.help.helmVersionToInstall",
-    "defaultValue": "latest"
-  }],
+  "inputs": [
+    {
+      "name": "helmVersionToInstall",
+      "label": "ms-resource:loc.input.label.helmVersionToInstall",
+      "type": "string",
+      "helpMarkDown": "ms-resource:loc.input.help.helmVersionToInstall",
+      "defaultValue": "latest"
+    }
+  ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node": {

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -3,7 +3,7 @@
     "name": "KubectlInstaller",
     "friendlyName": "Kubectl tool installer",
     "description": "Install Kubectl on agent machine",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks",
+    "helpUrl": "https://aka.ms/azpipes-kubectl-installer-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Kubernetes documentation](https://kubernetes.io/docs/home/)",
     "category": "Tool",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 165,
-        "Patch": 1
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -3,7 +3,7 @@
   "name": "KubectlInstaller",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks",
+  "helpUrl": "https://aka.ms/azpipes-kubectl-installer-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Tool",
   "visibility": [
@@ -13,21 +13,23 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 165,
-    "Patch": 1
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [
     "Kubectl"
   ],
   "groups": [],
-  "inputs": [{
-    "name": "kubectlVersion",
-    "label": "ms-resource:loc.input.label.kubectlVersion",
-    "type": "string",
-    "helpMarkDown": "ms-resource:loc.input.help.kubectlVersion",
-    "defaultValue": "latest"
-  }],
+  "inputs": [
+    {
+      "name": "kubectlVersion",
+      "label": "ms-resource:loc.input.label.kubectlVersion",
+      "type": "string",
+      "helpMarkDown": "ms-resource:loc.input.help.kubectlVersion",
+      "defaultValue": "latest"
+    }
+  ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node": {

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -3,7 +3,7 @@
     "name": "KubernetesManifest",
     "friendlyName": "Deploy to Kubernetes",
     "description": "Use Kubernetes manifest files to deploy to clusters or even bake the manifest files to be used for deployments using Helm charts",
-    "helpUrl": "https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/kubernetes-manifest",
+    "helpUrl": "https://aka.ms/azpipes-k8s-manifest-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Kubernetes documentation](https://kubernetes.io/docs/home/)",
     "category": "Deploy",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 165,
-        "Patch": 4
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -3,7 +3,7 @@
   "name": "KubernetesManifest",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/deploy/kubernetes-manifest",
+  "helpUrl": "https://aka.ms/azpipes-k8s-manifest-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 165,
-    "Patch": 4
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -3,7 +3,7 @@
     "name": "Kubernetes",
     "friendlyName": "Kubectl",
     "description": "Deploy, configure, update a Kubernetes cluster in Azure Container Service by running kubectl commands",
-    "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/kubernetes",
+    "helpUrl": "https://aka.ms/azpipes-kubectl-tsg",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=851275) or [see the Kubernetes documentation](https://kubernetes.io/docs/home/)",
     "category": "Deploy",
     "visibility": [
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 165,
-        "Patch": 2
+        "Minor": 166,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -3,7 +3,7 @@
   "name": "Kubernetes",
   "friendlyName": "ms-resource:loc.friendlyName",
   "description": "ms-resource:loc.description",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/kubernetes",
+  "helpUrl": "https://aka.ms/azpipes-kubectl-tsg",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Deploy",
   "visibility": [
@@ -13,12 +13,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 165,
-    "Patch": 2
+    "Minor": 166,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
-  "groups": [{
+  "groups": [
+    {
       "name": "kubernetesCluster",
       "displayName": "ms-resource:loc.group.displayName.kubernetesCluster",
       "isExpanded": true,
@@ -53,7 +54,8 @@
       "visibleRule": "command != login && command != logout"
     }
   ],
-  "inputs": [{
+  "inputs": [
+    {
       "name": "connectionType",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.connectionType",
@@ -417,7 +419,8 @@
       }
     }
   ],
-  "dataSourceBindings": [{
+  "dataSourceBindings": [
+    {
       "target": "azureContainerRegistry",
       "endpointId": "$(azureSubscriptionEndpointForSecrets)",
       "dataSourceName": "AzureRMContainerRegistries",
@@ -439,10 +442,12 @@
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
-  "outputVariables": [{
-    "name": "KubectlOutput",
-    "description": "Stores the output of the kubectl command"
-  }],
+  "outputVariables": [
+    {
+      "name": "KubectlOutput",
+      "description": "Stores the output of the kubectl command"
+    }
+  ],
   "execution": {
     "Node": {
       "target": "src//kubernetes.js"


### PR DESCRIPTION
We are setting the help url of these tasks to a redirection link. These tasks currently don't have a troubleshooting section so we are pointing the help link to the task documentation itself. Once we add the trouble shooting section, we will point the redirection url to that section