### PR TITLE
[NodeToolV0] Fix os arch determination on arm systems

### DIFF
--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -87,4 +87,18 @@ describe('NodeTool Suite', function () {
         }, tr, done);
     });
 
+    it('Installs the right version on linux-arm64', (done: MochaDone) => {
+        this.timeout(5000);
+
+        let tp: string = path.join(__dirname, 'L0DownloadLinuxArm64.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
+    });
+
 });

--- a/Tasks/NodeToolV0/Tests/L0.ts
+++ b/Tasks/NodeToolV0/Tests/L0.ts
@@ -73,4 +73,18 @@ describe('NodeTool Suite', function () {
         }, tr, done);
     });
 
+    it('Installs the right version on linux-armv7l', (done: MochaDone) => {
+        this.timeout(5000);
+
+        let tp: string = path.join(__dirname, 'L0DownloadLinuxArmv7l.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        runValidations(() => {
+            assert(tr.succeeded, 'NodeTool should have succeeded.');
+            assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        }, tr, done);
+    });
+
 });

--- a/Tasks/NodeToolV0/Tests/L0DownloadLinuxArm64.ts
+++ b/Tasks/NodeToolV0/Tests/L0DownloadLinuxArm64.ts
@@ -1,0 +1,82 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'nodetool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSpec', '11.3.0');
+tmr.setInput('checkLatest', 'false');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "assertAgent": {
+        "2.115.1": true
+    }};
+tmr.setAnswers(a);
+
+tmr.registerMock('os', {
+    platform: () => 'linux',
+    arch: () => 'arm64'
+});
+
+//Create assertAgent and getVariable mocks
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() == 'agent.tempdirectory') {
+        return 'temp';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+//Create tool-lib mock
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    isExplicitVersion: function(versionSpec) {
+        return false;
+    },
+    findLocalTool: function(toolName, versionSpec) {
+        if (toolName != 'node') {
+            throw new Error('Searching for wrong tool');
+        }
+        return false;
+    },
+    evaluateVersions: function(versions, versionSpec) {
+        let version: string;
+        for (let i = versions.length - 1; i >= 0; i--) {
+            const potential: string = versions[i];
+            const satisfied: boolean = potential === versionSpec;
+            if (satisfied) {
+                version = potential;
+                break;
+            }
+        }
+        return version;
+    },
+    cleanVersion: function(version) {
+        return version.slice(1);
+    },
+    downloadTool(url: string) {
+        if (url !== `https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-arm64.tar.gz`) {
+            throw {
+                httpStatusCode: '404'
+            };
+        }
+
+        return 'node-v11.3.0-linux-arm64.tar.gz';
+    },
+    extractTar(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    cacheDir(dir, tool, version) {
+        return 'path to tool';
+    },
+    prependPath(toolPath) {
+        return;
+    }
+});
+
+tmr.run();

--- a/Tasks/NodeToolV0/Tests/L0DownloadLinuxArmv7l.ts
+++ b/Tasks/NodeToolV0/Tests/L0DownloadLinuxArmv7l.ts
@@ -1,0 +1,95 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'nodetool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSpec', '11.3.0');
+tmr.setInput('checkLatest', 'false');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "assertAgent": {
+        "2.115.1": true
+    }};
+tmr.setAnswers(a);
+
+tmr.registerMock('os', {
+    platform: () => 'linux',
+    arch: () => 'arm'
+});
+
+//Create assertAgent and getVariable mocks
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() == 'agent.tempdirectory') {
+        return 'temp';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tlClone.execSync = function(tool: string, args: string[]) {
+    if (tool !== 'bash') {
+        throw new Error(`Expected "bash" but got "${tool}" in execSync`);
+    }
+
+    if (args[0] !== 'uname' || args[1] !== '-m') {
+        throw new Error(`Expected execSync args to be ["uname", "-m"]`);
+    }
+
+    return {
+        stdout: 'armv7l'
+    };
+};
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+//Create tool-lib mock
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    isExplicitVersion: function(versionSpec) {
+        return false;
+    },
+    findLocalTool: function(toolName, versionSpec) {
+        if (toolName != 'node') {
+            throw new Error('Searching for wrong tool');
+        }
+        return false;
+    },
+    evaluateVersions: function(versions, versionSpec) {
+        let version: string;
+        for (let i = versions.length - 1; i >= 0; i--) {
+            const potential: string = versions[i];
+            const satisfied: boolean = potential === versionSpec;
+            if (satisfied) {
+                version = potential;
+                break;
+            }
+        }
+        return version;
+    },
+    cleanVersion: function(version) {
+        return version.slice(1);
+    },
+    downloadTool(url: string) {
+        if (url !== `https://nodejs.org/dist/v11.3.0/node-v11.3.0-linux-armv7l.tar.gz`) {
+            throw {
+                httpStatusCode: '404'
+            };
+        }
+
+        return 'node-v11.3.0-linux-armv7l.tar.gz';
+    },
+    extractTar(downloadPath, extPath, _7zPath) {
+        return 'extPath';
+    },
+    cacheDir(dir, tool, version) {
+        return 'path to tool';
+    },
+    prependPath(toolPath) {
+        return;
+    }
+});
+
+tmr.run();

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -1,6 +1,6 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
-import * as toolRunner from 'azure-pipelines-task-lib/toolRunner';
+import * as toolRunner from 'azure-pipelines-task-lib/toolrunner';
 import * as restm from 'typed-rest-client/RestClient';
 import * as os from 'os';
 import * as path from 'path';

--- a/Tasks/NodeToolV0/nodetool.ts
+++ b/Tasks/NodeToolV0/nodetool.ts
@@ -1,5 +1,6 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
+import * as toolRunner from 'azure-pipelines-task-lib/toolRunner';
 import * as restm from 'typed-rest-client/RestClient';
 import * as os from 'os';
 import * as path from 'path';
@@ -223,6 +224,10 @@ function getArch(): string {
     let arch: string = os.arch();
     if (arch === 'ia32' || force32bit) {
         arch = 'x86';
+    }
+    if (arch === 'arm') {
+        const result: toolRunner.IExecSyncResult = taskLib.execSync('bash', ['uname', '-m']);
+        arch = result.stdout.toString().trim();
     }
     return arch;
 }

--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 176,
+        "Minor": 179,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 176,
+    "Minor": 179,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: NodeToolV0

**Description**: Fixed arch determination on arm systems: valid node distributions are 'linux-armv6l' or 'linux-armv7l', but currently this task tries to load nonexistent 'linux-arm' on both arches.

**Documentation changes required:** No

**Added unit tests:** ***Yes***

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/10295

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
