### PR TITLE
SSH + Windows Agents issues - ##[error]bash: ./sshscript: No such file or directory

### DIFF
--- a/Tasks/SshV0/ssh.ts
+++ b/Tasks/SshV0/ssh.ts
@@ -143,7 +143,7 @@ async function run() {
                 //change the line encodings
                 if (isWin) {
                     tl.debug('Fixing the line endings in case the file was created in Windows');
-                    const removeLineEndingsCmd = `tr -d \'\\015\' <${windowsEncodedRemoteScriptPath}> ${remoteScriptPath}`;
+                    const removeLineEndingsCmd = `tr -d \'\\015\' <${remoteScriptPath}> ${windowsEncodedRemoteScriptPath}`;
                     console.log(removeLineEndingsCmd);
                     await sshHelper.runCommandOnRemoteMachine(removeLineEndingsCmd, sshClientConnection, remoteCmdOptions);
                 }


### PR DESCRIPTION
**Task name**: SshV0 - https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks/SshV0

**Description**: Bug fix.
Removing line endings using:
const removeLineEndingsCmd = `tr -d \'\\015\' <${remoteScriptPath}> ${windowsEncodedRemoteScriptPath}`;

Is generating errors as example:
##[error]bash: ./sshscript_4324: No such file or directory

Refactoring to:
`tr -d \'\\015\' <${remoteScriptPath}> ${windowsEncodedRemoteScriptPath}`;

It was tested and resolved the issue. 

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** No

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
