### PR TITLE
Fixed link to NuGet task - MSBuild help markdown

### DIFF
--- a/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -22,7 +22,7 @@
   "loc.input.label.maximumCpuCount": "Build in Parallel",
   "loc.input.help.maximumCpuCount": "If your MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If your target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
   "loc.input.label.restoreNugetPackages": "Restore NuGet Packages",
-  "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget) task before the build.",
+  "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget) task before the build.",
   "loc.input.label.logProjectEvents": "Record Project Details",
   "loc.input.help.logProjectEvents": "Optionally record timeline details for each project (Windows only).",
   "loc.input.label.createLogFile": "Create Log File",

--- a/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MSBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -22,7 +22,7 @@
   "loc.input.label.maximumCpuCount": "Build in Parallel",
   "loc.input.help.maximumCpuCount": "If your MSBuild target configuration is compatible with building in parallel, you can optionally check this input to pass the /m switch to MSBuild (Windows only). If your target configuration is not compatible with building in parallel, checking this option may cause your build to result in file-in-use errors, or intermittent or inconsistent build failures.",
   "loc.input.label.restoreNugetPackages": "Restore NuGet Packages",
-  "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a [NuGet Tool Installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/nuget) task before the build.",
+  "loc.input.help.restoreNugetPackages": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget) task before the build.",
   "loc.input.label.logProjectEvents": "Record Project Details",
   "loc.input.help.logProjectEvents": "Optionally record timeline details for each project (Windows only).",
   "loc.input.label.createLogFile": "Create Log File",

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -131,7 +131,7 @@
             "defaultValue": "false",
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget) task before the build."
+            "helpMarkDown": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget) task before the build."
         },
         {
             "name": "logProjectEvents",

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 166,
-        "Patch": 2
+        "Minor": 178,
+        "Patch": 0
     },
     "demands": [
         "msbuild"
@@ -131,7 +131,7 @@
             "defaultValue": "false",
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "This option is deprecated. To restore NuGet packages, add a [NuGet Tool Installer](https://docs.microsoft.com/vsts/pipelines/tasks/tool/nuget) task before the build."
+            "helpMarkDown": "This option is deprecated. To restore NuGet packages, add a [NuGet](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget) task before the build."
         },
         {
             "name": "logProjectEvents",

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -11,7 +11,8 @@
   ],
   "author": "Microsoft Corporation",
   "version": {
-    "Major": 178,
+    "Major": 1,
+    "Minor": 178,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -11,9 +11,8 @@
   ],
   "author": "Microsoft Corporation",
   "version": {
-    "Major": 1,
-    "Minor": 166,
-    "Patch": 2
+    "Major": 178,
+    "Patch": 0
   },
   "demands": [
     "msbuild"


### PR DESCRIPTION
**Task name**: MSBuildV1

**Description**: Updated link to NuGet task in help markdown for restoreNugetPackages input - previously there was a reference to NuGetInstaller task, but it installs specific NuGet tool version instead of packages restoring.

**Documentation changes required:** N

**Added unit tests:** Not required

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
