### PR TITLE
PublishPipelineMetadata pushes empty resourceId when resourceUris is [] in METADATA_<guid> object.

### DIFF
--- a/Tasks/PublishPipelineMetadataV0/publishmetadata.ts
+++ b/Tasks/PublishPipelineMetadataV0/publishmetadata.ts
@@ -53,7 +53,7 @@ function constructMetadataRequestBody(requestObject: any): AttestationRequestPay
 
     let resourceUri: string[] = [];
     const resourceIds = tl.getVariable("RESOURCE_URIS");
-    if (!requestObject.resourceUris) {
+    if (!requestObject.resourceUris || requestObject.resourceUris.length == 0) {
         if (resourceIds) {
             const resourceIdArray = resourceIds.split(",");
             if (resourceIdArray.length == 0) {

--- a/Tasks/PublishPipelineMetadataV0/task.json
+++ b/Tasks/PublishPipelineMetadataV0/task.json
@@ -11,8 +11,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 165,
-        "Patch": 2
+        "Minor": 170,
+        "Patch": 0
     },
     "preview": true,
     "instanceNameFormat": "Publishing Metadata for pipeline $(System.DefinitionName) to Evidence store",

--- a/Tasks/PublishPipelineMetadataV0/task.loc.json
+++ b/Tasks/PublishPipelineMetadataV0/task.loc.json
@@ -11,8 +11,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 165,
-    "Patch": 2
+    "Minor": 170,
+    "Patch": 0
   },
   "preview": true,
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
When `METADATA_<guid>` variable is populated by a previous step with empty `resourceUris` array, the API call to add attestation details errors out because `resourceUri` array is empty.
Added array length check, while populating `resourceUri` to use the `RESOURCE_URIS` variable when the `resourceUris` array in `METADATA_<guid>` object is empty.