### PR TITLE
[PowerShellV2, BashV3, CmdLineV2] Removed stderr messages truncating

### DIFF
--- a/Tasks/BashV3/Tests/L0.ts
+++ b/Tasks/BashV3/Tests/L0.ts
@@ -114,6 +114,7 @@ describe('Bash Suite', function () {
         runValidations(() => {
             assert(tr.failed, 'Bash should have failed');
             assert(tr.stdout.indexOf('##vso[task.issue type=error;]myErrorTest') > 0, 'Bash should have correctly written myErrorTest');
+            assert(tr.stdout.length > 1000, 'Bash stderr output is not truncated');
         }, tr, done);
     });
 });

--- a/Tasks/BashV3/Tests/L0StdErr.ts
+++ b/Tasks/BashV3/Tests/L0StdErr.ts
@@ -24,6 +24,14 @@ tlClone.assertAgent = function(variable: string) {
 };
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
+function generateBigString(size: number) {
+    let result:string = '';
+    while (result.length < size) {
+        result += 'a';
+    }
+    return result;
+}
+
 // Mock task-lib
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'checkPath' : {
@@ -45,7 +53,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         'path/to/bash temp/path/fileName.sh': {
             "code": 0,
             "stdout": "",
-            "stderr": "myErrorTest"
+            "stderr": "myErrorTest" + generateBigString(1000)
         }
     }
 };

--- a/Tasks/BashV3/bash.ts
+++ b/Tasks/BashV3/bash.ts
@@ -139,17 +139,7 @@ async function run() {
         if (input_failOnStderr) {
             bash.on('stderr', (data: Buffer) => {
                 stderrFailure = true;
-                // Truncate to at most 10 error messages
-                if (aggregatedStderr.length < 10) {
-                    // Truncate to at most 1000 bytes
-                    if (data.length > 1000) {
-                        aggregatedStderr.push(`${data.toString('utf8', 0, 1000)}<truncated>`);
-                    } else {
-                        aggregatedStderr.push(data.toString('utf8'));
-                    }
-                } else if (aggregatedStderr.length === 10) {
-                    aggregatedStderr.push('Additional writes to stderr truncated');
-                }
+                aggregatedStderr.push(data.toString('utf8'));
             });
         }
 

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 177,
-        "Patch": 2
+        "Minor": 178,
+        "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 177,
-    "Patch": 2
+    "Minor": 178,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.115.0",

--- a/Tasks/CmdLineV2/Tests/L0.ts
+++ b/Tasks/CmdLineV2/Tests/L0.ts
@@ -45,6 +45,7 @@ describe('Cmd Suite', function () {
         runValidations(() => {
             assert(tr.failed, 'Bash should have failed');
             assert(tr.stdout.indexOf('##vso[task.issue type=error;]myErrorTest') > 0, 'Bash should have correctly written myErrorTest');
+            assert(tr.stdout.length > 1000, 'Bash stderr output is not truncated');
         }, tr, done);
     });
 });

--- a/Tasks/CmdLineV2/Tests/L0StdErr.ts
+++ b/Tasks/CmdLineV2/Tests/L0StdErr.ts
@@ -25,6 +25,14 @@ tlClone.assertAgent = function(variable: string) {
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 tmr.setInput('script2', `echo 'Hello world'\necho 'Goodbye world'`);
 
+function generateBigString(size: number) {
+    let result:string = '';
+    while (result.length < size) {
+        result += 'a';
+    }
+    return result;
+}
+
 // Mock task-lib
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'checkPath' : {
@@ -42,12 +50,12 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         'path/to/bash --noprofile --norc temp\\path\\fileName.sh': {
             "code": 0,
             "stdout": "",
-            "stderr": "myErrorTest"
+            "stderr": "myErrorTest" + generateBigString(1000)
         },
         'path/to/bash --noprofile --norc temp/path/fileName.sh': {
             "code": 0,
             "stdout": "",
-            "stderr": "myErrorTest"
+            "stderr": "myErrorTest" + generateBigString(1000)
         }
     }
 };

--- a/Tasks/CmdLineV2/cmdline.ts
+++ b/Tasks/CmdLineV2/cmdline.ts
@@ -54,17 +54,7 @@ async function run() {
         if (failOnStderr) {
             bash.on('stderr', (data: Buffer) => {
                 stderrFailure = true;
-                // Truncate to at most 10 error messages
-                if (aggregatedStderr.length < 10) {
-                    // Truncate to at most 1000 bytes
-                    if (data.length > 1000) {
-                        aggregatedStderr.push(`${data.toString('utf8', 0, 1000)}<truncated>`);
-                    } else {
-                        aggregatedStderr.push(data.toString('utf8'));
-                    }
-                } else if (aggregatedStderr.length === 10) {
-                    aggregatedStderr.push('Additional writes to stderr truncated');
-                }
+                aggregatedStderr.push(data.toString('utf8'));
             });
         }
 

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 177,
-        "Patch": 3
+        "Minor": 178,
+        "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines.",
     "showEnvironmentVariables": true,

--- a/Tasks/CmdLineV2/task.loc.json
+++ b/Tasks/CmdLineV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 177,
-    "Patch": 3
+    "Minor": 178,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "showEnvironmentVariables": true,

--- a/Tasks/PowerShellV2/Tests/L0.ts
+++ b/Tasks/PowerShellV2/Tests/L0.ts
@@ -75,8 +75,9 @@ describe('PowerShell Suite', function () {
         tr.run();
 
         runValidations(() => {
-            assert(tr.failed, 'Bash should have failed');
-            assert(tr.stdout.indexOf('##vso[task.issue type=error;]myErrorTest') > 0, 'Bash should have correctly written myErrorTest');
+            assert(tr.failed, 'Powershell should have failed');
+            assert(tr.stdout.indexOf('##vso[task.issue type=error;]myErrorTest') > 0, 'Powershell should have correctly written myErrorTest');
+            assert(tr.stdout.length > 1000, 'Powershell stderr output is not truncated');
         }, tr, done);
     });
 });

--- a/Tasks/PowerShellV2/Tests/L0StdErr.ts
+++ b/Tasks/PowerShellV2/Tests/L0StdErr.ts
@@ -25,6 +25,14 @@ tlClone.assertAgent = function(variable: string) {
 };
 tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
 
+function generateBigString(size: number) {
+    let result:string = '';
+    while (result.length < size) {
+        result += 'a';
+    }
+    return result;
+}
+
 // Mock task-lib
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     'checkPath' : {
@@ -46,12 +54,12 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp\\path\\fileName.ps1'": {
             "code": 0,
             "stdout": "",
-            "stderr": "myErrorTest"
+            "stderr": "myErrorTest" + generateBigString(1000)
         },
         "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp/path/fileName.ps1'": {
             "code": 0,
             "stdout": "",
-            "stderr": "myErrorTest"
+            "stderr": "myErrorTest" + generateBigString(1000)
         }
     },
     'stats': {

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -116,17 +116,7 @@ async function run() {
         if (input_failOnStderr) {
             powershell.on('stderr', (data: Buffer) => {
                 stderrFailure = true;
-                // Truncate to at most 10 error messages
-                if (aggregatedStderr.length < 10) {
-                    // Truncate to at most 1000 bytes
-                    if (data.length > 1000) {
-                        aggregatedStderr.push(`${data.toString('utf8', 0, 1000)}<truncated>`);
-                    } else {
-                        aggregatedStderr.push(data.toString('utf8'));
-                    }
-                } else if (aggregatedStderr.length === 10) {
-                    aggregatedStderr.push('Additional writes to stderr truncated');
-                }
+                aggregatedStderr.push(data.toString('utf8'));
             });
         }
 

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 177,
+        "Minor": 178,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 177,
+    "Minor": 178,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: PowerShellV2, BashV3, CmdLineV2

**Description**: Removed stderr messages truncating, because this breaks the masking of secrets in some cases (when the secret is more than 1000 bytes long)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
