### PR TITLE
WIP: Fix broken Docker builds when no tags are specified

### DIFF
--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -42,7 +42,7 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     let labelArguments = pipelineUtils.getDefaultLabels(addPipelineData);
 
     // get tags input
-    let tags = tl.getInput("tags").split(/[\n,]+/);
+    let tags = tl.getDelimitedInput("tags", /[\n,]+/);
 
     let tagArguments: string[] = [];
     // find all the tag arguments to be added to the command


### PR DESCRIPTION
Applying fix from https://github.com/microsoft/azure-pipelines-task-lib/pull/638 for issue https://github.com/microsoft/azure-pipelines-tasks/issues/12927.

This is WIP until:

- [ ] a build of https://github.com/microsoft/azure-pipelines-task-lib is pushed to NPM that is newer than 2.9.5 (The current release: https://www.npmjs.com/package/azure-pipelines-task-lib)
- [ ] update package-lock.json for DockerV2 to point to the newer version of the lib

FYI @ammohant and @damccorm .