### PR TITLE
Changing mode of kubeconfig file to remove helm warning (#13581)

### DIFF
--- a/Tasks/HelmDeployV0/Tests/L0.ts
+++ b/Tasks/HelmDeployV0/Tests/L0.ts
@@ -47,6 +47,7 @@ describe("HelmDeployV0 Suite", function () {
         process.env[shared.isHelmV3] = "true";
 
         tr.run();
+        assert(tr.stdout.indexOf("changed mode of file") != -1, "Mode of kubeconfig file should have been changed to 600");
         assert(tr.stdout.indexOf("v3") != -1, "Helm version 3 should have been installed");
         assert(tr.stdout.indexOf("STATUS: deployed") != -1, `Release should have been created with NAME: ${shared.testReleaseName}`);
         assert(tr.stdout.indexOf(`DeploymentDetailsApiResponse: {"mockKey":"mockValue"}`) != -1, "Web response should have been received for pushing metadata to evidence store");

--- a/Tasks/HelmDeployV0/Tests/TestSetup.ts
+++ b/Tasks/HelmDeployV0/Tests/TestSetup.ts
@@ -325,6 +325,9 @@ const fsClone = Object.assign({}, fs);
 fsClone.writeFileSync = function (path, data) {
     console.log(`wrote to ${path}`);
 };
+fsClone.chmodSync = function (path, mode) {
+    console.log(`changed mode of file at ${path} to ${mode}`);
+};
 tr.registerMock('fs', fsClone);
 
 import * as util from '../src/utils';

--- a/Tasks/HelmDeployV0/src/helm.ts
+++ b/Tasks/HelmDeployV0/src/helm.ts
@@ -53,6 +53,7 @@ async function getKubeConfigFile(): Promise<string> {
         var configFilePath = getKubeConfigFilePath();
         tl.debug(tl.loc("KubeConfigFilePath", configFilePath));
         fs.writeFileSync(configFilePath, config);
+        fs.chmodSync(configFilePath, '600');
         return configFilePath;
     });
 }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 176,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 176,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [


### PR DESCRIPTION
* Changing mode of kubeconfig file to remove helm warning

* Changing config mode to 600

* Adding assert to check mode change

**Task name**: HelmDeployV0

**Description**:  Porting changes from https://github.com/microsoft/azure-pipelines-tasks/pull/13581

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
