### PR TITLE
Admin username/password no longer required

### DIFF
--- a/Tasks/WindowsMachineFileCopyV2/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/RoboCopyJob.ps1
@@ -172,7 +172,14 @@ param (
         {
             try
             {
-                New-PSDrive -Name WFCPSDrive -PSProvider FileSystem -Root $destPath -Credential $psCredentialObject -ErrorAction 'Stop'
+				if ($psCredentialObject)
+				{
+					New-PSDrive -Name WFCPSDrive -PSProvider FileSystem -Root $destPath -Credential $psCredentialObject -ErrorAction 'Stop'
+				}
+				else
+				{
+					New-PSDrive -Name WFCPSDrive -PSProvider FileSystem -Root $destPath -ErrorAction 'Stop'
+				}
                 $foundParentPath = $true
                 Write-Verbose "Found parent path"
                 $relativePath = $path.Substring($destPath.Length)
@@ -205,10 +212,14 @@ param (
         }
     }
 
-    Validate-Credential $credential
-    $userName = Get-DownLevelLogonName -fqdn $fqdn -userName $($credential.UserName)
-    $password = $($credential.Password)  
-    $psCredentialObject = New-Object pscredential -ArgumentList $userName, (ConvertTo-SecureString -String $password -AsPlainText -Force)
+    $psCredentialObject = $null
+	if ($credential)
+	{
+		Validate-Credential $credential
+		$userName = Get-DownLevelLogonName -fqdn $fqdn -userName $($credential.UserName)
+		$password = $($credential.Password)  
+		$psCredentialObject = New-Object pscredential -ArgumentList $userName, (ConvertTo-SecureString -String $password -AsPlainText -Force)
+	}
    
     $machineShare = Get-MachineShare -fqdn $fqdn -targetPath $targetPath    
     $destinationNetworkPath = Get-DestinationNetworkPath -targetPath $targetPath -machineShare $machineShare
@@ -221,7 +232,14 @@ param (
     if($machineShare)
     {
         try {
-            New-PSDrive -Name "WFCPSDrive" -PSProvider FileSystem -Root $destinationNetworkPath -Credential $psCredentialObject -ErrorAction 'Stop'
+			if ($psCredentialObject)
+			{
+				New-PSDrive -Name "WFCPSDrive" -PSProvider FileSystem -Root $destinationNetworkPath -Credential $psCredentialObject -ErrorAction 'Stop'
+			}
+			else
+			{
+				New-PSDrive -Name "WFCPSDrive" -PSProvider FileSystem -Root $destinationNetworkPath -ErrorAction 'Stop'
+			}
         } catch {
             Write-VstsTaskError -Message (Get-VstsLocString -Key "WFC_FailedToCreatePSDrive" -ArgumentList $destinationNetworkPath, $($_.Exception.Message)) -ErrCode "WFC_FailedToCreatePSDrive"
             throw

--- a/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
@@ -37,8 +37,12 @@ try
 
     $machines = $machineNames.split(',') | ForEach-Object { if ($_ -and $_.trim()) { $_.trim() } }
 
-    $secureAdminPassword = ConvertTo-SecureString $adminPassword -AsPlainText -Force
-    $machineCredential = New-Object System.Net.NetworkCredential ($adminUserName, $secureAdminPassword)
+	$machineCredential = $null
+	if ($adminUserName -And $adminPassword)
+	{
+        $secureAdminPassword = ConvertTo-SecureString $adminPassword -AsPlainText -Force
+        $machineCredential = New-Object System.Net.NetworkCredential ($adminUserName, $secureAdminPassword)
+	}
 
     if ($machines.Count -eq 0)
     {


### PR DESCRIPTION
None of the WinRM-based file copies I have been able to find have optional username/password fields. I would simply like to copy with the machine credentials of the agent's machine. These modifications allow the machine file copy task to operate even if username/password are not provided.