### PR TITLE
[JenkinsQueueJobV2] Fix job hang out after unexpected response from Jenkins

### DIFF
--- a/Tasks/JenkinsQueueJobV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/JenkinsQueueJobV2/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Jenkins queue job",
-  "loc.helpMarkDown": "This task queues a job on a [Jenkins](https://jenkins.io/) server. Full integration capabilities require installation of the [Team Foundation Server Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin) on Jenkins. [More Information](http://go.microsoft.com/fwlink/?LinkId=816956).",
+  "loc.helpMarkDown": "[Learn more about this task](http://go.microsoft.com/fwlink/?LinkId=816956). This task queues a job on a [Jenkins](https://jenkins.io/) server. Full integration capabilities require installation of the [Team Foundation Server Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin) on Jenkins.",
   "loc.description": "Queue a job on a Jenkins server",
   "loc.instanceNameFormat": "Queue Jenkins job: $(jobName)",
   "loc.group.displayName.advanced": "Advanced",

--- a/Tasks/JenkinsQueueJobV2/Tests/L0.ts
+++ b/Tasks/JenkinsQueueJobV2/Tests/L0.ts
@@ -186,4 +186,19 @@ describe('JenkinsQueueJob L0 Suite', function () {
         assert.deepEqual(expectedScenario, executedScenario);
         done();
     });
+
+    it('[Job state] Check that trasntioin rules are defined for all states', (done) => {
+        try {
+            const stateList = Object.keys(JobState).filter((element) => isNaN(Number(element)));
+
+            for (const testedState of stateList) {
+                for (const state of stateList) {
+                    checkStateTransitions(JobState[testedState], JobState[state]);
+                }
+            }
+            done();
+        } catch (error) {
+            done(error);
+        }
+    });
 });

--- a/Tasks/JenkinsQueueJobV2/Tests/L0.ts
+++ b/Tasks/JenkinsQueueJobV2/Tests/L0.ts
@@ -6,6 +6,7 @@ import path = require('path');
 import os = require('os');
 import process = require('process');
 import fs = require('fs');
+import {JobState, checkStateTransitions} from '../states';
 
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
@@ -157,4 +158,32 @@ describe('JenkinsQueueJob L0 Suite', function () {
         }
     });
 
+    it('[Job state] Check state transition rules', (done) => {
+        let currentState: JobState = JobState.New;
+
+        // the longest scenario from possible
+        const expectedScenario: Array<JobState> = [
+            JobState.Locating,
+            JobState.Streaming,
+            JobState.Finishing,
+            JobState.Downloading,
+            JobState.Done
+        ];
+
+        const executedScenario: Array<JobState> = [];
+
+        for (const newState of expectedScenario) {
+            const isValidTransition: boolean = checkStateTransitions(currentState, newState);
+            if (isValidTransition) {
+                executedScenario.push(newState);
+                currentState = newState;
+            } else {
+                console.log(`Invalid state transition from: ${JobState[currentState]} to: ${JobState[newState]}`);
+                break;
+            }
+        }
+
+        assert.deepEqual(expectedScenario, executedScenario);
+        done();
+    });
 });

--- a/Tasks/JenkinsQueueJobV2/Tests/L0.ts
+++ b/Tasks/JenkinsQueueJobV2/Tests/L0.ts
@@ -158,7 +158,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         }
     });
 
-    it('[Job state] Check state transition rules', (done) => {
+    it('[Job state] Run the longest test scenario of the state transitions', (done) => {
         let currentState: JobState = JobState.New;
 
         // the longest scenario from possible
@@ -187,7 +187,7 @@ describe('JenkinsQueueJob L0 Suite', function () {
         done();
     });
 
-    it('[Job state] Check that trasntioin rules are defined for all states', (done) => {
+    it('[Job state] Check that transition rules are defined for all states', (done) => {
         try {
             const stateList = Object.keys(JobState).filter((element) => isNaN(Number(element)));
 

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -297,6 +297,8 @@ export class Job {
                     return;
                 } else if (httpResponse.statusCode !== 200) {
                     Util.failReturnCode(httpResponse, 'Job progress tracking failed to read job result');
+                    tl.error(`Job was killed because of an response with unexpected status code from Jenkins ${httpResponse.statusCode}`);
+                    thisJob.stopWork(0, JobState.Killed);
                 } else {
                     const parsedBody: {result: string, timestamp: number} = JSON.parse(body);
                     thisJob.debug(`parsedBody for: ${resultUrl} : ${JSON.stringify(parsedBody)}`);

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -297,7 +297,7 @@ export class Job {
                     return;
                 } else if (httpResponse.statusCode !== 200) {
                     Util.failReturnCode(httpResponse, 'Job progress tracking failed to read job result');
-                    tl.error(`Job was killed because of an response with unexpected status code from Jenkins ${httpResponse.statusCode}`);
+                    tl.error(`Job was killed because of an response with unexpected status code from Jenkins - ${httpResponse.statusCode}`);
                     thisJob.stopWork(0, JobState.Killed);
                 } else {
                     const parsedBody: {result: string, timestamp: number} = JSON.parse(body);

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -89,17 +89,32 @@ export class Job {
         } else {
             this.working = true;
             setTimeout(() => {
-                if (this.State === JobState.New) {
-                    this.initialize();
-                } else if (this.State === JobState.Streaming) {
-                    this.streamConsole();
-                } else if (this.State === JobState.Downloading) {
-                    this.downloadResults();
-                } else if (this.State === JobState.Finishing) {
-                    this.finish();
-                } else {
-                    // usually do not get here, but this can happen if another callback caused this job to be joined
-                    this.stopWork(this.queue.TaskOptions.pollIntervalMillis, null);
+                switch (this.State) {
+                    case (JobState.New): {
+                        this.initialize();
+                        break;
+                    }
+
+                    case (JobState.Streaming): {
+                        this.streamConsole();
+                        break;
+                    }
+
+                    case (JobState.Downloading): {
+                        this.downloadResults();
+                        break;
+                    }
+
+                    case (JobState.Finishing): {
+                        this.finish();
+                        break;
+                    }
+
+                    default: {
+                        // usually do not get here, but this can happen if another callback caused this job to be joined
+                        this.stopWork(this.queue.TaskOptions.pollIntervalMillis, null);
+                        break;
+                    }
                 }
             }, this.workDelay);
         }
@@ -280,7 +295,7 @@ export class Job {
                     Util.handleConnectionResetError(err); // something went bad
                     thisJob.stopWork(thisJob.queue.TaskOptions.pollIntervalMillis, thisJob.State);
                     return;
-                } else if (httpResponse.statusCode != 200) {
+                } else if (httpResponse.statusCode !== 200) {
                     Util.failReturnCode(httpResponse, 'Job progress tracking failed to read job result');
                 } else {
                     const parsedBody: {result: string, timestamp: number} = JSON.parse(body);

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -72,12 +72,12 @@ export class Job {
      * This defines all and validates all state transitions.
      */
     private changeState(newState: JobState) {
-        const currnetState: JobState = this.State;
-        this.debug(`state changed from ${JobState[currnetState]} to ${JobState[newState]}`);
+        const currentState: JobState = this.State;
+        this.debug(`state changed from ${JobState[currentState]} to ${JobState[newState]}`);
 
-        const validStateChange: boolean = checkStateTransitions(currnetState, newState);
+        const validStateChange: boolean = checkStateTransitions(currentState, newState);
         if (!validStateChange) {
-            Util.fail(`Invalid state change from: ${JobState[currnetState]} to: ${JobState[newState]} ${this}`);
+            Util.fail(`Invalid state change from: ${JobState[currentState]} to: ${JobState[newState]} ${this}`);
         }
 
         this.State = newState;

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -448,8 +448,8 @@ export class Job {
                 }
             }
         }).auth(thisJob.queue.TaskOptions.username, thisJob.queue.TaskOptions.password, true)
-        .on('error', (err) => { 
-            throw err; 
+        .on('error', (err) => {
+            throw err;
         });
     }
 

--- a/Tasks/JenkinsQueueJobV2/job.ts
+++ b/Tasks/JenkinsQueueJobV2/job.ts
@@ -11,29 +11,9 @@ import request = require('request');
 import { JobSearch } from './jobsearch';
 import { JobQueue } from './jobqueue';
 import { unzip } from './unzip';
+import {JobState, checkStateTransitions} from './states';
 
 import * as Util from './util';
-
-// Jobs transition between states as follows:
-// ------------------------------------------
-// BEGINNING STATE: New
-// New →            Locating, Streaming, Joined, Cut
-// Locating →       Streaming, Joined, Cut
-// Streaming →      Finishing
-// Finishing →      Downloading, Queued, Done
-// Downloading →    Done
-// TERMINAL STATES: Done, Queued, Joined, Cut
-export enum JobState {
-    New,       // 0 - The job is yet to begin
-    Locating,  // 1 - The job is being located
-    Streaming, // 2 - The job is running and its console output is streaming
-    Finishing, // 3 - The job has run and is "finishing"
-    Done,      // 4 - The job has run and is done
-    Joined,    // 5 - The job is considered complete because it has been joined to the execution of another matching job execution
-    Queued,    // 6 - The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting)
-    Cut,       // 7 - The job was cut from execution by the pipeline
-    Downloading// 8 - The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed)
-}
 
 export class Job {
     public Parent: Job; // if this job is a pipelined job, its parent that started it.
@@ -92,28 +72,15 @@ export class Job {
      * This defines all and validates all state transitions.
      */
     private changeState(newState: JobState) {
-        const oldState: JobState = this.State;
-        this.State = newState;
-        if (oldState !== newState) {
-            this.debug('state changed from: ' + oldState);
-            let validStateChange: boolean = false;
-            if (oldState === JobState.New) {
-                validStateChange = (newState === JobState.Locating || newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
-            } else if (oldState === JobState.Locating) {
-                validStateChange = (newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
-            } else if (oldState === JobState.Streaming) {
-                validStateChange = (newState === JobState.Finishing);
-            } else if (oldState === JobState.Finishing) {
-                validStateChange = (newState === JobState.Downloading || newState === JobState.Queued || newState === JobState.Done);
-            } else if (oldState === JobState.Downloading) {
-                validStateChange = (newState === JobState.Done);
-            } else if (oldState === JobState.Done || oldState === JobState.Joined || oldState === JobState.Cut) {
-                validStateChange = false; // these are terminal states
-            }
-            if (!validStateChange) {
-                Util.fail('Invalid state change from: ' + oldState + ' ' + this);
-            }
+        const currnetState: JobState = this.State;
+        this.debug(`state changed from ${JobState[currnetState]} to ${JobState[newState]}`);
+
+        const validStateChange: boolean = checkStateTransitions(currnetState, newState);
+        if (!validStateChange) {
+            Util.fail(`Invalid state change from: ${JobState[currnetState]} to: ${JobState[newState]} ${this}`);
         }
+
+        this.State = newState;
     }
 
     public DoWork() {

--- a/Tasks/JenkinsQueueJobV2/jobqueue.ts
+++ b/Tasks/JenkinsQueueJobV2/jobqueue.ts
@@ -6,9 +6,10 @@ import fs = require('fs');
 import path = require('path');
 import shell = require('shelljs');
 
-import { Job, JobState } from './job';
+import { Job } from './job';
 import { JobSearch } from './jobsearch';
 import { TaskOptions } from './jenkinsqueuejobtask';
+import { JobState } from './states';
 
 import util = require('./util');
 

--- a/Tasks/JenkinsQueueJobV2/jobsearch.ts
+++ b/Tasks/JenkinsQueueJobV2/jobsearch.ts
@@ -301,13 +301,13 @@ export class JobSearch {
 }
 
 interface Project {
-    name: string,
-    url: string,
-    color: string
+    name: string;
+    url: string;
+    color: string;
 }
 interface ParsedTaskBody {
-    downstreamProjects?: Project[],
+    downstreamProjects?: Project[];
     lastBuild?: {
         number: number
-    }
+    };
 }

--- a/Tasks/JenkinsQueueJobV2/jobsearch.ts
+++ b/Tasks/JenkinsQueueJobV2/jobsearch.ts
@@ -5,8 +5,9 @@ import tl = require('azure-pipelines-task-lib/task');
 import Q = require('q');
 import request = require('request');
 
-import { Job, JobState } from './job';
+import { Job } from './job';
 import { JobQueue } from './jobqueue';
+import { JobState } from './states';
 
 import util = require('./util');
 

--- a/Tasks/JenkinsQueueJobV2/states.ts
+++ b/Tasks/JenkinsQueueJobV2/states.ts
@@ -4,19 +4,20 @@
 // New →            Locating, Streaming, Joined, Cut
 // Locating →       Streaming, Joined, Cut
 // Streaming →      Finishing
-// Finishing →      Downloading, Queued, Done
+// Finishing →      Downloading, Queued, Done, Killed
 // Downloading →    Done
 // TERMINAL STATES: Done, Queued, Joined, Cut
 export enum JobState {
-    New,       // 0 - The job is yet to begin
-    Locating,  // 1 - The job is being located
-    Streaming, // 2 - The job is running and its console output is streaming
-    Finishing, // 3 - The job has run and is "finishing"
-    Done,      // 4 - The job has run and is done
-    Joined,    // 5 - The job is considered complete because it has been joined to the execution of another matching job execution
-    Queued,    // 6 - The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting)
-    Cut,       // 7 - The job was cut from execution by the pipeline
-    Downloading// 8 - The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed)
+    New,         // 0 - The job is yet to begin
+    Locating,    // 1 - The job is being located
+    Streaming,   // 2 - The job is running and its console output is streaming
+    Finishing,   // 3 - The job has run and is "finishing"
+    Done,        // 4 - The job has run and is done
+    Joined,      // 5 - The job is considered complete because it has been joined to the execution of another matching job execution
+    Queued,      // 6 - The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting)
+    Cut,         // 7 - The job was cut from execution by the pipeline
+    Downloading, // 8 - The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed)
+    Killed,      // 9 - The job has run and while "finishing" Jenkins provided unexpected answer via an HTTP request
 }
 
 export function checkStateTransitions (currentState: JobState, newState: JobState): boolean {
@@ -40,7 +41,7 @@ export function checkStateTransitions (currentState: JobState, newState: JobStat
         }
 
         case (JobState.Finishing): {
-            possibleStates = [JobState.Downloading, JobState.Queued, JobState.Done];
+            possibleStates = [JobState.Downloading, JobState.Queued, JobState.Done, JobState.Killed];
             break;
         }
 
@@ -52,7 +53,8 @@ export function checkStateTransitions (currentState: JobState, newState: JobStat
         case (JobState.Done):
         case (JobState.Joined):
         case (JobState.Queued):
-        case (JobState.Cut): {
+        case (JobState.Cut):
+        case (JobState.Killed): {
             break;
         }
 

--- a/Tasks/JenkinsQueueJobV2/states.ts
+++ b/Tasks/JenkinsQueueJobV2/states.ts
@@ -1,25 +1,57 @@
-// Jobs transition between states as follows:
-// ------------------------------------------
-// BEGINNING STATE: New
-// New →            Locating, Streaming, Joined, Cut
-// Locating →       Streaming, Joined, Cut
-// Streaming →      Finishing
-// Finishing →      Downloading, Queued, Done, Killed
-// Downloading →    Done
-// TERMINAL STATES: Done, Queued, Joined, Cut
+/**
+ * @enum {number} JobState
+ * @readonly
+ * @description Enum for job states
+ */
 export enum JobState {
-    New,         // 0 - The job is yet to begin
-    Locating,    // 1 - The job is being located
-    Streaming,   // 2 - The job is running and its console output is streaming
-    Finishing,   // 3 - The job has run and is "finishing"
-    Done,        // 4 - The job has run and is done
-    Joined,      // 5 - The job is considered complete because it has been joined to the execution of another matching job execution
-    Queued,      // 6 - The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting)
-    Cut,         // 7 - The job was cut from execution by the pipeline
-    Downloading, // 8 - The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed)
-    Killed,      // 9 - The job has run and while "finishing" Jenkins provided unexpected answer via an HTTP request
+    /** The job is yet to begin */
+    New,
+
+    /** The job is being located */
+    Locating,
+
+    /** The job is running and its console output is streaming */
+    Streaming,
+
+    /** The job has run and is "finishing" */
+    Finishing,
+
+    /** The job has run and is done */
+    Done,
+
+    /** The job is considered complete because it has been joined to the execution of another matching job execution */
+    Joined,
+
+    /** The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting) */
+    Queued,
+
+    /** The job was cut from execution by the pipeline */
+    Cut,
+
+    /** The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed) */
+    Downloading,
+
+    /** The job has run and while "finishing" Jenkins provided unexpected answer via an HTTP request */
+    Killed,
 }
 
+/**
+ * @function checkStateTransitions
+ * @description Check validation of transition between states
+ * @param {JobState} currentState - current job state
+ * @param {JobState} newState - future job state
+ * @throws {Error} When there was no transition rule for the current state
+ *
+ * @example
+ * Jobs transition between states as follows:
+ * BEGINNING STATE: New
+ *   New →            Locating, Streaming, Joined, Cut
+ *   Locating →       Streaming, Joined, Cut
+ *   Streaming →      Finishing
+ *   Finishing →      Downloading, Queued, Done, Killed
+ *   Downloading →    Done
+ * TERMINAL STATES: Done, Queued, Joined, Cut, Killed
+ */
 export function checkStateTransitions (currentState: JobState, newState: JobState): boolean {
     let isValidTransition: boolean = false;
     let possibleStates: Array<JobState> = [];

--- a/Tasks/JenkinsQueueJobV2/states.ts
+++ b/Tasks/JenkinsQueueJobV2/states.ts
@@ -1,0 +1,42 @@
+// Jobs transition between states as follows:
+// ------------------------------------------
+// BEGINNING STATE: New
+// New →            Locating, Streaming, Joined, Cut
+// Locating →       Streaming, Joined, Cut
+// Streaming →      Finishing
+// Finishing →      Downloading, Queued, Done
+// Downloading →    Done
+// TERMINAL STATES: Done, Queued, Joined, Cut
+export enum JobState {
+    New,       // 0 - The job is yet to begin
+    Locating,  // 1 - The job is being located
+    Streaming, // 2 - The job is running and its console output is streaming
+    Finishing, // 3 - The job has run and is "finishing"
+    Done,      // 4 - The job has run and is done
+    Joined,    // 5 - The job is considered complete because it has been joined to the execution of another matching job execution
+    Queued,    // 6 - The job was queued and will not be tracked for completion (as specified by the "Capture..." task setting)
+    Cut,       // 7 - The job was cut from execution by the pipeline
+    Downloading// 8 - The job has run and its results are being downloaded (occurs when the TFS Plugin for Jenkins is installed)
+}
+
+export function checkStateTransitions (currentState: JobState, newState: JobState): boolean {
+    let validStateChange: boolean = false;
+
+    if (currentState !== newState) {
+        if (currentState === JobState.New) {
+            validStateChange = (newState === JobState.Locating || newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
+        } else if (currentState === JobState.Locating) {
+            validStateChange = (newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
+        } else if (currentState === JobState.Streaming) {
+            validStateChange = (newState === JobState.Finishing);
+        } else if (currentState === JobState.Finishing) {
+            validStateChange = (newState === JobState.Downloading || newState === JobState.Queued || newState === JobState.Done);
+        } else if (currentState === JobState.Downloading) {
+            validStateChange = (newState === JobState.Done);
+        } else if (currentState === JobState.Done || currentState === JobState.Joined || currentState === JobState.Cut) {
+            validStateChange = false; // these are terminal states
+        }
+    }
+
+    return validStateChange;
+}

--- a/Tasks/JenkinsQueueJobV2/states.ts
+++ b/Tasks/JenkinsQueueJobV2/states.ts
@@ -20,23 +20,50 @@ export enum JobState {
 }
 
 export function checkStateTransitions (currentState: JobState, newState: JobState): boolean {
-    let validStateChange: boolean = false;
+    let isValidTransition: boolean = false;
+    let possibleStates: Array<JobState> = [];
 
-    if (currentState !== newState) {
-        if (currentState === JobState.New) {
-            validStateChange = (newState === JobState.Locating || newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
-        } else if (currentState === JobState.Locating) {
-            validStateChange = (newState === JobState.Streaming || newState === JobState.Joined || newState === JobState.Cut);
-        } else if (currentState === JobState.Streaming) {
-            validStateChange = (newState === JobState.Finishing);
-        } else if (currentState === JobState.Finishing) {
-            validStateChange = (newState === JobState.Downloading || newState === JobState.Queued || newState === JobState.Done);
-        } else if (currentState === JobState.Downloading) {
-            validStateChange = (newState === JobState.Done);
-        } else if (currentState === JobState.Done || currentState === JobState.Joined || currentState === JobState.Cut) {
-            validStateChange = false; // these are terminal states
+    switch (currentState) {
+        case (JobState.New): {
+            possibleStates = [JobState.Locating, JobState.Streaming, JobState.Joined, JobState.Cut];
+            break;
+        }
+
+        case (JobState.Locating): {
+            possibleStates = [JobState.Streaming, JobState.Joined, JobState.Cut];
+            break;
+        }
+
+        case (JobState.Streaming): {
+            possibleStates = [JobState.Finishing];
+            break;
+        }
+
+        case (JobState.Finishing): {
+            possibleStates = [JobState.Downloading, JobState.Queued, JobState.Done];
+            break;
+        }
+
+        case (JobState.Downloading): {
+            possibleStates = [JobState.Done];
+            break;
+        }
+
+        case (JobState.Done):
+        case (JobState.Joined):
+        case (JobState.Queued):
+        case (JobState.Cut): {
+            break;
+        }
+
+        default: {
+            throw new Error(`No transition rules defined for the ${currentState} state!`);
         }
     }
 
-    return validStateChange;
+    if (possibleStates.length > 0) {
+        isValidTransition = (possibleStates.indexOf(newState) !== -1);
+    }
+
+    return isValidTransition;
 }

--- a/Tasks/JenkinsQueueJobV2/task.json
+++ b/Tasks/JenkinsQueueJobV2/task.json
@@ -4,7 +4,7 @@
     "friendlyName": "Jenkins queue job",
     "description": "Queue a job on a Jenkins server",
     "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/jenkins-queue-job",
-    "helpMarkDown": "This task queues a job on a [Jenkins](https://jenkins.io/) server. Full integration capabilities require installation of the [Team Foundation Server Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin) on Jenkins. [More Information](http://go.microsoft.com/fwlink/?LinkId=816956).",
+    "helpMarkDown": "[Learn more about this task](http://go.microsoft.com/fwlink/?LinkId=816956). This task queues a job on a [Jenkins](https://jenkins.io/) server. Full integration capabilities require installation of the [Team Foundation Server Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin) on Jenkins.",
     "category": "Build",
     "visibility": [
         "Build",
@@ -14,8 +14,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 167,
-        "Patch": 2
+        "Minor": 171,
+        "Patch": 0
     },
     "groups": [
         {

--- a/Tasks/JenkinsQueueJobV2/task.loc.json
+++ b/Tasks/JenkinsQueueJobV2/task.loc.json
@@ -14,8 +14,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 167,
-    "Patch": 2
+    "Minor": 171,
+    "Patch": 0
   },
   "groups": [
     {

--- a/Tasks/JenkinsQueueJobV2/util.ts
+++ b/Tasks/JenkinsQueueJobV2/util.ts
@@ -15,7 +15,7 @@ import { TaskOptions } from './jenkinsqueuejobtask';
 export function getFullErrorMessage(httpResponse, message: string): string {
     const fullMessage: string = message +
         '\nHttpResponse.statusCode=' + httpResponse.statusCode +
-        '\nHttpResponse.statusMessage=' + httpResponse.statusMessage
+        '\nHttpResponse.statusMessage=' + httpResponse.statusMessage;
     return fullMessage;
 }
 
@@ -325,7 +325,7 @@ export class StringWritable extends stream.Writable {
     toString(): string {
         return this.value;
     }
-};
+}
 
 /**
  * Supported parameter types: boolean, string, choice, password

--- a/Tasks/JenkinsQueueJobV2/util.ts
+++ b/Tasks/JenkinsQueueJobV2/util.ts
@@ -257,14 +257,14 @@ function submitJob(taskOptions: TaskOptions): Q.Promise<string> {
                     } else {
                         defer.reject(err);
                     }
-                } else if (httpResponse.statusCode != 201) {
+                } else if (httpResponse.statusCode !== 201) {
                     defer.reject(getFullErrorMessage(httpResponse, 'Job creation failed.'));
                 } else {
                     const queueUri: string = addUrlSegment(httpResponse.headers.location, 'api/json');
                     defer.resolve(queueUri);
                 }
             }).auth(taskOptions.username, taskOptions.password, true);
-        } else if (httpResponse.statusCode != 201) {
+        } else if (httpResponse.statusCode !== 201) {
             defer.reject(getFullErrorMessage(httpResponse, 'Job creation failed.'));
         } else {
             taskOptions.teamBuildPluginAvailable = true;

--- a/Tasks/JenkinsQueueJobV2/util.ts
+++ b/Tasks/JenkinsQueueJobV2/util.ts
@@ -13,9 +13,7 @@ import { JobQueue } from './jobqueue';
 import { TaskOptions } from './jenkinsqueuejobtask';
 
 export function getFullErrorMessage(httpResponse, message: string): string {
-    const fullMessage: string = message +
-        '\nHttpResponse.statusCode=' + httpResponse.statusCode +
-        '\nHttpResponse.statusMessage=' + httpResponse.statusMessage;
+    const fullMessage: string = `${message}\nHttpResponse.statusCode=${httpResponse.statusCode}\nHttpResponse.statusMessage=${httpResponse.statusMessage}`;
     return fullMessage;
 }
 


### PR DESCRIPTION
PR fix [#9](https://github.com/microsoft/build-task-team/issues/9) and applying the following changes:

### Fixes
* Fixed situation when the job hang out after unexpected response from Jenkins
* Fixed `About this task` link, previously it redirects on Jenkins site instead of docs.microsoft.com

### Code refactor
* Resolved all tslint warnings
* Logics for checking state transition was exported into separate function - `checkStateTransitions`
* `JobState` enum and `checkStateTransitions` function was exported into a separate module and refactored.
* Documentation for job states was rewritten on JSdocs
* Refactored `DoWork` method from the `Job` class. The `if-else` was replaced on `switch`.
* Equals Operator was replaced on Strict Equals Operator for checking HTTP-request response. (Since this task using node package [request](https://github.com/request/request) for working with http-requests, all responses are instances of [http.IncomingMessage](https://nodejs.org/api/http.html#http_class_http_incomingmessage) class where `statusCode` type documented as `number`. So it's safe to use Strict Equals Operator.)

### Unit tests
* Added test with the longest test scenario of the state transitions
* Added test for checking that transition rules are defined for all job states
---
### Testing
* Changes were tested with self-hosted windows agent and local Jenkins instance.  
* All unit tests have passed.