### PR TITLE
Support installing macOS provisioning extension

### DIFF
--- a/Tasks/InstallAppleProvisioningProfileV1/preinstallprovprofile.ts
+++ b/Tasks/InstallAppleProvisioningProfileV1/preinstallprovprofile.ts
@@ -23,7 +23,7 @@ async function run() {
             let provProfilePath: string = await secureFileHelpers.downloadSecureFile(secureFileId);
 
             if (tl.exist(provProfilePath)) {
-                if (!provProfilePath.endsWith(".mobileprovision")) {
+                if (!provProfilePath.endsWith(".mobileprovision") && !provProfilePath.endsWith(".provisionprofile")) {
                     throw new Error(tl.loc('InvalidMobileProvisionFileExtension'));
                 }
                 const info = await sign.installProvisioningProfile(provProfilePath);

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -96,6 +96,6 @@
     "messages": {
         "InputProvisioningProfileNotFound": "Provisioning profile to be installed was not found at %s. Specify the full file path to a provisioning profile.",
         "InstallRequiresMac": "Install Apple Provisioning Profile requires a macOS agent. Installing on Windows or Linux is not supported by Apple.",
-        "InvalidMobileProvisionFileExtension": "Provisioning profile file should have the extension '.mobileprovision'"
+        "InvalidMobileProvisionFileExtension": "Provisioning profile file should have the extension '.mobileprovision' or '.provisionprofile'"
     }
 }


### PR DESCRIPTION
This fixes #13045

The file extensions for the provisioning profile on macOS/OSX is '.provisionprofile'. Only the mobile/iOS profile uses '.mobileprovision'

Just note: 
> I have absolutely no idea what else I have to change, or how to test this locally. I coded this all up in my mind. Actual brains need to work.
> Not sure how the tests should be written either...
> If tests need to be written and all that, then just let me know and I'll go read the docs
> 😬 

