### PR TITLE
[InstallAppleprovisioningProfileV1] Added patch number to task-lib dependency

### DIFF
--- a/Tasks/InstallAppleProvisioningProfileV1/package.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "azure-pipelines-tasks-ios-signing-common": "2.0.3-preview",
     "azure-pipelines-tasks-securefiles-common": "2.0.3-preview",
-    "azure-pipelines-task-lib": "^3.0.6-preview",
+    "azure-pipelines-task-lib": "^3.0.6-preview.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0"
   },


### PR DESCRIPTION
**Task name**: InstallAppleprovisioningProfileV1

**Description**: Added a patch number to task-lib dependency at package.json to prevent possible issues.
