### PR TITLE
[DownloadSecureFile] Increase default retry count value

### DIFF
--- a/Tasks/DownloadSecureFileV1/Tests/L0.ts
+++ b/Tasks/DownloadSecureFileV1/Tests/L0.ts
@@ -19,7 +19,7 @@ describe('DownloadSecureFile Suite', function () {
         tr.run();
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
-        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 8'), 'task should have used default retry count of 8');
         assert(tr.succeeded, 'task should have succeeded');
     });
 
@@ -36,7 +36,7 @@ describe('DownloadSecureFile Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Invalid retry count defaults to 5', function() {
+    it('Invalid retry count defaults to 8', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0InvalidRetryCount.js');
@@ -45,11 +45,11 @@ describe('DownloadSecureFile Suite', function () {
         tr.run();
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
-        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 8'), 'task should have used default retry count of 8');
         assert(tr.succeeded, 'task should have succeeded');
     });
 
-    it('Negative retry count defaults to 5', function() {
+    it('Negative retry count defaults to 8', function() {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
         let tp: string = path.join(__dirname, 'L0NegativeRetryCount.js');
@@ -58,7 +58,7 @@ describe('DownloadSecureFile Suite', function () {
         tr.run();
 
         assert(tr.stderr.length === 0, 'should not have written to stderr');
-        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 5'), 'task should have used default retry count of 5');
+        assert(tr.stdOutContained('##vso[task.debug]Mock SecureFileHelpers retry count set to: 8'), 'task should have used default retry count of 8');
         assert(tr.succeeded, 'task should have succeeded');
     });
 });

--- a/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
+++ b/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
@@ -11,7 +11,7 @@ async function run() {
 
         let retryCount = parseInt(tl.getInput('retryCount'));
         if (isNaN(retryCount) || retryCount < 0) {
-            retryCount = 5;
+            retryCount = 8;
         }
         // download decrypted contents
         secureFileId = tl.getInput('secureFile', true);

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 175,
+        "Minor": 177,
         "Patch": 0
     },
     "runsOn": [
@@ -36,7 +36,7 @@
             "name": "retryCount",
             "type": "string",
             "label": "Retry Count",
-            "defaultValue": "5",
+            "defaultValue": "8",
             "required": "false",
             "helpMarkDown": "Optional number of times to retry downloading a secure file if the download fails."
         }

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 175,
+    "Minor": 177,
     "Patch": 0
   },
   "runsOn": [
@@ -36,7 +36,7 @@
       "name": "retryCount",
       "type": "string",
       "label": "ms-resource:loc.input.label.retryCount",
-      "defaultValue": "5",
+      "defaultValue": "8",
       "required": "false",
       "helpMarkDown": "ms-resource:loc.input.help.retryCount"
     }


### PR DESCRIPTION
**Task name**: DownloadSecureFileV1

**Description**: Increased default `retryCount` value.

**Documentation changes required:** N

**Added unit tests:** Updated unit tests

**Attached related issue:** [#253](https://github.com/microsoft/build-task-team/issues/253)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] All unit tests passed
