### PR TITLE
Sync-Request in package.json version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "q": "1.4.1",
     "semver": "4.3.3",
     "shelljs": "^0.3.0",
-    "sync-request": "3.0.1",
+    "sync-request": "^3.0.1",
     "typed-rest-client": "1.0.9",
     "typescript": "2.3.4",
     "validator": "3.33.0"


### PR DESCRIPTION
**Task name**: N/A

**Description**: 
Issue #11136 Points out that sync-request is way more up-to-date than 3.0.1

Is there any reason not to advance the version for this library? At a minimum `^3.0.1` if not something higher? 

I personally am experiencing similar issues with this erroring out when being run on a pipeline agent even if my version of `package.json` has a higher version.

**Documentation changes required:** N?

**Added unit tests:** N

**Attached related issue:** Y #11136

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
