### PR TITLE
[InstallSSHKeyV0] Changed permissions setting code

### DIFF
--- a/Tasks/InstallSSHKeyV0/Tests/L0KeyAlreadyInstalled.ts
+++ b/Tasks/InstallSSHKeyV0/Tests/L0KeyAlreadyInstalled.ts
@@ -24,7 +24,8 @@ let answers: TaskLibAnswers = {
         "ssh-add": "/usr/bin/ssh-add",
         "rm": "/bin/rm",
         "cp": "/bin/cp",
-        "icacls": "/bin/icacls"
+        "icacls": "/bin/icacls",
+        "whoami": "/bin/whoami"
     },
     "checkPath": {
         "/usr/bin/security": true,
@@ -33,6 +34,7 @@ let answers: TaskLibAnswers = {
         "/bin/rm": true,
         "/bin/cp": true,
         "/bin/icacls": true,
+        "/bin/whoami": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true
@@ -62,6 +64,10 @@ let answers: TaskLibAnswers = {
             "code": 0,
             "stdout": ""
         },
+        "/bin/whoami /user /fo csv" : {
+            "code": 0,
+            "stdout": '"Username","SID"\r\n"testUser","someSID"'
+        }
     }
 };
 taskRunner.setAnswers(answers);

--- a/Tasks/InstallSSHKeyV0/Tests/L0KeyAlreadyInstalledWithoutPubKey.ts
+++ b/Tasks/InstallSSHKeyV0/Tests/L0KeyAlreadyInstalledWithoutPubKey.ts
@@ -27,7 +27,8 @@ let answers: TaskLibAnswers = {
         "rm": "/bin/rm",
         "cp": "/bin/cp",
         "icacls": "/bin/icacls",
-        "ssh-keygen": "/usr/bin/ssh-keygen"
+        "ssh-keygen": "/usr/bin/ssh-keygen",
+        "whoami": "/bin/whoami"
     },
     "checkPath": {
         "/usr/bin/security": true,
@@ -37,6 +38,7 @@ let answers: TaskLibAnswers = {
         "/bin/cp": true,
         "/bin/icacls": true,
         "/usr/bin/ssh-keygen": true,
+        "/bin/whoami": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true
@@ -66,9 +68,13 @@ let answers: TaskLibAnswers = {
             "code": 0,
             "stdout": ""
         },
-        "/usr/bin/ssh-keygen -y -f /build/temp/mySecureFileId.filename" : {
+        "/usr/bin/ssh-keygen -y -P  -f /build/temp/mySecureFileId.filename" : {
             "code": 0,
             "stdout": sshPublicKeyGenerated
+        },
+        "/bin/whoami /user /fo csv" : {
+            "code": 0,
+            "stdout": '"Username","SID"\r\n"testUser","someSID"'
         }
     }
 };

--- a/Tasks/InstallSSHKeyV0/Tests/L0KeyMalformed.ts
+++ b/Tasks/InstallSSHKeyV0/Tests/L0KeyMalformed.ts
@@ -24,7 +24,8 @@ let answers: TaskLibAnswers = {
         "ssh-add": "/usr/bin/ssh-add",
         "rm": "/bin/rm",
         "cp": "/bin/cp",
-        "icacls": "/bin/icacls"
+        "icacls": "/bin/icacls",
+        "whoami": "/bin/whoami"
     },
     "checkPath": {
         "/usr/bin/security": true,
@@ -33,6 +34,7 @@ let answers: TaskLibAnswers = {
         "/bin/rm": true,
         "/bin/cp": true,
         "/bin/icacls": true,
+        "/bin/whoami": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true
@@ -66,6 +68,10 @@ let answers: TaskLibAnswers = {
             "code": 0,
             "stdout": ""
         },
+        "/bin/whoami /user /fo csv" : {
+            "code": 0,
+            "stdout": '"Username","SID"\r\n"testUser","someSID"'
+        }
     }
 };
 taskRunner.setAnswers(answers);

--- a/Tasks/InstallSSHKeyV0/Tests/L0StartAgent.ts
+++ b/Tasks/InstallSSHKeyV0/Tests/L0StartAgent.ts
@@ -24,7 +24,8 @@ let answers: TaskLibAnswers = {
         "ssh-add": "/usr/bin/ssh-add",
         "rm": "/bin/rm",
         "cp": "/bin/cp",
-        "icacls": "/bin/icacls"
+        "icacls": "/bin/icacls",
+        "whoami": "/bin/whoami"
     },
     "checkPath": {
         "/usr/bin/security": true,
@@ -33,6 +34,7 @@ let answers: TaskLibAnswers = {
         "/bin/rm": true,
         "/bin/cp": true,
         "/bin/icacls": true,
+        "/bin/whoami": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true
@@ -66,6 +68,10 @@ let answers: TaskLibAnswers = {
             "code": 0,
             "stdout": ""
         },
+        "/bin/whoami /user /fo csv" : {
+            "code": 0,
+            "stdout": '"Username","SID"\r\n"testUser","someSID"'
+        }
     }
 };
 taskRunner.setAnswers(answers);

--- a/Tasks/InstallSSHKeyV0/Tests/L0StartAgentWithoutPubKey.ts
+++ b/Tasks/InstallSSHKeyV0/Tests/L0StartAgentWithoutPubKey.ts
@@ -25,7 +25,8 @@ let answers: TaskLibAnswers = {
         "rm": "/bin/rm",
         "cp": "/bin/cp",
         "icacls": "/bin/icacls",
-        "ssh-keygen": "/usr/bin/ssh-keygen"
+        "ssh-keygen": "/usr/bin/ssh-keygen",
+        "whoami": "/bin/whoami"
     },
     "checkPath": {
         "/usr/bin/security": true,
@@ -35,6 +36,7 @@ let answers: TaskLibAnswers = {
         "/bin/cp": true,
         "/bin/icacls": true,
         "/usr/bin/ssh-keygen": true,
+        "/bin/whoami": true
     },
     "exist": {
         "/build/temp/mySecureFileId.filename": true
@@ -68,9 +70,13 @@ let answers: TaskLibAnswers = {
             "code": 0,
             "stdout": ""
         },
-        "/usr/bin/ssh-keygen -y -f /build/temp/mySecureFileId.filename" : {
+        "/usr/bin/ssh-keygen -y -P  -f /build/temp/mySecureFileId.filename" : {
             "code": 0,
             "stdout": "ssh-rsa KEYINFORMATIONHERE sample@example.com"
+        },
+        "/bin/whoami /user /fo csv" : {
+            "code": 0,
+            "stdout": '"Username","SID"\r\n"testUser","someSID"'
         }
     }
 };

--- a/Tasks/InstallSSHKeyV0/installsshkey-util.ts
+++ b/Tasks/InstallSSHKeyV0/installsshkey-util.ts
@@ -135,8 +135,9 @@ export class SshToolRunner {
         fs.chmodSync(fileLocation, '0600');
     }
 
-    private generatePublicKey(privateKeyLocation: string) {
-        let keygenResult: trm.IExecSyncResult =  tl.execSync('ssh-keygen', ['-y', '-f', privateKeyLocation]);
+    private generatePublicKey(privateKeyLocation: string, passphrase: string) {
+        let args: string[] = ['-y','-P', passphrase || '', '-f', privateKeyLocation]
+        let keygenResult: trm.IExecSyncResult =  tl.execSync('ssh-keygen', args);
         return keygenResult.stdout;
     }
 
@@ -175,7 +176,7 @@ export class SshToolRunner {
         this.restrictPermissionsToFile(privateKeyLocation);
 
         if (!publicKey || publicKey.length === 0) {
-            publicKey = this.generatePublicKey(privateKeyLocation);
+            publicKey = this.generatePublicKey(privateKeyLocation, passphrase);
         }
 
         let publicKeyComponents: string[] = publicKey.split(' ');

--- a/Tasks/InstallSSHKeyV0/installsshkey-util.ts
+++ b/Tasks/InstallSSHKeyV0/installsshkey-util.ts
@@ -115,9 +115,20 @@ export class SshToolRunner {
         return executable;
     }
 
+    private getWindowsUsername(): string {
+        const options: trm.IExecOptions = <trm.IExecOptions> {
+            silent: true
+        };
+        const userInfo: string =  tl.execSync('whoami', ['/user', '/fo', 'csv'], options).stdout;
+        const lines: string[] = userInfo.split('\r\n');
+        const values: string[] = lines[1].split(',');
+        const username: string = values[0].trim();       
+        return username.replace(/(^\")|(\"$)/g, '').trim();
+    }
+
     private restrictPermissionsToFile(fileLocation: string): void {
         if (this.isWindows()) {
-            const userName: string = os.userInfo().username;
+            const userName: string = this.getWindowsUsername();
             tl.execSync('icacls', [fileLocation, '/inheritance:r']);
             tl.execSync('icacls', [fileLocation, '/grant:r', `${userName}:(F)`]);
         }

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 171,
+        "Minor": 172,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 171,
+    "Minor": 172,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
**Task name**: InstallSSHKeyV0

**Description**: 

- Changed code getting Windows user name to ensure that permissions are set correctly for proper user when agent is running as service (issue #12915).

- Made passphrase to be passed to ssh-keygen to fix the issue with InstallSSHKey task when public key is not specified and private key is protected with a passphrase. 

**Documentation changes required:** No

**Added unit tests:** Tests are updated

**Attached related issue:** #12915
