### PR TITLE
Fixing graph resource url

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
@@ -21,6 +21,8 @@ export class GraphManagementClient extends azureServiceClient.ServiceClient {
 
         if (baseUri) {
             this.baseUri = baseUri;
+        } else {
+            this.baseUri = credentials.activeDirectoryResourceId;
         }
 
         if (options.acceptLanguage) {

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "1.178.0",
+  "version": "1.178.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "1.178.0",
+  "version": "1.178.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeploymentV3

**Description**: Because of this [change](https://github.com/microsoft/azure-pipelines-tasks/pull/13647) GetServicePrincipal is failing as the ARM endpoint is used instead of graph endpoint. This change fixes the graph endpoint in GraphManagementClient.

**Documentation changes required:** (N) <Please mark if documentation changes are required>

**Added unit tests:** (N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y) https://github.com/microsoft/azure-pipelines-tasks/issues/13797

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
