### PR TITLE
Update Tasks for NuGet 5.8 release (#13876)

### DIFF
--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 4
+        "Patch": 5
     },
     "preview": false,
     "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 4
+    "Patch": 5
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/Common/packaging-common/Tests/NuGetMockHelper.ts
+++ b/Tasks/Common/packaging-common/Tests/NuGetMockHelper.ts
@@ -10,6 +10,9 @@ export function registerNugetToolGetterMock(tmr: tmrm.TaskMockRunner) {
         cacheBundledNuGet: function(version, path){
             return version;
         },
+        getMSBuildVersionString: function() {
+            return "1.0.0";
+        },
         FORCE_NUGET_4_0_0: 'FORCE_NUGET_4_0_0',
         NUGET_VERSION_4_0_0: '4.0.0',
         NUGET_VERSION_4_0_0_PATH_SUFFIX: 'NuGet/4.0.0/',
@@ -26,6 +29,9 @@ export function registerNugetToolGetterMockUnix(tmr: tmrm.TaskMockRunner) {
         },
         cacheBundledNuGet: function(version, path){
             return version;
+        },
+        getMSBuildVersionString: function() {
+            return "1.0.0";
         },
         FORCE_NUGET_4_0_0: 'FORCE_NUGET_4_0_0',
         NUGET_VERSION_4_0_0: '4.0.0',

--- a/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetToolGetter.ts
@@ -146,7 +146,11 @@ export async function cacheBundledNuGet(
     if (cachedVersionToUse == null) {
         // Attempt to match nuget.exe version with msbuild.exe version
         const msbuildSemVer = await getMSBuildVersion();
-        if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
+        if (msbuildSemVer && semver.gte(msbuildSemVer, '16.8.0')) {
+            taskLib.debug('Snapping to v5.8.0');
+            cachedVersionToUse = '5.8.0';
+            nugetPathSuffix = 'NuGet/5.8.0/';
+        } else if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
             taskLib.debug('Snapping to v5.4.0');
             cachedVersionToUse = '5.4.0';
             nugetPathSuffix = 'NuGet/5.4.0/';

--- a/Tasks/Common/utility-common/package-lock.json
+++ b/Tasks/Common/utility-common/package-lock.json
@@ -107,27 +107,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
       "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
-    "vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        }
-      }
-    },
     "vsts-task-lib": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 175,
+        "Minor": 179,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 175,
+    "Minor": 179,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",

--- a/Tasks/DownloadGitHubNpmPackageV1/task.json
+++ b/Tasks/DownloadGitHubNpmPackageV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 4
+        "Patch": 5
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadGitHubNpmPackageV1/task.loc.json
+++ b/Tasks/DownloadGitHubNpmPackageV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 4
+    "Patch": 5
   },
   "runsOn": [
     "Agent",

--- a/Tasks/DownloadGitHubNugetPackageV1/task.json
+++ b/Tasks/DownloadGitHubNugetPackageV1/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 7
+        "Patch": 8
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet restore",

--- a/Tasks/DownloadGitHubNugetPackageV1/task.loc.json
+++ b/Tasks/DownloadGitHubNugetPackageV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 7
+    "Patch": 8
   },
   "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,8 +9,8 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,8 +9,8 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "Adds support to download Maven, Python, Universal and Npm packages.",

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,8 +9,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/GitHubReleaseV0/task.json
+++ b/Tasks/GitHubReleaseV0/task.json
@@ -14,7 +14,7 @@
     "preview": true,
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/GitHubReleaseV0/task.json
+++ b/Tasks/GitHubReleaseV0/task.json
@@ -14,8 +14,8 @@
     "preview": true,
     "version": {
         "Major": 0,
-        "Minor": 175,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/GitHubReleaseV0/task.loc.json
+++ b/Tasks/GitHubReleaseV0/task.loc.json
@@ -14,7 +14,7 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/GitHubReleaseV0/task.loc.json
+++ b/Tasks/GitHubReleaseV0/task.loc.json
@@ -14,8 +14,8 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 175,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/GitHubReleaseV1/task.json
+++ b/Tasks/GitHubReleaseV1/task.json
@@ -14,7 +14,7 @@
     "preview": false,
     "version": {
         "Major": 1,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/GitHubReleaseV1/task.json
+++ b/Tasks/GitHubReleaseV1/task.json
@@ -14,8 +14,8 @@
     "preview": false,
     "version": {
         "Major": 1,
-        "Minor": 175,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/GitHubReleaseV1/task.loc.json
+++ b/Tasks/GitHubReleaseV1/task.loc.json
@@ -14,7 +14,7 @@
   "preview": false,
   "version": {
     "Major": 1,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/GitHubReleaseV1/task.loc.json
+++ b/Tasks/GitHubReleaseV1/task.loc.json
@@ -14,8 +14,8 @@
   "preview": false,
   "version": {
     "Major": 1,
-    "Minor": 175,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV0/task.loc.json
+++ b/Tasks/NpmV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV0/task.loc.json
+++ b/Tasks/NpmV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/make.json
+++ b/Tasks/NuGetCommandV2/make.json
@@ -44,8 +44,12 @@
                 "dest": "./NuGet/4.1.0/"
             },
             {
-                "url": "https://azureartifactstools.blob.core.windows.net/nuget/NuGet.5.4.0.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGet/5.4.0/NuGet.zip",
                 "dest": "./NuGet/5.4.0/"
+            },
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGet/5.8.0/NuGet.zip",
+                "dest": "./NuGet/5.8.0/"
             },
             {
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/CredentialProvider.TeamBuild/15.105.25712.0/CredentialProvider.TeamBuild.zip",

--- a/Tasks/NuGetCommandV2/nugetcommandmain.ts
+++ b/Tasks/NuGetCommandV2/nugetcommandmain.ts
@@ -19,7 +19,9 @@ async function main(): Promise<void> {
     tl.debug("Getting NuGet");
     let nuGetPath: string;
     let nugetVersion: string;
+    let msBuildVersion: string;
     try {
+        msBuildVersion = await nuGetGetter.getMSBuildVersionString();
         nuGetPath = tl.getVariable(nuGetGetter.NUGET_EXE_TOOL_PATH_ENV_VAR)
                     || tl.getVariable(NUGET_EXE_CUSTOM_LOCATION);
         if (!nuGetPath) {
@@ -35,7 +37,7 @@ async function main(): Promise<void> {
         tl.setResult(tl.TaskResult.Failed, error.message);
         return;
     } finally{
-        _logNugetStartupVariables(nuGetPath, nugetVersion);
+        _logNugetStartupVariables(nuGetPath, nugetVersion, msBuildVersion);
     }
 
     const nugetCommand = tl.getInput("command", true);
@@ -58,7 +60,7 @@ async function main(): Promise<void> {
     }
 }
 
-function _logNugetStartupVariables(nuGetPath: string, nugetVersion: string) {
+function _logNugetStartupVariables(nuGetPath: string, nugetVersion: string, msBuildSemVer: string) {
     try {
         const nugetfeedtype = tl.getInput("nugetfeedtype");
         let externalendpoint = null;
@@ -120,6 +122,7 @@ function _logNugetStartupVariables(nuGetPath: string, nugetVersion: string) {
                 "verbosityrestore": tl.getInput("verbosityrestore"),
                 "nuGetPath": nuGetPath,
                 "nugetVersion": nugetVersion,
+                "msBuildVersion": msBuildSemVer
             };
 
         telemetry.emitTelemetry("Packaging", "NuGetCommand", nugetTelem);

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -43,14 +43,14 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
-      "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "adm-zip": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -174,14 +174,14 @@
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "ltx": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
-      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
         "inherits": "^2.0.4"
       }
@@ -274,7 +274,6 @@
       "requires": {
         "js-yaml": "3.6.1",
         "semver": "^5.4.1",
-        "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       }
@@ -283,27 +282,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "vso-node-api": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-      "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-      "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "^0.12.0",
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "typed-rest-client": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-          "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        }
-      }
     },
     "vsts-task-lib": {
       "version": "2.6.0",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,8 +9,8 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -9,7 +9,7 @@
     "author": "Lawrence Gripper",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Lawrence Gripper",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Lawrence Gripper",
   "version": {
     "Major": 0,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/nugetinstaller.ts
+++ b/Tasks/NuGetRestoreV1/nugetinstaller.ts
@@ -12,7 +12,8 @@ import * as nutil from "packaging-common/nuget/Utility";
 import peParser = require('packaging-common/pe-parser/index');
 import {VersionInfo} from "packaging-common/pe-parser/VersionResource";
 import * as pkgLocationUtils from "packaging-common/locationUtilities";
-import { getProjectAndFeedIdFromInputParam } from "packaging-common/util"
+import { getProjectAndFeedIdFromInputParam } from "packaging-common/util";
+import * as telemetry from "utility-common/telemetry";
 
 const NUGET_ORG_V2_URL: string = "https://www.nuget.org/api/v2/";
 const NUGET_ORG_V3_URL: string = "https://api.nuget.org/v3/index.json";
@@ -41,7 +42,8 @@ async function main(): Promise<void> {
     tl.debug("got the uris");
     let buildIdentityDisplayName: string = null;
     let buildIdentityAccount: string = null;
-
+    let nuGetPath: string = undefined;
+    let nuGetVersionString: string = null;
     try {
         tl.setResourcePath(path.join(__dirname, "task.json"));
 
@@ -64,7 +66,6 @@ async function main(): Promise<void> {
         
         // Getting NuGet
         tl.debug('Getting NuGet');
-        let nuGetPath: string = undefined;
         try {
             nuGetPath = process.env[nuGetGetter.NUGET_EXE_TOOL_PATH_ENV_VAR];
             if (!nuGetPath){
@@ -77,6 +78,9 @@ async function main(): Promise<void> {
         }
         
         const nuGetVersion: VersionInfo = await peParser.getFileVersionInfoAsync(nuGetPath);
+        if (nuGetVersion && nuGetVersion.fileVersion){
+            nuGetVersionString = nuGetVersion.fileVersion.toString();
+        }
 
         // Discovering NuGet quirks based on the version
         tl.debug('Getting NuGet quirks');
@@ -222,6 +226,8 @@ async function main(): Promise<void> {
         }
 
         tl.setResult(tl.TaskResult.Failed, tl.loc("PackagesFailedToInstall"));
+    } finally {
+        _logNuGetRestoreVariables(nuGetPath, nuGetVersionString);
     }
 }
 
@@ -253,6 +259,28 @@ function restorePackagesAsync(solutionFile: string, options: RestoreOptions): Q.
     }
     
     return nugetTool.exec({ cwd: path.dirname(solutionFile) } as IExecOptions);
+}
+
+function _logNuGetRestoreVariables(nuGetPath: string, nuGetVersion: string) {
+    try {
+        const telem = {
+            "solution": tl.getPathInput("solution", true, false),
+            "isNoCacheEnabled": tl.getBoolInput("noCache"),
+            "verbosity": tl.getInput("verbosity"),
+            "packagesDirectory": tl.getPathInput("packagesDirectory"),
+            "NUGET_EXE_TOOL_PATH_ENV_VAR": tl.getVariable(nuGetGetter.NUGET_EXE_TOOL_PATH_ENV_VAR),
+            "nuGetPath": nuGetPath,
+            "nuGetVersion": nuGetVersion,
+            "SYSTEMVSSCONNECTION": tl.getEndpointUrl("SYSTEMVSSCONNECTION", false),
+            "ExtraUrlPrefixesForTesting": tl.getVariable("NuGetTasks.ExtraUrlPrefixesForTesting"),
+            "selectOrConfig": tl.getInput("selectOrConfig"),
+            "nugetConfigPath": tl.getPathInput("nugetConfigPath", false, true),
+            "isIncludeNuGetOrgEnabled": tl.getBoolInput("includeNuGetOrg", false)
+        };
+        telemetry.emitTelemetry("Packaging", "NuGetRestore", telem);
+    } catch (err) {
+        tl.debug(`Unable to log NuGet Tool Installer task init telemetry. Err:(${err})`);
+    }
 }
 
 main();

--- a/Tasks/NuGetRestoreV1/package-lock.json
+++ b/Tasks/NuGetRestoreV1/package-lock.json
@@ -6,85 +6,81 @@
   "dependencies": {
     "@types/ini": {
       "version": "1.3.30",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/ini/-/ini-1.3.30.tgz",
-      "integrity": "sha1-0UhUWcn62E6TdBS4MqKttknqs3k="
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-1.3.30.tgz",
+      "integrity": "sha512-2+iF8zPSbpU83UKE+PNd4r/MhwNAdyGpk3H+VMgEH3EhjFZq1kouLgRoZrmIcmoGX97xFvqdS44DkICR5Nz3tQ=="
     },
     "@types/ltx": {
       "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/ltx/-/ltx-2.8.0.tgz",
-      "integrity": "sha1-hzfrLVKxYKa7nkbhgddMjylixQQ=",
+      "resolved": "https://registry.npmjs.org/@types/ltx/-/ltx-2.8.0.tgz",
+      "integrity": "sha512-qHnPVD0FFquypl7Yy8qqvDjhnX3c7toUYjjALK+bug7MfR2WCRTIjw+GUMfehRi/Mbhj5rLAQerPTnTCUzSCWg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/mocha": {
       "version": "5.2.6",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/mocha/-/mocha-5.2.6.tgz",
-      "integrity": "sha1-uGItUFV90VXp8vY0t9aP043l6Us="
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
+      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw=="
     },
     "@types/mockery": {
       "version": "1.4.29",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/mockery/-/mockery-1.4.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
       "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U="
     },
     "@types/node": {
       "version": "10.12.9",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha1-oHv6dDMUceHcIqR+tyAmhD97lcg="
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
+      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA=="
     },
     "@types/q": {
       "version": "1.5.2",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/q/-/q-1.5.2.tgz",
-      "integrity": "sha1-aQoUdbhPKohP0HzXl8APXzE1bqg="
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/semver": {
       "version": "5.5.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha1-FGwqKe59O65L8vyydGNuJkyBPEU="
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.4",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/@types/uuid/-/uuid-3.4.4.tgz",
-      "integrity": "sha1-evaTYPpl7w3stB/RUL9MpcDO/fU=",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
-          "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         }
       }
     },
     "azure-devops-node-api": {
-      "version": "6.6.3",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/azure-devops-node-api/-/azure-devops-node-api-6.6.3.tgz",
-      "integrity": "sha1-ll0P5coIlENWsDPzEK4GQsFM7Y4=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.0.0.tgz",
+      "integrity": "sha512-QkIzphuE3y/hZVMB6ONN0Dev5r9+CIAiopWulwoYx1Er0kYcsbXsKXKynuLSxsVPocMppbr4YPhTsX2eHY/Mjw==",
       "requires": {
-        "os": "0.1.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "1.0.9",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
         "typed-rest-client": {
-          "version": "1.0.9",
-          "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
-          "integrity": "sha1-Uxe2B8nI7kJbZCYMkknUANCmvxo=",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+          "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
           "requires": {
             "tunnel": "0.0.4",
             "underscore": "1.8.3"
@@ -107,8 +103,8 @@
     },
     "azure-pipelines-tool-lib": {
       "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
-      "integrity": "sha1-UPxF1/R2j4/fdQPH50wSYfKaY9U=",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.0.1",
@@ -121,8 +117,8 @@
       "dependencies": {
         "typed-rest-client": {
           "version": "1.0.9",
-          "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
-          "integrity": "sha1-Uxe2B8nI7kJbZCYMkknUANCmvxo=",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
           "requires": {
             "tunnel": "0.0.4",
             "underscore": "1.8.3"
@@ -151,36 +147,32 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "ip-address": {
-      "version": "5.9.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/ip-address/-/ip-address-5.9.0.tgz",
-      "integrity": "sha1-5QGzoNqeMdmhTvfM3AXFVSxGWVQ=",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash.find": "^4.6.0",
-        "lodash.max": "^4.0.1",
-        "lodash.merge": "^4.6.1",
-        "lodash.padstart": "^4.6.1",
-        "lodash.repeat": "^4.1.0",
-        "sprintf-js": "1.1.1"
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
       }
     },
     "js-yaml": {
       "version": "3.6.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/js-yaml/-/js-yaml-3.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
       "requires": {
         "argparse": "^1.0.7",
@@ -189,40 +181,20 @@
     },
     "jsbn": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/jsbn/-/jsbn-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
-    "lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha1-hzVWbGGLNan3YFILSHrnllivE2o="
-    },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ="
-    },
-    "lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
-    },
-    "lodash.repeat": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-      "integrity": "sha1-/H3oEx2MisB+S0n3T/6CnR8r7EQ="
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "ltx": {
-      "version": "2.8.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/ltx/-/ltx-2.8.1.tgz",
-      "integrity": "sha1-WrJ3Drnm0KeNvtKUFtcG2HQrZlg=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "^2.0.4"
       }
     },
     "minimatch": {
@@ -238,11 +210,6 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "packaging-common": {
       "version": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
       "requires": {
@@ -253,14 +220,26 @@
         "@types/node": "10.12.9",
         "@types/q": "1.5.2",
         "adm-zip": "^0.4.11",
-        "azure-devops-node-api": "^6.6.0",
+        "azure-devops-node-api": "8.0.0",
         "azure-pipelines-task-lib": "2.8.0",
         "azure-pipelines-tool-lib": "0.12.0",
         "ini": "^1.3.4",
         "ip-address": "^5.8.9",
         "ltx": "^2.6.2",
         "q": "^1.5.0",
-        "typed-rest-client": "0.12.0"
+        "semver": "^5.5.0",
+        "typed-rest-client": "1.2.0"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+          "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        }
       }
     },
     "q": {
@@ -280,7 +259,7 @@
     },
     "semver-compare": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/semver-compare/-/semver-compare-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
     "shelljs": {
@@ -289,9 +268,9 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "tunnel": {
       "version": "0.0.4",
@@ -324,7 +303,6 @@
       "requires": {
         "js-yaml": "3.6.1",
         "semver": "^5.4.1",
-        "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
       }
@@ -346,8 +324,8 @@
     },
     "vsts-task-lib": {
       "version": "2.6.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
-      "integrity": "sha1-yCAH5mgpoc06JM4DHxU0ECVr8Kg=",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -359,7 +337,7 @@
     },
     "vsts-task-tool-lib": {
       "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
       "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
       "requires": {
         "semver": "^5.3.0",
@@ -371,7 +349,7 @@
       "dependencies": {
         "typed-rest-client": {
           "version": "0.9.0",
-          "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
           "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
           "requires": {
             "tunnel": "0.0.4",
@@ -380,7 +358,7 @@
         },
         "vsts-task-lib": {
           "version": "2.0.4-preview",
-          "resolved": "https://pkgs.dev.azure.com/codesharing-SU0/_packaging/aamalladTestFeed/npm/registry/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
           "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
           "requires": {
             "minimatch": "^3.0.0",

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,8 +9,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetToolInstallerV0/make.json
+++ b/Tasks/NuGetToolInstallerV0/make.json
@@ -1,6 +1,11 @@
 {
     "common": [
         {
+            "module": "../Common/utility-common",
+            "type": "node",
+            "compile": true
+        },
+        {
             "module": "../Common/packaging-common",
             "type": "node",
             "compile": true

--- a/Tasks/NuGetToolInstallerV0/nugettoolinstaller.ts
+++ b/Tasks/NuGetToolInstallerV0/nugettoolinstaller.ts
@@ -1,29 +1,66 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as semver from 'semver';
 import * as path from "path";
+import * as peParser from "packaging-common/pe-parser";
+import {VersionInfo} from "packaging-common/pe-parser/VersionResource";
+import * as telemetry from "utility-common/telemetry";
 
 import nuGetGetter = require("packaging-common/nuget/NuGetToolGetter");
 
 async function run() {
+    let nugetVersion: string;
+    let checkLatest: boolean;
+    let nuGetPath: string;
+    let msbuildSemVer: string;
     try {
         taskLib.setResourcePath(path.join(__dirname, "task.json"));
 
         let versionSpec = taskLib.getInput('versionSpec', false);
         if (!versionSpec) {
-            const msbuildSemVer = await nuGetGetter.getMSBuildVersion();
-            if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
+            msbuildSemVer = await nuGetGetter.getMSBuildVersionString();
+            if (msbuildSemVer && semver.gte(msbuildSemVer, '16.8.0')) {
+                taskLib.debug('Defaulting to 5.8.0 for msbuild version: ' + msbuildSemVer);
+                versionSpec = '5.8.0';
+            } else if (msbuildSemVer && semver.gte(msbuildSemVer, '16.5.0')) {
                 taskLib.debug('Defaulting to 4.8.2 for msbuild version: ' + msbuildSemVer);
                 versionSpec = '4.8.2';
             } else {
                 versionSpec = '4.3.0';
             }
         }
-        let checkLatest = taskLib.getBoolInput('checkLatest', false);
-        await nuGetGetter.getNuGet(versionSpec, checkLatest, true);
+        checkLatest = taskLib.getBoolInput('checkLatest', false);
+        nuGetPath = await nuGetGetter.getNuGet(versionSpec, checkLatest, true);
+
+        const nugetVersionInfo: VersionInfo = await peParser.getFileVersionInfoAsync(nuGetPath);
+        if (nugetVersionInfo && nugetVersionInfo.fileVersion){
+            nugetVersion = nugetVersionInfo.fileVersion.toString();
+        }
+
     }
     catch (error) {
         console.error('ERR:' + error.message);
         taskLib.setResult(taskLib.TaskResult.Failed, "");
+    } finally {
+        _logNugetToolInstallerStartupVariables(nugetVersion, checkLatest, nuGetPath, msbuildSemVer)
+    }
+}
+
+function _logNugetToolInstallerStartupVariables(nugetVersion: string, 
+    checkLatest: boolean, 
+    nuGetPath: string,
+    msBuildSemVer: any) {
+    try {
+        const telem = {
+            "NUGET_EXE_TOOL_PATH_ENV_VAR": taskLib.getVariable(nuGetGetter.NUGET_EXE_TOOL_PATH_ENV_VAR),
+            "isCheckLatestEnabled": checkLatest,
+            "requestedNuGetVersionSpec": taskLib.getInput('versionSpec', false),
+            "nuGetPath": nuGetPath,
+            "nugetVersion": nugetVersion,
+            "msBuildVersion": msBuildSemVer
+        };
+        telemetry.emitTelemetry("Packaging", "NuGetToolInstaller", telem);
+    } catch (err) {
+        taskLib.debug(`Unable to log NuGet Tool Installer task init telemetry. Err:(${err})`);
     }
 }
 

--- a/Tasks/NuGetToolInstallerV0/package-lock.json
+++ b/Tasks/NuGetToolInstallerV0/package-lock.json
@@ -43,14 +43,29 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.8.tgz",
-      "integrity": "sha512-zHWce3allXWSmRx6/AGXKCtSOA7JjeWd2L3t4aHfysNk8mouQnWCocveaT7a4IEIlPVHp81jzlnknqTgCjCLXA=="
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "adm-zip": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
+      }
     },
     "azure-devops-node-api": {
       "version": "8.0.0",
@@ -119,6 +134,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -139,20 +159,29 @@
         "sprintf-js": "1.1.2"
       }
     },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
+    },
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "ltx": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
-      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
         "inherits": "^2.0.4"
       }
@@ -235,10 +264,68 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
+    "utility-common": {
+      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
+      "requires": {
+        "js-yaml": "3.6.1",
+        "semver": "^5.4.1",
+        "vsts-task-lib": "2.6.0",
+        "vsts-task-tool-lib": "0.4.0"
+      }
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "vsts-task-lib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "vsts-task-tool-lib": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+      "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
+      "requires": {
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.9.0",
+        "uuid": "^3.0.1",
+        "vsts-task-lib": "2.0.4-preview"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        },
+        "vsts-task-lib": {
+          "version": "2.0.4-preview",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+          "requires": {
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
+          }
+        }
+      }
     }
   }
 }

--- a/Tasks/NuGetToolInstallerV0/package.json
+++ b/Tasks/NuGetToolInstallerV0/package.json
@@ -23,6 +23,7 @@
     },
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
-        "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz"
+        "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
+        "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz"
     }
 }

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 174,
+        "Minor": 179,
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 174,
+    "Minor": 179,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV1/make.json
+++ b/Tasks/NuGetToolInstallerV1/make.json
@@ -1,6 +1,11 @@
 {
     "common": [
         {
+            "module": "../Common/utility-common",
+            "type": "node",
+            "compile": true
+        },
+        {
             "module": "../Common/packaging-common",
             "type": "node",
             "compile": true

--- a/Tasks/NuGetToolInstallerV1/nugettoolinstaller.ts
+++ b/Tasks/NuGetToolInstallerV1/nugettoolinstaller.ts
@@ -1,19 +1,55 @@
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import * as nuGetGetter from 'packaging-common/nuget/NuGetToolGetter';
+import * as peParser from "packaging-common/pe-parser";
+import {VersionInfo} from "packaging-common/pe-parser/VersionResource";
+import * as telemetry from "utility-common/telemetry";
 
 const DEFAULT_NUGET_VERSION = '>=4.9';
 
 async function run() {
+    let nugetVersion: string;
+    let checkLatest: boolean;
+    let nuGetPath: string;
+    let msBuildSemVer: string;
     try {
         taskLib.setResourcePath(path.join(__dirname, 'task.json'));
 
         const versionSpec = taskLib.getInput('versionSpec', false) || DEFAULT_NUGET_VERSION;
-        const checkLatest = taskLib.getBoolInput('checkLatest', false);
-        await nuGetGetter.getNuGet(versionSpec, checkLatest, true);
+        checkLatest = taskLib.getBoolInput('checkLatest', false);
+        nuGetPath = await nuGetGetter.getNuGet(versionSpec, checkLatest, true);
+
+        const nugetVersionInfo: VersionInfo = await peParser.getFileVersionInfoAsync(nuGetPath);
+        if (nugetVersionInfo && nugetVersionInfo.fileVersion){
+            nugetVersion = nugetVersionInfo.fileVersion.toString();
+        }
+
+        msBuildSemVer = await nuGetGetter.getMSBuildVersionString();
     } catch (error) {
         console.error('ERR:' + error.message);
         taskLib.setResult(taskLib.TaskResult.Failed, '');
+    } finally {
+        _logNugetToolInstallerStartupVariables(nugetVersion, checkLatest, nuGetPath, msBuildSemVer)
+    }
+}
+
+function _logNugetToolInstallerStartupVariables(nugetVersion: string, 
+    checkLatest: boolean, 
+    nuGetPath: string,
+    msBuildSemVer: string) {
+    try {
+        const telem = {
+            "NUGET_EXE_TOOL_PATH_ENV_VAR": taskLib.getVariable(nuGetGetter.NUGET_EXE_TOOL_PATH_ENV_VAR),
+            "DEFAULT_NUGET_VERSION": DEFAULT_NUGET_VERSION,
+            "isCheckLatestEnabled": checkLatest,
+            "requestedNuGetVersionSpec": taskLib.getInput('versionSpec', false),
+            "nuGetPath": nuGetPath,
+            "nugetVersion": nugetVersion,
+            "msBuildVersion": msBuildSemVer
+        };
+        telemetry.emitTelemetry("Packaging", "NuGetToolInstaller", telem);
+    } catch (err) {
+        taskLib.debug(`Unable to log NuGet Tool Installer task init telemetry. Err:(${err})`);
     }
 }
 

--- a/Tasks/NuGetToolInstallerV1/package-lock.json
+++ b/Tasks/NuGetToolInstallerV1/package-lock.json
@@ -43,17 +43,29 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.6.tgz",
-      "integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
-      "requires": {
-        "@types/node": "*"
-      }
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
+      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
+      }
     },
     "azure-devops-node-api": {
       "version": "8.0.0",
@@ -122,6 +134,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -142,20 +159,29 @@
         "sprintf-js": "1.1.2"
       }
     },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
+      }
+    },
     "jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "ltx": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.9.2.tgz",
-      "integrity": "sha512-llB7HflFhlfsYYT1SAe80elCBO5C20ryLdwPB/A/BZk38hhVeZztDlWQ9uTyvKNPX4aK6sA+JfS1f/mfzp5cxA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.10.0.tgz",
+      "integrity": "sha512-RB4zR6Mrp/0wTNS9WxMvpgfht/7u/8QAC9DpPD19opL/4OASPa28uoliFqeDkLUU8pQ4aeAfATBZmz1aSAHkMw==",
       "requires": {
         "inherits": "^2.0.4"
       }
@@ -190,6 +216,7 @@
         "ip-address": "^5.8.9",
         "ltx": "^2.6.2",
         "q": "^1.5.0",
+        "semver": "^5.5.0",
         "typed-rest-client": "1.2.0"
       }
     },
@@ -237,10 +264,68 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
     },
+    "utility-common": {
+      "version": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
+      "requires": {
+        "js-yaml": "3.6.1",
+        "semver": "^5.4.1",
+        "vsts-task-lib": "2.6.0",
+        "vsts-task-tool-lib": "0.4.0"
+      }
+    },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "vsts-task-lib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.6.0.tgz",
+      "integrity": "sha512-ja2qX4BIUvswcNbGtIoGo1SM5mRVc3Yaf7oM4oY64bNHs04chKfvH6f3cDDG0pd44OrZIGQE9LgECzeau6z2wA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "vsts-task-tool-lib": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.0.tgz",
+      "integrity": "sha1-zOtRxyh3yWTI5E3p7eovZfyKyPk=",
+      "requires": {
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "^0.9.0",
+        "uuid": "^3.0.1",
+        "vsts-task-lib": "2.0.4-preview"
+      },
+      "dependencies": {
+        "typed-rest-client": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.9.0.tgz",
+          "integrity": "sha1-92jMDcP06VDwbgSCXDaz54NKofI=",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        },
+        "vsts-task-lib": {
+          "version": "2.0.4-preview",
+          "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.0.4-preview.tgz",
+          "integrity": "sha1-nU63UAoL2a1Z429w8iqtxuK6+NI=",
+          "requires": {
+            "minimatch": "^3.0.0",
+            "mockery": "^1.7.0",
+            "q": "^1.1.2",
+            "semver": "^5.1.0",
+            "shelljs": "^0.3.0",
+            "uuid": "^3.0.1"
+          }
+        }
+      }
     }
   }
 }

--- a/Tasks/NuGetToolInstallerV1/package.json
+++ b/Tasks/NuGetToolInstallerV1/package.json
@@ -23,6 +23,7 @@
     },
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
-        "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz"
+        "packaging-common": "file:../../_build/Tasks/Common/packaging-common-1.0.1.tgz",
+        "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz"
     }
 }

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 174,
+        "Minor": 179,
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 174,
+    "Minor": 179,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,7 +10,7 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,8 +10,8 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-        "Minor": 179,
-        "Patch": 0
+        "Minor": 178,
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -10,8 +10,8 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "version": {
     "Major": 0,
-    "Minor": 179,
-    "Patch": 0
+    "Minor": 178,
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -10,7 +10,7 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,8 +9,8 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,7 +9,7 @@
     "category": "Package",
     "version": {
         "Major": 0,
-        "Minor": 175,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,7 +9,7 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 175,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 175,
-        "Patch": 0
+        "Patch": 1
     },
     "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 175,
-    "Patch": 0
+    "Patch": 1
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 179,
+        "Minor": 178,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 174,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "satisfies": [
         "Node",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 179,
+    "Minor": 178,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 174,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "satisfies": [
     "Node",

--- a/package-lock.json
+++ b/package-lock.json
@@ -699,7 +699,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "dev": true,
       "requires": {
         "asap": "~2.0.3"


### PR DESCRIPTION
patch tasks for NuGet 5.8 release

**Task name**: NuGet* tasks

**Description**: Update how NuGetToolGetter is retrieving NuGet version based on msbuild version

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N/A

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
