### PR TITLE
Fix KubernetesManifest bake on KUBECONFIG empty

### DIFF
--- a/Tasks/KubernetesManifestV0/src/actions/bake.ts
+++ b/Tasks/KubernetesManifestV0/src/actions/bake.ts
@@ -38,7 +38,7 @@ class HelmRenderEngine extends RenderEngine {
     public bake = async (): Promise<any> => {
         // Helm latest releases require restricted permissions on Kubeconfig
         const kubeconfigPath = tl.getVariable('KUBECONFIG');
-        if (kubeconfigPath != null)
+        if (kubeconfigPath)
             fs.chmodSync(kubeconfigPath, '600');
         const helmPath = await helmutility.getHelm();
         const helmCommand = new Helm(helmPath, TaskParameters.namespace);

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: KubernetesManifestV0

**Description**: The logic check did not account for empty strings. This fix allows KUBECONFIG="" to bypass the logic branch. Fixes #13911

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #13911 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
