### PR TITLE
DownloadSecureFileV1 - added socketTimeout input

### DIFF
--- a/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadSecureFileV1/Strings/resources.resjson/en-US/resources.resjson
@@ -6,5 +6,7 @@
   "loc.input.label.secureFile": "Secure File",
   "loc.input.help.secureFile": "The file name or GUID of the secure file to download to the agent machine. The file will be deleted after the pipeline runs.",
   "loc.input.label.retryCount": "Retry Count",
-  "loc.input.help.retryCount": "Optional number of times to retry downloading a secure file if the download fails."
+  "loc.input.help.retryCount": "Optional number of times to retry downloading a secure file if the download fails.",
+  "loc.input.label.socketTimeout": "Socket Timeout",
+  "loc.input.help.socketTimeout": "Optional timeout for a socket associated with downloading secure file request in ms."
 }

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@types/node": "^6.0.0",
     "azure-pipelines-task-lib": "^2.8.0",
-    "azure-pipelines-tasks-securefiles-common": "1.0.0"
+    "azure-pipelines-tasks-securefiles-common": "1.0.1"
   }
 }

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@types/node": "^6.0.0",
     "azure-pipelines-task-lib": "^2.8.0",
-    "azure-pipelines-tasks-securefiles-common": "1.0.1"
+    "azure-pipelines-tasks-securefiles-common": "1.178.0"
   }
 }

--- a/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
+++ b/Tasks/DownloadSecureFileV1/predownloadsecurefile.ts
@@ -10,12 +10,18 @@ async function run() {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
         let retryCount = parseInt(tl.getInput('retryCount'));
+        let socketTimeout = parseInt(tl.getInput('socketTimeout'));
         if (isNaN(retryCount) || retryCount < 0) {
             retryCount = 8;
         }
+
+        if (isNaN(socketTimeout) || socketTimeout < 0) {
+            socketTimeout = undefined;
+        }
+
         // download decrypted contents
         secureFileId = tl.getInput('secureFile', true);
-        secureFileHelpers = new secureFilesCommon.SecureFileHelpers(retryCount);
+        secureFileHelpers = new secureFilesCommon.SecureFileHelpers(retryCount, socketTimeout);
         let secureFilePath: string = await secureFileHelpers.downloadSecureFile(secureFileId);
 
         if (tl.exist(secureFilePath)) {

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 178,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
-        "Patch": 0
+        "Minor": 177,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 177,
+        "Minor": 178,
         "Patch": 0
     },
     "runsOn": [
@@ -39,6 +39,14 @@
             "defaultValue": "8",
             "required": "false",
             "helpMarkDown": "Optional number of times to retry downloading a secure file if the download fails."
+        },
+        {
+            "name": "socketTimeout",
+            "type": "string",
+            "label": "Socket Timeout",
+            "defaultValue": "",
+            "required": "false",
+            "helpMarkDown": "Optional timeout for a socket associated with downloading secure file request in ms."
         }
     ],
     "outputVariables": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
-    "Patch": 0
+    "Minor": 177,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 177,
+    "Minor": 178,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 178,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
-    "Patch": 0
+    "Minor": 177,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",
@@ -39,6 +39,14 @@
       "defaultValue": "8",
       "required": "false",
       "helpMarkDown": "ms-resource:loc.input.help.retryCount"
+    },
+    {
+      "name": "socketTimeout",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.socketTimeout",
+      "defaultValue": "",
+      "required": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.socketTimeout"
     }
   ],
   "outputVariables": [

--- a/common-npm-packages/securefiles-common/securefiles-common.ts
+++ b/common-npm-packages/securefiles-common/securefiles-common.ts
@@ -7,19 +7,17 @@ import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBase
 export class SecureFileHelpers {
     serverConnection: WebApi;
 
-    constructor(retryCount?: number, socketTimeout?: number) {
+    constructor(retryCount?: number) {
         const serverUrl: string = tl.getVariable('System.TeamFoundationCollectionUri');
         const serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         const authHandler = getPersonalAccessTokenHandler(serverCreds);
 
         const maxRetries = retryCount && retryCount >= 0 ? retryCount : 5; // Default to 5 if not specified
-
         tl.debug('Secure file retry count set to: ' + maxRetries);
         const proxy = tl.getHttpProxyConfiguration();
         let options: IRequestOptions = {
             allowRetries: true,
-            maxRetries,
-            socketTimeout
+            maxRetries
         };
 
         if (proxy) {

--- a/common-npm-packages/securefiles-common/securefiles-common.ts
+++ b/common-npm-packages/securefiles-common/securefiles-common.ts
@@ -7,17 +7,19 @@ import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBase
 export class SecureFileHelpers {
     serverConnection: WebApi;
 
-    constructor(retryCount?: number) {
+    constructor(retryCount?: number, socketTimeout?: number) {
         const serverUrl: string = tl.getVariable('System.TeamFoundationCollectionUri');
         const serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         const authHandler = getPersonalAccessTokenHandler(serverCreds);
 
         const maxRetries = retryCount && retryCount >= 0 ? retryCount : 5; // Default to 5 if not specified
+
         tl.debug('Secure file retry count set to: ' + maxRetries);
         const proxy = tl.getHttpProxyConfiguration();
         let options: IRequestOptions = {
             allowRetries: true,
-            maxRetries
+            maxRetries,
+            socketTimeout
         };
 
         if (proxy) {


### PR DESCRIPTION
**Task name**: DownloadSecureFileV1

**Description**: added socket timeout input - this should allow to increase timeout for socket under download secure file request.

**Documentation changes required:** Y

**Added unit tests:** N - going to add some unit test separately

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
