### PR TITLE
[PowerShellV2] Fixing of incorrect use of -Command parameter by PowerShell Task

### DIFF
--- a/Tasks/PowerShellV2/Tests/L0Args.ts
+++ b/Tasks/PowerShellV2/Tests/L0Args.ts
@@ -43,11 +43,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "temp/path"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp\\path\\fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp\\path\\fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp/path/fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp/path/fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         }

--- a/Tasks/PowerShellV2/Tests/L0External.ts
+++ b/Tasks/PowerShellV2/Tests/L0External.ts
@@ -42,11 +42,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "temp/path"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp\\path\\fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp\\path\\fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp/path/fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp/path/fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         }

--- a/Tasks/PowerShellV2/Tests/L0Inline.ts
+++ b/Tasks/PowerShellV2/Tests/L0Inline.ts
@@ -42,11 +42,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "temp/path"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp\\path\\fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp\\path\\fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp/path/fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp/path/fileName.ps1'": {
             "code": 0,
             "stdout": "my script output"
         }

--- a/Tasks/PowerShellV2/Tests/L0StdErr.ts
+++ b/Tasks/PowerShellV2/Tests/L0StdErr.ts
@@ -51,12 +51,12 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             "code": 0,
             "stdout": "temp/path"
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp\\path\\fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp\\path\\fileName.ps1'": {
             "code": 0,
             "stdout": "",
             "stderr": "myErrorTest" + generateBigString(1000)
         },
-        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command . 'temp/path/fileName.ps1'": {
+        "path/to/powershell -NoLogo -NoProfile -NonInteractive -Command & 'temp/path/fileName.ps1'": {
             "code": 0,
             "stdout": "",
             "stderr": "myErrorTest" + generateBigString(1000)

--- a/Tasks/PowerShellV2/powershell.ps1
+++ b/Tasks/PowerShellV2/powershell.ps1
@@ -102,7 +102,7 @@ try {
         $powershellPath = Get-Command -Name powershell.exe -CommandType Application | Select-Object -First 1 -ExpandProperty Path
     }
     Assert-VstsPath -LiteralPath $powershellPath -PathType 'Leaf'
-    $arguments = "-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command `". '$($filePath.Replace("'", "''"))'`""
+    $arguments = "-NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command `"& '$($filePath.Replace("'", "''"))'`""
     $splat = @{
         'FileName'         = $powershellPath
         'Arguments'        = $arguments

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -101,7 +101,7 @@ async function run() {
             .arg('-NoProfile')
             .arg('-NonInteractive')
             .arg('-Command')
-            .arg(`. '${filePath.replace(/'/g, "''")}'`);
+            .arg(`& '${filePath.replace(/'/g, "''")}'`);
         let options = <tr.IExecOptions>{
             cwd: input_workingDirectory,
             failOnStdErr: false,

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: PowerShellV2

**Description**: We have wrong formatting of the powershell command execution. Instead of the '&' operator we are using '.' operator that produces unexpected behavior for the customer: by logs script completed and has no errors, but in fact it doesn't created some files that it should produce. As it goes from my investigation script exiting before some actions completed, because if we add Start-Sleep command with period of about 2 seconds in the end of the customer's script it will completed successfully. Such behavior is not reproducible if we are using '&' operator for command execution, powershell is waiting for all the processes to be completed and after that exiting. 
So in this pr we are changing formatting of command execution according the powershell documentation regarding command execution: [link](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1#-command
)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
