### PR TITLE
Keystore alias not required for android signing

### DIFF
--- a/Tasks/AndroidSigningV3/androidsigning.ts
+++ b/Tasks/AndroidSigningV3/androidsigning.ts
@@ -38,7 +38,7 @@ const apksigning = (fn: string) => {
     const keystoreFile = tl.getTaskVariable('KEYSTORE_FILE_PATH');
 
     // Get keystore alias
-    const keystoreAlias = tl.getInput('keystoreAlias', true);
+    const keystoreAlias = tl.getInput('keystoreAlias', false);
 
     const keystorePass = tl.getInput('keystorePass', false);
 

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 156,
+        "Minor": 169,
         "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 156,
+    "Minor": 169,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
The documentation says this field is not required, and the tool in use works fine without an alias.