### PR TITLE
Changed JS replace function from string to regex version where needed

### DIFF
--- a/Tasks/ACRTaskV0/task.json
+++ b/Tasks/ACRTaskV0/task.json
@@ -16,7 +16,7 @@
     "version": {
         "Major": 0,
         "Minor": 162,
-        "Patch": 6
+        "Patch": 7
     },
     "instanceNameFormat": "acrTask",
     "showEnvironmentVariables": true,

--- a/Tasks/AzureCLIV2/src/ScriptType.ts
+++ b/Tasks/AzureCLIV2/src/ScriptType.ts
@@ -55,7 +55,7 @@ export class WindowsPowerShell extends ScriptType {
             .arg('-ExecutionPolicy')
             .arg('Unrestricted')
             .arg('-Command')
-            .arg(`. '${this._scriptPath.replace("'", "''")}'`);
+            .arg(`. '${this._scriptPath.replace(/'/g, "''")}'`);
         return tool;
     }
 
@@ -75,7 +75,7 @@ export class PowerShellCore extends ScriptType {
             .arg('-ExecutionPolicy')
             .arg('Unrestricted')
             .arg('-Command')
-            .arg(`. '${this._scriptPath.replace("'", "''")}'`);
+            .arg(`. '${this._scriptPath.replace(/'/g, "''")}'`);
         return tool;
     }
 

--- a/Tasks/AzureCLIV2/src/Utility.ts
+++ b/Tasks/AzureCLIV2/src/Utility.ts
@@ -50,7 +50,7 @@ export class Utility {
             }
         }
 
-        let content: string = `. '${filePath.replace("'", "''")}' `;
+        let content: string = `. '${filePath.replace(/'/g, "''")}' `;
         if (scriptArguments) {
             content += scriptArguments;
         }

--- a/Tasks/AzureFunctionOnKubernetesV0/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 165,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "groups": [{

--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -71,7 +71,7 @@ async function run() {
         }
 
         if (scriptType.toUpperCase() == 'FILEPATH') {
-            contents.push(`. '${scriptPath.replace("'", "''")}' ${scriptArguments}`.trim());
+            contents.push(`. '${scriptPath.replace(/'/g, "''")}' ${scriptArguments}`.trim());
             console.log(tl.loc('JS_FormattedCommand', contents[contents.length - 1]));
         }
         else {
@@ -105,7 +105,7 @@ async function run() {
             .arg('-ExecutionPolicy')
             .arg('Unrestricted')
             .arg('-Command')
-            .arg(`. '${filePath.replace("'", "''")}'`);
+            .arg(`. '${filePath.replace(/'/g, "''")}'`);
 
         let options = <tr.IExecOptions>{
             cwd: input_workingDirectory,

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -68,7 +68,7 @@ async function run() {
         }
 
         if (scriptType.toUpperCase() == 'FILEPATH') {
-            contents.push(`. '${scriptPath.replace("'", "''")}' ${scriptArguments}`.trim());
+            contents.push(`. '${scriptPath.replace(/'/g, "''")}' ${scriptArguments}`.trim());
             console.log(tl.loc('JS_FormattedCommand', contents[contents.length - 1]));
         }
         else {
@@ -100,7 +100,7 @@ async function run() {
             .arg('-ExecutionPolicy')
             .arg('Unrestricted')
             .arg('-Command')
-            .arg(`. '${filePath.replace("'", "''")}'`);
+            .arg(`. '${filePath.replace(/'/g, "''")}'`);
 
         let options = <tr.IExecOptions>{
             cwd: input_workingDirectory,

--- a/Tasks/AzureResourceGroupDeploymentV2/operations/ResourceGroup.ts
+++ b/Tasks/AzureResourceGroupDeploymentV2/operations/ResourceGroup.ts
@@ -285,7 +285,7 @@ export class ResourceGroup {
         } else {
             name = this.taskParameters.csmFileLink;
         }
-        name = path.basename(name).split(".")[0].replace(" ", "");
+        name = path.basename(name).split(".")[0].replace(/\s/g, "");
         name = name.substr(0, 40);
         var timestamp = new Date(Date.now());
         var uniqueId = uuid().substr(0, 4);

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
@@ -204,7 +204,7 @@ class Utils {
         } else {
             name = taskParameters.csmFileLink;
         }
-        name = path.basename(name).split(".")[0].replace(" ", "");
+        name = path.basename(name).split(".")[0].replace(/\s/g, "");
         name = name.substr(0, 40);
         var timestamp = new Date(Date.now());
         var uniqueId = uuid().substr(0, 4);

--- a/Tasks/BashV3/bash.ts
+++ b/Tasks/BashV3/bash.ts
@@ -79,18 +79,18 @@ async function run() {
             // If the executable bit is not set, source the script and warn. The user should either make it executable or pin to the old behavior.
             // See https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/bashnote.md
             if (old_source_behavior) {
-                contents = `. '${targetFilePath.replace("'", "'\\''")}' ${input_arguments}`.trim();
+                contents = `. '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
             } else {
                 // Check if executable bit is set
                 const stats: fs.Stats = tl.stats(input_filePath);
                 // Check file's executable bit.
                 if ((stats.mode & 1) > 0) {
-                    contents = `bash '${targetFilePath.replace("'", "'\\''")}' ${input_arguments}`.trim();
+                    contents = `bash '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
                 }
                 else {
                     tl.debug(`File permissions: ${stats.mode}`);
                     tl.warning('Executable bit is not set on target script, sourcing instead of executing. More info at https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/bashnote.md');
-                    contents = `. '${targetFilePath.replace("'", "'\\''")}' ${input_arguments}`.trim();
+                    contents = `. '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
                 }
             }
             console.log(tl.loc('JS_FormattedCommand', contents));

--- a/Tasks/Common/docker-common-v2/dockercommandutils.ts
+++ b/Tasks/Common/docker-common-v2/dockercommandutils.ts
@@ -332,8 +332,8 @@ export async function getImageRootfsLayers(connection: ContainerConnection, imag
     await defer.promise;
 
     // Remove '[' and ']' from output
-    output = output.replace("[", "");
-    output = output.replace("]", "");
+    output = output.replace(/\[/g, "");
+    output = output.replace(/]/g, "");
 
     // Return array of rootLayers in the form -> [sha256:2c833f307fd8f18a378b71d3c43c575fabdb88955a2198662938ac2a08a99928,sha256:5f349fdc9028f7edde7f8d4c487d59b3e4b9d66a367dc85492fc7a81abf57b41, ...]
     let rootLayers = output.split(" ");

--- a/Tasks/ContainerBuildV0/task.json
+++ b/Tasks/ContainerBuildV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 165,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 162,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": true,
     "demands": [],

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 166,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 166,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Simplified the task YAML by:<br/>&nbsp;- Removing the Container registry type input<br/>&nbsp;- Removing complex inputs as they can be passed as arguments to the command.",

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 166,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 166,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -46,7 +46,7 @@ async function run() {
         let contents: string[] = [];
         contents.push(`$ErrorActionPreference = '${input_errorActionPreference}'`);
         if (input_targetType.toUpperCase() == 'FILEPATH') {
-            contents.push(`. '${input_filePath.replace("'", "''")}' ${input_arguments}`.trim());
+            contents.push(`. '${input_filePath.replace(/'/g, "''")}' ${input_arguments}`.trim());
             console.log(tl.loc('JS_FormattedCommand', contents[contents.length - 1]));
         }
         else {
@@ -85,7 +85,7 @@ async function run() {
             .arg('-NoProfile')
             .arg('-NonInteractive')
             .arg('-Command')
-            .arg(`. '${filePath.replace("'", "''")}'`);
+            .arg(`. '${filePath.replace(/'/g, "''")}'`);
         let options = <tr.IExecOptions>{
             cwd: input_workingDirectory,
             failOnStdErr: false,


### PR DESCRIPTION
Changed single-time javascript replacements (string version of Javascript replace function), which should actually be global replacements, to global replacements (regex version of Javascript replace function).

This is due to a quirks in javascript which is often overlooked: pure string replacements will only replace the FIRST occurrence of the string. However, most of the time you want to replace all occurences. For this you need to use the regex version of the javascript replace function. So I changed the string-replacements to regex-replacements where every occurence of a string should be replaced.