### PR TITLE
Fixing build by removing code sign summary file

### DIFF
--- a/ci/sign-all-tasks.yml
+++ b/ci/sign-all-tasks.yml
@@ -28,3 +28,7 @@ steps:
   displayName: Sign Task Nuget Packages
   condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), ne(variables['numTasks'], 0), eq(variables.os, 'Windows_NT'))
 
+- script: del ${{ parameters.layoutRoot }}\CodeSignSummary*.md
+  displayName: Remove CodeSignSummary file from package folder
+  condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), ne(variables['numTasks'], 0), eq(variables.os, 'Windows_NT'))
+


### PR DESCRIPTION
if there are files at the root of the Tasks.zip, the code errors out
Removing the code sign summary file should fix this.