### PR TITLE
[CMakeV1] Made the task to be executed through shell.

### DIFF
--- a/Tasks/CMakeV1/cmaketask.ts
+++ b/Tasks/CMakeV1/cmaketask.ts
@@ -3,25 +3,25 @@ import tl = require('azure-pipelines-task-lib/task');
 import trm = require('azure-pipelines-task-lib/toolrunner');
 
 async function run() {
-    try {   
-		tl.setResourcePath(path.join( __dirname, 'task.json'));
+    try {
+        tl.setResourcePath(path.join(__dirname, 'task.json'));
 
-		const cmake: trm.ToolRunner = tl.tool(tl.which('cmake', true));
+        const cmake: trm.ToolRunner = tl.tool(tl.which('cmake', true));
 
-		const cwd: string = tl.getPathInput('cwd', true, false);
-		tl.mkdirP(cwd);
-		tl.cd(cwd);
+        const cwd: string = tl.getPathInput('cwd', true, false);
+        tl.mkdirP(cwd);
+        tl.cd(cwd);
 
         cmake.line(tl.getInput('cmakeArgs', false));
-        
+
         const options: trm.IExecOptions = <trm.IExecOptions>{
             shell: true
         };
 
-		const code: number = await cmake.exec(options);
+        const code: number = await cmake.exec(options);
         tl.setResult(tl.TaskResult.Succeeded, tl.loc('CMakeReturnCode', code));
     }
-    catch(err) {
+    catch (err) {
         tl.error(err.message);
         tl.setResult(tl.TaskResult.Failed, tl.loc('CMakeFailed', err.message));
     }    

--- a/Tasks/CMakeV1/cmaketask.ts
+++ b/Tasks/CMakeV1/cmaketask.ts
@@ -1,5 +1,3 @@
-
-
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 import trm = require('azure-pipelines-task-lib/toolrunner');
@@ -8,15 +6,19 @@ async function run() {
     try {   
 		tl.setResourcePath(path.join( __dirname, 'task.json'));
 
-		var cmake: trm.ToolRunner = tl.tool(tl.which('cmake', true));
+		const cmake: trm.ToolRunner = tl.tool(tl.which('cmake', true));
 
-		var cwd: string = tl.getPathInput('cwd', true, false);
+		const cwd: string = tl.getPathInput('cwd', true, false);
 		tl.mkdirP(cwd);
 		tl.cd(cwd);
 
-		cmake.line(tl.getInput('cmakeArgs', false));
+        cmake.line(tl.getInput('cmakeArgs', false));
+        
+        const options: trm.IExecOptions = <trm.IExecOptions>{
+            shell: true
+        };
 
-		var code: number = await cmake.exec();
+		const code: number = await cmake.exec(options);
         tl.setResult(tl.TaskResult.Succeeded, tl.loc('CMakeReturnCode', code));
     }
     catch(err) {

--- a/Tasks/CMakeV1/package-lock.json
+++ b/Tasks/CMakeV1/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "azure-pipelines-task-lib": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.3.tgz",
-      "integrity": "sha512-SPWKSfgmjyBDVIMzXnnPH0Gv7YXZ+AQ3SyIhNNALAmQpOltqJhgslvzrOClR5rKuoOyJlG0AWZILbZIXCkztAA==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.9.5.tgz",
+      "integrity": "sha512-yI338OHDRmsW8YRmoXffqi1ZgqbtaT4+7E2K2luLw/OJ93v9OK/0Ul1bov0X+IWzL73U3N2IbUnRIODQa38SBQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",

--- a/Tasks/CMakeV1/package.json
+++ b/Tasks/CMakeV1/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "azure-pipelines-task-lib": "^2.9.3"
+    "azure-pipelines-task-lib": "^2.9.5"
   }
 }

--- a/Tasks/CMakeV1/task.json
+++ b/Tasks/CMakeV1/task.json
@@ -15,8 +15,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 166,
-        "Patch": 1
+        "Minor": 170,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "CMake $(cmakeArgs)",

--- a/Tasks/CMakeV1/task.loc.json
+++ b/Tasks/CMakeV1/task.loc.json
@@ -15,8 +15,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 166,
-    "Patch": 1
+    "Minor": 170,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Related to issue #12848

Made the task to be executed through shell specific for the environment to handle variables in command string properly.

**NOTE:** [These changes in azure-pipelines-task-lib](https://github.com/microsoft/azure-pipelines-task-lib/pull/637) are required.