### PR TITLE
[InstallAppleCertificateV2] fixing the cert common name extraction regex

### DIFF
--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -547,11 +547,13 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
                 // Remove colons separating each octet.
                 fingerprint = value.replace(/:/g, '').trim();
             } else if (key === 'subject') {
-                // Example value: "/UID=E848ASUQZY/CN=iPhone Developer: Chris Sidi (7RZ3N927YF)/OU=DJ8T2973U7/O=Chris Sidi/C=US"
+                // Example value1: "/UID=E848ASUQZY/CN=iPhone Developer: Chris Sidi (7RZ3N927YF)/OU=DJ8T2973U7/O=Chris Sidi/C=US"
+                // Example value2: "/UID=E848ASUQZY/CN=iPhone Developer: Chris / Sidi (7RZ3N927YF)/OU=DJ8T2973U7/O=Chris Sidi/C=US"
+                // Example value3: "/UID=E848ASUQZY/OU=DJ8T2973U7/O=Chris Sidi/C=US/CN=iPhone Developer: Chris Sidi (7RZ3N927YF)"
                 // Extract the common name.
-                const matches: string[] = value.match(/\/CN=([^/]+)/);
-                if (matches && matches[1]) {
-                    commonName = matches[1].trim();
+                const matches: string[] = value.match(/\/CN=.*?(?=\/[A-Z]+=|$)/);
+                if (matches && matches[0]) {
+                    commonName = matches[0].replace("/CN=", "");
                 }
             } else if (key === 'notBefore') {
                 // Example value: "Nov 13 03:37:42 2018 GMT"

--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -551,7 +551,7 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
                 // Example value2: "/UID=E848ASUQZY/CN=iPhone Developer: Chris / Sidi (7RZ3N927YF)/OU=DJ8T2973U7/O=Chris Sidi/C=US"
                 // Example value3: "/UID=E848ASUQZY/OU=DJ8T2973U7/O=Chris Sidi/C=US/CN=iPhone Developer: Chris Sidi (7RZ3N927YF)"
                 // Extract the common name.
-                const matches: string[] = value.match(/\/CN=.*?(?=\/[A-Z]+=|$)/);
+                const matches: string[] = value.match(/\/CN=.*?(?=\/[A-Za-z]+=|$)/);
                 if (matches && matches[0]) {
                     commonName = matches[0].replace("/CN=", "");
                 }

--- a/Tasks/Common/ios-signing-common/ios-signing-common.ts
+++ b/Tasks/Common/ios-signing-common/ios-signing-common.ts
@@ -553,7 +553,7 @@ export async function getP12Properties(p12Path: string, p12Pwd: string): Promise
                 // Extract the common name.
                 const matches: string[] = value.match(/\/CN=.*?(?=\/[A-Za-z]+=|$)/);
                 if (matches && matches[0]) {
-                    commonName = matches[0].replace("/CN=", "");
+                    commonName = matches[0].trim().replace("/CN=", "");
                 }
             } else if (key === 'notBefore') {
                 // Example value: "Nov 13 03:37:42 2018 GMT"

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 156,
+        "Minor": 157,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 157,
-        "Patch": 0
+        "Minor": 156,
+        "Patch": 1
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 156,
-        "Patch": 1
+        "Minor": 157,
+        "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 156,
+    "Minor": 157,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 157,
-    "Patch": 0
+    "Minor": 156,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 156,
-    "Patch": 1
+    "Minor": 157,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 156,
+        "Minor": 157,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 157,
-        "Patch": 0
+        "Minor": 156,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 156,
-        "Patch": 1
+        "Minor": 157,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 156,
+    "Minor": 157,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 157,
-    "Patch": 0
+    "Minor": 156,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 156,
-    "Patch": 1
+    "Minor": 157,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 151,
-        "Patch": 2
+        "Minor": 152,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
     "demands": [

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 151,
-        "Patch": 3
+        "Minor": 152,
+        "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
     "demands": [

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 152,
-        "Patch": 0
+        "Minor": 151,
+        "Patch": 3
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8, Xcode 9 and Xcode 10. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
     "demands": [

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 151,
-    "Patch": 2
+    "Minor": 152,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 151,
-    "Patch": 3
+    "Minor": 152,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 152,
-    "Patch": 0
+    "Minor": 151,
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
Issue posted here:
https://developercommunity.visualstudio.com/content/problem/967683/installapplecertificate-vsts-task-signingidentity.html

We have a certificate with SLASH in its commonName.
when tested with a self signed cert:

```
subject=/C=KR/ST=Seoul/L=Seoul/O=MS/OU=MS/CN=test_cert_/_with_slash/emailAddress=test@ms.com
```
And checked the below variables, its returning `test_cert_`

$(APPLE_CERTIFICATE_SIGNING_IDENTITY) 
$(InstallAppleCertificate.signingIdentity)

When verified the code, Regex thats being used in extracting the commonName is not handling these cases.

https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/Common/ios-signing-common/ios-signing-common.ts#L552

The current regex `/\/CN=([^/]+)/` looks for just slash.
The fix is to have a positive lookahead for /O= or /OU= or /C= or /emailAddress= etc.

so came up with this regex`/\/CN=.*?(?=\/[A-Za-z]+=|$)/`

Let me know any concerns.
