### PR TITLE
Fix ARM template deployment task subscription input to make it editable

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 6
+        "Patch": 8
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",
@@ -78,6 +78,9 @@
             "required": true,
             "groupName": "AzureDetails",
             "helpMarkDown": "Select the Azure subscription",
+            "properties": {
+                "EditableOptions": "True"
+            },
             "visibleRule": "deploymentScope != Management Group"
         },
         {

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 6
+    "Patch": 8
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",
@@ -78,6 +78,9 @@
       "required": true,
       "groupName": "AzureDetails",
       "helpMarkDown": "ms-resource:loc.input.help.subscriptionName",
+      "properties": {
+        "EditableOptions": "True"
+      },
       "visibleRule": "deploymentScope != Management Group"
     },
     {


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeploymentV3

**Description**: Subscription Input field is not editable which blocks this task to be used in task group. In this PR, I have made this editable.

**Documentation changes required:** (N)

**Added unit tests:** (N)
**Attached related issue:** (Y) https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1730302

**Checklist**:
- [Y] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [Y] Checked that applied changes work as expected
