### PR TITLE
Update helpMarkDown for AndroidSigningV3 apksignerArguments

### DIFF
--- a/Tasks/AndroidSigningV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AndroidSigningV3/Strings/resources.resjson/en-US/resources.resjson
@@ -19,7 +19,7 @@
   "loc.input.label.keyPass": "Key password",
   "loc.input.help.keyPass": "Enter the key password for the alias and keystore file. Use a new variable with its lock enabled on the Variables tab to encrypt this value.",
   "loc.input.label.apksignerArguments": "apksigner arguments",
-  "loc.input.help.apksignerArguments": "Provide any options to pass to the apksigner command line. Default is: -verbose -sigalg MD5withRSA -digestalg SHA1",
+  "loc.input.help.apksignerArguments": "Provide any options to pass to the apksigner command line. Default is: --verbose",
   "loc.input.label.apksignerLocation": "apksigner location",
   "loc.input.help.apksignerLocation": "Optionally specify the location of the apksigner executable used during signing. This defaults to the apksigner found in the Android SDK version folder that your application builds against.",
   "loc.input.label.zipalign": "Zipalign",

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 175,
+        "Minor": 176,
         "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 175,
+    "Minor": 176,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: AndroidSigningV3

**Description**: reworked https://github.com/microsoft/build-task-team/issues/212

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
