### PR TITLE
[SSHV0] Fix bash: No such file or directory issue

### DIFF
--- a/Tasks/SshV0/ssh2helpers.ts
+++ b/Tasks/SshV0/ssh2helpers.ts
@@ -205,11 +205,12 @@ export interface ScpConfig {
 }
 
 /**
- * This function generates a new file with *_unix extension on the remote host 
+ * This function generates a new file with *_unix extension on the remote host
  * which contains the same file but without Windows CR LF
  * @param {ssh2.Client} sshClientConnection - ssh client instance
  * @param {RemoteCommandOptions} remoteCmdOptions
  * @param {string} remoteInputFilePath - remote path to target file
+ * @throws will throw an error if command execution fails on remote host
  * @return {string} - path to the generated file
 */
 export async function clearFileFromWindowsCRLF(sshClientConnection: ssh2.Client, remoteCmdOptions: RemoteCommandOptions, remoteInputFilePath: string): Promise<string> {
@@ -217,7 +218,7 @@ export async function clearFileFromWindowsCRLF(sshClientConnection: ssh2.Client,
     const removeLineEndingsCmd = `tr -d \'\\015\' <${remoteInputFilePath}> ${remoteOutputFilePath}`;
 
     console.log(removeLineEndingsCmd);
-    
+
     try {
         tl.debug(`Removing Windows CR LF from ${remoteInputFilePath}`);
         await runCommandOnRemoteMachine(removeLineEndingsCmd, sshClientConnection, remoteCmdOptions);
@@ -226,6 +227,6 @@ export async function clearFileFromWindowsCRLF(sshClientConnection: ssh2.Client,
     }
 
     tl.debug(`Path to generated file = ${remoteOutputFilePath}`);
-    
+
     return remoteOutputFilePath;
 }

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 176,
-        "Patch": 1
+        "Minor": 177,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 176,
-    "Patch": 1
+    "Minor": 177,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**:  SSHV0

**Description**: 
This PR fixes `bash: No such file or directory` problem when ssh task running on windows agent.

_Changes:_
- Fixed problem with the naming of script file on remote host.
- All logic for remove Windows CR LF from the script file was extracted to separate function
- Updated comments for source code
- Removed extra variables

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** 
- https://github.com/microsoft/build-task-team/issues/286
- https://github.com/microsoft/azure-pipelines-tasks/issues/13661

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected