### PR TITLE
[securefiles-common] Update dependencies

### DIFF
--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.0-preview",
+  "version": "2.0.1-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,8 +28,7 @@
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
-      "dev": true
+      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/qs": {
       "version": "6.9.5",

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.0-preview",
+  "version": "2.0.1-preview",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
+    "@types/node": "^14.10.0",
+    "@types/q": "^1.5.4",
     "azure-devops-node-api": "7.2.0",
     "azure-pipelines-task-lib": "^3.0.1-preview"
   },
   "devDependencies": {
-    "typescript": "^4.0.0",
-    "@types/node": "^14.10.0",
-    "@types/q": "^1.5.4"
+    "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
**Task name**: securefiles-common

**Description**: Updated tasklib version to 3.0.3-preview, moved @types from devDependencies to dependencies

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/298

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
