### PR TITLE
Update artifacts credential provider version to 0.1.23

### DIFF
--- a/Tasks/NuGetAuthenticateV0/make.json
+++ b/Tasks/NuGetAuthenticateV0/make.json
@@ -17,7 +17,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.20/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.23/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetAuthenticateV0/task.json
+++ b/Tasks/NuGetAuthenticateV0/task.json
@@ -13,8 +13,8 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 167,
-        "Patch": 2
+        "Minor": 171,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.120.0",
     "instanceNameFormat": "NuGet Authenticate",

--- a/Tasks/NuGetAuthenticateV0/task.loc.json
+++ b/Tasks/NuGetAuthenticateV0/task.loc.json
@@ -13,8 +13,8 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 167,
-    "Patch": 2
+    "Minor": 171,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.120.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/NuGetCommandV2/make.json
+++ b/Tasks/NuGetCommandV2/make.json
@@ -52,7 +52,7 @@
                 "dest": "./CredentialProvider/"
             },
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.20/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.23/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 171,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 171,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: NuGetAuthenticateV0 and NuGetCommandV2

**Description**: update artifacts cred provider version

**Documentation changes required:**  N

**Added unit tests:**  N

**Attached related issue:**  N

**Checklist**:
- [ x ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ x ] Checked that applied changes work as expected
