### PR TITLE
[JavaToolInstaller] Added missed string resources

### DIFF
--- a/Tasks/JavaToolInstallerV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/JavaToolInstallerV0/Strings/resources.resjson/en-US/resources.resjson
@@ -63,5 +63,7 @@
   "loc.messages.DetachDiskImage": "Detaching a disk image.",
   "loc.messages.PkgPathDoesNotExist": "Package path does not exist.",
   "loc.messages.PreInstalledJavaUpgraded": "Preinstalled JDK updated.",
-  "loc.messages.JavaSuccessfullyInstalled": "Java has been successfully installed"
+  "loc.messages.JavaSuccessfullyInstalled": "Java has been successfully installed",
+  "loc.messages.ArchiveWasExtractedEarlier": "Archive with JDK was extracted earlier - skipping extracting",
+  "loc.messages.ExtractingArchiveToPath": "Extracting archive to: %s"
 }

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -188,6 +188,8 @@
         "DetachDiskImage": "Detaching a disk image.",
         "PkgPathDoesNotExist": "Package path does not exist.",
         "PreInstalledJavaUpgraded": "Preinstalled JDK updated.",
-        "JavaSuccessfullyInstalled": "Java has been successfully installed"
+        "JavaSuccessfullyInstalled": "Java has been successfully installed",
+        "ArchiveWasExtractedEarlier": "Archive with JDK was extracted earlier - skipping extracting",
+        "ExtractingArchiveToPath": "Extracting archive to: %s"
     }
 }

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 174,
-        "Patch": 1
+        "Patch": 2
     },
     "satisfies": [
         "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -188,6 +188,8 @@
     "DetachDiskImage": "ms-resource:loc.messages.DetachDiskImage",
     "PkgPathDoesNotExist": "ms-resource:loc.messages.PkgPathDoesNotExist",
     "PreInstalledJavaUpgraded": "ms-resource:loc.messages.PreInstalledJavaUpgraded",
-    "JavaSuccessfullyInstalled": "ms-resource:loc.messages.JavaSuccessfullyInstalled"
+    "JavaSuccessfullyInstalled": "ms-resource:loc.messages.JavaSuccessfullyInstalled",
+    "ArchiveWasExtractedEarlier": "ms-resource:loc.messages.ArchiveWasExtractedEarlier",
+    "ExtractingArchiveToPath": "ms-resource:loc.messages.ExtractingArchiveToPath"
   }
 }

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 174,
-    "Patch": 1
+    "Patch": 2
   },
   "satisfies": [
     "Java",


### PR DESCRIPTION
**Task name**: JavaToolInstaller

**Description**: Added missed string resources for JavaToolInstaller task. 

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/13411

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
