### PR TITLE
Fixed parameters passing for ExtractFiles task

### DIFF
--- a/Tasks/ExtractFilesV1/Tests/L0Extract.ts
+++ b/Tasks/ExtractFilesV1/Tests/L0Extract.ts
@@ -50,8 +50,8 @@ let sevenZip2Command: string = `${zipExecutable} -aoa x -o${__dirname} ${path.jo
 let tarCommand = `${zipExecutable} -aoa x -o${__dirname} ${path.join(__dirname, 'tar.tar')}`;
 if (!isWindows) {
     zipExecutable = 'path/to/unzip'
-    sevenZip1Command = `${zipExecutable} ${path.join(__dirname, 'zip1.zip')} -o -d ${__dirname}`;
-    sevenZip2Command = `${zipExecutable} ${path.join(__dirname, 'zip2.zip')} -o -d ${__dirname}`;
+    sevenZip1Command = `${zipExecutable} -o ${path.join(__dirname, 'zip1.zip')} -d ${__dirname}`;
+    sevenZip2Command = `${zipExecutable} -o ${path.join(__dirname, 'zip2.zip')} -d ${__dirname}`;
     tarCommand = `path/to/tar -xvf -k ${path.join(__dirname, 'tar.tar')} -C ${__dirname}`;
 }
 

--- a/Tasks/ExtractFilesV1/Tests/L0Extract.ts
+++ b/Tasks/ExtractFilesV1/Tests/L0Extract.ts
@@ -52,7 +52,7 @@ if (!isWindows) {
     zipExecutable = 'path/to/unzip'
     sevenZip1Command = `${zipExecutable} -o ${path.join(__dirname, 'zip1.zip')} -d ${__dirname}`;
     sevenZip2Command = `${zipExecutable} -o ${path.join(__dirname, 'zip2.zip')} -d ${__dirname}`;
-    tarCommand = `path/to/tar -xvf -k ${path.join(__dirname, 'tar.tar')} -C ${__dirname}`;
+    tarCommand = `path/to/tar -xvf ${path.join(__dirname, 'tar.tar')} -C ${__dirname}`;
 }
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -218,11 +218,8 @@ function tarExtract(file, destinationFolder) {
         xpTarLocation = tl.which('tar', true);
     }
     var tar = tl.tool(xpTarLocation);
-    if (overwriteExistingFiles) {
-        tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
-    } else {
-        tar.arg('-xvkf');
-    }
+    // in tar tool we are ignoring state of overwrite flag as it is overwriting files in output by default and k flag forbid overwriting
+    tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
     tar.arg(file);
     tar.arg('-C');
     tar.arg(destinationFolder);

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -218,8 +218,11 @@ function tarExtract(file, destinationFolder) {
         xpTarLocation = tl.which('tar', true);
     }
     var tar = tl.tool(xpTarLocation);
-    // in tar tool we are ignoring state of overwrite flag as it is overwriting files in output by default and k flag forbid overwriting
-    tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
+    if (overwriteExistingFiles) {
+        tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
+    } else {
+        tar.arg('-xvkf');
+    }
     tar.arg(file);
     tar.arg('-C');
     tar.arg(destinationFolder);

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -191,10 +191,10 @@ function unzipExtract(file, destinationFolder) {
         xpUnzipLocation = tl.which('unzip', true);
     }
     var unzip = tl.tool(xpUnzipLocation);
-    unzip.arg(file);
     if (overwriteExistingFiles) {
         unzip.arg('-o');
     }
+    unzip.arg(file);
     unzip.arg('-d');
     unzip.arg(destinationFolder);
     return handleExecResult(unzip.execSync(), file);

--- a/Tasks/ExtractFilesV1/extractfilestask.ts
+++ b/Tasks/ExtractFilesV1/extractfilestask.ts
@@ -218,9 +218,10 @@ function tarExtract(file, destinationFolder) {
         xpTarLocation = tl.which('tar', true);
     }
     var tar = tl.tool(xpTarLocation);
-    tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
     if (overwriteExistingFiles) {
-        tar.arg('-k');
+        tar.arg('-xvf'); // tar will correctly handle compression types outlined in isTar()
+    } else {
+        tar.arg('-xvkf');
     }
     tar.arg(file);
     tar.arg('-C');

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 178,
-        "Patch": 3
+        "Patch": 4
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 178,
-    "Patch": 3
+    "Patch": 4
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
**Task name**: ExtractFilesV1

**Description**: Was fixed wrong formatting of arguments for unzip tool, it is also fixing wrong behavior of tar tool

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) #13835 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected