### PR TITLE
Fix for empty startupcommand

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV3/operations/ContainerBasedDeploymentUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/operations/ContainerBasedDeploymentUtility.ts
@@ -44,10 +44,11 @@ export class ContainerBasedDeploymentUtility {
         var startupCommand: string = taskParameters.StartupCommand;
         var configSettingsParameters = taskParameters.ConfigurationSettings;
         var appSettingsNewProperties = !!configSettingsParameters ? parse(configSettingsParameters.trim()): { };
-        appSettingsNewProperties.appCommandLine = {
-            'value': startupCommand
+        if(!!startupCommand) {
+            appSettingsNewProperties.appCommandLine = {
+                'value': startupCommand
+            }
         }
-
         appSettingsNewProperties.linuxFxVersion = {
             'value': "DOCKER|" + imageName
         }

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV3

**Description**: After changing **vsts-task-lib** to **azure-pipelines-task-lib** default value for empty taskparameters changed from `null` to `undefined` which caused to fail PATCH config API with error `BadRequest - HTTP request body must not be empty. (CODE: 400)`

For null value request body formed was like this

```
{
	"properties": {
		"appCommandLine": null,
		"linuxFxVersion": "DOCKER|diaggarwsimplesacr.azurecr.io/diaggarwsimples:1578"
	}
}
```
For undefined value request body formed was like this

```
{
	"properties": {
		"appCommandLine": {},
		"linuxFxVersion": "DOCKER|diaggarwsimplesacr.azurecr.io/diaggarwsimples:1578"
	}
}
```
because of empty object value of appCommandLine it started failing. This PR will fix this issue

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
