### PR TITLE
Allow user to specify storage account for deployment packages

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/Publish-AzureCloudDeployment.ps1
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/Publish-AzureCloudDeployment.ps1
@@ -21,6 +21,7 @@ try{
     $NewServiceCustomCertificates = Get-VstsInput -Name NewServiceCustomCertificates
 
     $EnableAdvancedStorageOptions = Get-VstsInput -Name EnableAdvancedStorageOptions -AsBool
+    $SpecifyStorageAccountForPackages = Get-VstsInput -Name SpecifyStorageAccountForPackages -AsBool
     $ARMConnectedServiceName = Get-VstsInput -Name ARMConnectedServiceName
     $ARMStorageAccount = Get-VstsInput -Name ARMStorageAccount
 
@@ -33,6 +34,13 @@ try{
     {
         $endpoint = Get-VstsEndpoint -Name $ARMConnectedServiceName -Require
         Initialize-AzureRMModule -Endpoint $endpoint
+    }
+
+    # Initialize current storage account if required
+    if ($SpecifyStorageAccountForPackages)
+    {
+        $subscription = Get-AzureSubscription
+        Set-AzureSubscription -CurrentStorageAccountName $StorageAccount -SubscriptionId $subscription.SubscriptionId
     }
 
     # Load all dependent files for execution

--- a/Tasks/AzureCloudPowerShellDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -8,6 +8,8 @@
   "loc.input.help.ConnectedServiceName": "Azure Classic subscription to target for deployment.",
   "loc.input.label.EnableAdvancedStorageOptions": "Enable ARM storage support",
   "loc.input.help.EnableAdvancedStorageOptions": "Select to enable ARM storage support for this task.",
+  "loc.input.label.SpecifyStorageAccountForPackages": "Specify Storage Account for deployment packages",
+  "loc.input.help.SpecifyStorageAccountForPackages": "Select to specify which classic storage account is used for deployment packages.",
   "loc.input.label.StorageAccount": "Storage account (Classic)",
   "loc.input.help.StorageAccount": "Storage account must exist prior to deployment.",
   "loc.input.label.ARMConnectedServiceName": "Azure subscription (ARM)",

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 167,
-        "Patch": 1
+        "Minor": 168,
+        "Patch": 0
     },
     "demands": [
         "azureps"
@@ -51,6 +51,14 @@
             "required": true
         },
         {
+            "name": "SpecifyStorageAccountForPackages",
+            "type": "boolean",
+            "label": "Specify Storage Account for deployment packages",
+            "defaultValue": "false",
+            "helpMarkDown": "Select to specify which classic storage account is used for deployment packages.",
+            "required": true
+        },
+        {
             "name": "StorageAccount",
             "type": "pickList",
             "label": "Storage account (Classic)",
@@ -60,7 +68,7 @@
                 "EditableOptions": "True"
             },
             "helpMarkDown": "Storage account must exist prior to deployment.",
-            "visibleRule": "EnableAdvancedStorageOptions = false"
+            "visibleRule": "EnableAdvancedStorageOptions = false || SpecifyStorageAccountForPackages = true"
 
         },
         {

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 167,
-    "Patch": 1
+    "Minor": 168,
+    "Patch": 0
   },
   "demands": [
     "azureps"
@@ -51,6 +51,14 @@
       "required": true
     },
     {
+      "name": "SpecifyStorageAccountForPackages",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.SpecifyStorageAccountForPackages",
+      "defaultValue": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.SpecifyStorageAccountForPackages",
+      "required": true
+    },
+    {
       "name": "StorageAccount",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.StorageAccount",
@@ -60,7 +68,7 @@
         "EditableOptions": "True"
       },
       "helpMarkDown": "ms-resource:loc.input.help.StorageAccount",
-      "visibleRule": "EnableAdvancedStorageOptions = false"
+      "visibleRule": "EnableAdvancedStorageOptions = false || SpecifyStorageAccountForPackages = true"
     },
     {
       "name": "ARMConnectedServiceName",


### PR DESCRIPTION
When Set-AzureDeployment is run it will use whichever storage account is currently set in the subscription context under `CurrentStorageAccountName` (can be seen by running Get-AzureSubscription). If this is unset it will fail with the error `CurrentStorageAccountName is not set. Use Set-AzureSubscription subname -CurrentStorageAccountName storageaccount to set it.`.

This PR will allow the user to specify the classic storage account to use for deployment packages to resolve this error.