### PR TITLE
[ios-signing-common] Update dependencies

### DIFF
--- a/common-npm-packages/ios-signing-common/package-lock.json
+++ b/common-npm-packages/ios-signing-common/package-lock.json
@@ -28,8 +28,7 @@
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
-      "dev": true
+      "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -47,9 +46,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-pipelines-task-lib": {
-      "version": "3.0.1-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.1-preview.tgz",
-      "integrity": "sha512-L+yfKb915dkvI0x15m5Rwxa0Qh2/07iFRLzHu2RdgMcjUrsuKC6rH1ehnqhCqmB+/W5wNm/EalYF1jFLOUYU9A==",
+      "version": "3.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.3-preview.tgz",
+      "integrity": "sha512-mRz6GQrDi3CTKz0Y9pxsokywxwx2969ti+HWokRm3kGjBOhaSrz21XodYApGUzq5v5XnO3vCcqhsaSLFVz80RQ==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -133,6 +132,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -149,6 +153,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "http-basic": {
@@ -171,9 +183,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.39",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.39.tgz",
-          "integrity": "sha512-dJLCxrpQmgyxYGcl0Ae9MTsQgI22qHHcGFj/8VKu7McJA5zQpnuGjoksnxbo1JxSjW/Nahnl13W8MYZf01CZHA=="
+          "version": "10.17.40",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
+          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA=="
         }
       }
     },
@@ -195,6 +207,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -296,10 +316,11 @@
       }
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -368,9 +389,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.64",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.64.tgz",
-          "integrity": "sha512-/EwBIb+imu8Qi/A3NF9sJ9iuKo7yV+pryqjmeRqaU0C4wBAOhas5mdvoYeJ5PCKrh6thRSJHdoasFqh3BQGILA=="
+          "version": "8.10.65",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.65.tgz",
+          "integrity": "sha512-xdcqtQl1g3p/49kmcj7ZixPWOcNHA1tYNz+uN0PJEcgtN6zywK74aacTnd3eFGPuBpD7kK8vowmMRkUt6jHU/Q=="
         }
       }
     },

--- a/common-npm-packages/ios-signing-common/package.json
+++ b/common-npm-packages/ios-signing-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-ios-signing-common",
-  "version": "2.0.0-preview",
+  "version": "2.0.1-preview",
   "description": "Azure Pipelines tasks iOS Signing Common",
   "main": "ios-signing-common.js",
   "scripts": {
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.0.1-preview"
-  },
-  "devDependencies": {
     "@types/node": "^14.10.0",
     "@types/q": "^1.5.4",
+    "azure-pipelines-task-lib": "^3.0.3-preview"
+  },
+  "devDependencies": {
     "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
**Task name**: ios-signing-common

**Description**: Updated tasklib version to 3.0.3-preview, moved @types from devDependencies to dependencies

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/298

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
