### PR TITLE
Build Machine Image task is not able to execute the script inline with arguments

### DIFF
--- a/Tasks/PackerBuildV1/DefaultTemplates/custom.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/custom.linux.template.json
@@ -55,7 +55,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/custom.managed.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/custom.managed.linux.template.json
@@ -54,7 +54,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/default.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/default.linux.template.json
@@ -59,7 +59,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/default.managed.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/default.managed.linux.template.json
@@ -56,7 +56,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
**Task name**: Build Machine Image

**Description**: Build Machine Image task is not able to execute the script inline with arguments. Removed the source command(.) from the packer inline.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N
**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
