### PR TITLE
[MavenV3] Updated java-common lib

### DIFF
--- a/Tasks/MavenV3/package-lock.json
+++ b/Tasks/MavenV3/package-lock.json
@@ -143,9 +143,9 @@
       }
     },
     "azure-pipelines-tasks-java-common": {
-      "version": "1.177.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-java-common/-/azure-pipelines-tasks-java-common-1.177.0.tgz",
-      "integrity": "sha512-r3L5Lu8H8Vtt3Szlb0nZAISh84gRAjKhoqBq+w+q5g1E0RhDVUK4S22F4iPxSNQ6A677N1o5VSY5Zz10pz5Y8w==",
+      "version": "1.177.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-java-common/-/azure-pipelines-tasks-java-common-1.177.1.tgz",
+      "integrity": "sha512-Ik9hpdbmJOaipu1aOPbEt3mdrhWn7afXXlsuCEbtmW9LE5w8mmED0LQRe4/qqrvXhRrIlPZwTHCNju2kRW/1WQ==",
       "requires": {
         "@types/semver": "^7.3.3",
         "azure-pipelines-task-lib": "^2.8.0",
@@ -630,9 +630,9 @@
       "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
     },
     "ltx": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
-      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
         "inherits": "^2.0.4"
       },
@@ -698,7 +698,6 @@
     },
     "packaging-common": {
       "version": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
-      "integrity": "sha512-eXr8gINUC+ETUkIuKagomUzVBFTNr3GJrryc1hvD82/ywqm2elTJK9fJVJUGtrb2Jjb+kHuIoJGZ4CaxvpOqCQ==",
       "requires": {
         "@types/ini": "1.3.30",
         "@types/ltx": "2.8.0",

--- a/Tasks/MavenV3/package-lock.json
+++ b/Tasks/MavenV3/package-lock.json
@@ -143,12 +143,25 @@
       }
     },
     "azure-pipelines-tasks-java-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-java-common/-/azure-pipelines-tasks-java-common-1.0.0.tgz",
-      "integrity": "sha512-T3lsf2sjudgHlj6lpFdT9wl99OrhHPa7sQGZo1hBACRupxOohY6IwyzWm5pa2W2Hdi+ThhweLM04RgJm1wMk1Q==",
+      "version": "1.177.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-java-common/-/azure-pipelines-tasks-java-common-1.177.0.tgz",
+      "integrity": "sha512-r3L5Lu8H8Vtt3Szlb0nZAISh84gRAjKhoqBq+w+q5g1E0RhDVUK4S22F4iPxSNQ6A677N1o5VSY5Zz10pz5Y8w==",
       "requires": {
+        "@types/semver": "^7.3.3",
         "azure-pipelines-task-lib": "^2.8.0",
-        "semver": "^5.1.0"
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@types/semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
       }
     },
     "azure-pipelines-tool-lib": {
@@ -685,6 +698,7 @@
     },
     "packaging-common": {
       "version": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
+      "integrity": "sha512-eXr8gINUC+ETUkIuKagomUzVBFTNr3GJrryc1hvD82/ywqm2elTJK9fJVJUGtrb2Jjb+kHuIoJGZ4CaxvpOqCQ==",
       "requires": {
         "@types/ini": "1.3.30",
         "@types/ltx": "2.8.0",

--- a/Tasks/MavenV3/package.json
+++ b/Tasks/MavenV3/package.json
@@ -13,7 +13,7 @@
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tasks-codeanalysis-common": "1.0.0",
     "azure-pipelines-tasks-codecoverage-tools": "1.0.0",
-    "azure-pipelines-tasks-java-common": "1.0.0",
+    "azure-pipelines-tasks-java-common": "1.177.0",
     "base-64": "^0.1.0",
     "fs-extra": "^0.30.0",
     "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",

--- a/Tasks/MavenV3/package.json
+++ b/Tasks/MavenV3/package.json
@@ -13,7 +13,7 @@
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tasks-codeanalysis-common": "1.0.0",
     "azure-pipelines-tasks-codecoverage-tools": "1.0.0",
-    "azure-pipelines-tasks-java-common": "1.177.0",
+    "azure-pipelines-tasks-java-common": "1.177.1",
     "base-64": "^0.1.0",
     "fs-extra": "^0.30.0",
     "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 176,
-        "Patch": 1
+        "Minor": 177,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 176,
-    "Patch": 1
+    "Minor": 177,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
**Task name**: MavenV3

**Description**: 
Updated java-common lib to include [these changes](https://github.com/microsoft/azure-pipelines-tasks/pull/13526).
This update is aimed to resolve issue [#217](https://github.com/microsoft/build-task-team/issues/217) by fixing the process of JAVA_HOME value retrieving from Windows registry.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#217](https://github.com/microsoft/build-task-team/issues/217)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] Checked that all unit tests passed
