### PR TITLE
Modified universal packages version number retrieval

### DIFF
--- a/Tasks/Common/packaging-common/universal/ArtifactToolUtilities.ts
+++ b/Tasks/Common/packaging-common/universal/ArtifactToolUtilities.ts
@@ -162,16 +162,14 @@ export async function getHighestPackageVersionFromFeed(serviceUri: string, acces
 
     const result = await feedConnection.rest.get(data.requestUrl);
     if(result.result != null) {
-        if (!result.result['count']){
-            return "0.0.0";
-        }
-        else{
+        if (result.result['count'] > 0){
             for(var element of result.result['value']) {
                 if (element.name === packageName.toLowerCase()){
                     return element.versions[0].version;
                 }
             };
         }
+        return "0.0.0";
     }
     
     return null;


### PR DESCRIPTION
**Task name**: UniversalPackages
**Description**: <Describe your changes here>

**Documentation changes required:** No, I didn't find the relevant documentation location.

**Added unit tests:** No, I tried to find the relevant test in the Test folder but couldn't find it,

**Attached related issue:** Yes: https://github.com/microsoft/azure-pipelines-tasks/issues/13983

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
