### PR TITLE
Fix kubectl Kubernetes service connection field in logout command

### DIFF
--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 175,
-        "Patch": 3
+        "Minor": 177,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -22,8 +22,7 @@
         {
             "name": "kubernetesCluster",
             "displayName": "Kubernetes Cluster",
-            "isExpanded": true,
-            "visibleRule": "command != logout"
+            "isExpanded": true
         },
         {
             "name": "commands",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 175,
-    "Patch": 3
+    "Minor": 177,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: KubernetesV1

**Description**: With this change it will show Kubernetes service connection field in the kubectl(KubernetesV1) task with logout as command.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y #13704 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
