### PR TITLE
Add "nobuild" option to dotnet test

### DIFF
--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -167,6 +167,11 @@ export class dotNetExe {
             const dotnet = tl.tool(dotnetPath);
             dotnet.arg(this.command);
             dotnet.arg(projectFile);
+
+            if (tl.getBoolInput("nobuild")) {
+                dotnet.arg("--no-build");
+            }
+
             dotnet.line(this.arguments);
             try {
                 const result = await dotnet.exec(<tr.IExecOptions>{

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -372,9 +372,9 @@
             "type": "boolean",
             "label": "Do not build",
             "defaultValue": "false",
-            "helpMarkDown": "Don't build the project before packing. Corresponds to the --no-build command line parameter.",
+            "helpMarkDown": "Don't build the project before testing/packing. Corresponds to the --no-build command line parameter.",
             "required": false,
-            "visibleRule": "command = pack"
+            "visibleRule": "command = pack || command = test"
         },
         {
             "name": "includesymbols",

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 174,
+        "Minor": 273,
         "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 174,
+    "Minor": 273,
     "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",


### PR DESCRIPTION
**Task name**: DotNetCoreCLI

**Description**:  Allow dotnet test to understand nobuild parameter (same as dotnet pack)

**Documentation changes required:** N. For me, it should just work.

**Added unit tests:** N . Do I need to? Please point me. 

**Attached related issue:** #9239

**Checklist**:
- [X ] Task version was bumped 
- [ ] Checked that applied changes work as expected

Please point me to docs how to I check my change...
