### PR TITLE
Printing bake command output in debug logs

### DIFF
--- a/Tasks/KubernetesManifestV0/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV0/Tests/L0.ts
@@ -243,7 +243,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--name newReleaseName') > -1, 'bake should have overriden release name');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         done();
     });
 
@@ -261,7 +260,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
         assert(tr.stdout.indexOf('--name ') <= -1, 'bake should not have added --name arg');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         done(tr.stderr);
     });
 
@@ -279,7 +277,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
         assert(tr.stdout.indexOf('--name ') <= -1, 'bake should not have added --name arg');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         done(tr.stderr);
     });
 
@@ -297,7 +294,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--name newReleaseName') > -1, 'bake should have overriden release name');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         assert(tr.stdout.indexOf('Namespace was not supplied nor present in the endpoint; using "default" namespace instead.') > -1, 'should have added a debug log');
         done();
     });
@@ -317,7 +313,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
         assert(tr.stdout.indexOf('--name ') <= -1, 'bake should not have added --name arg');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         assert(tr.stdout.indexOf('Namespace was not supplied nor present in the endpoint; using "default" namespace instead.') > -1, 'should have added a debug log');
         done();
     });
@@ -336,7 +331,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
         assert(tr.stdout.indexOf('--set name=value:with:colons') > -1, 'should have parsed the :s correctly');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         assert(tr.stdout.indexOf('Namespace was not supplied nor present in the endpoint; using "default" namespace instead.') > -1, 'should have added a debug log');
         done();
     });
@@ -355,7 +349,6 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
         assert(tr.stdout.indexOf('--set name=value:with:colons') > -1, 'should have parsed the :s correctly');
-        assert(tr.stdout.indexOf('baked manifest from helm chart') === -1, 'should have masked the baked manifest from stdout');
         assert(tr.stdout.indexOf('Namespace was not supplied nor present in the endpoint; using "default" namespace instead.') > -1, 'should have added a debug log');
         done();
     });

--- a/Tasks/KubernetesManifestV0/src/actions/bake.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/bake.ts
@@ -44,6 +44,7 @@ class HelmRenderEngine extends RenderEngine {
             tl.setResult(tl.TaskResult.Failed, result.stderr);
             return;
         }
+        tl.debug(result.stdout);
         const pathToBakedManifest = this.getTemplatePath();
         fs.writeFileSync(pathToBakedManifest, result.stdout);
         this.updateImages(pathToBakedManifest);
@@ -86,6 +87,7 @@ class KomposeRenderEngine extends RenderEngine {
         if (result.code !== 0 || result.error) {
             throw result.error;
         }
+        tl.debug(result.stdout);
         this.updateImages(pathToBakedManifest);
         tl.setVariable('manifestsBundle', pathToBakedManifest);
     }
@@ -100,6 +102,11 @@ class KustomizeRenderEngine extends RenderEngine {
         command.arg(['kustomize', tl.getPathInput('kustomizationPath')]);
 
         const result = command.execSync({ silent: true } as IExecOptions);
+        if (result.stderr) {
+            tl.setResult(tl.TaskResult.Failed, result.stderr);
+            return;
+        }
+        tl.debug(result.stdout);
         const pathToBakedManifest = this.getTemplatePath();
         fs.writeFileSync(pathToBakedManifest, result.stdout);
         this.updateImages(pathToBakedManifest);

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 169,
-        "Patch": 4
+        "Minor": 173,
+        "Patch": 0
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 169,
-    "Patch": 4
+    "Minor": 173,
+    "Patch": 0
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
**Task name**: KubernetesManifestV0

**Description**: 
1. Added bake command outputs to debug log (The output of Kompose command is directly written into a file).
2. Added a check in Kustomize command to fail the task in case of errors.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Updated

**Attached related issue:** (Y/N) Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
