### PR TITLE
[ExtractFilesV1] Add warning for when no archives were found

### DIFF
--- a/Tasks/ExtractFilesV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/ExtractFilesV1/Strings/resources.resjson/en-US/resources.resjson
@@ -30,6 +30,7 @@
   "loc.messages.DecompressedTempTar": "Decompressed temporary tar from: %s to: %s",
   "loc.messages.RemoveTempDir": "Removing temp folder: %s",
   "loc.messages.ExtractFailedCannotCreate": "Extraction failed for file: %s because temporary location could not be created: %s",
+  "loc.messages.NoFilesFound": "No archives were found using specified file patterns",
   "loc.messages.FoundFiles": "Found: %d files to extract:",
   "loc.messages.CleanDestDir": "Cleaning destination folder before extraction: %s",
   "loc.messages.CreateDestDir": "Creating destination folder: %s",

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -312,7 +312,7 @@ function doWork() {
         var files: string[] = findFiles();
 
         if (files.length === 0) {
-            tl.warning(tl.loc('NoFilesFound', files.length));
+            tl.warning(tl.loc('NoFilesFound'));
         }
 
         console.log(tl.loc('FoundFiles', files.length));

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -310,6 +310,11 @@ function doWork() {
 
         // Find matching archive files
         var files: string[] = findFiles();
+
+        if (files.length === 0) {
+            tl.warning(tl.loc('NoFilesFound', files.length));
+        }
+
         console.log(tl.loc('FoundFiles', files.length));
         for (var i = 0; i < files.length; i++) {
             console.log(files[i]);

--- a/Tasks/ExtractFilesV1/package-lock.json
+++ b/Tasks/ExtractFilesV1/package-lock.json
@@ -31,9 +31,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "14.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
-      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
+      "version": "14.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.0.tgz",
+      "integrity": "sha512-BfbIHP9IapdupGhq/hc+jT5dyiBVZ2DdeC5WwJWQWDb0GijQlzUFAeIQn/2GtvZcd2HVUU7An8felIICFTC2qg=="
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -70,9 +70,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -145,6 +145,11 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -161,6 +166,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
       }
     },
     "http-basic": {
@@ -183,9 +196,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+          "version": "10.17.40",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
+          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA=="
         }
       }
     },
@@ -207,6 +220,14 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "is-core-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
+      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -308,10 +329,11 @@
       }
     },
     "resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
       "requires": {
+        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -380,9 +402,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.64",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.64.tgz",
-          "integrity": "sha512-/EwBIb+imu8Qi/A3NF9sJ9iuKo7yV+pryqjmeRqaU0C4wBAOhas5mdvoYeJ5PCKrh6thRSJHdoasFqh3BQGILA=="
+          "version": "8.10.65",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.65.tgz",
+          "integrity": "sha512-xdcqtQl1g3p/49kmcj7ZixPWOcNHA1tYNz+uN0PJEcgtN6zywK74aacTnd3eFGPuBpD7kK8vowmMRkUt6jHU/Q=="
         }
       }
     },

--- a/Tasks/ExtractFilesV1/package-lock.json
+++ b/Tasks/ExtractFilesV1/package-lock.json
@@ -31,9 +31,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "14.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.0.tgz",
-      "integrity": "sha512-BfbIHP9IapdupGhq/hc+jT5dyiBVZ2DdeC5WwJWQWDb0GijQlzUFAeIQn/2GtvZcd2HVUU7An8felIICFTC2qg=="
+      "version": "14.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
+      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -70,9 +70,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -145,11 +145,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -166,14 +161,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "http-basic": {
@@ -196,9 +183,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.40",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.40.tgz",
-          "integrity": "sha512-3hZT2z2/531A5pc8hYhn1gU5Qb1SIRSgMLQ6zuHA5xtt16lWAxUGprtr8lJuc9zNJMXEIIBWfSnzqBP/4mglpA=="
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
         }
       }
     },
@@ -220,14 +207,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
-    },
-    "is-core-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
-      "requires": {
-        "has": "^1.0.3"
-      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -329,11 +308,10 @@
       }
     },
     "resolve": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "requires": {
-        "is-core-module": "^2.0.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -402,9 +380,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.65",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.65.tgz",
-          "integrity": "sha512-xdcqtQl1g3p/49kmcj7ZixPWOcNHA1tYNz+uN0PJEcgtN6zywK74aacTnd3eFGPuBpD7kK8vowmMRkUt6jHU/Q=="
+          "version": "8.10.64",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.64.tgz",
+          "integrity": "sha512-/EwBIb+imu8Qi/A3NF9sJ9iuKo7yV+pryqjmeRqaU0C4wBAOhas5mdvoYeJ5PCKrh6thRSJHdoasFqh3BQGILA=="
         }
       }
     },

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -86,6 +86,7 @@
         "DecompressedTempTar": "Decompressed temporary tar from: %s to: %s",
         "RemoveTempDir": "Removing temp folder: %s",
         "ExtractFailedCannotCreate": "Extraction failed for file: %s because temporary location could not be created: %s",
+        "NoFilesFound": "No .zip files were found using specified file patterns",
         "FoundFiles": "Found: %d files to extract:",
         "CleanDestDir": "Cleaning destination folder before extraction: %s",
         "CreateDestDir": "Creating destination folder: %s",

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -18,7 +18,7 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 177,
+        "Minor": 178,
         "Patch": 0
     },
     "instanceNameFormat": "Extract files $(message)",

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -86,7 +86,7 @@
         "DecompressedTempTar": "Decompressed temporary tar from: %s to: %s",
         "RemoveTempDir": "Removing temp folder: %s",
         "ExtractFailedCannotCreate": "Extraction failed for file: %s because temporary location could not be created: %s",
-        "NoFilesFound": "No .zip files were found using specified file patterns",
+        "NoFilesFound": "No archives were found using specified file patterns",
         "FoundFiles": "Found: %d files to extract:",
         "CleanDestDir": "Cleaning destination folder before extraction: %s",
         "CreateDestDir": "Creating destination folder: %s",

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 177,
+    "Minor": 178,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -86,6 +86,7 @@
     "DecompressedTempTar": "ms-resource:loc.messages.DecompressedTempTar",
     "RemoveTempDir": "ms-resource:loc.messages.RemoveTempDir",
     "ExtractFailedCannotCreate": "ms-resource:loc.messages.ExtractFailedCannotCreate",
+    "NoFilesFound": "ms-resource:loc.messages.NoFilesFound",
     "FoundFiles": "ms-resource:loc.messages.FoundFiles",
     "CleanDestDir": "ms-resource:loc.messages.CleanDestDir",
     "CreateDestDir": "ms-resource:loc.messages.CreateDestDir",


### PR DESCRIPTION
**Task name**: ExtractFilesV1

**Description**: Add warning for when no archives were found

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/316

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected ([pipeline run](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=43&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=0479c6b7-9905-5be5-91c6-fe518b1ea5ba&l=11))
