### PR TITLE
Check outputFormat when it is not provided as input.

### DIFF
--- a/Tasks/KubernetesV1/Tests/L0.ts
+++ b/Tasks/KubernetesV1/Tests/L0.ts
@@ -13,6 +13,7 @@ describe('Kubernetes Suite', function() {
     beforeEach(() => {
         process.env[shared.isKubectlPresentOnMachine] = "true";
         process.env[shared.endpointAuthorizationType] = "Kubeconfig";
+        process.env[shared.TestEnvVars.outputFormat] = 'json';
         delete process.env[shared.TestEnvVars.command];
         delete process.env[shared.TestEnvVars.containerType];
         delete process.env[shared.TestEnvVars.connectionType];
@@ -33,7 +34,6 @@ describe('Kubernetes Suite', function() {
         delete process.env[shared.TestEnvVars.useConfigMapFile];
         delete process.env[shared.TestEnvVars.configMapFile];
         delete process.env[shared.TestEnvVars.configMapArguments];
-        delete process.env[shared.TestEnvVars.outputFormat];
         delete process.env[shared.TestEnvVars.configuration];
         delete process.env["chmodShouldThrowError"];
     });
@@ -488,6 +488,23 @@ describe('Kubernetes Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`Skipping -o in args as outputFormat is 'none' or empty.`) != -1, 'outputFormat skipped');
+        assert(tr.stdout.indexOf(`[command]kubectl create secrets my-secret`) != -1, "kubectl create should run");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Runs successfully for kubectl create and skip print for empty outputFormat', (done:MochaDone) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.Commands.create;
+        process.env[shared.TestEnvVars.arguments] = "secrets my-secret";
+        process.env[shared.TestEnvVars.outputFormat] = '';
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf(`[command]kubectl create secrets my-secret`) != -1, "kubectl create should run");
         console.log(tr.stderr);
         done();
@@ -508,7 +525,6 @@ describe('Kubernetes Suite', function() {
         console.log(tr.stderr);
         done();
     }); 
-
 
     it('Runs successfully for checking whether secrets, configmaps and kubectl commands are run in a consecutive manner', (done:MochaDone) => {
         let tp = path.join(__dirname, 'TestSetup.js');

--- a/Tasks/KubernetesV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesV1/Tests/TestSetup.ts
@@ -39,7 +39,7 @@ tr.setInput('versionOrLocation', process.env[shared.TestEnvVars.versionOrLocatio
 tr.setInput('versionSpec', process.env[shared.TestEnvVars.versionSpec] || "1.13.2");
 tr.setInput('checkLatest', process.env[shared.TestEnvVars.checkLatest] || "false");
 tr.setInput('specifyLocation', process.env[shared.TestEnvVars.specifyLocation] || "");
-tr.setInput('outputFormat', process.env[shared.TestEnvVars.outputFormat] || 'json');
+tr.setInput('outputFormat', process.env[shared.TestEnvVars.outputFormat]);
 tr.setInput('dockerRegistryEndpoint', 'dockerhubendpoint');
 tr.setInput('kubernetesServiceEndpoint', 'kubernetesEndpoint');
 tr.setInput('azureSubscriptionEndpoint', 'AzureRMSpn');

--- a/Tasks/KubernetesV1/src/kubernetescommand.ts
+++ b/Tasks/KubernetesV1/src/kubernetescommand.ts
@@ -25,19 +25,21 @@ export function run(connection: ClusterConnection, kubecommand: string, outputUp
 function getCommandOutputFormat(kubecommand: string): string[] {
     var args: string[] = [];
     var outputFormat = tl.getInput("outputFormat", false);
-    switch (outputFormat) {
-        case '':
-        case 'none':
-            tl.debug(`Skipping -o in args as outputFormat is 'none' or empty.`);
-            return args;
-        case 'json':
-        case 'yaml':
-            if (!isJsonOrYamlOutputFormatSupported(kubecommand)) {
+    if (outputFormat) {
+        switch (outputFormat) {
+            case '':
+            case 'none':
+                tl.debug(`Skipping -o in args as outputFormat is 'none' or empty.`);
                 return args;
-            }
-        default:
-            args[0] = "-o";
-            args[1] = outputFormat;
+            case 'json':
+            case 'yaml':
+                if (!isJsonOrYamlOutputFormatSupported(kubecommand)) {
+                    return args;
+                }
+            default:
+                args[0] = "-o";
+                args[1] = outputFormat;
+        }
     }
     return args;
 }

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 171,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 171,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: KubernetesV1

**Description**: Check outputFormat when it is not provided as input or empty string.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) [13184](https://github.com/microsoft/azure-pipelines-tasks/issues/13184)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
