### PR TITLE
Cherry-pick VS/nuget compat issue workarounds to m168

### DIFF
--- a/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
@@ -108,7 +108,7 @@ function pathExistsAsFile(path: string) {
 }
 
 // Based on code in Tasks\Common\MSBuildHelpers\msbuildhelpers.ts
-async function getMSBuildVersionString(): Promise<string> {
+export async function getMSBuildVersionString(): Promise<string> {
     const msbuild2019Path = 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/MSBuild/Current/Bin/msbuild.exe';
     let version: string;
     let path: string = taskLib.which('msbuild', false);
@@ -135,7 +135,7 @@ async function getMSBuildVersionString(): Promise<string> {
     return version;
 }
 
-async function getMSBuildVersion(): Promise<semver.SemVer> {
+export async function getMSBuildVersion(): Promise<semver.SemVer> {
     const version = await getMSBuildVersionString();
     return semver.coerce(version);
 }

--- a/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
@@ -130,6 +130,7 @@ async function getMSBuildVersionString(): Promise<string> {
             }
         });
         await getVersionTool.exec();
+        taskLib.debug('Finished running msbuild /version /nologo');
     }
     return version;
 }
@@ -145,7 +146,8 @@ export async function cacheBundledNuGet(
     if (cachedVersionToUse == null) {
         // Attempt to match nuget.exe version with msbuild.exe version
         const msbuildSemVer = await getMSBuildVersion();
-        if (msbuildSemVer && semver.gt(msbuildSemVer, '16.5.0')) {
+        if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
+            taskLib.debug('Snapping to v5.4.0');
             cachedVersionToUse = '5.4.0';
             nugetPathSuffix = 'NuGet/5.4.0/';
         } else {

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,13 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-<<<<<<< HEAD
     "Minor": 168,
     "Patch": 0
-=======
-    "Minor": 167,
-    "Patch": 3
->>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,8 +17,13 @@
   "demands": [],
   "version": {
     "Major": 2,
+<<<<<<< HEAD
     "Minor": 168,
     "Patch": 0
+=======
+    "Minor": 167,
+    "Patch": 3
+>>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,13 +9,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
     "Patch": 0
-=======
-    "Minor": 167,
-    "Patch": 1
->>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,8 +9,13 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
     "Patch": 0
+=======
+    "Minor": 167,
+    "Patch": 1
+>>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,11 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "Adds support to download Maven, Python, Universal and Npm packages.",

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,11 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,11 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,11 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,7 +17,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,11 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,11 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,7 +17,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,11 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,11 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,7 +17,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,7 +9,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,11 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,11 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,7 +9,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,11 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,7 +9,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,11 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,7 +9,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,11 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,11 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,7 +9,11 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,11 +9,7 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,11 +9,7 @@
   "author": "Lawrence Gripper",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,7 +9,11 @@
   "author": "Lawrence Gripper",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetToolInstallerV0/nugettoolinstaller.ts
+++ b/Tasks/NuGetToolInstallerV0/nugettoolinstaller.ts
@@ -1,4 +1,5 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
+import * as semver from 'semver';
 import * as path from "path";
 
 import nuGetGetter = require("packaging-common/nuget/NuGetToolGetter");
@@ -7,7 +8,16 @@ async function run() {
     try {
         taskLib.setResourcePath(path.join(__dirname, "task.json"));
 
-        let versionSpec = taskLib.getInput('versionSpec', true);
+        let versionSpec = taskLib.getInput('versionSpec', false);
+        if (!versionSpec) {
+            const msbuildSemVer = await nuGetGetter.getMSBuildVersion();
+            if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
+                taskLib.debug('Defaulting to 4.8.2 for msbuild version: ' + msbuildSemVer);
+                versionSpec = '4.8.2';
+            } else {
+                versionSpec = '4.3.0';
+            }
+        }
         let checkLatest = taskLib.getBoolInput('checkLatest', false);
         await nuGetGetter.getNuGet(versionSpec, checkLatest, true);
     }

--- a/Tasks/NuGetToolInstallerV0/package-lock.json
+++ b/Tasks/NuGetToolInstallerV0/package-lock.json
@@ -43,17 +43,14 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.6.tgz",
-      "integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
+      "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
     },
     "azure-devops-node-api": {
       "version": "8.0.0",
@@ -190,6 +187,7 @@
         "ip-address": "^5.8.9",
         "ltx": "^2.6.2",
         "q": "^1.5.0",
+        "semver": "^5.5.0",
         "typed-rest-client": "1.2.0"
       }
     },
@@ -238,9 +236,9 @@
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     }
   }
 }

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,11 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": false,
     "satisfies": [

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -28,8 +28,7 @@
             "name": "versionSpec",
             "type": "string",
             "label": "Version of NuGet.exe to install",
-            "defaultValue": "4.3.0",
-            "required": true,
+            "required": false,
             "helpMarkDown": "A version or version range that specifies the NuGet version to make available on the path. Use x as a wildcard. See the [list of available NuGet versions](http://dist.nuget.org/tools.json).\n\nIf you want to match a pre-release version, the specification must contain a major, minor, patch, and pre-release version from the list above.\n\nExamples: 4.x, 3.3.x, 2.8.6, >=4.0.0-0"
         },
         {

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,7 +14,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -14,11 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -28,8 +28,7 @@
       "name": "versionSpec",
       "type": "string",
       "label": "ms-resource:loc.input.label.versionSpec",
-      "defaultValue": "4.3.0",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.versionSpec"
     },
     {

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -14,7 +14,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": false,
     "satisfies": [

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -14,11 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -14,7 +14,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -14,11 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -14,7 +14,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,11 +10,7 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,7 +10,11 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -14,8 +14,12 @@
     "Minor": 168,
 =======
     "Minor": 167,
+<<<<<<< HEAD
 >>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
+=======
+    "Patch": 1
+>>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -10,16 +10,8 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
-<<<<<<< HEAD
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
-=======
-    "Patch": 1
->>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -10,7 +10,11 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,7 +9,11 @@
     "category": "Package",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -13,8 +13,12 @@
         "Minor": 168,
 =======
         "Minor": 167,
+<<<<<<< HEAD
 >>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
+=======
+        "Patch": 1
+>>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
     },
     "runsOn": [
         "Agent",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,16 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
-<<<<<<< HEAD
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
-=======
-        "Patch": 1
->>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
     },
     "runsOn": [
         "Agent",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,16 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
-<<<<<<< HEAD
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
-=======
-    "Patch": 1
->>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -13,8 +13,12 @@
     "Minor": 168,
 =======
     "Minor": 167,
+<<<<<<< HEAD
 >>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
+=======
+    "Patch": 1
+>>>>>>> d62214607... Probing directly for msbuild under VS2019 install path on Windows (#12638)
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,7 +9,11 @@
   "category": "Package",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,7 +9,11 @@
     "category": "Package",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,11 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,11 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,7 +9,11 @@
   "category": "Package",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,11 @@
     "category": "Package",
     "version": {
         "Major": 0,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,11 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,11 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,11 @@
   "category": "Package",
   "version": {
     "Major": 0,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 165,
-        "Patch": 4
+        "Patch": 5
     },
    "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 165,
-        "Patch": 6
+        "Patch": 7
     },
    "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 165,
-        "Patch": 5
+        "Patch": 6
     },
    "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 165,
-        "Patch": 3
+        "Patch": 4
     },
    "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 56
+    "Patch": 66
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 46
+    "Patch": 56
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 36
+    "Patch": 46
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 66
+    "Patch": 76
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,7 +16,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
+<<<<<<< HEAD
         "Minor": 168,
+=======
+        "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,11 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-<<<<<<< HEAD
         "Minor": 168,
-=======
-        "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 168,
-        "Patch": 0
+        "Patch": 1
     },
     "satisfies": [
         "Node",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 168,
-    "Patch": 0
+    "Patch": 1
   },
   "satisfies": [
     "Node",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,7 +16,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
+<<<<<<< HEAD
     "Minor": 168,
+=======
+    "Minor": 167,
+>>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,11 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-<<<<<<< HEAD
     "Minor": 168,
-=======
-    "Minor": 167,
->>>>>>> c076185c1... Select nuget version based on msbuild version (m167) (#12637)
     "Patch": 0
   },
   "satisfies": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "adm-zip": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+      "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo=",
       "dev": true
     },
     "ansi-red": {
@@ -28,7 +28,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -49,7 +49,7 @@
     "azure-devops-node-api": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-9.0.1.tgz",
-      "integrity": "sha512-0veE4EWHObJxzwgHlydG65BjNMuLPkR1nzcQ2K51PIho1/F4llpKt3pelC30Vbex5zA9iVgQ9YZGlkkvOBSksw==",
+      "integrity": "sha1-um3OfydNsBWJplPNvfQ+cen5tSc=",
       "dev": true,
       "requires": {
         "tunnel": "0.0.4",
@@ -60,7 +60,7 @@
         "typed-rest-client": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-          "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+          "integrity": "sha1-cjCF0gPzjX0UcnHl7Tp1SI60SgI=",
           "dev": true,
           "requires": {
             "tunnel": "0.0.4",
@@ -106,7 +106,7 @@
     "coffee-script": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM=",
       "dev": true
     },
     "commander": {
@@ -200,7 +200,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "expand-range": {
@@ -320,7 +320,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
       "dev": true
     },
     "is-extendable": {
@@ -391,7 +391,7 @@
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -454,7 +454,7 @@
     "markdown-toc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
-      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "integrity": "sha1-RKFWBoREkDFK/ARESD+eexEiwzk=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.2",
@@ -869,7 +869,7 @@
     "typed-rest-client": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
-      "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+      "integrity": "sha1-Uxe2B8nI7kJbZCYMkknUANCmvxo=",
       "dev": true,
       "requires": {
         "tunnel": "0.0.4",


### PR DESCRIPTION
Cherry-picks four PRs originally merged to releases/m167
- [Select nuget version based on msbuild version](https://github.com/microsoft/azure-pipelines-tasks/pull/12637)
- [Probing directly for msbuild under VS2019 install path on Windows](https://github.com/microsoft/azure-pipelines-tasks/pull/12638)
- [Including equlity check against msbuild version](https://github.com/microsoft/azure-pipelines-tasks/pull/12639)
- [Change the default for NuGetToolInstaller0 from 4.3.0 to 4.8.2](https://github.com/microsoft/azure-pipelines-tasks/pull/12646)