### PR TITLE
[AzureFileCopy] Fix code regression

### DIFF
--- a/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
+++ b/Tasks/AzureFileCopyV2/AzureUtilityGTE1.0.ps1
@@ -24,7 +24,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName -ErrorAction Stop
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ErrorAction Stop | Where-Object { ($_.ResourceType -eq $ARMStorageAccountResourceType) -and ($_.Name -eq $storageAccountName)}
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 171,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 171,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
+++ b/Tasks/AzureFileCopyV3/AzureUtilityARM.ps1
@@ -10,7 +10,7 @@ function Get-AzureStorageAccountResourceGroupName
     if (-not [string]::IsNullOrEmpty($storageAccountName))
     {
         Write-Verbose "[Azure Call]Getting resource details for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
-        $azureStorageAccountResourceDetails = Get-AzureRmResource -ResourceType $ARMStorageAccountResourceType -Name $storageAccountName -ErrorAction Stop
+        $azureStorageAccountResourceDetails = Get-AzureRmResource -ErrorAction Stop | Where-Object { ($_.ResourceType -eq $ARMStorageAccountResourceType) -and ($_.Name -eq $storageAccountName)}
         Write-Verbose "[Azure Call]Retrieved resource details successfully for azure storage account resource: $storageAccountName with resource type: $ARMStorageAccountResourceType"
 
         $azureResourceGroupName = $azureStorageAccountResourceDetails.ResourceGroupName

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 171,
-        "Patch": 3
+        "Patch": 4
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 171,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
We had to replace existing `Get-AzureRmStorageAccount` cmdlet with `Get-AzureRmResource` cmdlet as `Get-AzureRmStorageAccount` was throwing serialization exception with Azure PowerShell version `6.13.1`. This fails even on local execution.

![image](https://user-images.githubusercontent.com/20986928/87603360-9cf89980-c715-11ea-9a3c-1394e92f50f3.png)

Fix for https://github.com/microsoft/azure-pipelines-tasks/issues/13263

With this change, the following scenarios have been covered:

**Hosted Agents**
- [x] vs2017-win2016
- [x] windows-2019

**Self-Hosted Agents running Azure PowerShell version:**
- [x] 6.13.1
- [x] 6.7.0
- [x] 5.7.0
- [x] 5.1.1
- [x] 4.2.1
- [x] 3.8.0
- [x] 2.1.0

**Storage account types:**
- [x] Standard V2
- [x] Standard V1
- [x] Standard blob storage
- [x] Premium V2
- [x] Premium V1

**Service principal scope:**
- [x] Entire Subscription 
- [x] Specific Resource group 