### PR TITLE
Fixed issue with interactive mode for runOptions=commands

### DIFF
--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -107,7 +107,7 @@ async function run() {
                     tl.debug(`Running command ${command} on remote machine.`);
                     console.log(command);
                     const returnCode: string = await sshHelper.runCommandOnRemoteMachine(
-                        command, sshClientConnection, remoteCmdOptions);
+                        command, sshClientConnection, remoteCmdOptions, password, interactiveSession);
                     tl.debug(`Command ${command} completed with return code = ${returnCode}`);
                 }
             } else {

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 0,
         "Minor": 173,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 0,
     "Minor": 173,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",


### PR DESCRIPTION
**Task name**: SshV0

**Description**: interactiveSession option doesn't work as expected if runOptions=commands. Fixed behavior - currently interactive session works fine for runOptions=commands.

**Documentation changes required:** No

**Added unit tests:** No, created work item for e2e tests - https://github.com/microsoft/azure-pipelines-canary/issues/345

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13311

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected - tested that commands like 'sudo' work fine with interactiveSession=true,  runOptions=commands
