### PR TITLE
Add allowPackageConflicts for npm publish

### DIFF
--- a/Tasks/NpmV1/Tests/L0.ts
+++ b/Tasks/NpmV1/Tests/L0.ts
@@ -307,6 +307,20 @@ describe('Npm Task', function () {
         done();
     });
 
+    it ('publish using continueOnConflicts', (done: MochaDone) => {
+        this.timeout(1000);
+        let tp = path.join(__dirname, 'publish-feed-continueOnConflicts.js');
+        let tr = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert.equal(tr.invokedToolCount, 3, 'task should have run npm');
+        assert(tr.stdOutContained('The feed already contains the package'), 'npm should fail with feed already contains package');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
     it ('publish using external registry', (done: MochaDone) => {
         this.timeout(1000);
         let tp = path.join(__dirname, 'publish-external.js');

--- a/Tasks/NpmV1/Tests/publish-feed-continueOnConflicts.ts
+++ b/Tasks/NpmV1/Tests/publish-feed-continueOnConflicts.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+
+import { TaskLibAnswerExecResult } from 'azure-pipelines-task-lib/mock-answer';
+
+import { NpmCommand, NpmTaskInput, RegistryLocation } from '../constants';
+import { NpmMockHelper } from './NpmMockHelper';
+
+let taskPath = path.join(__dirname, '..', 'npm.js');
+let tmr = new NpmMockHelper(taskPath);
+
+tmr.setInput(NpmTaskInput.Command, NpmCommand.Publish);
+tmr.setInput(NpmTaskInput.WorkingDir, 'workingDir');
+tmr.setInput(NpmTaskInput.PublishRegistry, RegistryLocation.Feed);
+tmr.setInput(NpmTaskInput.PublishFeed, 'SomeFeedId');
+tmr.setInput(NpmTaskInput.AllowPackageConflicts, 'true');
+tmr.mockNpmCommand('publish', {
+    code: 403,
+    stderr: 'The feed already contains the package \'packageName\' at version \'1.0.0\'',
+    stdout: 'The feed already contains the package \'packageName\' at version \'1.0.0\''
+} as TaskLibAnswerExecResult);
+tmr.answers.rmRF[path.join('workingDir', '.npmrc')] = { success: true };
+tmr.answers["stats"] = {"workingDir": {"isDirectory":true}};
+
+tmr.run();

--- a/Tasks/NpmV1/Tests/publish-feed-continueOnConflicts.ts
+++ b/Tasks/NpmV1/Tests/publish-feed-continueOnConflicts.ts
@@ -15,7 +15,6 @@ tmr.setInput(NpmTaskInput.PublishFeed, 'SomeFeedId');
 tmr.setInput(NpmTaskInput.AllowPackageConflicts, 'true');
 tmr.mockNpmCommand('publish', {
     code: 403,
-    stderr: 'The feed already contains the package \'packageName\' at version \'1.0.0\'',
     stdout: 'The feed already contains the package \'packageName\' at version \'1.0.0\''
 } as TaskLibAnswerExecResult);
 tmr.answers.rmRF[path.join('workingDir', '.npmrc')] = { success: true };

--- a/Tasks/NpmV1/constants.ts
+++ b/Tasks/NpmV1/constants.ts
@@ -22,4 +22,5 @@ export class NpmTaskInput {
     public static PublishRegistry: string = 'publishRegistry';
     public static PublishFeed: string = 'publishFeed';
     public static PublishEndpoint: string = 'publishEndpoint';
+    public static AllowPackageConflicts: string = 'allowPackageConflicts';
 }

--- a/Tasks/NpmV1/npmpublish.ts
+++ b/Tasks/NpmV1/npmpublish.ts
@@ -21,7 +21,7 @@ export async function run(packagingLocation: PackagingLocation): Promise<void> {
     npm.line('publish');
 
     npm.execSync();
-
+    
     tl.rmRF(npmrc);
     tl.rmRF(util.getTempPath());
 }

--- a/Tasks/NpmV1/npmtoolrunner.ts
+++ b/Tasks/NpmV1/npmtoolrunner.ts
@@ -53,18 +53,20 @@ export class NpmToolRunner extends tr.ToolRunner {
         );
     }
 
-    public execSync(options?: tr.IExecSyncOptions): tr.IExecSyncResult {
+    public execSync(options?: tr.IExecSyncOptions): tr.IExecSyncResult { 
         options = this._prepareNpmEnvironment(options);
-
         this._saveProjectNpmrc();
         const execResult = super.execSync(options);
         this._restoreProjectNpmrc();
-        if (execResult.code !== 0) {
+
+        const continueOnConflict: boolean = tl.getBoolInput("allowPackageConflicts"); 
+        if(continueOnConflict && execResult.stderr.indexOf("The feed already contains")>0){
+            tl.debug(`A conflict with package occurred, ignoring it since "Allow duplicates" was selected.`); 
+        } else if (execResult.code !== 0) {
             telemetry.logResult('Packaging', 'npm', execResult.code);
             this._printDebugLogSync(this._getDebugLogPath(options));
             throw new Error(tl.loc('NpmFailed', execResult.code));
         }
-
         return execResult;
     }
 

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -146,6 +146,15 @@
             "visibleRule": "command = publish && publishRegistry = useFeed"
         },
         {
+            "name": "allowPackageConflicts",
+            "type": "boolean",
+            "label": "Allow duplicates to be skipped",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "If you continually publish a set of packages and only change the version number of the subset of packages that changed, use this option. It allows the task to report success even if some of your packages are rejected with '403 Forbidden - The feed already contains the package'.",
+            "visibleRule": "command = publish && publishRegistry = useFeed"
+        },
+        {
             "groupName": "publishRegistries",
             "name": "publishEndpoint",
             "label": "External Registry",


### PR DESCRIPTION
Adding the ability to allow package conflicts on publishing to npm build. This support the scenario where npm packages gets published from a larger build, where not every build updates the npm package. In this case, if the npm package version has not been updated, the npm package doesn't need to be published and the build can just continue. 

The current behavior is that npm fails with a 403 Forbidden. "The feed already contains the package 'packageName' at version 'x.x.x'. This causes the build to be red, or when "continue on error" is set on the task, the build is yellow. We would like the build to be green, because there is no need to publish a new version. 

We try here to mimic the behavior from the nuget publish task. When the allowPackageConflicts property is set on the task, this task completes successfully when the package version has already been published.

I was not able to build or test the project locally, because of an error during the build step (https://github.com/microsoft/azure-pipelines-tasks/issues/11136), so I am hoping a build will run for this PR. If so I will update the PR based on the build results. 