### PR TITLE
[Java-common] Fixed semver version and localization issues

### DIFF
--- a/common-npm-packages/java-common/java-common.ts
+++ b/common-npm-packages/java-common/java-common.ts
@@ -1,9 +1,12 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as trm from 'azure-pipelines-task-lib/toolrunner';
 import os = require('os');
+import path = require('path');
 import semver = require('semver');
 import coerce = require('semver/functions/coerce');
 import SemVer = require('semver/classes/semver');
+
+tl.setResourcePath(path.join(__dirname, 'lib.json'));
 
 const isWindows: boolean = os.platform() === 'win32';
 const jdkKeySign: string = 'JavaSoft';

--- a/common-npm-packages/java-common/lib.json
+++ b/common-npm-packages/java-common/lib.json
@@ -1,0 +1,9 @@
+{
+    "messages": {
+        "SearchingRegistryKeys": "Searching for registry keys for JDK %s",
+        "RegistryKeysFound": "Number of registry keys found: %s",
+        "LocateJVMBasedOnVersionAndArch": "Locate JAVA_HOME for Java %s %s",
+        "UnsupportedJdkWarning": "JDK 9 and JDK 10 are out of support. Please switch to a later version in your project and pipeline. Attempting to build with JDK 11...",
+        "FailedToLocateSpecifiedJVM": "Failed to find the specified JDK version. Please ensure the specified JDK version is installed on the agent and the environment variable '%s' exists and is set to the location of a corresponding JDK or use the [Java Tool Installer](https://docs.microsoft.com/en-us/vsts/build-release/tasks/tool/java-tool-installer) task to install the desired JDK."
+    }
+}

--- a/common-npm-packages/java-common/package-lock.json
+++ b/common-npm-packages/java-common/package-lock.json
@@ -20,6 +20,13 @@
         "semver": "^5.1.0",
         "shelljs": "^0.3.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "balanced-match": {
@@ -60,9 +67,9 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "shelljs": {
       "version": "0.3.0",

--- a/common-npm-packages/java-common/package-lock.json
+++ b/common-npm-packages/java-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-java-common",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/semver": "^7.3.3",
     "azure-pipelines-task-lib": "^2.8.0",
-    "semver": "^5.1.0"
+    "semver": "^7.3.2"
   },
   "devDependencies": {
     "typescript": "2.3.4"

--- a/common-npm-packages/java-common/package.json
+++ b/common-npm-packages/java-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-java-common",
-  "version": "1.176.0",
+  "version": "1.177.0",
   "description": "Azure Pipelines tasks Java Common",
   "main": "java-common.js",
   "scripts": {


### PR DESCRIPTION
**Task name**: Java-common

**Description**: 

Addition to #13526 

- Fixed issue with "can not find module 'semver/functions/coerce'" error thrown when the latest semver version is not installed for a caller task.
- Fixed localization issue (strings defined in this package can not be found if they're not defined in calling task).

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#225](https://github.com/microsoft/build-task-team/issues/225)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
