### PR TITLE
Use writeFileSync instead of writeFile

### DIFF
--- a/Tasks/PowerShellV2/Tests/L0Args.ts
+++ b/Tasks/PowerShellV2/Tests/L0Args.ts
@@ -65,7 +65,7 @@ tmr.setAnswers(a);
 // Mock fs
 const fs = require('fs');
 const fsClone = Object.assign({}, fs);
-fsClone.writeFile = function(filePath, contents, options) {
+fsClone.writeFileSync = function(filePath, contents, options) {
     // Normalize to linux paths for logs we check
     console.log(`Writing ${contents} to ${filePath.replace(/\\/g, '/')}`);
 }

--- a/Tasks/PowerShellV2/Tests/L0External.ts
+++ b/Tasks/PowerShellV2/Tests/L0External.ts
@@ -64,7 +64,7 @@ tmr.setAnswers(a);
 // Mock fs
 const fs = require('fs');
 const fsClone = Object.assign({}, fs);
-fsClone.writeFile = function(filePath, contents, options) {
+fsClone.writeFileSync = function(filePath, contents, options) {
     // Normalize to linux paths for logs we check
     console.log(`Writing ${contents} to ${filePath.replace(/\\/g, '/')}`);
 }

--- a/Tasks/PowerShellV2/Tests/L0Inline.ts
+++ b/Tasks/PowerShellV2/Tests/L0Inline.ts
@@ -64,7 +64,7 @@ tmr.setAnswers(a);
 // Mock fs
 const fs = require('fs');
 const fsClone = Object.assign({}, fs);
-fsClone.writeFile = function(filePath, contents, options) {
+fsClone.writeFileSync = function(filePath, contents, options) {
     // Normalize to linux paths for logs we check
     console.log(`Writing ${contents} to ${filePath.replace(/\\/g, '/')}`);
 }

--- a/Tasks/PowerShellV2/Tests/L0StdErr.ts
+++ b/Tasks/PowerShellV2/Tests/L0StdErr.ts
@@ -67,7 +67,7 @@ tmr.setAnswers(a);
 // Mock fs
 const fs = require('fs');
 const fsClone = Object.assign({}, fs);
-fsClone.writeFile = function(filePath, contents, options) {
+fsClone.writeFileSync = function(filePath, contents, options) {
     // Normalize to linux paths for logs we check
     console.log(`Writing ${contents} to ${filePath.replace(/\\/g, '/')}`);
 }

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -67,7 +67,7 @@ async function run() {
         let tempDirectory = tl.getVariable('agent.tempDirectory');
         tl.checkPath(tempDirectory, `${tempDirectory} (agent.tempDirectory)`);
         let filePath = path.join(tempDirectory, uuidV4() + '.ps1');
-        await fs.writeFile(
+        fs.writeFileSync(
             filePath,
             '\ufeff' + contents.join(os.EOL), // Prepend the Unicode BOM character.
             { encoding: 'utf8' });            // Since UTF8 encoding is specified, node will

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 169,
+        "Minor": 170,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 169,
+    "Minor": 170,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Right now, we use fs.writeFile which has a contract that changed from Node 6 to Node 10 and we're using the old version. This is fine most of the time, but if someone is using a container that supplies Node >= 10, it blows up.

Fixes #12771