### PR TITLE
Users/anchauh/arg v3task fix 171

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/models/TaskParameters.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/models/TaskParameters.ts
@@ -88,6 +88,8 @@ export class TaskParameters {
                 }
             }
 
+            this.action = tl.getInput("action");
+
             //Location
             this.location = tl.getInput("location");
             if(!this.location && this.deploymentScope === "Resource Group" && this.action != "DeleteRG"){
@@ -116,7 +118,6 @@ export class TaskParameters {
             this.graphCredentials = await this.getGraphCredentials(this.connectedService);
             this.deploymentOutputs = tl.getInput("deploymentOutputs");
             this.addSpnToEnvironment = tl.getBoolInput("addSpnToEnvironment", false);
-            this.action = tl.getInput("action");
 
             return this;
         } catch (error) {

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 6
+        "Patch": 7
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 3,
         "Minor": 2,
-        "Patch": 7
+        "Patch": 8
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",
@@ -78,6 +78,9 @@
             "required": true,
             "groupName": "AzureDetails",
             "helpMarkDown": "Select the Azure subscription",
+            "properties": {
+                "EditableOptions": "True"
+            },
             "visibleRule": "deploymentScope != Management Group"
         },
         {

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 7
+    "Patch": 8
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",
@@ -78,6 +78,9 @@
       "required": true,
       "groupName": "AzureDetails",
       "helpMarkDown": "ms-resource:loc.input.help.subscriptionName",
+      "properties": {
+        "EditableOptions": "True"
+      },
       "visibleRule": "deploymentScope != Management Group"
     },
     {

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 2,
-    "Patch": 6
+    "Patch": 7
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeploymentV3

**Description**: 1. Subscription Input field is not editable which blocks this task to be used in task group. In this PR, I have made this editable. 2. Fix the resource group deletion.

**Documentation changes required:** (N) <Please mark if documentation changes are required>

**Added unit tests:** (N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y) https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1730302

**Checklist**:
- [Y ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [Y ] Checked that applied changes work as expected
