### PR TITLE
[AzureFileCopy] Use Get-AzureRmResource instead of Get-AzureRmStorageAccount

### DIFF
--- a/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
+++ b/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
@@ -24,7 +24,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmStorageAccount -ErrorAction Stop | Where-Object { $_.StorageAccountName -eq $storageAccountName }
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
+++ b/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
@@ -24,7 +24,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName -ErrorAction Stop
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 171,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 171,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
+++ b/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
@@ -10,7 +10,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmStorageAccount -ErrorAction Stop | Where-Object { $_.StorageAccountName -eq $storageAccountName }
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
+++ b/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
@@ -10,7 +10,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName -ErrorAction Stop
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 171,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 171,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
**Task name**: AzureFileCopyV2 and AzureFileCopyV3

**Description**: 
The recent change to use latest Azure PowerShell modules (6.13.1) introduced a regression in the task. The command Get-AzureRmStorageAccount started failing with error:
**##[debug]Microsoft.Rest.SerializationException: Unable to deserialize the response. ---> Newtonsoft.Json.JsonSerializationException: Error converting value "FileStorage" to type 'System.Nullable`1[Microsoft.Azure.Management.Storage.Models.Kind]'. Path '', line 1, position 19442. ---> System.ArgumentException: Requested value 'FileStorage' was not found.**

On further investigation, it was found that this was already a known issue https://github.com/Azure/azure-powershell/issues/7780. This issue was fixed with Az modules. 

As per the current fix, we are removing dependency on Get-AzureRmStorageAccount cmdlet and will be using Get-AzureRmResource to fetch the storage account details. 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

Fix for https://github.com/microsoft/azure-pipelines-tasks/issues/13225