### PR TITLE
[SshV0] Downgrade uuid npm package version 

### DIFF
--- a/Tasks/SshV0/package-lock.json
+++ b/Tasks/SshV0/package-lock.json
@@ -253,9 +253,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "uuid": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
-      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/Tasks/SshV0/package.json
+++ b/Tasks/SshV0/package.json
@@ -6,6 +6,6 @@
     "azure-pipelines-task-lib": "^2.9.3",
     "scp2": "0.5.0",
     "ssh2": "0.8.2",
-    "uuid": "^8.2.0"
+    "uuid": "^3.2.1"
   }
 }

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 173,
-        "Patch": 1
+        "Minor": 174,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.102.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 173,
-    "Patch": 1
+    "Minor": 174,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.102.0",


### PR DESCRIPTION
**Task name**:  SshV0

**Description**: Version of uuid npm package was downgraded to support self-hosted agents with versions < 2.165.0

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:**

- https://github.com/microsoft/azure-pipelines-tasks/issues/13385

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
