### PR TITLE
Symbols add retry

### DIFF
--- a/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
+++ b/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
@@ -49,48 +49,7 @@ param(
 
 $ErrorActionPreference = "Stop"
 
-# -----------------------------------------------------------------------------
-# Methods
-# -----------------------------------------------------------------------------
-function Download-SymbolClient([string]$symbolServiceUri, [string]$directory)
-{
-    $clientFetchUrl = $symbolServiceUri + "/_apis/symbol/client/task"
-
-    "Downloading $clientFetchUrl to $directory" | Write-Verbose
-
-    $symbolAppZip = Join-Path $directory "symbol.app.buildtask.zip"
-    (New-Object System.Net.WebClient).DownloadFile($clientFetchUrl, $symbolAppZip)
-
-    "Download complete" | Write-Verbose
-
-    return $symbolAppZip
-}
-
-function Get-SymbolClientVersion([string]$symbolServiceUri)
-{
-    "Getting latest symbol.app.buildtask.zip package" | Write-Verbose
-
-    $versionUrl = $symbolServiceUri + "/_apis/symbol/client/"
-    try
-    {
-        $versionResponse = Invoke-WebRequest -Uri $versionUrl -Method Head -UseDefaultCredentials -UseBasicParsing
-    }
-    catch [System.Net.WebException] 
-    {
-        Write-Host "StatusCode '$($_.Exception.Response.StatusCode)' returned on account $symbolServiceUri"
-        
-        if ($_.Exception.Response.StatusCode -eq 404) {
-            throw "The Azure Artifacts Symbol Server feature is not enabled for this account. See https://go.microsoft.com/fwlink/?linkid=846265 for instructions on how to enable it.`n`n "
-        }
-        
-        throw  $_
-    }
-    $versionHeader = $versionResponse.Headers["symbol-client-version"]
-
-    "Most recent version is $versionHeader" | Write-Verbose
-
-    return $versionHeader
-}
+. $PSScriptRoot\SymbolClientFunctions.ps1
 
 function Publish-Symbols([string]$symbolServiceUri, [string]$requestName, [string]$sourcePath, [string]$expirationInDays, [string]$personalAccessToken)
 {
@@ -139,73 +98,6 @@ function Publish-Symbols([string]$symbolServiceUri, [string]$requestName, [strin
     {
         $env:SYMBOL_PAT_AUTH_TOKEN = ''
     }
-}
-
-function Run-SymbolCommand([string]$assemblyPath, [string]$arguments)
-{
-    $exe = "$assemblyPath\symbol.exe"
-    $traceLevel = if ($DetailedLog) { "verbose" } else { "info" }
-    $arguments += " --tracelevel $traceLevel --globalretrycount 2"
-
-    Invoke-VstsTool -FileName $exe -Arguments $arguments | ForEach-Object { $_.Replace($arguments, $displayArgs) }
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "$exe exited with exit code $LASTEXITCODE"
-    }
-}
-
-function Unzip-SymbolClient([string]$clientZip, [string]$destinationDirectory)
-{
-    "Unzipping $clientZip" | Write-Verbose
-
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    [System.IO.Compression.ZipFile]::ExtractToDirectory($clientZip, $destinationDirectory)
-
-    "Unzipped" | Write-Verbose
-}
-
-function Update-SymbolClient([string]$symbolServiceUri, [string]$symbolClientLocation)
-{
-    "Checking for most recent symbol.app.buildtask.zip version" | Write-Verbose
-
-    # Check latest package version.
-    $availableVersion = Get-SymbolClientVersion $symbolServiceUri
-
-    $agent = Get-VstsTaskVariable -Name 'agent.version'
-    if (!$agent -or (([version]'2.115.0').CompareTo([version]$agent) -ge 1)) {
-        $symbolPathRoot = Join-Path $env:APPDATA "VSOSymbolClient"        
-    }
-    else {
-        $symbolPathRoot = Join-Path (Get-VstsTaskVariable -Name 'Agent.ToolsDirectory') "VSOSymbolClient"
-    }
-    $clientPath = Join-Path $symbolPathRoot $availableVersion
-    $completeMarkerFile = Join-Path $clientPath "symbol.app.buildtask.complete"
-    $symbolClientZip = Join-Path $clientPath "symbol.app.buildtask.zip"
-    $modulePath = Join-Path $clientPath "lib\net45"
-
-    if ( ! $(Test-Path $completeMarkerFile -PathType Leaf) ) {
-        "$completeMarkerFile not found" | Write-Host
-
-        if ( $(Test-Path $clientPath -PathType Container) ) {
-            "Cleaning $clientPath" | Write-Host
-            Remove-Item "$clientPath" -recurse | Write-Host
-        }
-
-        "Creating $clientPath" | Write-Host
-        New-Item -ItemType directory -Path $clientPath | Write-Host
-        $symbolClientZip = Download-SymbolClient $symbolServiceUri $clientPath
-
-        Unzip-SymbolClient $symbolClientZip $clientPath | Write-Host
-
-        [IO.File]::WriteAllBytes( $completeMarkerFile, @() )
-
-        "Update complete" | Write-Host
-    }
-    else {
-        "$completeMarkerFile exists" | Write-Host
-    }
-
-    return $modulePath
 }
 
 # Publish the symbols

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -13,7 +13,7 @@ param()
 Trace-VstsEnteringInvocation $MyInvocation
 
 $ErrorActionPreference = "Stop"
-Import-Module $PSScriptRoot\..\Common\PowershellHelpers
+Import-Module $PSScriptRoot\ps_modules\PowershellHelpers\PowershellHelpers.psm1
 
 function Get-SymbolServiceUri ([string]$collectionUri)
 {

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -13,19 +13,21 @@ param()
 Trace-VstsEnteringInvocation $MyInvocation
 
 $ErrorActionPreference = "Stop"
+Import-Module $PSScriptRoot\..\Common\PowershellHelpers
 
 function Get-SymbolServiceUri ([string]$collectionUri)
 {
     $serviceDefinitionUri = "$collectionUri/_apis/servicedefinitions/locationservice2/951917ac-a960-4999-8464-e3f0aa25b381"
-    $result = Invoke-WebRequest $serviceDefinitionUri -UseBasicParsing
-
+    $action = { Invoke-WebRequest $serviceDefinitionUri -UseBasicParsing }
+    $result = Invoke-ActionWithRetries -Action $action -MaxTries 5
     if ($result.StatusCode -eq 200) {
         $locationUri = (ConvertFrom-Json $result.Content).locationMappings[0].location
         if (-not $locationUri) {
             throw "No location mappings found while querying $serviceDefinitionUri"
         }
         $locationServiceUri = "$locationUri/_apis/servicedefinitions/locationservice2/00000016-0000-8888-8000-000000000000"
-        $result = Invoke-WebRequest $locationServiceUri -UseBasicParsing
+        $action = { Invoke-WebRequest $locationServiceUri -UseBasicParsing }
+        $result = Invoke-ActionWithRetries -Action $action -MaxTries 5
         if ($result.StatusCode -ne 200) {
             throw "Failure while querying '$locationServiceUri', returned $($result.StatusCode)"
         }

--- a/Tasks/PublishSymbolsV2/SymbolClientFunctions.ps1
+++ b/Tasks/PublishSymbolsV2/SymbolClientFunctions.ps1
@@ -1,0 +1,115 @@
+[CmdletBinding()]
+param()
+# -----------------------------------------------------------------------------
+# Methods
+# -----------------------------------------------------------------------------
+Import-Module $PSScriptRoot\ps_modules\PowershellHelpers\PowershellHelpers.psm1
+
+function Download-SymbolClient([string]$symbolServiceUri, [string]$directory)
+{
+    $clientFetchUrl = $symbolServiceUri + "/_apis/symbol/client/task"
+
+    "Downloading $clientFetchUrl to $directory" | Write-Verbose
+
+    $symbolAppZip = Join-Path $directory "symbol.app.buildtask.zip"
+    $action = (New-Object System.Net.WebClient).DownloadFile($clientFetchUrl, $symbolAppZip)
+    Invoke-ActionWithRetries -Action $action -MaxTries 5
+
+    "Download complete" | Write-Verbose
+
+    return $symbolAppZip
+}
+
+function Get-SymbolClientVersion([string]$symbolServiceUri)
+{
+    "Getting latest symbol.app.buildtask.zip package" | Write-Verbose
+
+    $versionUrl = $symbolServiceUri + "/_apis/symbol/client/"
+    try
+    {
+        $action = { Invoke-WebRequest -Uri $versionUrl -Method Head -UseDefaultCredentials -UseBasicParsing }
+        $versionResponse = Invoke-ActionWithRetries -Action $action -MaxTries 5
+    }
+    catch [System.Net.WebException] 
+    {
+        Write-Host "StatusCode '$($_.Exception.Response.StatusCode)' returned on account $symbolServiceUri"
+        
+        if ($_.Exception.Response.StatusCode -eq 404) {
+            throw "The Azure Artifacts Symbol Server feature is not enabled for this account. See https://go.microsoft.com/fwlink/?linkid=846265 for instructions on how to enable it.`n`n "
+        }
+        
+        throw  $_
+    }
+    $versionHeader = $versionResponse.Headers["symbol-client-version"]
+
+    "Most recent version is $versionHeader" | Write-Verbose
+
+    return $versionHeader
+}
+
+function Run-SymbolCommand([string]$assemblyPath, [string]$arguments)
+{
+    $exe = "$assemblyPath\symbol.exe"
+    $traceLevel = if ($DetailedLog) { "verbose" } else { "info" }
+    $arguments += " --tracelevel $traceLevel --globalretrycount 2"
+
+    Invoke-VstsTool -FileName $exe -Arguments $arguments | ForEach-Object { $_.Replace($arguments, $displayArgs) }
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$exe exited with exit code $LASTEXITCODE"
+    }
+}
+
+function Unzip-SymbolClient([string]$clientZip, [string]$destinationDirectory)
+{
+    "Unzipping $clientZip" | Write-Verbose
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($clientZip, $destinationDirectory)
+
+    "Unzipped" | Write-Verbose
+}
+
+function Update-SymbolClient([string]$symbolServiceUri, [string]$symbolClientLocation)
+{
+    "Checking for most recent symbol.app.buildtask.zip version" | Write-Verbose
+
+    # Check latest package version.
+    $availableVersion = Get-SymbolClientVersion $symbolServiceUri
+
+    $agent = Get-VstsTaskVariable -Name 'agent.version'
+    if (!$agent -or (([version]'2.115.0').CompareTo([version]$agent) -ge 1)) {
+        $symbolPathRoot = Join-Path $env:APPDATA "VSOSymbolClient"        
+    }
+    else {
+        $symbolPathRoot = Join-Path (Get-VstsTaskVariable -Name 'Agent.ToolsDirectory') "VSOSymbolClient"
+    }
+    $clientPath = Join-Path $symbolPathRoot $availableVersion
+    $completeMarkerFile = Join-Path $clientPath "symbol.app.buildtask.complete"
+    $symbolClientZip = Join-Path $clientPath "symbol.app.buildtask.zip"
+    $modulePath = Join-Path $clientPath "lib\net45"
+
+    if ( ! $(Test-Path $completeMarkerFile -PathType Leaf) ) {
+        "$completeMarkerFile not found" | Write-Host
+
+        if ( $(Test-Path $clientPath -PathType Container) ) {
+            "Cleaning $clientPath" | Write-Host
+            Remove-Item "$clientPath" -recurse | Write-Host
+        }
+
+        "Creating $clientPath" | Write-Host
+        New-Item -ItemType directory -Path $clientPath | Write-Host
+        $symbolClientZip = Download-SymbolClient $symbolServiceUri $clientPath
+
+        Unzip-SymbolClient $symbolClientZip $clientPath | Write-Host
+
+        [IO.File]::WriteAllBytes( $completeMarkerFile, @() )
+
+        "Update complete" | Write-Host
+    }
+    else {
+        "$completeMarkerFile exists" | Write-Host
+    }
+
+    return $modulePath
+}

--- a/Tasks/PublishSymbolsV2/SymbolClientFunctions.ps1
+++ b/Tasks/PublishSymbolsV2/SymbolClientFunctions.ps1
@@ -12,7 +12,7 @@ function Download-SymbolClient([string]$symbolServiceUri, [string]$directory)
     "Downloading $clientFetchUrl to $directory" | Write-Verbose
 
     $symbolAppZip = Join-Path $directory "symbol.app.buildtask.zip"
-    $action = (New-Object System.Net.WebClient).DownloadFile($clientFetchUrl, $symbolAppZip)
+    $action = { (New-Object System.Net.WebClient).DownloadFile($clientFetchUrl, $symbolAppZip) }
     Invoke-ActionWithRetries -Action $action -MaxTries 5
 
     "Download complete" | Write-Verbose

--- a/Tasks/PublishSymbolsV2/Tests/Get-SymbolClientVersion.SucceedsWithRetry.ps1
+++ b/Tasks/PublishSymbolsV2/Tests/Get-SymbolClientVersion.SucceedsWithRetry.ps1
@@ -1,0 +1,34 @@
+[CmdletBinding()]
+param()
+
+# Setup
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\SymbolClientFunctions.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..\ps_modules\PowershellHelpers
+
+# Test 1 - Get-MsiAccessToken returns correct access token if token fetching api returns 200
+$global:attempt = 1;
+Register-Mock Invoke-WebRequest {
+    if($global:attempt -le 3)
+    {
+        $global:attempt++
+        throw "Error"
+    }
+	return @{
+		StatusCode = 200
+		Headers = @{"symbol-client-version"= "1.0.0"}
+	}
+} 
+
+$result = Get-SymbolClientVersion "https://example.com"
+
+Assert-WasCalled Invoke-WebRequest -Times 4
+Assert-AreEqual $result "1.0.0"
+
+# Test 2 - Get-MsiAccessToken throws error if token fetching api throws error
+Unregister-Mock Invoke-WebRequest
+Register-Mock Invoke-WebRequest {
+    throw "error"
+}
+
+Assert-Throws { Get-SymbolClientVersion "https://example.com" }

--- a/Tasks/PublishSymbolsV2/Tests/L0.ts
+++ b/Tasks/PublishSymbolsV2/Tests/L0.ts
@@ -78,6 +78,9 @@ describe('PublishSymbols Suite', function () {
         it('(Get-SourceProvider) warns for unsupported provider', (done) => {
             psr.run(path.join(__dirname, 'Get-SourceProvider.WarnsForUnsupportedProvider.ps1'), done);
         })
+        it('(Get-SymbolClientVersion) succeeds on retry', (done) => {
+            psr.run(path.join(__dirname, 'Get-SymbolClientVersion.SucceedsWithRetry.ps1'), done);
+        })
         it('(Get-ValidValue) returns within range', (done) => {
             psr.run(path.join(__dirname, 'Get-ValidValue.ReturnsWithinRange.ps1'), done);
         })

--- a/Tasks/PublishSymbolsV2/make.json
+++ b/Tasks/PublishSymbolsV2/make.json
@@ -1,4 +1,10 @@
 {
+  "common": [
+    {
+        "module": "../Common/PowershellHelpers",
+        "type": "ps"
+    }
+  ],
   "externals": {
     "nugetv2": [
       {

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 0,
-        "Patch": 18
+        "Patch": 19
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,8 +13,8 @@
     "preview": false,
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 19
+        "Minor": 172,
+        "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,9 +13,9 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 0,
-    "Patch": 19
-  },
+    "Minor": 172,
+    "Patch": 0
+},
   "minimumAgentVersion": "1.95.0",
   "groups": [
     {

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -15,7 +15,7 @@
     "Major": 2,
     "Minor": 172,
     "Patch": 0
-},
+  },
   "minimumAgentVersion": "1.95.0",
   "groups": [
     {

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 0,
-    "Patch": 18
+    "Patch": 19
   },
   "minimumAgentVersion": "1.95.0",
   "groups": [


### PR DESCRIPTION
**Task name**: PublishSymbolsV2

**Description**: Wrap invoke-webrequest in retries.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) N

**Checklist**:
- [X ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
