### PR TITLE
[JavaToolInstaller]. Handling for 'unknown' errors

### DIFF
--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -170,7 +170,18 @@ export class JavaFilesExtractor {
         initialDirectoriesList = taskLib.find(this.destinationFolder).filter(x => taskLib.stats(x).isDirectory());
 
         const jdkFile = path.normalize(repoRoot);
-        const stats = taskLib.stats(jdkFile);
+
+        const ERR_SHARE_ACCESS = -4094;
+        let stats;
+        try {
+            stats = taskLib.stats(jdkFile);
+        } catch (error) {
+            if (error.errno === ERR_SHARE_ACCESS) {
+                throw new Error(taskLib.loc('ShareAccessError', error.path));
+            }
+            throw(error);
+        }
+
         if (stats.isFile()) {
             await this.extractFiles(jdkFile, fileEnding);
             finalDirectoriesList = taskLib.find(this.destinationFolder).filter(x => taskLib.stats(x).isDirectory());

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -11,6 +11,7 @@ interface IDirectoriesDictionary {
 }
 
 export class JavaFilesExtractor {
+    readonly ERR_SHARE_ACCESS = -4094;
     public destinationFolder: string;
     public readonly win: boolean;
 
@@ -171,12 +172,11 @@ export class JavaFilesExtractor {
 
         const jdkFile = path.normalize(repoRoot);
 
-        const ERR_SHARE_ACCESS = -4094;
-        let stats;
+        let stats: taskLib.FsStats;
         try {
             stats = taskLib.stats(jdkFile);
         } catch (error) {
-            if (error.errno === ERR_SHARE_ACCESS) {
+            if (error.errno === this.ERR_SHARE_ACCESS) {
                 throw new Error(taskLib.loc('ShareAccessError', error.path));
             }
             throw(error);

--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -11,7 +11,7 @@ interface IDirectoriesDictionary {
 }
 
 export class JavaFilesExtractor {
-    readonly ERR_SHARE_ACCESS = -4094;
+    private readonly ERR_SHARE_ACCESS = -4094;
     public destinationFolder: string;
     public readonly win: boolean;
 

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 171,
+        "Minor": 173,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -178,6 +178,6 @@
         "JavaNotPreinstalled": "Java %s is not preinstalled on this agent",
         "UsePreinstalledJava": "Use preinstalled JDK from %s",
         "WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside.",
-        "ShareAccessError": "Network shared resource not available (%s)"
+        "ShareAccessError": "Network shared resource not available: (%s)"
     }
 }

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -177,6 +177,7 @@
         "CorrelationIdForARM": "Correlation ID from ARM api call response : %s",
         "JavaNotPreinstalled": "Java %s is not preinstalled on this agent",
         "UsePreinstalledJava": "Use preinstalled JDK from %s",
-        "WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside."
+        "WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside.",
+        "ShareAccessError": "Network shared resource not available (%s)"
     }
 }

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 171,
+    "Minor": 173,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: JavaToolInstaller

**Description**: Added handling for an error that occurs when calling a `stat` method for an inaccessible Windows share.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13006 and https://github.com/microsoft/azure-pipelines-tasks/issues/12200

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
