### PR TITLE
Fixed matching files to search files inside directory

### DIFF
--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -84,7 +84,7 @@ function findFiles(): string[] {
             var allFiles = tl.find(parseResult.directory);
             tl.debug('Candidates found for match: ' + allFiles.length);
 
-            var matched = minimatch.match(allFiles, parseResult.search, matchOptions);
+            var matched = minimatch.match(allFiles, path.join(parseResult.directory, parseResult.search), matchOptions);
 
             // ensure only files are added, since our search results may include directories
             for (var j = 0; j < matched.length; j++) {

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -18,8 +18,8 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 165,
-        "Patch": 2
+        "Minor": 175,
+        "Patch": 0
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 165,
-    "Patch": 2
+    "Minor": 175,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
**Task name**: ExtractFilesV1

**Description**: Changed the way of matching files using a pattern. 

Array allFiles [here](https://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/ExtractFilesV1/extractfilestask.ts#L84) contains all the files inside the target directory found recursively. So call

`minimatch.match(allFiles, *.zip, matchOptions);`

returns all files that match the pattern ignoring the folder structure. Updated call

`minimatch.match(allFiles, directore/*.zip, matchOptions);`

returns files from the correct directory.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** 

- https://github.com/microsoft/azure-pipelines-tasks/issues/13434

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
