### PR TITLE
virtual directories are not created in AzureFileCopyV4 using blob prefix

### DIFF
--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -213,7 +213,8 @@ function Upload-FilesToAzureContainer
         Write-Output (Get-VstsLocString -Key "AFC_UploadFilesStorageAccount" -ArgumentList $sourcePath, $storageAccountName, $containerName, $blobPrefix)
 
         $blobPrefix = $blobPrefix.Trim()
-        $containerURL = [string]::Format("{0}/{1}/{2}", $blobStorageEndpoint.Trim("/"), $containerName, $blobPrefix).Trim("/")
+        $containerURL = [string]::Format("{0}/{1}/{2}", $blobStorageEndpoint.Trim("/"), $containerName, $blobPrefix.Trim("/"))
+        $containerURL = $containerURL + "/"
         $containerURL = $containerURL.Replace('$','`$')
         $azCopyExeLocation = Join-Path -Path $azCopyLocation -ChildPath "AzCopy.exe"
 

--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -213,7 +213,7 @@ function Upload-FilesToAzureContainer
         Write-Output (Get-VstsLocString -Key "AFC_UploadFilesStorageAccount" -ArgumentList $sourcePath, $storageAccountName, $containerName, $blobPrefix)
 
         $blobPrefix = $blobPrefix.Trim()
-        $containerURL = [string]::Format("{0}/{1}/{2}", $blobStorageEndpoint.Trim("/"), $containerName, $blobPrefix.Trim("/"))
+        $containerURL = [string]::Format("{0}/{1}/{2}", $blobStorageEndpoint.Trim("/"), $containerName, $blobPrefix).Trim("/")
         $containerURL = $containerURL + "/"
         $containerURL = $containerURL.Replace('$','`$')
         $azCopyExeLocation = Join-Path -Path $azCopyLocation -ChildPath "AzCopy.exe"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 175,
-        "Patch": 5
+        "Minor": 178,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 175,
-    "Patch": 5
+    "Minor": 178,
+    "Patch": 0
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
**Task name**: AzureFileCopyV4

**Description**: Added "/" at the end of destination blob storage url

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://developercommunity.visualstudio.com/content/problem/1109500/azure-file-copy-task-drops-file-name-when-using-pr.html

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
