### PR TITLE
Updating routing rules for ABTT

### DIFF
--- a/issue-rules.yml
+++ b/issue-rules.yml
@@ -53,8 +53,7 @@ rules:
 # Area: CrossPlatform
 - valueFor: '**Enter Task Name**'
   contains: 'Android'
-  addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']
+  addLabels: ['Area: ABTT']
 - valueFor: '**Enter Task Name**'
   contains: 'CocoaPods'
   addLabels: ['Area: CrossPlatform']
@@ -80,12 +79,10 @@ rules:
   assign: ['leantk']  
 - valueFor: '**Enter Task Name**'
   contains: 'XCode'
-  addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']      
+  addLabels: ['Area: ABTT']     
 - valueFor: '**Enter Task Name**'
   contains: 'Xamarin'
-  addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']     
+  addLabels: ['Area: ABTT']   
 # Area: Release
 - valueFor: '**Enter Task Name**'
   contains: 'AzureCli'
@@ -319,7 +316,7 @@ rules:
 # add likely teams to look at based on text searches
 nomatches:
 - contains: 'Xcode' 
-  addLabels: ['Area: CrossPlatform']
+  addLabels: ['Area: ABTT']
 - contains: 'Bash' 
   addLabels: ['Area: Core']
 - contains: 'Nuget' 

--- a/issue-rules.yml
+++ b/issue-rules.yml
@@ -36,7 +36,10 @@ rules:
   addLabels: ['Area: Build']
 - valueFor: '**Enter Task Name**'
   contains: 'MSBuild'
-  addLabels: ['Area: Build']  
+  addLabels: ['Area: Build']
+- valueFor: '**Enter Task Name**'
+  contains: 'CMake'
+  addLabels: ['Area: ABTT']
 # Area: Core
 - valueFor: '**Enter Task Name**'
   contains: 'Bash'
@@ -50,6 +53,9 @@ rules:
 - valueFor: '**Enter Task Name**'
   contains: 'PowerShellV2'
   addLabels: ['Area: Core']
+- valueFor: '**Enter Task Name**'
+  contains: 'SSH'
+  addLabels: ['Area: ABTT']
 # Area: CrossPlatform
 - valueFor: '**Enter Task Name**'
   contains: 'Android'


### PR DESCRIPTION
Starting to auto-assign tasks to ABTT area. @damccorm I didn't see anything for the ssh tasks so I'm assuming we don't auto-route those