### PR TITLE
Replace default value for the archiveFilePatterns input

### DIFF
--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 176,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [
@@ -27,7 +27,7 @@
             "name": "archiveFilePatterns",
             "type": "multiLine",
             "label": "Archive file patterns",
-            "defaultValue": "*.zip",
+            "defaultValue": "**/*.zip",
             "required": true,
             "helpMarkDown": "File paths or patterns of the archive files to extract.  Supports multiple lines of minimatch patterns.  [More Information](https://go.microsoft.com/fwlink/?LinkId=800269)",
             "properties": {

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 176,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
@@ -27,7 +27,7 @@
       "name": "archiveFilePatterns",
       "type": "multiLine",
       "label": "ms-resource:loc.input.label.archiveFilePatterns",
-      "defaultValue": "*.zip",
+      "defaultValue": "**/*.zip",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.archiveFilePatterns",
       "properties": {


### PR DESCRIPTION
**Task name**:  ExtractFiles

**Description**: Default archiveFilePatterns input value was changed to \*\*\/\*.zip. Previous \*.zip was used incorrectly to extract all archives recursively. This was fixed in this [PR](https://github.com/microsoft/azure-pipelines-tasks/pull/13450). Pattern \*\*\/\*.zip does the same extracting all zip archives recursively.

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 

- https://github.com/microsoft/build-task-team/issues/270

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
