### PR TITLE
[DotNetCoreCLIV2]adding option in case packageFile is .nuspec

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -354,7 +354,7 @@ describe('DotNetCoreExe Suite', function () {
 
         tr.run();
         assert(tr.invokedToolCount == 1, 'should have run dotnet once');
-        assert(tr.ran('c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=x.y.z-CI-YYYYMMDD-HHMMSS'), 'it should have run dotnet');
+        assert(tr.ran('c:\\path\\dotnet.exe pack -p:NuspecFile=c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=x.y.z-CI-YYYYMMDD-HHMMSS'), 'it should have run dotnet');
         assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
         assert(tr.succeeded, 'should have succeeded');
         assert.equal(tr.errorIssues.length, 0, "should have no errors");
@@ -369,7 +369,7 @@ describe('DotNetCoreExe Suite', function () {
 
         tr.run();
         assert(tr.invokedToolCount == 1, 'should have run dotnet once');
-        assert(tr.ran('c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=XX.YY.ZZ'), 'it should have run dotnet');
+        assert(tr.ran('c:\\path\\dotnet.exe pack -p:NuspecFile=c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=XX.YY.ZZ'), 'it should have run dotnet');
         assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
         assert(tr.succeeded, 'should have succeeded');
         assert.equal(tr.errorIssues.length, 0, "should have no errors");

--- a/Tasks/DotNetCoreCLIV2/Tests/PackTests/packEnvVar.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/PackTests/packEnvVar.ts
@@ -24,7 +24,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "dotnet": "c:\\path\\dotnet.exe"
     },
     "exec": {
-        "c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=XX.YY.ZZ": {
+        "c:\\path\\dotnet.exe pack -p:NuspecFile=c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=XX.YY.ZZ": {
             "code": 0,
             "stdout": "dotnet output",
             "stderr": ""

--- a/Tasks/DotNetCoreCLIV2/Tests/PackTests/packPrerelease.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/PackTests/packPrerelease.ts
@@ -26,7 +26,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "dotnet": "c:\\path\\dotnet.exe"
     },
     "exec": {
-        "c:\\path\\dotnet.exe pack c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=x.y.z-CI-YYYYMMDD-HHMMSS": {
+        "c:\\path\\dotnet.exe pack -p:NuspecFile=c:\\agent\\home\\directory\\foo.nuspec --output C:\\out\\dir /p:PackageVersion=x.y.z-CI-YYYYMMDD-HHMMSS": {
             "code": 0,
             "stdout": "dotnet output",
             "stderr": ""

--- a/Tasks/DotNetCoreCLIV2/packcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/packcommand.ts
@@ -138,7 +138,11 @@ function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: str
     let dotnet = tl.tool(dotnetPath);
 
     dotnet.arg("pack");
-    dotnet.arg(packageFile);
+    
+    if(packageFile.endsWith(".nuspec")) {
+        dotnet.arg("-p:NuspecFile="+packageFile);
+    }
+    else dotnet.arg(packageFile);
 
     if (outputDir) {
         dotnet.arg("--output");

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 175,
+        "Minor": 177,
         "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 175,
+    "Minor": 177,
     "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: Handling the case where .nuspec file is provided for dotnet pack command (merged into master - #13712 )

**Documentation changes required:** No
**Added unit tests:** No

**Attached related issue:** #13674 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
