### PR TITLE
Mark items as stale after 180 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
         stale-pr-message: 'This PR is stale because it has been open for a year with no activity. Remove the stale label or comment on the PR otherwise this will be closed in 5 days'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'
-        days-before-stale: 365
+        days-before-stale: 180
         days-before-close: 5
         operations-per-run: 100
         exempt-issue-labels: 'backlog'


### PR DESCRIPTION
This brings this in line with what we have in our other repos (e.g. https://github.com/microsoft/azure-pipelines-agent/blob/5649ac959eeab1dde6bc8acda87250c8f18f3bd5/.github/workflows/stale.yml#L18) - this also probably means its not high enough priority to address.