### PR TITLE
Bumping AzFileCopy Version

### DIFF
--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 171,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 171,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 171,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 171,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
**Task name**: AzureFileCopyV2,V3

**Description**: Bumping up patch to manage the hotfix

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required> No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
