### PR TITLE
Bump azure-devops-node-api version in securefiles-common package

### DIFF
--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "6.14.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.4.tgz",
-      "integrity": "sha512-UqB7h2dVJr/KdZXRMJIhNUWT0HXVe9UNvfLCOsqiSGKAVaAp0QniYHlU9yegxyG6Ug2rc7VdAD4hYj3VghqvAw=="
+      "version": "10.17.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
+      "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -105,9 +105,9 @@
       }
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "underscore": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "1.178.0",
+  "version": "1.179.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -15,25 +15,13 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "typed-rest-client": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-          "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
-          "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
-          }
-        }
       }
     },
     "azure-pipelines-task-lib": {
@@ -81,15 +69,15 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "semver": {
       "version": "5.5.0",
@@ -102,9 +90,19 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
+    "typed-rest-client": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "requires": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "1.8.3"
+      }
     },
     "typescript": {
       "version": "2.3.4",

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^6.0.0",
     "@types/q": "^1.5.2",
-    "azure-devops-node-api": "7.2.0",
+    "azure-devops-node-api": "10.1.2",
     "azure-pipelines-task-lib": "^2.8.0"
   },
   "devDependencies": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "1.178.0",
+  "version": "1.179.0",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -17,12 +17,12 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@types/node": "^6.0.0",
+    "@types/node": "^10.17.0",
     "@types/q": "^1.5.2",
     "azure-devops-node-api": "10.1.2",
     "azure-pipelines-task-lib": "^2.8.0"
   },
   "devDependencies": {
-    "typescript": "2.3.4"
+    "typescript": "4.0.2"
   }
 }


### PR DESCRIPTION
**Task name**: azure-pipelines-tasks-securefiles-common

**Description**: We need to bump version of azure-pipelines-tasks-securefiles-common package to use latest version of typed-rest-client. This should resolve ETIMEDOUT issue with tasks that depends this package as it was added handling of network errors in HttpClient of typed-rest-client by this [PR](https://github.com/microsoft/typed-rest-client/pull/223).  

**Documentation changes required:** (Y/N) N

**Added unit tests:** N

**Attached related issue:** [#1795923](https://github.com/microsoft/build-task-team/issues/473), [#1796623](https://github.com/microsoft/build-task-team/issues/480), [#1796303](https://github.com/microsoft/build-task-team/issues/477), [#1796304](https://github.com/microsoft/build-task-team/issues/478)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
