### PR TITLE
Updated PublishTestResultsV2 task to version 2.171.0

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/12191186/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/12348207/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 170,
+        "Minor": 171,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 170,
+    "Minor": 171,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
Updated PublishTestResultsV2 version from 12191186 to 12348207
Build link :https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=12348207&view=results