### PR TITLE
Added arguments support for run a docker compose command action in DockerComposeV0

### DIFF
--- a/Tasks/DockerComposeV0/Tests/L0.ts
+++ b/Tasks/DockerComposeV0/Tests/L0.ts
@@ -132,6 +132,24 @@ describe('Docker Compose Suite', function() {
             done();
         });
 
+        it('Runs successfully for windows docker compose command with arguments', (done:MochaDone) => {
+            let tp = path.join(__dirname, 'L0Windows.js');
+            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+            process.env["__command__"] = "Run a Docker Compose command";
+            process.env["__container_type__"] = "Azure Container Registry"
+            process.env["__dockerComposeCommand__"] = "pull"
+            process.env["__arguments__"] = "service1 service2";
+            
+            tr.run();
+            
+            assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+            assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.stdout.indexOf("[command]docker-compose -f F:\\dir2\\docker-compose.yml up pull service1 service2") != -1, "successfully ran up command");
+            console.log(tr.stderr);
+            done();
+        });
+
         it('Runs successfully for windows docker compose up command with ACR and additional docker compose relative file path', (done:MochaDone) => {
             let tp = path.join(__dirname, 'L0Windows.js');
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/DockerComposeV0/Tests/L0.ts
+++ b/Tasks/DockerComposeV0/Tests/L0.ts
@@ -147,6 +147,7 @@ describe('Docker Compose Suite', function() {
             assert(tr.succeeded, 'task should have succeeded');
             assert(tr.stdout.indexOf("[command]docker-compose -f F:\\dir2\\docker-compose.yml up pull service1 service2") != -1, "successfully ran up command");
             console.log(tr.stderr);
+            console.log(tr.stdout);
             done();
         });
 

--- a/Tasks/DockerComposeV0/Tests/L0.ts
+++ b/Tasks/DockerComposeV0/Tests/L0.ts
@@ -145,9 +145,8 @@ describe('Docker Compose Suite', function() {
             assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
             assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
             assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.stdout.indexOf("[command]docker-compose -f F:\\dir2\\docker-compose.yml up pull service1 service2") != -1, "successfully ran up command");
+            assert(tr.stdout.indexOf("[command]docker-compose -f F:\\dir2\\docker-compose.yml pull service1 service2") != -1, "docker compose <command> should run with arguments");
             console.log(tr.stderr);
-            console.log(tr.stdout);
             done();
         });
 
@@ -329,5 +328,22 @@ describe('Docker Compose Suite', function() {
             done();
         });
 
+        it('Runs successfully for linux docker compose command with arguments', (done:MochaDone) => {
+            let tp = path.join(__dirname, 'L0Linux.js');
+            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+            process.env["__command__"] = "Run a Docker Compose command";
+            process.env["__container_type__"] = "Azure Container Registry"
+            process.env["__dockerComposeCommand__"] = "pull"
+            process.env["__arguments__"] = "service1 service2";
+            
+            tr.run();
+            
+            assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
+            assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.stdout.indexOf("[command]docker-compose -f /tmp/tempdir/100/docker-compose.yml pull service1 service2") != -1, "docker compose <command> should run with arguments");
+            console.log(tr.stderr);
+            done();
+        });
     }
 });

--- a/Tasks/DockerComposeV0/Tests/L0Linux.ts
+++ b/Tasks/DockerComposeV0/Tests/L0Linux.ts
@@ -93,6 +93,9 @@ let a: any = <any>{
         }, "docker-compose-userdefined -f /tmp/tempdir/100/docker-compose.yml config" :{
             "code": 0,
             "stdout": "services:\n  redis:\n    image: redis:alpine\n  web:\n    build:\n      context: /tmp/tempdir/100\n    ports:\n    - 5000:5000/tcp\n    volumes:\n    - /tmp/tempdir/100:/code:rw\nversion: '2.0'"
+        }, "docker-compose -f /tmp/tempdir/100/docker-compose.yml pull service1 service2" :{
+            "code": 0,
+            "stdout": "successfully pulled the passed service images"
         }
     },
     "exist": {

--- a/Tasks/DockerComposeV0/Tests/L0Windows.ts
+++ b/Tasks/DockerComposeV0/Tests/L0Windows.ts
@@ -94,6 +94,10 @@ let a: any = <any>{
         "docker-compose-userdefined -f F:\\dir2\\docker-compose.yml build" :{
             "code": 0,
             "stdout": "sucessfully built the service images"
+        },
+        "docker-compose -f F:\\dir2\\docker-compose.yml up pull service1 service2" :{
+            "code": 0,
+            "stdout": "successfully pulled the passed service images"
         }
     },
     "exist": {

--- a/Tasks/DockerComposeV0/Tests/L0Windows.ts
+++ b/Tasks/DockerComposeV0/Tests/L0Windows.ts
@@ -95,7 +95,7 @@ let a: any = <any>{
             "code": 0,
             "stdout": "sucessfully built the service images"
         },
-        "docker-compose -f F:\\dir2\\docker-compose.yml up pull service1 service2" :{
+        "docker-compose -f F:\\dir2\\docker-compose.yml pull service1 service2" :{
             "code": 0,
             "stdout": "successfully pulled the passed service images"
         }

--- a/Tasks/DockerComposeV0/dockercomposecommand.ts
+++ b/Tasks/DockerComposeV0/dockercomposecommand.ts
@@ -3,10 +3,15 @@
 import * as tl from "azure-pipelines-task-lib/task";
 import DockerComposeConnection from "./dockercomposeconnection";
 import * as utils from "./utils";
+import * as dockerCommandUtils from "azure-pipelines-tasks-docker-common-v2/dockercommandutils";
 
 export function run(connection: DockerComposeConnection, outputUpdate: (data: string) => any): any {
     var command = connection.createComposeCommand();
     command.line(tl.getInput("dockerComposeCommand", true));
+
+    var args = tl.getInput("arguments", false);
+    var commandArgs = dockerCommandUtils.getCommandArguments(args || "");
+    command.line(commandArgs || "");
 
     return connection.execCommandWithLogging(command)
     .then((output) => outputUpdate(utils.writeTaskOutput("command", output)));

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 175,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 175,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: DockerComposeV0

**Description**: The `Run a Docker Compose Command` action was showing up the `arguments` input in the UI but was not accepting any in the task's end.

**Documentation changes required:** N <Please mark if documentation changes are required> 

**Added unit tests:**  Y <Please mark if unit tests were added or updated according changes>

**Attached related issue:** Y <Please add link to related issue here>

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
