### PR TITLE
[FileTransform] Accept absolute paths for -transform parameter

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 178,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 178,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/Common/webdeployment-common-v2/Tests/L1SpecialXdtTransformAbsolute.ts
+++ b/Tasks/Common/webdeployment-common-v2/Tests/L1SpecialXdtTransformAbsolute.ts
@@ -1,0 +1,7 @@
+var path = require('path');
+var ltx = require('ltx');
+var xdtTransform = require('webdeployment-common-v2/xdttransformationutility.js');
+var workingDirectory = path.join(__dirname, 'L1XdtTransform');
+process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = workingDirectory;
+xdtTransform.specialXdtTransformation(workingDirectory, path.join(workingDirectory, 'Web.Debug.config'), 'Web_test.config');
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = 'DefaultWorkingDirectory';

--- a/Tasks/Common/webdeployment-common-v2/Tests/L1SpecialXdtTransformRelative.ts
+++ b/Tasks/Common/webdeployment-common-v2/Tests/L1SpecialXdtTransformRelative.ts
@@ -1,0 +1,7 @@
+var path = require('path');
+var ltx = require('ltx');
+var xdtTransform = require('webdeployment-common-v2/xdttransformationutility.js');
+var workingDirectory = path.join(__dirname, 'L1XdtTransform');
+process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] = workingDirectory;
+xdtTransform.specialXdtTransformation(workingDirectory, 'Web.Debug.config', 'Web_test.config',);
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = 'DefaultWorkingDirectory';

--- a/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
+++ b/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
@@ -108,7 +108,7 @@ export function specialXdtTransformation(rootFolder, transformConfig, sourceConf
             }
         }
         else {
-            transformXmlFile = path.join(rootFolder, transformConfig);
+            transformXmlFile = path.resolve(rootFolder, transformConfig);
             transformXmlFiles[transformXmlFile.toLowerCase()] = transformXmlFile;
         }
 
@@ -123,7 +123,7 @@ export function specialXdtTransformation(rootFolder, transformConfig, sourceConf
             }    
         }
         
-        for(var transformXmlFile in transformXmlFiles) {                
+        for(var transformXmlFile in transformXmlFiles) {
             if(sourceXmlFiles[transformXmlFile.toLowerCase()] || tl.exist(transformXmlFile)) {
                 console.log(tl.loc('ApplyingXDTtransformation' , transformXmlFile , sourceXmlFile));
                 applyXdtTransformation(sourceXmlFile, transformXmlFile, destinationXmlFile);

--- a/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
+++ b/Tasks/Common/webdeployment-common-v2/xdttransformationutility.ts
@@ -128,6 +128,8 @@ export function specialXdtTransformation(rootFolder, transformConfig, sourceConf
                 console.log(tl.loc('ApplyingXDTtransformation' , transformXmlFile , sourceXmlFile));
                 applyXdtTransformation(sourceXmlFile, transformXmlFile, destinationXmlFile);
                 isTransformationApplied = true;
+            } else {
+                tl.debug(`Could not apply XDT transformation file ${transformXmlFile}`);
             }
         }
     }

--- a/Tasks/FileTransformV1/Tests/L0.ts
+++ b/Tasks/FileTransformV1/Tests/L0.ts
@@ -1,9 +1,19 @@
 import fs = require('fs');
 import assert = require('assert');
+import * as ttm from 'vsts-task-lib/mock-test';
 import path = require('path');
+import tl = require('azure-pipelines-task-lib');
+var ltx = require('ltx');
 
 describe('FileTransformV1 Suite', function () {
     before(() => {
+        // uncomment to enable test tracing
+        // process.env['TASK_TEST_TRACE'] = 1; 
+    })
+
+    beforeEach(() => {
+        // we need to do this every time, as some tests access / write to the same file
+        tl.cp(path.join(__dirname, "..", "node_modules","webdeployment-common-v2","Tests", 'L1XdtTransform', 'Web.config'), path.join(__dirname, "..", "node_modules","webdeployment-common-v2","Tests", 'L1XdtTransform', 'Web_test.config'), '-f', false);
     });
 
     after(() => {
@@ -13,4 +23,27 @@ describe('FileTransformV1 Suite', function () {
         // TODO - add real tests
         done();
     });
+
+    if(tl.getPlatform() === tl.Platform.Windows) {
+        var testSpecialXdtTransform = (fileName: string, done: MochaDone) => {
+            this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+            let tp = path.join(__dirname, "..", "node_modules", "webdeployment-common-v2", "Tests", fileName);
+            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+            tr.run();
+
+            var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","webdeployment-common-v2","Tests", 'L1XdtTransform', 'Web_test.config')));
+            var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","webdeployment-common-v2","Tests", 'L1XdtTransform','Web_Expected.config')));
+            assert(ltx.equal(resultFile, expectFile) , 'Should Transform attributes on Web.config');
+            done();
+        };
+
+        it('Runs successfully with XML Transformation on relative paths (L1)', (done:MochaDone) => {
+            testSpecialXdtTransform('L1SpecialXdtTransformRelative.js', done);
+        });
+
+        it('Runs successfully with XML Transformation on absolute paths (L1)', (done:MochaDone) => {
+            testSpecialXdtTransform('L1SpecialXdtTransformAbsolute.js', done);
+        });
+    }
 });

--- a/Tasks/FileTransformV1/package-lock.json
+++ b/Tasks/FileTransformV1/package-lock.json
@@ -79,9 +79,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary": {
       "version": "0.3.0",
@@ -93,9 +93,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -111,12 +111,12 @@
       }
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
@@ -263,14 +263,14 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -300,9 +300,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "ltx": {
       "version": "2.8.0",
@@ -370,9 +370,9 @@
       "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -464,9 +464,22 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "vsts-task-lib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.7.0.tgz",
+      "integrity": "sha512-zQqgneIZG3VY84RoIzkQr07r9fDH3lPpj6Qp07K89co/vyFznWJYpkjcdxubQm1YvgNu/P0yWYLdDruHyGGdtA==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
+      }
     },
     "webdeployment-common-v2": {
       "version": "file:../../_build/Tasks/Common/webdeployment-common-v2-2.0.0.tgz",
@@ -477,7 +490,8 @@
         "ltx": "2.8.0",
         "q": "1.4.1",
         "winreg": "1.2.2",
-        "xml2js": "0.4.13"
+        "xml2js": "0.4.13",
+        "xmldom": "^0.1.27"
       }
     },
     "winreg": {
@@ -500,9 +514,14 @@
       }
     },
     "xmlbuilder": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
-      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
+    },
+    "xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/Tasks/FileTransformV1/package.json
+++ b/Tasks/FileTransformV1/package.json
@@ -21,6 +21,7 @@
     "@types/node": "6.0.68",
     "@types/q": "1.0.7",
     "q": "1.4.1",
+    "vsts-task-lib": "^2.7.0",
     "webdeployment-common-v2": "file:../../_build/Tasks/Common/webdeployment-common-v2-2.0.0.tgz"
   }
 }

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "instanceNameFormat": "File Transform: $(Package)",

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -17,8 +17,8 @@
     ],
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 179,
+        "Patch": 0
     },
     "preview": "true",
     "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 0,
-    "Patch": 9
+    "Minor": 179,
+    "Patch": 0
   },
   "preview": "true",
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: FileTransform

**Description**: This PR changes the way the path of the transformation xml file is resolved in the XDT transformations utility (used in both FileTransform v1 and v2 tasks). Currently `path.join` is used, while this PR changes this to `path.resolve`. This allows specifying absolute paths for the transformation parameter, as described in #13948.  

Previously, setting e.g. `D:\tmp\test.release.config` as the transformation xml with `D:\somewhere\else` as the working root would result in the task looking for `D:\somewhere\else\\D:\tmp\test.release.config`. Now this path would be (correctly) resolved to `D:\tmp\test.release.config`.

This PR also bumps the versions of some more tasks (`AzureMysqlDeploymentV1`, `AzureRmWebAppDeploymentV4`, `IISWebAppDeploymentOnMachineGroupV0`, `MysqlDeploymentOnMachineGroupV1`) which make use of the affected common package, but not of the affected function.

**Documentation changes required:** N

**Added unit tests:** Y - only for FileTransformV1 (unit tests for FileTransformV2 would be a 1:1 copy)

**Attached related issue:** Y (#13948) 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected (Compare the [new output](https://janbeckmann.visualstudio.com/0fd64480-b471-43e0-b1f9-92e8f85b2e36/_apis/build/builds/25/logs/7) with the [output from the issue](https://janbeckmann.visualstudio.com/0fd64480-b471-43e0-b1f9-92e8f85b2e36/_apis/build/builds/24/logs/7))
