### PR TITLE
[JavaToolInstaller] Add validation when using azureStorage

### DIFF
--- a/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
+++ b/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
@@ -62,7 +62,7 @@ async function getJava(versionSpec: string): Promise<void> {
         if (fromAzure) {
             // download from azure and save to temporary directory
             console.log(taskLib.loc('RetrievingJdkFromAzure'));
-            const fileNameAndPath: string = taskLib.getInput('azureCommonVirtualFile', false);
+            const fileNameAndPath: string = taskLib.getInput('azureCommonVirtualFile', true);
             const azureDownloader = new AzureStorageArtifactDownloader(taskLib.getInput('azureResourceManagerEndpoint', true),
                 taskLib.getInput('azureStorageAccountName', true), taskLib.getInput('azureContainerName', true), "");
             await azureDownloader.downloadArtifacts(extractLocation, '*' + fileNameAndPath);

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 175,
-        "Patch": 1
+        "Minor": 176,
+        "Patch": 0
     },
     "satisfies": [
         "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 175,
-    "Patch": 1
+    "Minor": 176,
+    "Patch": 0
   },
   "satisfies": [
     "Java",


### PR DESCRIPTION
**Task name**: JavaToolInstaller

**Description**: Changed `azureCommonVirtualFile` option to required since it's required when `jdkSourceOption == AzureStorage`

**Documentation changes required:** No, according to the documentation this option is required

**Added unit tests:** N

**Attached related issue:** #13258, #9772

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
