### PR TITLE
Update cred provider version to 0.1.24

### DIFF
--- a/Tasks/NuGetAuthenticateV0/make.json
+++ b/Tasks/NuGetAuthenticateV0/make.json
@@ -17,7 +17,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.23/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.24/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetAuthenticateV0/task.json
+++ b/Tasks/NuGetAuthenticateV0/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 171,
+        "Minor": 172,
         "Patch": 0
     },
     "minimumAgentVersion": "2.120.0",

--- a/Tasks/NuGetAuthenticateV0/task.loc.json
+++ b/Tasks/NuGetAuthenticateV0/task.loc.json
@@ -13,7 +13,7 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 171,
+    "Minor": 172,
     "Patch": 0
   },
   "minimumAgentVersion": "2.120.0",

--- a/Tasks/NuGetCommandV2/make.json
+++ b/Tasks/NuGetCommandV2/make.json
@@ -52,7 +52,7 @@
                 "dest": "./CredentialProvider/"
             },
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.23/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.24/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 171,
-        "Patch": 1
+        "Minor": 172,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 171,
-    "Patch": 1
+    "Minor": 172,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: NuGetAuthenticateV0, NuGetCommandV2

**Description**: Update credential provider version to 0..24

**Documentation changes required:** (Y/N) n

**Added unit tests:** (Y/N) n

**Attached related issue:** (Y/N) https://github.com/microsoft/artifacts-credprovider/issues/192

**Checklist**:
- [x ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x ] Checked that applied changes work as expected
