### PR TITLE
Cache: Allow writing to existing caches

### DIFF
--- a/Tasks/CacheV2/Strings/resources.resjson/de-de/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/de-de/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/en-US/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/es-es/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/es-es/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/fr-fr/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/ja-jp/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "캐시 적중 변수",
   "loc.input.help.cacheHitVar": "캐시가 복원되면(캐시 적중이 발생하면) 'true'로 설정하고 그러지 않으면 'false'로 설정할 변수입니다.",
   "loc.input.label.restoreKeys": "추가 복원 키 접두사",
-  "loc.input.help.restoreKeys": "기본 키 누락 시 사용되는 추가 복원 키 접두사입니다. 새 줄로 구분한 키 접두사 목록일 수 있습니다."
+  "loc.input.help.restoreKeys": "기본 키 누락 시 사용되는 추가 복원 키 접두사입니다. 새 줄로 구분한 키 접두사 목록일 수 있습니다.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "缓存命中变量",
   "loc.input.help.cacheHitVar": "要在还原缓存(即缓存命中)时设置为 \"true\"、在其他情况下设置为 \"false\" 的变量。",
   "loc.input.label.restoreKeys": "其他还原键前缀",
-  "loc.input.help.restoreKeys": "主键缺失时使用的其他还原键前缀。这可以是以换行符分隔的键前缀列表。"
+  "loc.input.help.restoreKeys": "主键缺失时使用的其他还原键前缀。这可以是以换行符分隔的键前缀列表。",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/CacheV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -10,5 +10,7 @@
   "loc.input.label.cacheHitVar": "Cache hit variable",
   "loc.input.help.cacheHitVar": "Variable to set to 'true' when the cache is restored (i.e. a cache hit), otherwise set to 'false'.",
   "loc.input.label.restoreKeys": "Additional restore key prefixes",
-  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+  "loc.input.help.restoreKeys": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes.",
+  "loc.input.label.immutable": "Prevent caches from being overwritten",
+  "loc.input.help.immutable": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
 }

--- a/Tasks/CacheV2/task.json
+++ b/Tasks/CacheV2/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 1
+        "Minor": 175,
+        "Patch": 0
     },
     "groups": [],
     "demands": [],
@@ -47,6 +47,14 @@
             "defaultValue": "",
             "required": false,
             "helpMarkDown": "Additional restore key prefixes that are used if the primary key misses. This can be a newline-delimited list of key prefixes."
+        },
+        {
+            "name": "immutable",
+            "type": "boolean",
+            "label": "Prevent caches from being overwritten",
+            "defaultValue": true,
+            "required": false,
+            "helpMarkDown": "Caches that already exist cannot be overwritten. This setting allows them to be overwritable even with a fixed fingerprint."
         }
     ],
     "instanceNameFormat": "Cache",

--- a/Tasks/CacheV2/task.loc.json
+++ b/Tasks/CacheV2/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 0,
-    "Patch": 1
+    "Minor": 175,
+    "Patch": 0
   },
   "groups": [],
   "demands": [],
@@ -47,6 +47,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.restoreKeys"
+    },
+    {
+      "name": "immutable",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.immutable",
+      "defaultValue": true,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.immutable"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: Cache

**Description**: Added immutable input

**Documentation changes required:**  Y

**Added unit tests:** N

**Attached related issue:**

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

I've been needing this for a long time, really since the Cache task was still in beta. I've been looking through the issues and the docs, and I've concluded that this kind of functionality really needs to be here, in a dedicated form.

The docs compare and contrast Artifacts with Caching, saying Artifacts are for necessary outputs from one stage/pipeline to another, and Caching is for dependencies which might be acquirable elsewhere. It seems to me there is a third type, and that is actual file caching of compiled output.

In looking around, I saw [this comment](https://github.com/microsoft/azure-pipelines-tasks/issues/10842#issuecomment-510637798) which mentions a "rolling" cache idea, but the poster seems to be out-thinking themselves with regards to the keys. Most build systems (e.g. make, msbuild, etc) already check for outdated output and do incremental recompiling. I see no need for any kind of commit sha checking. Simply allow users to save the data, and let the build systems handl the rest.

I also saw an aside about security concerns. I can't really imagine how or why that's an issue, but at least by adding an input that is defaulted to read-only, there shouldn't be any worries about issues popping up for various pipelines.

Let me do my best to emphasize that this is desperately needed. Build times are absurd without caching. I wish msbuild had a more robust solution than what it has now, but we can't even use that without a mutable cache. The fallback key system is too clumsy, and it can lead to odd behavior (if we write to a specific key, and read from a general key, then we have to import all previous caches. If those caches have the same files, which files wind up being used?).

Please give this PR some consideration, I would really appreciate it.

p.s. I was unable to build either side of this, so it isn't tested. If it is wildly wrong, I will gladly work to get it right.

Cross PR: https://github.com/microsoft/azure-pipelines-agent/pull/3090