### PR TITLE
adding support for linux arm architecture for kubectl and helm install

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV0/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 170,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [

--- a/Tasks/AzureFunctionOnKubernetesV0/task.loc.json
+++ b/Tasks/AzureFunctionOnKubernetesV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 170,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/Common/kubernetes-common-v2/helmutility.ts
+++ b/Tasks/Common/kubernetes-common-v2/helmutility.ts
@@ -6,6 +6,7 @@ import * as util from 'util';
 import * as uuidV4 from 'uuid/v4';
 import * as tl from 'azure-pipelines-task-lib/task';
 import { getExecutableExtension } from './utility';
+import * as  osutil from './osutility';
 const semver = require('semver');
 
 const helmToolName = 'helm';
@@ -52,7 +53,8 @@ function findHelm(rootFolder: string) {
 function getHelmDownloadURL(version: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://get.helm.sh/helm-%s-linux-amd64.zip', version);
+            const architecture = osutil.getSupportedLinuxArchitecture();
+            return util.format('https://get.helm.sh/helm-%s-linux-%s.zip', version, architecture);
 
         case 'Darwin':
             return util.format('https://get.helm.sh/helm-%s-darwin-amd64.zip', version);

--- a/Tasks/Common/kubernetes-common-v2/kubectlutility.ts
+++ b/Tasks/Common/kubernetes-common-v2/kubectlutility.ts
@@ -6,6 +6,7 @@ import * as util from 'util';
 import * as yaml from 'js-yaml';
 import * as fs from 'fs';
 import { getExecutableExtension } from './utility';
+import * as  osutil from './osutility';
 
 const kubectlToolName = 'kubectl';
 export const stableKubectlVersion = 'v1.14.0';
@@ -73,7 +74,8 @@ function getTempDirectory(): string {
 function getkubectlDownloadURL(version: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl', version);
+            const architecture = osutil.getSupportedLinuxArchitecture();
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/%s/kubectl', version, architecture);
 
         case 'Darwin':
             return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl', version);

--- a/Tasks/Common/kubernetes-common-v2/osutility.ts
+++ b/Tasks/Common/kubernetes-common-v2/osutility.ts
@@ -1,0 +1,10 @@
+let os = require('os');
+
+export function getSupportedLinuxArchitecture(): string {
+    let supportedArchitecture = "amd64";
+    const architecture = os.arch();
+    if (architecture.startsWith("arm")) { //both arm64 and arm are handled
+        supportedArchitecture = architecture;
+    }
+    return supportedArchitecture;
+}

--- a/Tasks/DockerInstallerV0/src/utils.ts
+++ b/Tasks/DockerInstallerV0/src/utils.ts
@@ -57,9 +57,14 @@ function findDocker(rootFolder: string) {
 
 function getDockerDownloadURL(version: string, releaseType: string): string {
     var platform;
+    let architecture = "x86_64";
     switch (os.type()) {
         case 'Linux':
-            platform = "linux"; break;
+            platform = "linux";
+            if (os.arch() === "arm64") {
+                architecture = "aarch64";
+            }
+            break;
 
         case 'Darwin':
             platform = "mac"; break;
@@ -68,7 +73,8 @@ function getDockerDownloadURL(version: string, releaseType: string): string {
         case 'Windows_NT':
             platform = "win"; break;
     }
-    return util.format("https://download.docker.com/%s/static/%s/x86_64/docker-%s%s",platform, releaseType, version, getArchiveExtension());
+    return util.format("https://download.docker.com/%s/static/%s/%s/docker-%s%s", platform, releaseType,
+        architecture, version, getArchiveExtension());
 }
 
 function getExecutableExtension(): string {

--- a/Tasks/DockerInstallerV0/task.json
+++ b/Tasks/DockerInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 166,
-        "Patch": 2
+        "Minor": 167,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/DockerInstallerV0/task.json
+++ b/Tasks/DockerInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 167,
+        "Minor": 171,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerInstallerV0/task.loc.json
+++ b/Tasks/DockerInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 167,
+    "Minor": 171,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DockerInstallerV0/task.loc.json
+++ b/Tasks/DockerInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 166,
-    "Patch": 2
+    "Minor": 167,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 171,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 171,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 170,
+        "Minor": 171,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 169,
-        "Patch": 1
+        "Minor": 170,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 169,
-    "Patch": 1
+    "Minor": 170,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 170,
+    "Minor": 171,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 170,
+        "Minor": 171,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 169,
-        "Patch": 1
+        "Minor": 170,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 170,
+    "Minor": 171,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 169,
-    "Patch": 1
+    "Minor": 170,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 169,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 169,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 170,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 170,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
Added support for arm architecture on linux platform for kubectl and helm install tasks.
Verified the changes on a ARM64 Ubuntu machine.

This will fix the issues #11596, #11597 and #11598