### PR TITLE
[Maven] Skip tests in verify phase

### DIFF
--- a/Tasks/MavenV2/maventask.ts
+++ b/Tasks/MavenV2/maventask.ts
@@ -423,7 +423,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
-            mvnReport.arg("-Dmaven.test.skip=true");
+            mvnReport.arg("-Dmaven.test.skip=true"); // This argument added to skip tests to avoid running them twice. More about this argument: http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV2/maventask.ts
+++ b/Tasks/MavenV2/maventask.ts
@@ -423,6 +423,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
+            mvnReport.arg("-Dmaven.test.skip.exec");
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV2/maventask.ts
+++ b/Tasks/MavenV2/maventask.ts
@@ -423,7 +423,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
-            mvnReport.arg("-Dmaven.test.skip.exec");
+            mvnReport.arg("-Dmaven.test.skip=true");
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 175,
-        "Patch": 2
+        "Minor": 176,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 175,
-    "Patch": 2
+    "Minor": 176,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -435,7 +435,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
-            mvnReport.arg("-Dmaven.test.skip.exec");
+            mvnReport.arg("-Dmaven.test.skip=true");
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -435,6 +435,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
+            mvnReport.arg("-Dmaven.test.skip.exec");
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV3/maventask.ts
+++ b/Tasks/MavenV3/maventask.ts
@@ -435,7 +435,7 @@ function publishCodeCoverage(isCodeCoverageOpted: boolean): Q.Promise<boolean> {
             }
             mvnReport.line(mavenOptions);
             mvnReport.arg("verify");
-            mvnReport.arg("-Dmaven.test.skip=true");
+            mvnReport.arg("-Dmaven.test.skip=true"); // This argument added to skip tests to avoid running them twice. More about this argument: http://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html
             mvnReport.exec().then(function (code) {
                 publishCCToTfs();
                 defer.resolve(true);

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 175,
-        "Patch": 1
+        "Minor": 176,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 175,
-    "Patch": 1
+    "Minor": 176,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
**Task name**:  MavenV2, MavenV3

**Description**: Removed running tests phase in 'verify' phase to avoid running them twice

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#6458](https://github.com/microsoft/azure-pipelines-tasks/issues/6458)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
