### PR TITLE
[BashV3] Removed execute permissions check

### DIFF
--- a/Tasks/BashV3/bash.ts
+++ b/Tasks/BashV3/bash.ts
@@ -72,26 +72,14 @@ async function run() {
             else {
                 targetFilePath = input_filePath;
             }
-
-            // Choose 1 of 3 behaviors:
+            // Choose behavior:
             // If they've set old_source_behavior, source the script. This is what we used to do and needs to hang around forever for back compat reasons
-            // If the executable bit is set, execute the script. This is our new desired behavior.
-            // If the executable bit is not set, source the script and warn. The user should either make it executable or pin to the old behavior.
+            // If they've not, execute the script with bash. This is our new desired behavior.
             // See https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/bashnote.md
             if (old_source_behavior) {
                 contents = `. '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
             } else {
-                // Check if executable bit is set
-                const stats: fs.Stats = tl.stats(input_filePath);
-                // Check file's executable bit.
-                if ((stats.mode & 1) > 0) {
-                    contents = `bash '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
-                }
-                else {
-                    tl.debug(`File permissions: ${stats.mode}`);
-                    tl.warning('Executable bit is not set on target script, sourcing instead of executing. More info at https://github.com/Microsoft/azure-pipelines-tasks/blob/master/docs/bashnote.md');
-                    contents = `. '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
-                }
+                contents = `bash '${targetFilePath.replace(/'/g, "'\\''")}' ${input_arguments}`.trim();
             }
             console.log(tl.loc('JS_FormattedCommand', contents));
         }

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 163,
-        "Patch": 3
+        "Minor": 171,
+        "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 163,
-    "Patch": 3
+    "Minor": 171,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.115.0",

--- a/docs/bashnote.md
+++ b/docs/bashnote.md
@@ -1,15 +1,8 @@
 # BashV3 Note
 
 As of August 2019, the BashV3 task has started executing scripts with a target script type of "File Path" instead of sourcing them in the default case.
-This does not work for scripts that do not have the executable bit set.
-For backwards compatibility, we will continue to source scripts that don't have the executable bit set. This will throw a warning.
+For backwards compatibility, we will continue to support scripts sourcing.
 
 ## Solution
 
-For most users, the correct response should be to make sure the executable bit is set on their script.
-
-```
-chmod +x <filename>
-```
-
-If you know what you're doing and want your script to be sourced without a warning, set the ```AZP_BASHV3_OLD_SOURCE_BEHAVIOR``` pipeline variable to true. This is not recommended.
+If you know what you're doing and want your script to be sourced, set the ```AZP_BASHV3_OLD_SOURCE_BEHAVIOR``` pipeline variable to true. This is not recommended.


### PR DESCRIPTION
Related issue: #12318

Changes:
- Removed execute permissions check as long as it's required to have only read permissions to source script file or execute it with `bash` command.
- Updated BashV3 Note.