### PR TITLE
[DownloadBuildArtifactsV0] Fixed description for BuildNumber output variable

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 167,
-        "Patch": 2
+        "Minor": 178,
+        "Patch": 0
     },
     "groups": [
         {
@@ -261,7 +261,7 @@
     "outputVariables": [
         {
             "name": "BuildNumber",
-            "description": "Stores the build number of the build artifact source"
+            "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>" 
         }
     ]
 }

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -261,7 +261,7 @@
     "outputVariables": [
         {
             "name": "BuildNumber",
-            "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>" 
+            "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>" 
         }
     ]
 }

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 167,
-    "Patch": 2
+    "Minor": 178,
+    "Patch": 0
   },
   "groups": [
     {
@@ -261,7 +261,7 @@
   "outputVariables": [
     {
       "name": "BuildNumber",
-      "description": "Stores the build number of the build artifact source"
+      "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>"
     }
   ]
 }

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -261,7 +261,7 @@
   "outputVariables": [
     {
       "name": "BuildNumber",
-      "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>"
+      "description": "Stores the build number of the build artifact source.<br />Please note that in fact it returns <b>BuildId</b> due to backward compatibility <p>[More Information](https://docs.microsoft.com/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)</p>"
     }
   ]
 }


### PR DESCRIPTION
**Task name**: DownloadBuildArtifactsV0

**Description**: Fixed the description for BuildNumber output variable to emphasize that it actually contains the build id instead of the build number due to backward compatibility:
![image](https://user-images.githubusercontent.com/16704239/97462913-734a3380-18fc-11eb-9d41-ceaddd47d2eb.png)


**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) No

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/12797

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
