### PR TITLE
Adding checkbox in AzurePSV4

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 6,
-        "Patch": 16
+        "Patch": 17
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 6,
-    "Patch": 16
+    "Patch": 17
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 156,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 156,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 10
+        "Patch": 11
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 10
+    "Patch": 11
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 4,
-        "Patch": 12
+        "Patch": 13
     },
     "preview": true,
     "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 4,
-    "Patch": 12
+    "Patch": 13
   },
   "preview": true,
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 12
+        "Patch": 13
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 12
+    "Patch": 13
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 4,
-        "Patch": 28
+        "Patch": 29
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 4,
-    "Patch": 28
+    "Patch": 29
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
@@ -10,6 +10,7 @@ $__vsts_input_errorActionPreference = Get-VstsInput -Name errorActionPreference
 $__vsts_input_failOnStandardError = Get-VstsInput -Name FailOnStandardError
 $targetAzurePs = Get-VstsInput -Name TargetAzurePs
 $customTargetAzurePs = Get-VstsInput -Name CustomTargetAzurePs
+$restrictContext = Get-VstsInput -Name RestrictContextToCurrentTask -AsBool
 
 # Validate the script path and args do not contains new-lines. Otherwise, it will
 # break invoking the script via Invoke-Expression.
@@ -137,5 +138,5 @@ finally {
 
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
     Remove-EndpointSecrets
-    Disconnect-AzureAndClearContext -ErrorAction SilentlyContinue
+    Disconnect-AzureAndClearContext -restrictContext $restrictContext -ErrorAction SilentlyContinue
 }

--- a/Tasks/AzurePowerShellV4/InitializeAz.ps1
+++ b/Tasks/AzurePowerShellV4/InitializeAz.ps1
@@ -43,10 +43,10 @@ Write-Host "##[command]Import-Module -Name $($module.Path) -Global"
 $module = Import-Module -Name $module.Path -Global -PassThru -Force
 
 # Clear context
-Write-Host "##[command]Clear-AzContext -Scope Process"
-$null = Clear-AzContext -Scope Process
 Write-Host "##[command]Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
 $null = Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue 
+Write-Host "##[command]Clear-AzContext -Scope Process"
+$null = Clear-AzContext -Scope Process
 
 $scopeLevel = "Subscription"
 if($endpointObject.scopeLevel) {

--- a/Tasks/AzurePowerShellV4/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzurePowerShellV4/Strings/resources.resjson/en-US/resources.resjson
@@ -19,6 +19,8 @@
   "loc.input.help.errorActionPreference": "Select the value of the ErrorActionPreference variable for executing the script.",
   "loc.input.label.FailOnStandardError": "Fail on Standard Error",
   "loc.input.help.FailOnStandardError": "If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream.",
+  "loc.input.label.RestrictContextToCurrentTask": "Restrict scope of context to current task",
+  "loc.input.help.RestrictContextToCurrentTask": "If this is true, this task will restrict the scope of context to current task only and the context will not be available to other tasks in the pipeline when using private agent.",
   "loc.input.label.TargetAzurePs": "Azure PowerShell Version",
   "loc.input.help.TargetAzurePs": "In case of hosted agents, the supported Azure PowerShell Version is: 1.0.0(Hosted VS2017 Queue).\nTo pick the latest version available on the agent, select \"Latest installed version\".\n\nFor private agents you can specify preferred version of Azure PowerShell using \"Specify version\"",
   "loc.input.label.CustomTargetAzurePs": "Preferred Azure PowerShell Version",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 4,
         "Minor": 3,
-        "Patch": 13
+        "Patch": 14
     },
     "preview": true,
     "releaseNotes": "Added support for Az Module and cross platform agents.",
@@ -111,6 +111,14 @@
             "required": false,
             "defaultValue": "false",
             "helpMarkDown": "If this is true, this task will fail if any errors are written to the error pipeline, or if any data is written to the Standard Error stream."
+        },
+        {
+            "name": "RestrictContextToCurrentTask",
+            "type": "boolean",
+            "label": "Restrict scope of context to current task",
+            "required": false,
+            "defaultValue": "false",
+            "helpMarkDown": "If this is true, this task will restrict the scope of context to current task only and the context will not be available to other tasks in the pipeline when using private agent."
         },
         {
             "name": "TargetAzurePs",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 4,
     "Minor": 3,
-    "Patch": 13
+    "Patch": 14
   },
   "preview": true,
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -111,6 +111,14 @@
       "required": false,
       "defaultValue": "false",
       "helpMarkDown": "ms-resource:loc.input.help.FailOnStandardError"
+    },
+    {
+      "name": "RestrictContextToCurrentTask",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.RestrictContextToCurrentTask",
+      "required": false,
+      "defaultValue": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.RestrictContextToCurrentTask"
     },
     {
       "name": "TargetAzurePs",

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -72,10 +72,10 @@ function Initialize-AzSubscription {
     Set-UserAgent
     
     # Clear context
-    Write-Host "##[command]Clear-AzContext -Scope Process"
-    $null = Clear-AzContext -Scope Process
     Write-Host "##[command]Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
     $null = Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue
+    Write-Host "##[command]Clear-AzContext -Scope Process"
+    $null = Clear-AzContext -Scope Process
 
     $environmentName = "AzureCloud"
     if($Endpoint.Data.Environment) {

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -488,7 +488,8 @@ function Add-AzureStackAzureRmEnvironment {
 function Disconnect-AzureAndClearContext {
     [CmdletBinding()]
     param(
-        [string]$authScheme = 'ServicePrincipal'
+        [string]$authScheme = 'ServicePrincipal',
+        [string]$restrictContext = 'False'
     )
 
     try {
@@ -496,7 +497,7 @@ function Disconnect-AzureAndClearContext {
             Write-Verbose "Trying to disconnect from Azure and clear context at process scope"
 
             if (Get-Module Az.Accounts -ListAvailable) {
-                Disconnect-UsingAzModule
+                Disconnect-UsingAzModule -restrictContext $restrictContext
             }
             else {
                 Disconnect-UsingARMModule
@@ -511,9 +512,15 @@ function Disconnect-AzureAndClearContext {
 
 function Disconnect-UsingAzModule {
     [CmdletBinding()]
-    param()
+    param(
+        [string]$restrictContext = 'False'
+    )
 
-    if (Get-Command -Name "Disconnect-AzAccount" -ErrorAction "SilentlyContinue" -and CmdletHasMember -cmdlet Disconnect-AzAccount -memberName Scope) {	
+    if (Get-Command -Name "Disconnect-AzAccount" -ErrorAction "SilentlyContinue" -and CmdletHasMember -cmdlet Disconnect-AzAccount -memberName Scope) {
+        if ($restrictContext -eq 'True') {
+            Write-Host "##[command]Disconnect-AzAccount -Scope CurrentUser -ErrorAction Stop"
+            $null = Disconnect-AzAccount -Scope CurrentUser -ErrorAction Stop
+        }	
         Write-Host "##[command]Disconnect-AzAccount -Scope Process -ErrorAction Stop"	
         $null = Disconnect-AzAccount -Scope Process -ErrorAction Stop
     }

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 6,
-        "Patch": 21
+        "Patch": 22
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 6,
-    "Patch": 21
+    "Patch": 22
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
**Task name**: AzurePowerShellV4

**Description**: In AzurePowerShellV4 task, we are providing the option of checkbox named restrict scope of context to current task. if it is true, this task will restrict the scope of context to current task only and the context will not be available to other tasks in the pipeline when using private agent. By default, it is false in AzurePowerShellV4

**Attached related issue:** (Y/N) MSRC Case 57599 - Azure Pipelines AzurePowershell task does not scope/terminate sessions correctly

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
