### PR TITLE
$ issue in connection string fixed

### DIFF
--- a/Tasks/SqlAzureDacpacDeploymentV1/SqlAzureActions.ps1
+++ b/Tasks/SqlAzureDacpacDeploymentV1/SqlAzureActions.ps1
@@ -272,6 +272,7 @@ function Run-SqlCmd {
     }
     elseif ($authenticationType -eq "connectionString") {
       Check-ConnectionString
+      $connectionString = EscapeSpecialChars -str $connectionString
       $commandToRun = "Invoke-Sqlcmd -connectionString `"$connectionString`" "
       $commandToLog = "Invoke-Sqlcmd -connectionString `"**********`" "
     }
@@ -279,7 +280,7 @@ function Run-SqlCmd {
       Check-connectionString
       $connectionString = Get-AADAuthenticationConnectionString -authenticationType $authenticationType -serverName $serverName -databaseName $databaseName -sqlUserName $sqlUserName -sqlPassword $sqlPassword
       $commandToRun = "Invoke-Sqlcmd -connectionString `"$connectionString`" "
-      $commandToLog = "Invoke-Sqlcmd -connectionString `"$connectionString`" "
+      $commandToLog = "Invoke-Sqlcmd -connectionString `"**********`" "
     }
 
     $commandToRun += " -Inputfile `"$sqlFilePath`" " + $sqlcmdAdditionalArguments

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 171,
-        "Patch": 4
+        "Minor": 178,
+        "Patch": 0
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 171,
-    "Patch": 4
+    "Minor": 178,
+    "Patch": 0
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
**Task name**: SqlAzureDacpacDeployment

**Description**: $ symbol in password breaks connection to DB using connection string

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y #13671 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
