### PR TITLE
Port fix Build Machine Image task is not able to execute the script inline with arguments (#13393)

### DIFF
--- a/Tasks/PackerBuildV1/DefaultTemplates/custom.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/custom.linux.template.json
@@ -55,7 +55,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/custom.managed.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/custom.managed.linux.template.json
@@ -54,7 +54,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/default.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/default.linux.template.json
@@ -59,7 +59,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/DefaultTemplates/default.managed.linux.template.json
+++ b/Tasks/PackerBuildV1/DefaultTemplates/default.managed.linux.template.json
@@ -56,7 +56,7 @@
             "cd /deployTemp",
             "ls",
             "chmod +x /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}}",
-            ". /deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
+            "/deployTemp/{{user `package_name`}}/{{user `script_relative_path`}} {{user `script_arguments`}}"
         ]
     },
     {

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 1,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
Port master PR #13393 

**Task name**: PackerBuildV1

**Description**: Port fix Build Machine Image task is not able to execute the script inline with arguments (#13393)

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
