### PR TITLE
Require adding all agent plugin tasks to bump script before running.

### DIFF
--- a/make.js
+++ b/make.js
@@ -553,7 +553,7 @@ target.publish = function() {
 }
 
 
-var agentPluginTaskNames = ['DownloadPipelineArtifact', 'PublishPipelineArtifact'];
+var agentPluginTaskNames = ['Cache', 'CacheBeta', 'DownloadPipelineArtifact', 'PublishPipelineArtifact'];
 // used to bump the patch version in task.json files
 target.bump = function() {
     verifyAllAgentPluginTasksAreInSkipList();

--- a/make.js
+++ b/make.js
@@ -604,7 +604,7 @@ function verifyAllAgentPluginTasksAreInSkipList() {
         }
 
         if (missingTaskNames.length > 0) {
-            fail('Broken');
+            fail('Broken: ' + JSON.stringify(missingTaskNames));
         }
     });
 }

--- a/make.js
+++ b/make.js
@@ -553,9 +553,11 @@ target.publish = function() {
 }
 
 
-var agentPluginTasks = ['DownloadPipelineArtifact', 'PublishPipelineArtifact'];
+var agentPluginTaskNames = ['DownloadPipelineArtifact', 'PublishPipelineArtifact'];
 // used to bump the patch version in task.json files
 target.bump = function() {
+    verifyAllAgentPluginTasksAreInSkipList();
+
     taskList.forEach(function (taskName) {
         // load files
         var taskJsonPath = path.join(__dirname, 'Tasks', taskName, 'task.json');
@@ -565,7 +567,7 @@ target.bump = function() {
         var taskLocJson = JSON.parse(fs.readFileSync(taskLocJsonPath));
 
         // skip agent plugin tasks
-        if(agentPluginTasks.indexOf(taskJson.name) > -1) {
+        if(agentPluginTaskNames.indexOf(taskJson.name) > -1) {
             return;
         }
 
@@ -584,6 +586,25 @@ target.bump = function() {
             (taskJson.version.Minor !== taskLocJson.version.Minor) || 
             (taskJson.version.Patch !== taskLocJson.version.Patch)) {
             console.log(`versions dont match for task '${taskName}', task json: ${JSON.stringify(taskJson.version)} task loc json: ${JSON.stringify(taskLocJson.version)}`);
+        }
+    });
+}
+
+function verifyAllAgentPluginTasksAreInSkipList() {
+    taskList.forEach(function (taskName) {
+        // load files
+        var missingTaskNames = [];
+        var taskJsonPath = path.join(__dirname, 'Tasks', taskName, 'task.json');
+        var taskJson = JSON.parse(fs.readFileSync(taskJsonPath));
+
+        if (taskJson.execution.AgentPlugin) {
+            if (agentPluginTaskNames.indexOf(taskJson.name) === -1) {
+                missingTaskNames.push(taskJson.name);
+            }
+        }
+
+        if (missingTaskNames.length > 0) {
+            fail('Broken');
         }
     });
 }

--- a/make.js
+++ b/make.js
@@ -591,22 +591,23 @@ target.bump = function() {
 }
 
 function verifyAllAgentPluginTasksAreInSkipList() {
+    var missingTaskNames = [];
+
     taskList.forEach(function (taskName) {
         // load files
-        var missingTaskNames = [];
         var taskJsonPath = path.join(__dirname, 'Tasks', taskName, 'task.json');
         var taskJson = JSON.parse(fs.readFileSync(taskJsonPath));
 
-        if (taskJson.execution.AgentPlugin) {
-            if (agentPluginTaskNames.indexOf(taskJson.name) === -1) {
+        if (taskJson.execution && taskJson.execution.AgentPlugin) {
+            if (agentPluginTaskNames.indexOf(taskJson.name) === -1 && missingTaskNames.indexOf(taskJson.name) === -1) {
                 missingTaskNames.push(taskJson.name);
             }
         }
-
-        if (missingTaskNames.length > 0) {
-            fail('Broken: ' + JSON.stringify(missingTaskNames));
-        }
     });
+
+    if (missingTaskNames.length > 0) {
+        fail('The following tasks must be added to agentPluginTaskNames: ' + JSON.stringify(missingTaskNames));
+    }
 }
 
 // Generate sprintly zip


### PR DESCRIPTION
During bump, check for any Tasks that have `AgentPlugin` as the `execution`. If they do, they must be in the skip list.

If Tasks are missing, the user will see:

![image](https://user-images.githubusercontent.com/450490/79572887-abd69e00-808b-11ea-9264-99cdda5e369d.png)
