### PR TITLE
Update docs to reflect command is supported on 2020

### DIFF
--- a/docs/authoring/commands.md
+++ b/docs/authoring/commands.md
@@ -440,7 +440,7 @@ To invoke a logging command, simply emit the command via standard output. For ex
                     Update release name for current release.<br>
                     <b>Example:</b> <br>
                     <code>##vso[release.updatereleasename]my-new-release-name</code><br>
-                    This command is not supported in Azure DevOps Server(TFS).
+                    This command is not supported in Azure DevOps Server (TFS) 2019 and below.
                 </p>
             </td>
             <td>


### PR DESCRIPTION
Updates authoring docs to reflect that the updating of Release Name works on Azure DevOps Server 2020 by adding a "not supported on 2019 and below)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/azure-pipelines-tasks/13702)
<!-- Reviewable:end -->
