### PR TITLE
[JavaToolInstallerV0] - add support of bin in the root, JDK file validation

### DIFF
--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -4,6 +4,12 @@ import * as path from 'path';
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
 
+export const BIN_FOLDER = 'bin';
+
+interface IDirectoriesDictionary {
+    [key: string]: null
+}
+
 export class JavaFilesExtractor {
     public destinationFolder: string;
     public readonly win: boolean;
@@ -131,6 +137,24 @@ export class JavaFilesExtractor {
         }    
     }
 
+    /**
+     * Creates a list of directories on the root level of structure.
+     * @param pathsArray - contains paths to all the files inside the structure
+     * @param root - path to the directory we want to get the structure of
+     */
+    private static sliceStructure(pathsArray: Array<string>, root: string = pathsArray[0]): Array<string>{
+        const dirPathLength = root.length;
+        const structureObject: IDirectoriesDictionary = {};
+        for(let i = 0; i < pathsArray.length; i++){
+            const pathStr = pathsArray[i];
+            const cleanPathStr = pathStr.slice(dirPathLength + 1);
+            const dirPathArray = cleanPathStr.split(path.sep);
+            // Create the list of unique values
+            structureObject[dirPathArray[0]] = null;
+        }
+        return Object.keys(structureObject);
+    }
+
     public async unzipJavaDownload(repoRoot: string, fileEnding: string, extractLocation: string): Promise<string> {
         this.destinationFolder = extractLocation;
         let initialDirectoriesList: string[];
@@ -148,9 +172,21 @@ export class JavaFilesExtractor {
         const jdkFile = path.normalize(repoRoot);
         const stats = taskLib.stats(jdkFile);
         if (stats.isFile()) {
-            await this.extractFiles(jdkFile, fileEnding)
+            await this.extractFiles(jdkFile, fileEnding);
             finalDirectoriesList = taskLib.find(this.destinationFolder).filter(x => taskLib.stats(x).isDirectory());
-            jdkDirectory = finalDirectoriesList.filter(dir => initialDirectoriesList.indexOf(dir) < 0)[0];
+            const freshExtractedDirectories = finalDirectoriesList.filter(dir => initialDirectoriesList.indexOf(dir) < 0);
+            const rootStructure = JavaFilesExtractor.sliceStructure(freshExtractedDirectories, this.destinationFolder);
+            let jdkDirectory = freshExtractedDirectories[0];
+            if (rootStructure.find(dir => dir === BIN_FOLDER)){
+                // In case of 'bin' folder was extracted directly to the destination folder
+                jdkDirectory = path.join(jdkDirectory, '..');
+            } else {
+                // Check if bin is inside the current JDK directory
+                const ifBinExists = fs.existsSync(path.join(jdkDirectory, BIN_FOLDER));
+                if (rootStructure.length > 1 || !ifBinExists){
+                    throw new Error(taskLib.loc('WrongArchiveStructure'));
+                }
+            }
             taskLib.debug(`Using folder "${jdkDirectory}" for JDK`);
             this.unpackJars(jdkDirectory, path.join(jdkDirectory, 'bin'));
             return jdkDirectory;

--- a/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
+++ b/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
@@ -5,6 +5,8 @@ import toolLib = require('azure-pipelines-tool-lib/tool');
 
 import { AzureStorageArtifactDownloader } from "./AzureStorageArtifacts/AzureStorageArtifactDownloader";
 import { JavaFilesExtractor } from './FileExtractor/JavaFilesExtractor';
+import {BIN_FOLDER} from "./FileExtractor/JavaFilesExtractor";
+
 taskLib.setResourcePath(path.join(__dirname, 'task.json'));
 
 async function run() {
@@ -76,7 +78,7 @@ async function getJava(versionSpec: string) {
     console.log(taskLib.loc('SetExtendedJavaHome', extendedJavaHome, jdkDirectory));
     taskLib.setVariable('JAVA_HOME', jdkDirectory);
     taskLib.setVariable(extendedJavaHome, jdkDirectory);
-    toolLib.prependPath(path.join(jdkDirectory, 'bin'));    
+    toolLib.prependPath(path.join(jdkDirectory, BIN_FOLDER));
 }
 
 function sleepFor(sleepDurationInMillisecondsSeconds): Promise<any> {

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -176,6 +176,7 @@
         "ExpiredServicePrincipal": "Could not fetch access token for Azure. Verify if the Service Principal used is valid and not expired.",
         "CorrelationIdForARM": "Correlation ID from ARM api call response : %s",
         "JavaNotPreinstalled": "Java %s is not preinstalled on this agent",
-        "UsePreinstalledJava": "Use preinstalled JDK from %s"
+        "UsePreinstalledJava": "Use preinstalled JDK from %s",
+        "WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside."
     }
 }

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -176,6 +176,7 @@
     "ExpiredServicePrincipal": "ms-resource:loc.messages.ExpiredServicePrincipal",
     "CorrelationIdForARM": "ms-resource:loc.messages.CorrelationIdForARM",
     "JavaNotPreinstalled": "ms-resource:loc.messages.JavaNotPreinstalled",
-    "UsePreinstalledJava": "ms-resource:loc.messages.UsePreinstalledJava"
+    "UsePreinstalledJava": "ms-resource:loc.messages.UsePreinstalledJava",
+    "WrongArchiveStructure": "ms-resource:loc.messages.WrongArchiveStructure"
   }
 }


### PR DESCRIPTION
Closes #12858 
- [x] Added support of 'bin' folder right inside the JDK archive
- [x] Added error handler which informs the user if the JDK Archive is valid