### PR TITLE
HelmDeployV0: set failOnStderr to false by default

### DIFF
--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 176,
-        "Patch": 1
+        "Minor": 177,
+        "Patch": 0
     },
     "demands": [],
     "groups": [
@@ -430,7 +430,7 @@
             "name": "failOnStderr",
             "type": "boolean",
             "label": "Fail on Standard Error",
-            "defaultValue": "true",
+            "defaultValue": "false",
             "helpMarkDown": "If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream. Otherwise the task will rely on the exit code to determine failure.",
             "groupName": "advanced"
         },


### PR DESCRIPTION
Signed-off-by: Matthew Fisher <matt.fisher@microsoft.com>

**Task name**: HelmDeployV0

**Description**:  By default, a pipeline should not fail when a warning message is displayed on standard error. Helm and other CLI tools use standard error to display informational as well as warning messages, but informational messages should not prevent the user from deploying. If an error should occur, Helm will stop and return a non-zero exit code.

**Documentation changes required:** Maybe? Users may set failOnStderr to true to revert to the previous behaviour.

**Added unit tests:** No

**Attached related issue:** Yes: https://github.com/microsoft/azure-pipelines-tasks/issues/13594#issuecomment-697485926

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
