### PR TITLE
Adding null check in script arguments

### DIFF
--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -70,6 +70,11 @@ async function run() {
             contents.push(`${azFilePath} -endpoint '${endpoint}' -targetAzurePs  ${targetAzurePs}`);
         }
 
+        if(scriptArguments == null)
+        {
+            scriptArguments = "";
+        }
+
         if (scriptType.toUpperCase() == 'FILEPATH') {
             contents.push(`. '${scriptPath.replace(/'/g, "''")}' ${scriptArguments}`.trim());
             console.log(tl.loc('JS_FormattedCommand', contents[contents.length - 1]));

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 176,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 176,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -67,6 +67,11 @@ async function run() {
             contents.push(`${azFilePath} -endpoint '${endpoint}' -targetAzurePs  ${targetAzurePs}`);
         }
 
+        if(scriptArguments == null)
+        {
+            scriptArguments = "";
+        }
+
         if (scriptType.toUpperCase() == 'FILEPATH') {
             contents.push(`. '${scriptPath.replace(/'/g, "''")}' ${scriptArguments}`.trim());
             console.log(tl.loc('JS_FormattedCommand', contents[contents.length - 1]));

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 176,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 176,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [


### PR DESCRIPTION
**Task name**: AzurePowerShellV4/V5

**Description**: Adding null check in script arguments for ubuntu agent. When nothing is passed in script arguments, the value is null for ubuntu agent which is causing unexpected error. Thereby setting the argument to empty whenever it is null.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13551

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
