### PR TITLE
fix dotnet nuget push onPrem by setting credential configuration

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -421,22 +421,6 @@ describe('DotNetCoreExe Suite', function () {
         done();
     });
 
-    it('pushes successfully to internal onprem feed, does not set auth in config', (done: MochaDone) => {
-        this.timeout(1000);
-
-        let tp = path.join(__dirname, './PushTests/internalFeedOnPrem.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
-        assert(tr.invokedToolCount == 1, 'should have run dotnet once');
-        assert(tr.ran('c:\\path\\dotnet.exe nuget push c:\\agent\\home\\directory\\foo.nupkg --source https://vsts/packagesource --api-key VSTS'), 'it should have run dotnet');
-        assert(tr.stdOutContained('Push to internal OnPrem server detected. Credential configuration will be skipped.'), "should detect internal onprem push");
-        assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
-        assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
-    });
-
     it('push fails when projects are not found', (done: MochaDone) => {
         this.timeout(1000);
 

--- a/Tasks/DotNetCoreCLIV2/package-lock.json
+++ b/Tasks/DotNetCoreCLIV2/package-lock.json
@@ -48,9 +48,9 @@
       "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "adm-zip": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
     },
     "archiver": {
       "version": "1.2.0",

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -12,7 +12,6 @@ import * as pkgLocationUtils from 'packaging-common/locationUtilities';
 import { getProjectAndFeedIdFromInputParam, logError } from 'packaging-common/util';
 
 export async function run(): Promise<void> {
-    tl.loc('DeprecatingDotnet2_2');
     let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -12,6 +12,7 @@ import * as pkgLocationUtils from 'packaging-common/locationUtilities';
 import { getProjectAndFeedIdFromInputParam, logError } from 'packaging-common/util';
 
 export async function run(): Promise<void> {
+    tl.loc('DeprecatingDotnet2_2');
     let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet);
@@ -71,8 +72,7 @@ export async function run(): Promise<void> {
         // Setting up auth info
         const accessToken = pkgLocationUtils.getSystemAccessToken();
         const isInternalFeed: boolean = nugetFeedType === 'internal';
-        const useCredConfig = useCredentialConfiguration(isInternalFeed);
-        const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, useCredConfig);
+        const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
 
         let configFile = null;
         let apiKey: string;
@@ -145,14 +145,15 @@ export async function run(): Promise<void> {
                     break;
             }
         }
-
+        
+        // Setting creds in the temp NuGet.config if needed
         nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
 
         const dotnetPath = tl.which('dotnet', true);
 
         try {
             for (const packageFile of filesList) {
-
+                
                 await dotNetNuGetPushAsync(dotnetPath, packageFile, feedUri, apiKey, configFile, tempNuGetConfigDirectory);
             }
         } finally {
@@ -189,14 +190,4 @@ function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: 
     // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
     const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
     return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
-}
-
-function useCredentialConfiguration(isInternalFeed: boolean): boolean {
-    // if we are pushing to an internal on-premises server, then credential configuration is not possible
-    // and integrated authentication must be used
-    const useCredConfig = !(isInternalFeed && commandHelper.isOnPremisesTfs());
-    if (!useCredConfig) {
-        tl.debug('Push to internal OnPrem server detected. Credential configuration will be skipped.');
-    }
-    return useCredConfig;
 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 171,
-        "Patch": 4
+        "Minor": 172,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 171,
-    "Patch": 4
+    "Minor": 172,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: Set and use credential configuration always

**Documentation changes required:** N

**Added unit tests:** Y - removed a superfluous test

**Attached related issue:** https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1733349

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
