### PR TITLE
Corrrecting permission of container in AzureFileCopyV4

### DIFF
--- a/Tasks/AzureFileCopyV4/AzureFileCopy.ps1
+++ b/Tasks/AzureFileCopyV4/AzureFileCopy.ps1
@@ -119,7 +119,7 @@ try {
         {
             $containerName = [guid]::NewGuid().ToString()
             Write-Verbose "Container Name input not found. Creating Temporary container for uploading files."
-            Create-AzureContainer -containerName $containerName -storageContext $storageContext -isPremiumStorage $isPremiumStorage  
+            Create-AzureContainer -containerName $containerName -storageContext $storageContext
         }
         else
         {
@@ -130,7 +130,7 @@ try {
             if($containerPresent -eq $null)
             {
                 Write-Verbose "Creating container if the containerName provided does not exist"
-                Create-AzureContainer -containerName $containerName -storageContext $storageContext -isPremiumStorage $isPremiumStorage
+                Create-AzureContainer -containerName $containerName -storageContext $storageContext
             }
         }
 

--- a/Tasks/AzureFileCopyV4/AzureUtilityARM.ps1
+++ b/Tasks/AzureFileCopyV4/AzureUtilityARM.ps1
@@ -43,20 +43,14 @@ function Create-AzureStorageContext
 function Create-AzureContainer
 {
     param([string]$containerName,
-          [object]$storageContext,
-          [boolean]$isPremiumStorage)
+          [object]$storageContext)
 
     if(-not [string]::IsNullOrEmpty($containerName) -and $storageContext)
     {
         $storageAccountName = $storageContext.StorageAccountName
 
         Write-Verbose "[Azure Call]Creating container: $containerName in storage account: $storageAccountName"
-        if ($isPremiumStorage) 
-        {
-            $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -ErrorAction Stop
-        } else {
-            $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
-        }
+        $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
         Write-Verbose "[Azure Call]Created container: $containerName successfully in storage account: $storageAccountName"
     }
 }

--- a/Tasks/AzureFileCopyV4/AzureUtilityARM.ps1
+++ b/Tasks/AzureFileCopyV4/AzureUtilityARM.ps1
@@ -55,7 +55,7 @@ function Create-AzureContainer
         {
             $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -ErrorAction Stop
         } else {
-            $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -Permission Container -ErrorAction Stop
+            $container = New-AzureStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
         }
         Write-Verbose "[Azure Call]Created container: $containerName successfully in storage account: $storageAccountName"
     }

--- a/Tasks/AzureFileCopyV4/AzureUtilityAz1.0.ps1
+++ b/Tasks/AzureFileCopyV4/AzureUtilityAz1.0.ps1
@@ -44,20 +44,14 @@ function Create-AzureStorageContext
 function Create-AzureContainer
 {
     param([string]$containerName,
-          [object]$storageContext,
-          [boolean]$isPremiumStorage)
+          [object]$storageContext)
 
     if(-not [string]::IsNullOrEmpty($containerName) -and $storageContext)
     {
         $storageAccountName = $storageContext.StorageAccountName
 
         Write-Verbose "[Azure Call]Creating container: $containerName in storage account: $storageAccountName"
-        if ($isPremiumStorage) 
-        {
-            $container = New-AzStorageContainer -Name $containerName -Context $storageContext -ErrorAction Stop
-        } else {
-            $container = New-AzStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
-        }
+        $container = New-AzStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
         Write-Verbose "[Azure Call]Created container: $containerName successfully in storage account: $storageAccountName"
     }
 }

--- a/Tasks/AzureFileCopyV4/AzureUtilityAz1.0.ps1
+++ b/Tasks/AzureFileCopyV4/AzureUtilityAz1.0.ps1
@@ -56,7 +56,7 @@ function Create-AzureContainer
         {
             $container = New-AzStorageContainer -Name $containerName -Context $storageContext -ErrorAction Stop
         } else {
-            $container = New-AzStorageContainer -Name $containerName -Context $storageContext -Permission Container -ErrorAction Stop
+            $container = New-AzStorageContainer -Name $containerName -Context $storageContext -Permission Off -ErrorAction Stop
         }
         Write-Verbose "[Azure Call]Created container: $containerName successfully in storage account: $storageAccountName"
     }

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 178,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 178,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
**Task name**: AzureFileCopyV4

**Description**: Container was getting created with 'conatainer' permissions where anyone can access the storage account. This is unlike AzureFileCopyV3, where container gets created with 'private' access. So, making this behavior same as AzureFileCopyV3

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13196

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

**Test Cases**:
1. Have checked copying of files using azure blob.
2. Have checked copying of files using azure vm.