### PR TITLE
Updated PublishTestResultsV2 task to version 2.167.0

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/11600856/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/11761551/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 166,
+        "Minor": 167,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 166,
+    "Minor": 167,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
“Updated PublishTestResultsV2 version from 11600856 to 11761551
https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=11761551&view=results
