### PR TITLE
[MSBuildHelpers] Added preview version for Node 10 migration

### DIFF
--- a/common-npm-packages/MSBuildHelpers/ArgumentFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/ArgumentFunctions.ps1
@@ -1,0 +1,47 @@
+function Format-MSBuildArguments {
+    [CmdletBinding()]
+    param(
+        [string]$MSBuildArguments,
+        [string]$Platform,
+        [string]$Configuration,
+        [string]$VSVersion,
+        [switch]$MaximumCpuCount)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        if ($Platform) {
+            Test-MSBuildParam $Platform 'Platform'
+            $MSBuildArguments = "$MSBuildArguments /p:platform=`"$Platform`""
+        }
+
+        if ($Configuration) {
+            Test-MSBuildParam $Configuration 'Configuration'
+            $MSBuildArguments = "$MSBuildArguments /p:configuration=`"$Configuration`""
+        }
+
+        if ($VSVersion) {
+            $MSBuildArguments = "$MSBuildArguments /p:VisualStudioVersion=`"$VSVersion`""
+        }
+
+        if ($MaximumCpuCount) {
+            $MSBuildArguments = "$MSBuildArguments /m"
+        }
+        
+        $userAgent = Get-VstsTaskVariable -Name AZURE_HTTP_USER_AGENT
+        if ($userAgent) {
+            $MSBuildArguments = "$MSBuildArguments /p:_MSDeployUserAgent=`"$userAgent`""
+        }
+
+        $MSBuildArguments
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
+function Test-MSBuildParam ([string]$msbuildParam, [string]$parameterName)
+{
+    if ($msBuildParam -match '[<>*|:\/&%"#?]')
+    {
+        throw "The value of MSBuild parameter '$parameterName' ($msBuildParam) contains an invalid character. The value of $parameterName may not contain any of the following characters: < > * | : \ / & % `" # ?"
+    }
+}

--- a/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
@@ -1,0 +1,176 @@
+########################################
+# Public functions.
+########################################
+function Invoke-BuildTools {
+    [CmdletBinding()]
+    param(
+        [switch]$NuGetRestore,
+        [string[]]$SolutionFiles,
+        [string]$MSBuildLocation, # TODO: Switch MSBuildLocation to mandatory. Both callers (MSBuild and VSBuild task) throw prior to reaching here if MSBuild cannot be resolved.
+        [string]$MSBuildArguments,
+        [switch]$Clean,
+        [switch]$NoTimelineLogger,
+        [switch]$CreateLogFile,
+        [string]$LogFileVerbosity)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        foreach ($file in $SolutionFiles) {
+            if ($NuGetRestore) {
+                Invoke-NuGetRestore -File $file
+            }
+            
+            $splat = @{ }
+
+            if ($LogFileVerbosity) {
+                $splat["LogFileVerbosity"] = $LogFileVerbosity
+            }
+
+            if ($Clean) {
+                if ($CreateLogFile) {
+                    $splat["LogFile"] = "$file-clean.log"
+                }
+                Invoke-MSBuild -ProjectFile $file -Targets Clean -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
+            }
+
+            # If we cleaned and passed /t targets, we don't need to run them again
+            if (!$Clean -or $MSBuildArguments -notmatch "[/-]t(arget)?:\S+") {
+                if ($CreateLogFile) {
+                    $splat["LogFile"] = "$file.log"
+                }
+                Invoke-MSBuild -ProjectFile $file -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
+            }
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
+########################################
+# Private functions.
+########################################
+function Invoke-MSBuild {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$ProjectFile,
+        [string]$Targets,
+        [string]$LogFile,
+        [string]$LogFileVerbosity,
+        [switch]$NoTimelineLogger,
+        [string]$MSBuildPath, # TODO: Switch MSBuildPath to mandatory. Both callers (MSBuild and VSBuild task) throw prior to reaching here if MSBuild cannot be resolved.
+        [string]$AdditionalArguments)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        # Get the MSBuild path.
+        if (!$MSBuildPath) {
+            $MSBuildPath = Get-MSBuildPath # TODO: Delete this condition block. Both callers (MSBuild and VSBuild task) throw prior to reaching here if MSBuild cannot be resolved.
+        } else {
+            $MSBuildPath = [System.Environment]::ExpandEnvironmentVariables($MSBuildPath)
+            if ($MSBuildPath -notlike '*msbuild.exe') {
+                $MSBuildPath = [System.IO.Path]::Combine($MSBuildPath, 'msbuild.exe')
+            }
+        }
+
+        # Validate the path exists.
+        $null = Assert-VstsPath -LiteralPath $MSBuildPath -PathType Leaf
+
+        # Don't show the logo and do not allow node reuse so all child nodes are shut down once the master
+        # node has completed build orchestration.
+        $arguments = "`"$ProjectFile`" /nologo /nr:false"
+
+        # Add the targets if specified.
+        if ($Targets) {
+            $arguments = "$arguments /t:`"$Targets`""
+        }
+
+        # If a log file was specified then hook up the default file logger.
+        if ($LogFile) {
+            $arguments = "$arguments /fl /flp:`"logfile=$LogFile;verbosity=$LogFileVerbosity`""
+        }
+
+        # Start the detail timeline.
+        $detailId = ''
+        if (!$NoTimelineLogger) {
+            $detailId = [guid]::NewGuid()
+            $detailName = Get-VstsLocString -Key MSB_Build0 -ArgumentList ([System.IO.Path]::GetFileName($ProjectFile))
+            $detailStartTime = [datetime]::UtcNow.ToString('O')
+            Write-VstsLogDetail -Id $detailId -Type Process -Name $detailName -Progress 0 -StartTime $detailStartTime -State Initialized -AsOutput
+        }
+
+        # Store the solution folder so we can provide solution-relative paths (for now) for the project events.
+        $solutionDirectory = [System.IO.Path]::GetDirectoryName($ProjectFile)
+
+        # Hook up the custom logger.
+        $loggerAssembly = "$PSScriptRoot\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
+        Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
+        $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
+
+        # Append additional arguments.
+        if ($AdditionalArguments) {
+            $arguments = "$arguments $AdditionalArguments"
+        }
+
+        $global:LASTEXITCODE = ''
+        try {
+            # Invoke MSBuild.
+            Invoke-VstsTool -FileName $MSBuildPath -Arguments $arguments -RequireExitCodeZero
+            if ($LASTEXITCODE -ne 0) {
+                Write-VstsSetResult -Result Failed -DoNotThrow
+            }
+        } finally {
+            # Complete the detail timeline.
+            if (!$NoTimelineLogger) {
+                if ($LASTEXITCODE -ne 0) {
+                    $detailResult = 'Failed'
+                } else {
+                    $detailResult = 'Succeeded'
+                }
+
+                $detailFinishTime = [datetime]::UtcNow.ToString('O')
+                Write-VstsLogDetail -Id $detailId -FinishTime $detailFinishTime -Progress 100 -State Completed -Result $detailResult -AsOutput
+            }
+
+            if ($LogFile) {
+                if (Test-Path -Path $LogFile) {
+                    Write-Host "##vso[task.uploadfile]$LogFile"
+                } else {
+                    Write-Verbose "Skipping upload of '$LogFile' since it does not exist."
+                }
+            }
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
+function Invoke-NuGetRestore {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true, Position = 1)]
+        [string]$File)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        Write-Warning (Get-VstsLocString -Key MSB_RestoreNuGetPackagesDeprecated)
+        try {
+            $nuGetPath = Assert-VstsPath -LiteralPath "$(Get-VstsTaskVariable -Name Agent.HomeDirectory -Require)\externals\nuget\NuGet.exe" -PathType Leaf -PassThru
+        } catch {
+            # Temporary fallback logic for legacy Windows agent.
+            $nuGetPath = Assert-VstsPath -LiteralPath "$(Get-VstsTaskVariable -Name Agent.HomeDirectory -Require)\Agent\Worker\Tools\NuGet.exe" -PathType Leaf -PassThru
+        }
+
+        if ($env:NUGET_EXTENSIONS_PATH) {
+            Write-Host (Get-VstsLocString -Key MSB_DetectedNuGetExtensionsLoaderPath0 -ArgumentList $env:NUGET_EXTENSIONS_PATH)
+        }
+
+        $directory = [System.IO.Path]::GetDirectoryName($file)
+        Invoke-VstsTool -FileName $nuGetPath -Arguments "restore `"$file`" -NonInteractive" -WorkingDirectory $directory -RequireExitCodeZero
+        if ($LASTEXITCODE -ne 0) {
+            Write-VstsSetResult -Result Failed -DoNotThrow
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}

--- a/common-npm-packages/MSBuildHelpers/MSBuildHelpers.psm1
+++ b/common-npm-packages/MSBuildHelpers/MSBuildHelpers.psm1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param()
+Import-VstsLocStrings "$PSScriptRoot\module.json"
+. $PSScriptRoot\ArgumentFunctions
+. $PSScriptRoot\InvokeFunctions
+. $PSScriptRoot\PathFunctions
+Export-ModuleMember -Function @(
+    # Argument functions.
+    'Format-MSBuildArguments'
+    # Invoke functions.
+    'Invoke-BuildTools'
+    # Path functions.
+    'Get-MSBuildPath'
+    'Get-SolutionFiles'
+    'Get-VisualStudio'
+    'Select-MSBuildPath'
+)

--- a/common-npm-packages/MSBuildHelpers/PathFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/PathFunctions.ps1
@@ -1,0 +1,309 @@
+########################################
+# Public functions.
+########################################
+$script:visualStudioCache = @{ }
+
+########################################
+# Public functions.
+########################################
+function Get-MSBuildPath {
+    [CmdletBinding()]
+    param(
+        [string]$Version,
+        [string]$Architecture)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        # Only attempt to find Microsoft.Build.Utilities.Core.dll from a VS 15 Willow install
+        # when "15.0" or latest is specified. In 15.0, the method GetPathToBuildToolsFile(...)
+        # has regressed. When it is called for a version that is not found, the latest version
+        # found is returned instead. Same for "16.0"
+        [System.Reflection.Assembly]$msUtilities = $null
+        if (($Version -eq "16.0" -or !$Version) -and # !$Version indicates "latest"
+            ($visualStudio16 = Get-VisualStudio 16) -and
+            $visualStudio16.installationPath) {
+
+            $msbuildUtilitiesPath = [System.IO.Path]::Combine($visualStudio16.installationPath, "MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll")
+            if (Test-Path -LiteralPath $msbuildUtilitiesPath -PathType Leaf) {
+                Write-Verbose "Loading $msbuildUtilitiesPath"
+                $msUtilities = [System.Reflection.Assembly]::LoadFrom($msbuildUtilitiesPath)
+            }
+        }
+        elseif (($Version -eq "15.0" -or !$Version) -and # !$Version indicates "latest"
+            ($visualStudio15 = Get-VisualStudio 15) -and
+            $visualStudio15.installationPath) {
+
+            $msbuildUtilitiesPath = [System.IO.Path]::Combine($visualStudio15.installationPath, "MSBuild\15.0\Bin\Microsoft.Build.Utilities.Core.dll")
+            if (Test-Path -LiteralPath $msbuildUtilitiesPath -PathType Leaf) {
+                Write-Verbose "Loading $msbuildUtilitiesPath"
+                $msUtilities = [System.Reflection.Assembly]::LoadFrom($msbuildUtilitiesPath)
+            }
+        }
+
+        # Fallback to searching the GAC.
+        if (!$msUtilities) {
+            $msbuildUtilitiesAssemblies = @(
+                "Microsoft.Build.Utilities.Core, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.Core, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.v12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+                "Microsoft.Build.Utilities.v4.0, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
+            )
+
+            # Attempt to load a Microsoft build utilities DLL.
+            $index = 0
+            [System.Reflection.Assembly]$msUtilities = $null
+            while (!$msUtilities -and $index -lt $msbuildUtilitiesAssemblies.Length) {
+                Write-Verbose "Loading $($msbuildUtilitiesAssemblies[$index])"
+                try {
+                    $msUtilities = [System.Reflection.Assembly]::Load((New-Object System.Reflection.AssemblyName($msbuildUtilitiesAssemblies[$index])))
+                } catch [System.IO.FileNotFoundException] {
+                    Write-Verbose "Not found."
+                }
+
+                $index++
+            }
+        }
+
+        [string]$msBuildPath = $null
+
+        # Default to x86 architecture if not specified.
+        if (!$Architecture) {
+            $Architecture = "x86"
+        }
+
+        if ($msUtilities -ne $null) {
+            [type]$t = $msUtilities.GetType('Microsoft.Build.Utilities.ToolLocationHelper')
+            if ($t -ne $null) {
+                # Attempt to load the method info for GetPathToBuildToolsFile. This method
+                # is available in the 16.0, 15.0, 14.0, and 12.0 utilities DLL. It is not available
+                # in the 4.0 utilities DLL.
+                [System.Reflection.MethodInfo]$mi = $t.GetMethod(
+                    "GetPathToBuildToolsFile",
+                    [type[]]@( [string], [string], $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
+                if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
+                    $versions = "16.0", "15.0", "14.0", "12.0", "4.0"
+                    if ($Version) {
+                        $versions = @( $Version )
+                    }
+
+                    # Translate the architecture parameter into the corresponding value of the
+                    # DotNetFrameworkArchitecture enum. Parameter three of the target method info
+                    # takes this enum. Leverage parameter three to get to the enum's type info.
+                    $param3 = $mi.GetParameters()[2]
+                    $archValues = [System.Enum]::GetValues($param3.ParameterType)
+                    [object]$archValue = $null
+                    if ($Architecture -eq 'x86') {
+                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                    } elseif ($Architecture -eq 'x64') {
+                        $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
+                    } else {
+                        $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                    }
+
+                    # Attempt to resolve the path for each version.
+                    $versionIndex = 0
+                    while (!$msBuildPath -and $versionIndex -lt $versions.Length) {
+                        $msBuildPath = $mi.Invoke(
+                            $null,
+                            @( 'msbuild.exe' # string fileName
+                                $versions[$versionIndex] # string toolsVersion
+                                $archValue ))
+                        $versionIndex++
+                    }
+                } elseif (!$Version -or $Version -eq "4.0") {
+                    # Attempt to load the method info GetPathToDotNetFrameworkFile. This method
+                    # is available in the 4.0 utilities DLL.
+                    $mi = $t.GetMethod(
+                        "GetPathToDotNetFrameworkFile",
+                        [type[]]@( [string], $msUtilities.GetType("Microsoft.Build.Utilities.TargetDotNetFrameworkVersion"), $msUtilities.GetType("Microsoft.Build.Utilities.DotNetFrameworkArchitecture") ))
+                    if ($mi -ne $null -and $mi.GetParameters().Length -eq 3) {
+                        # Parameter two of the target method info takes the TargetDotNetFrameworkVersion
+                        # enum. Leverage parameter two to get the enum's type info.
+                        $param2 = $mi.GetParameters()[1];
+                        $frameworkVersionValues = [System.Enum]::GetValues($param2.ParameterType);
+
+                        # Translate the architecture parameter into the corresponding value of the
+                        # DotNetFrameworkArchitecture enum. Parameter three of the target method info
+                        # takes this enum. Leverage parameter three to get to the enum's type info.
+                        $param3 = $mi.GetParameters()[2];
+                        $archValues = [System.Enum]::GetValues($param3.ParameterType);
+                        [object]$archValue = $null
+                        if ($Architecture -eq "x86") {
+                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                        } elseif ($Architecture -eq "x64") {
+                            $archValue = $archValues.GetValue(2) # DotNetFrameworkArchitecture.Bitness64
+                        } else {
+                            $archValue = $archValues.GetValue(1) # DotNetFrameworkArchitecture.Bitness32
+                        }
+
+                        # Attempt to resolve the path.
+                        $msBuildPath = $mi.Invoke(
+                            $null,
+                            @( "msbuild.exe" # string fileName
+                                $frameworkVersionValues.GetValue($frameworkVersionValues.Length - 1) # enum TargetDotNetFrameworkVersion.VersionLatest
+                                $archValue ))
+                    }
+                }
+            }
+        }
+
+        if ($msBuildPath -and (Test-Path -LiteralPath $msBuildPath -PathType Leaf)) {
+            Write-Verbose "MSBuild: $msBuildPath"
+            $msBuildPath
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
+function Get-SolutionFiles {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Solution)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        if ($Solution.Contains("*") -or $Solution.Contains("?")) {
+            $solutionFiles = Find-VstsFiles -LegacyPattern $Solution
+            if (!$solutionFiles.Count) {
+                throw (Get-VstsLocString -Key MSB_SolutionNotFoundUsingSearchPattern0 -ArgumentList $Solution)
+            }
+        } else {
+            $solutionFiles = ,$Solution
+        }
+
+        $solutionFiles
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+
+function Get-VisualStudio {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet(15, 16)]
+        [int]$MajorVersion)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        if (!$script:visualStudioCache.ContainsKey("$MajorVersion.0")) {
+            try {
+                # Query for the latest $MajorVersion.* version.
+                #
+                # Note, the capability is registered as VisualStudio_16.0, however the actual version
+                # may be something like 16.2.
+                Write-Verbose "Getting latest Visual Studio $MajorVersion setup instance."
+                $output = New-Object System.Text.StringBuilder
+                Invoke-VstsTool -FileName "$PSScriptRoot\vswhere\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -latest -format json" -RequireExitCodeZero 2>&1 |
+                    ForEach-Object {
+                        if ($_ -is [System.Management.Automation.ErrorRecord]) {
+                            Write-Verbose "STDERR: $($_.Exception.Message)"
+                        }
+                        else {
+                            Write-Verbose $_
+                            $null = $output.AppendLine($_)
+                        }
+                    }
+                $script:visualStudioCache["$MajorVersion.0"] = (ConvertFrom-Json -InputObject $output.ToString()) |
+                    Select-Object -First 1
+                if (!$script:visualStudioCache["$MajorVersion.0"]) {
+                    # Query for the latest $MajorVersion.* BuildTools.
+                    #
+                    # Note, whereas VS 16.x version number is always 16.0.*, BuildTools does not follow the
+                    # the same scheme. It appears to follow the 16.<UPDATE_NUMBER>.* versioning scheme.
+                    Write-Verbose "Getting latest BuildTools 16 setup instance."
+                    $output = New-Object System.Text.StringBuilder
+                    Invoke-VstsTool -FileName "$PSScriptRoot\vswhere\vswhere.exe" -Arguments "-version [$MajorVersion.0,$($MajorVersion+1).0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
+                        ForEach-Object {
+                            if ($_ -is [System.Management.Automation.ErrorRecord]) {
+                                Write-Verbose "STDERR: $($_.Exception.Message)"
+                            }
+                            else {
+                                Write-Verbose $_
+                                $null = $output.AppendLine($_)
+                            }
+                        }
+                    $script:visualStudioCache["$MajorVersion.0"] = (ConvertFrom-Json -InputObject $output.ToString()) |
+                        Select-Object -First 1
+                }
+            } catch {
+                Write-Verbose ($_ | Out-String)
+                $script:visualStudioCache["$MajorVersion.0"] = $null
+            }
+        }
+
+        return $script:visualStudioCache["$MajorVersion.0"]
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}
+function Select-MSBuildPath {
+    [CmdletBinding()]
+    param(
+        [string]$Method,
+        [string]$Location,
+        [string]$PreferredVersion,
+        [string]$Architecture)
+
+    Trace-VstsEnteringInvocation $MyInvocation
+    try {
+        # Default the msbuildLocationMethod if not specified. The input msbuildLocationMethod
+        # was added to the definition after the input msbuildLocation.
+        if ("$Method".ToUpperInvariant() -ne 'LOCATION' -and "$Method".ToUpperInvariant() -ne 'VERSION') {
+            # Infer the msbuildLocationMethod based on the whether msbuildLocation is specified.
+            if ($Location) {
+                $Method = 'location'
+            } else {
+                $Method = 'version'
+            }
+
+            Write-Verbose "Defaulted MSBuild location method to: $Method"
+        }
+
+        if ("$Method".ToUpperInvariant() -eq 'LOCATION') {
+            # Return the location.
+            if ($Location) {
+                return $Location
+            }
+
+            # Fallback to version lookup.
+            Write-Verbose "Location not specified. Looking up by version instead."
+        }
+
+        $specificVersion = $PreferredVersion -and $PreferredVersion -ne 'latest'
+        $versions = "16.0", '15.0', '14.0', '12.0', '4.0' | Where-Object { $_ -ne $PreferredVersion }
+
+        # Look for a specific version of MSBuild.
+        if ($specificVersion) {
+            if (($path = Get-MSBuildPath -Version $PreferredVersion -Architecture $Architecture)) {
+                return $path
+            }
+
+            # Attempt to fallback.
+            Write-Verbose "Specified version '$PreferredVersion' and architecture '$Architecture' not found. Attempting to fallback."
+        }
+
+        # Look for the latest version of MSBuild.
+        foreach ($version in $versions) {
+            if (($path = Get-MSBuildPath -Version $version -Architecture $Architecture)) {
+                # Warn falling back.
+                if ($specificVersion) {
+                    Write-Warning (Get-VstsLocString -Key 'MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2' -ArgumentList $PreferredVersion, $Architecture, $version)
+                }
+
+                return $path
+            }
+        }
+
+        # Error. Not found.
+        if ($specificVersion) {
+            Write-Error (Get-VstsLocString -Key 'MSB_MSBuildNotFoundVersion0Architecture1' -ArgumentList $PreferredVersion, $Architecture)
+        } else {
+            Write-Error (Get-VstsLocString -Key 'MSB_MSBuildNotFound')
+        }
+    } finally {
+        Trace-VstsLeavingInvocation $MyInvocation
+    }
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/de-de/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/de-de/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Build {0}",
+  "loc.messages.MSB_BuildToolNotFound": "MSBuild oder xbuild(Mono) wurde auf dem Mac-/Linux-Agent nicht gefunden.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Der Pfad des NuGet-Extensionladeprogramms wurde erkannt. Die Umgebungsvariable \"NUGET_EXTENSIONS_PATH\" ist auf \"{0}\" festgelegt.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "MSBuild-Version \"15.0\" wurde bei der Architektur \"{0}\" nicht gefunden. Überprüfen Sie, ob der Architektureingabewert korrekt ist und ob Visual Studio 2017 installiert ist. MSBuild-Version \"15.0\" ist enthalten, wenn Visual Studio 2017 installiert ist.",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild wurde nicht gefunden. Versuchen Sie, den Speicherort von \"msbuild.exe\" anzugeben oder Visual Studio zu installieren. MSBuild ist enthalten, wenn Visual Studio installiert ist.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "MSBuild wurde für Version \"{0}\" und Architektur \"{1}\" nicht gefunden. Testen Sie eine andere Kombination aus Version und Architektur, geben Sie einen Speicherort an, oder installieren Sie die entsprechende Version von Visual Studio. MSBuild ist enthalten, wenn Visual Studio installiert ist.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "Die Option \"NuGet-Pakete wiederherstellen\" ist veraltet. Fügen Sie Ihrer Builddefinition zum Wiederherstellen von NuGet-Paketen im Build einen Task für den NuGet-Toolinstaller hinzu.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "Die Lösung wurde mithilfe des Suchmusters \"{0}\" nicht gefunden.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "Die MSBuild-Version \"{0}\" für Architektur \"{1}\" wurde nicht gefunden. Die Version \"{2}\" wird verwendet."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/en-US/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/en-US/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Build {0}",
+  "loc.messages.MSB_BuildToolNotFound": "MSBuild or xbuild(Mono) were not found on the Mac/Linux agent.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Detected NuGet extensions loader path. Environment variable NUGET_EXTENSIONS_PATH is set to '{0}'.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "MSBuild version '15.0' was not found for architecture '{0}'. Verify the architecture input value is correct and verify Visual Studio 2017 is installed. MSBuild version '15.0' is included when Visual Studio 2017 is installed.",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild was not found. Try specifying the location to msbuild.exe or install Visual Studio. MSBuild is included when Visual Studio is installed.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "MSBuild was not found for version '{0}' and architecture '{1}'. Try a different version/architecture combination, specify a location, or install the appropriate version of Visual Studio. MSBuild is included when Visual Studio is installed.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "The 'Restore NuGet Packages' option is deprecated. To restore NuGet packages in your build, add a NuGet Tool Installer task to your build definition.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "Solution not found using search pattern '{0}'.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "Unable to find MSBuild version '{0}' for architecture '{1}'. Falling back to version '{2}'."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/es-es/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/es-es/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Compilación {0}",
+  "loc.messages.MSB_BuildToolNotFound": "No se encontró MSBuild o xbuild (Mono) en el agente para Mac o Linux.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Se detectó la ruta de acceso del cargador de extensiones de NuGet. La variable de entorno NUGET_EXTENSIONS_PATH está establecida en '{0}'.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "No se encontró la versión de MSBuild \"15.0\" para la arquitectura \"{0}\". Compruebe que el valor de entrada de la arquitectura es correcto y compruebe que Visual Studio 2017 está instalado. La versión de MSBuild \"15.0\" se incluyó con la instalación de Visual Studio 2017.",
+  "loc.messages.MSB_MSBuildNotFound": "No se encontró MSBuild. Pruebe a especificar la ubicación de msbuild.exe o instale Visual Studio. MSBuild se incluyó con la instalación de Visual Studio.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "No se encontró MSBuild para la versión \"{0}\" y la arquitectura \"{1}\". Pruebe una combinación diferente de versión/arquitectura, especifique una ubicación o instale la versión adecuada de Visual Studio. MSBuild se incluyó con la instalación de Visual Studio.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "La opción \"Restaurar paquetes de NuGet\" está en desuso. Para restaurar paquetes de NuGet en la compilación, agregue una tarea del instalador de la herramienta NuGet a la definición de compilación.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "No se encontró la solución con el patrón de búsqueda '{0}'.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "No se encuentra la versión de MSBuild \"{0}\" para la arquitectura \"{1}\". Revirtiendo a la versión \"{2}\"."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Build {0}",
+  "loc.messages.MSB_BuildToolNotFound": "MSBuild ou xbuild (Mono) sont introuvables sur l'agent Mac/Linux.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Le chemin du chargeur d'extensions NuGet a été détecté. La variable d'environnement NUGET_EXTENSIONS_PATH a la valeur '{0}'.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "MSBuild version '15.0' est introuvable pour l'architecture '{0}'. Vérifiez que la valeur d'entrée de l'architecture est correcte et que Visual Studio 2017 est installé. MSBuild version '15.0' est inclus durant l'installation de Visual Studio 2017.",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild est introuvable. Essayez de spécifier l'emplacement à msbuild.exe, ou installez Visual Studio. MSBuild est inclus durant l'installation de Visual Studio.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "MSBuild est introuvable pour la version '{0}' et l'architecture '{1}'. Essayez une autre combinaison version/architecture, spécifiez un emplacement, ou installez la version appropriée de Visual Studio. MSBuild est inclus durant l'installation de Visual Studio.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "L'option Restaurer des packages NuGet est dépréciée. Pour restaurer des packages NuGet dans votre build, ajoutez une tâche Programme d'installation de l'outil NuGet à votre définition de build.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "Solution introuvable à l'aide du modèle de recherche '{0}'.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "MSBuild version '{0}' est introuvable pour l'architecture '{1}'. Retour à la version '{2}'."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/it-IT/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Compilazione {0}",
+  "loc.messages.MSB_BuildToolNotFound": "MSBuild o xbuild (Mono) non è stato trovato nell'agente Mac/Linux.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Il percorso del caricatore delle estensioni NuGet è stato rilevato. La variabile di ambiente NUGET_EXTENSIONS_PATH è impostata su '{0}'.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "La versione '15.0' di MSBuild non è stata trovata per l'architettura '{0}'. Verificare che il valore di input dell'architettura sia corretto e che Visual Studio 2017 sia installato. La versione '15.0' di MSBuild è inclusa quando si installa Visual Studio 2017.",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild non è stato trovato. Provare a specificare il percorso di msbuild.exe o installare Visual Studio. MSBuild è incluso quando Visual Studio è installato.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "MSBuild non è stato trovato per la versione '{0}' e l'architettura '{1}'. Provare con una combinazione diversa di versione/architettura, specificare un percorso oppure installare la versione appropriata di Visual Studio. MSBuild è incluso quando si installa Visual Studio.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "L'opzione 'Ripristina pacchetti NuGet' è deprecata. Per ripristinare i pacchetti NuGet nella compilazione, aggiungere un'attività Programma di installazione strumento NuGet alla definizione di compilazione.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "Non sono state trovate soluzioni con il criterio di ricerca '{0}'.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "La versione '{0}' di MSBuild non è stata trovata per l'architettura '{1}'. Verrà eseguito il fallback alla versione '{2}'."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "ビルド: {0}",
+  "loc.messages.MSB_BuildToolNotFound": "MSBuild または xbuild(Mono) が Mac/Linux エージェント上に見つかりませんでした。",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "NuGet 拡張機能のローダー パスが検出されました。環境変数 NUGET_EXTENSIONS_PATH が '{0}' に設定されています。",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "MSBuild バージョン '15.0' がアーキテクチャ '{0}' にありません。アーキテクチャの入力値が正しいことを確認し、Visual Studio 2017 がインストールされていることを確認してください。MSBuild バージョン '15.0' は、Visual Studio 2017 のインストール時にインストールされます。",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild が見つかりませんでした。msbuild.exe の場所を指定するか、Visual Studio をインストールしてください。MSBuild は Visual Studio のインストール時にインストールされます。",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "バージョン '{0}' およびアーキテクチャ '{1}' の MSBuild が見つかりませんでした。バージョン/アーキテクチャの別の組み合わせを試し、場所を指定し、適切なバージョンの Visual Studio をインストールしてください。MSBuild は Visual Studio のインストール時にインストールされます。",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "'NuGet パッケージの復元' オプションは非推奨になりました。ビルド内の NuGet パッケージを復元するには、NuGet Tool インストーラーのタスクをビルド定義に追加します。",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "検索パターン '{0}' を使ってソリューションが見つかりませんでした。",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "アーキテクチャ '{1}' の MSBuild バージョン '{0}' が見つかりません。バージョン '{2}' にフォールバックします。"
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "빌드 {0}",
+  "loc.messages.MSB_BuildToolNotFound": "Mac/Linux 에이전트에서 MSBuild 또는 xbuild(Mono)를 찾을 수 없습니다.",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "NuGet 확장 로드 경로가 검색되었습니다. 환경 변수 NUGET_EXTENSIONS_PATH는 '{0}'(으)로 설정되어 있습니다.",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "아키텍처 '{0}'에 대해 MSBuild 버전 '15.0'을 찾을 수 없습니다. 아키텍처 입력 값이 올바른지 확인하고 Visual Studio 2017이 설치되어 있는지 확인하세요. Visual Studio 2017을 설치할 때 MSBuild 버전 '15.0'이 포함됩니다.",
+  "loc.messages.MSB_MSBuildNotFound": "MSBuild를 찾을 수 없습니다. msbuild.exe에 대한 위치를 지정하거나 Visual Studio를 설치하세요. Visual Studio를 설치할 때 MSBuild가 포함됩니다.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "버전 '{0}' 및 아키텍처 '{1}'에 대해 MSBuild를 찾을 수 없습니다. 다른 버전/아키텍처 조합을 시도해 보거나, 위치를 지정하거나, 적합한 버전의 Visual Studio를 설치해 보세요. Visual Studio를 설치할 때 MSBuild가 포함됩니다.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "'NuGet 패키지 복원' 옵션은 사용되지 않습니다. 빌드에서 NuGet 패키지를 복원하려면 빌드 정의에 NuGet 도구 설치 관리자 작업을 추가하세요.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "검색 패턴 '{0}'을(를) 사용하여 솔루션을 찾을 수 없습니다.",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "아키텍처 '{1}'에 대해 MSBuild 버전 '{0}'을(를) 찾을 수 없습니다. '{2}' 버전을 대신 사용합니다."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "Сборка {0}",
+  "loc.messages.MSB_BuildToolNotFound": "В агенте Mac/Linux не удалось найти MSBuild или xbuild (Mono).",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "Обнаружен путь к загрузчику расширений NuGet. Для переменной среды NUGET_EXTENSIONS_PATH задано значение \"{0}\".",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "Не найдено средство MSBuild 15.0 для архитектуры \"{0}\". Проверьте правильность входного значения архитектуры и убедитесь, что среда Visual Studio 2017 установлена. Средство MSBuild версии 15.0 включено в установку Visual Studio 2017.",
+  "loc.messages.MSB_MSBuildNotFound": "Не найдено средство MSBuild. Укажите расположение msbuild.exe или установите Visual Studio. Средство MSBuild включено в установку Visual Studio.",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "Не найдено средство MSBuild \"{0}\" для архитектуры \"{1}\". Попробуйте использовать другую комбинацию версии и архитектуры, укажите расположение или установите соответствующую версию Visual Studio. Средство MSBuild включено в установку Visual Studio.",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "Параметр \"Восстановить пакеты NuGet\" является устаревшим. Чтобы восстановить пакеты NuGet в сборке, добавьте задание установщика средства NuGet в определение сборки.",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "Не удалось найти решение по шаблону поиска \"{0}\".",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "Не удалось найти MSBuild версии \"{0}\" для архитектуры \"{1}\". Выполняется откат к версии {2}."
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "生成 {0}",
+  "loc.messages.MSB_BuildToolNotFound": "Mac/Linux 代理上找不到 MSBuild 或 xbuild(Mono)。",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "已检测到 NuGet 扩展加载程序路径。将环境变量 NUGET_EXTENSIONS_PATH 设置为“{0}”。",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "找不到适用于体系结构“{0}”的 MSBuild 版本 \"15.0\"。请验证体系结构输入值正确，且已安装 Visual Studio 2017。安装 Visual Studio 2017 时 MSBuild 版本 \"15.0\" 也包括在内。",
+  "loc.messages.MSB_MSBuildNotFound": "找不到 MSBuild。尝试指定 msbuild.exe 的位置或安装 Visual Studio。安装 Visual Studio 时 MSBuild 也包括在内。",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "找不到适用于体系结构“{1}”的 MSBuild 版本“{0}”。请尝试其他版本/体系结构组合，指定一个位置或安装合适版本的 Visual Studio。安装 Visual Studio 时 MSBuild 也包括在内。",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "“还原 NuGet 包”选项已弃用。若要在生成中还原 NuGet 包，请将 NuGet 工具安装程序任务添加到生成定义中。",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "使用搜索模式“{0}”找不到解决方案。",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "找不到适用于体系结构“{1}”的 MSBuild 版本“{0}”。正在回退到版本“{2}”。"
+}

--- a/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/common-npm-packages/MSBuildHelpers/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,0 +1,11 @@
+{
+  "loc.messages.MSB_Build0": "組建 {0}",
+  "loc.messages.MSB_BuildToolNotFound": "在 Mac/Linux 代理程式上找不到 MSBuild 或 xbuild (Mono)。",
+  "loc.messages.MSB_DetectedNuGetExtensionsLoaderPath0": "偵測到 NuGet 擴充功能載入器路徑。環境變數 NUGET_EXTENSIONS_PATH 設定為 '{0}'。",
+  "loc.messages.MSB_MSBuild15NotFoundionArchitecture0": "架構 '{0}' 中找不到 MSBuild 版本 '15.0'。請確認架構輸入值是否正確，且確認是否已安裝 Visual Studio 2017。已安裝 Visual Studio 2017 時會包含 MSBuild 版本 '15.0'。",
+  "loc.messages.MSB_MSBuildNotFound": "找不到 MSBuild。請嘗試指定 msbuild.exe 的位置或安裝 Visual Studio。已安裝 Visual Studio 時會包含 MSBuild。",
+  "loc.messages.MSB_MSBuildNotFoundVersion0Architecture1": "版本 '{0}' 與架構 '{1}' 中找不到 MSBuild。請嘗試其他版本/架構組合的、指定位置，或安裝正確的 Visual Studio 版本。已安裝 Visual Studio 時會包含 MSBuild。",
+  "loc.messages.MSB_RestoreNuGetPackagesDeprecated": "[還原 NuGet 套件] 選項即將淘汰。若要還原組件中的 NuGet 套件，請在組建定義中新增 NuGet 工具安裝程式工作。",
+  "loc.messages.MSB_SolutionNotFoundUsingSearchPattern0": "使用搜尋模式 '{0}' 找不到解決方案。",
+  "loc.messages.MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "找不到架構 '{1}' 的 MSBuild 版本 '{0}'。切換回版本 '{2}'。"
+}

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsConfigurationProperty.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsConfigurationProperty.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+Register-Mock Get-VstsTaskVariable { '' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+$actual = Format-MSBuildArguments -MSBuildArguments 'Some arguments' -Configuration 'Some configuration'
+
+# Assert.
+Assert-AreEqual "Some arguments /p:configuration=`"Some configuration`"" $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsMaximumCpuCount.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsMaximumCpuCount.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+Register-Mock Get-VstsTaskVariable { '' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+$actual = Format-MSBuildArguments -MSBuildArguments 'Some arguments' -MaximumCpuCount
+
+# Assert.
+Assert-AreEqual "Some arguments /m" $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsMsDeployUserAgentProperty.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsMsDeployUserAgentProperty.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+Register-Mock Get-VstsTaskVariable { 'TFS_Build' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+$actual = Format-MSBuildArguments -MSBuildArguments 'Some arguments'
+
+# Assert.
+Assert-AreEqual "Some arguments /p:_MSDeployUserAgent=`"TFS_Build`"" $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsPlatformProperty.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsPlatformProperty.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+Register-Mock Get-VstsTaskVariable { '' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+$actual = Format-MSBuildArguments -MSBuildArguments 'Some arguments' -Platform 'Some platform'
+
+# Assert.
+Assert-AreEqual "Some arguments /p:platform=`"Some platform`"" $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsVSVersionProperty.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.AddsVSVersionProperty.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+Register-Mock Get-VstsTaskVariable { '' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+$actual = Format-MSBuildArguments -MSBuildArguments 'Some arguments' -VSVersion 'Some version'
+
+# Assert.
+Assert-AreEqual "Some arguments /p:VisualStudioVersion=`"Some version`"" $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.RejectsInvalidCharacters.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Format-MSBuildArguments.RejectsInvalidCharacters.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+$acceptPlatformCases = 'x86', 'x64', 'Any CPU', 'NewPlatform'
+
+Register-Mock Get-VstsTaskVariable { '' } -- -Name AZURE_HTTP_USER_AGENT
+
+# Act.
+foreach ($acceptPlatformCase in $acceptPlatformCases)
+{
+    $accepted = $false
+    try {
+        $result = Format-MSBuildArguments -Platform $acceptPlatformCase
+        $accepted = $true
+    }
+    catch {
+        Write-Host 'Unexpected Exception:'
+        Write-Host $_
+    }
+
+    #Assert.
+    Assert-AreEqual $true $accepted "Expected the following Platform to be accepted: $acceptPlatformCase"
+}
+
+# Arrange.
+$acceptConfigurationCases = 'Release', 'Debug', 'DEBUG', 'Any Other Text Not Containing Forbidden Punctuation'
+
+# Act.
+foreach ($acceptConfigurationCase in $acceptConfigurationCases)
+{
+    $accepted = $false
+    try {
+        $result = Format-MSBuildArguments -Configuration $acceptConfigurationCase
+        $accepted = $true
+    }
+    catch {
+        Write-Host 'Unexpected Exception:'
+        Write-Host $_
+    }
+
+    # Assert.
+    Assert-AreEqual $true $accepted "Expected the following Configuration to be accepted: $acceptConfigurationCase"
+}
+
+# Arrange.
+$rejectCases = 'Release; /Logger:"\\networkshare\\NotActuallyALogger.dll', 'Angle<Braces', 'secarB>elgnA', 'ASTER*SKS', 'AMPER&AND', 'PER%ENT', '"double quotes"', '#HASHTAGS', 'question marks?'
+
+# Act.
+foreach ($rejectCase in $rejectCases)
+{
+    $accepted = $false
+    try {
+        $result = Format-MSBuildArguments -Platform $rejectCase
+        $accepted = $true
+    }
+    catch {
+        
+    }
+
+    # Assert.
+    Assert-AreEqual $false $accepted "Expected the following Platform to be rejected: $rejectCase"
+}
+
+# Act.
+foreach ($rejectCase in $rejectCases)
+{
+    $accepted = $false
+    try {
+        $result = Format-MSBuildArguments -Configuration $rejectCase
+        $accepted = $true
+    }
+    catch {
+        
+    }
+
+    # Assert.
+    Assert-AreEqual $false $accepted "Expected the following Configuration to be rejected: $rejectCase"
+}

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ResolvesWildcards.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ResolvesWildcards.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$expected = 'Some solution 1', 'Some solution 2'
+$solutions = 'Some * solution', 'Some ? solution'
+foreach ($solution in $solutions) {
+    Register-Mock Find-VstsFiles { $expected } -- -LegacyPattern $solution
+
+    # Act.
+    $actual = Get-SolutionFiles -Solution $solution
+
+    # Assert.
+    Assert-AreEqual $expected $actual
+}

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ReturnsNonWildcardSolution.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ReturnsNonWildcardSolution.ps1
@@ -1,0 +1,13 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Register-Mock Find-VstsFiles { $expected } -- -LegacyPattern $solution
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+# Act.
+$actual = Get-SolutionFiles -Solution 'Some solution'
+
+# Assert.
+Assert-AreEqual 'Some solution' $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ThrowsIfNoSolution.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ThrowsIfNoSolution.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Register-Mock Find-VstsFiles { $expected } -- -LegacyPattern $solution
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+# Act/Assert.
+Assert-Throws { Get-SolutionFiles -Solution '' } -MessagePattern *Cannot*bind*Solution*

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ThrowsIfNoSolutionFound.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-SolutionFiles.ThrowsIfNoSolutionFound.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Register-Mock Find-VstsFiles { } -- -LegacyPattern 'Some * solution'
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+# Act/Assert.
+Assert-Throws { Get-SolutionFiles -Solution 'Some * solution' } -MessagePattern *solution*not*found*using*search*pattern*

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.CachesNotFoundResult.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.CachesNotFoundResult.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$script:vsCount = 0
+$script:buildToolsCount = 0
+Register-Mock Invoke-VstsTool {
+        $script:vsCount++
+        "["
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -latest -format json" -RequireExitCodeZero
+Register-Mock Invoke-VstsTool {
+        $script:buildToolsCount++
+        "["
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 15
+$actual = Get-VisualStudio 15
+
+# Assert.
+Assert-AreEqual -Expected $null -Actual $actual
+Assert-AreEqual -Expected 1 -Actual $script:vsCount
+Assert-AreEqual -Expected 1 -Actual $script:buildToolsCount

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.CachesResult.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.CachesResult.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Invoke-VstsTool {
+        "["
+        "  {"
+        "    `"installationPath`": `"path1`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 15
+$actual = Get-VisualStudio 15
+
+# Assert.
+Assert-AreEqual -Expected "path1" -Actual $actual.installationPath
+Assert-WasCalled Invoke-VstsTool -Times 1

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.FallsBackToBuildTools.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.FallsBackToBuildTools.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$script:vsCount = 0
+$script:buildToolsCount = 0
+Register-Mock Invoke-VstsTool {
+        $script:vsCount++
+        "[]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -latest -format json" -RequireExitCodeZero
+Register-Mock Invoke-VstsTool {
+        $script:buildToolsCount++
+        "["
+        "  {"
+        "    `"installationPath`": `"build tools path`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 15
+$actual = Get-VisualStudio 15
+
+# Assert.
+Assert-AreEqual -Expected "build tools path" -Actual $actual.installationPath
+Assert-AreEqual -Expected 1 -Actual $script:vsCount
+Assert-AreEqual -Expected 1 -Actual $script:buildToolsCount

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.IgnoresStderr.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_15_0.IgnoresStderr.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Invoke-VstsTool {
+        Write-Error "Some simulated STDERR content" -ErrorAction Continue 2>&1
+        "["
+        "  {"
+        "    `"installationPath`": `"some path`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [15.0,16.0) -latest -format json" -RequireExitCodeZero
+
+# Act.
+$actual = Get-VisualStudio 15
+
+# Assert.
+Assert-AreEqual -Expected "some path" -Actual $actual.installationPath

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.CachesNotFoundResult.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.CachesNotFoundResult.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$script:vsCount = 0
+$script:buildToolsCount = 0
+Register-Mock Invoke-VstsTool {
+        $script:vsCount++
+        "["
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -latest -format json" -RequireExitCodeZero
+Register-Mock Invoke-VstsTool {
+        $script:buildToolsCount++
+        "["
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 16
+$actual = Get-VisualStudio 16
+
+# Assert.
+Assert-AreEqual -Expected $null -Actual $actual
+Assert-AreEqual -Expected 1 -Actual $script:vsCount
+Assert-AreEqual -Expected 1 -Actual $script:buildToolsCount

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.CachesResult.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.CachesResult.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Invoke-VstsTool {
+        "["
+        "  {"
+        "    `"installationPath`": `"path1`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 16
+$actual = Get-VisualStudio 16
+
+# Assert.
+Assert-AreEqual -Expected "path1" -Actual $actual.installationPath
+Assert-WasCalled Invoke-VstsTool -Times 1

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.FallsBackToBuildTools.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.FallsBackToBuildTools.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$script:vsCount = 0
+$script:buildToolsCount = 0
+Register-Mock Invoke-VstsTool {
+        $script:vsCount++
+        "[]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -latest -format json" -RequireExitCodeZero
+Register-Mock Invoke-VstsTool {
+        $script:buildToolsCount++
+        "["
+        "  {"
+        "    `"installationPath`": `"build tools path`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero
+
+# Act.
+$null = Get-VisualStudio 16
+$actual = Get-VisualStudio 16
+
+# Assert.
+Assert-AreEqual -Expected "build tools path" -Actual $actual.installationPath
+Assert-AreEqual -Expected 1 -Actual $script:vsCount
+Assert-AreEqual -Expected 1 -Actual $script:buildToolsCount

--- a/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.IgnoresStderr.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Get-VisualStudio_16_0.IgnoresStderr.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Invoke-VstsTool {
+        Write-Error "Some simulated STDERR content" -ErrorAction Continue 2>&1
+        "["
+        "  {"
+        "    `"installationPath`": `"some path`""
+        "  }"
+        "]"
+    } -- -FileName (Resolve-Path $PSScriptRoot\..\vswhere\vswhere.exe).Path -Arguments "-version [16.0,17.0) -latest -format json" -RequireExitCodeZero
+
+# Act.
+$actual = Get-VisualStudio 16
+
+# Assert.
+Assert-AreEqual -Expected "some path" -Actual $actual.installationPath

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.InvokesAllToolsForAllFiles.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.InvokesAllToolsForAllFiles.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$directory1 = 'Some drive:\Some directory 1'
+$directory2 = 'Some drive:\Some directory 2'
+$file1 = "$directory1\Some solution 1"
+$file2 = "$directory2\Some solution 2"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+Register-Mock Invoke-NuGetRestore { 'NuGet output 1' } -- -File $file1
+Register-Mock Invoke-NuGetRestore { 'NuGet output 2' } -- -File $file2
+Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1-clean.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file1, $file2 -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean -NoTimelineLogger -CreateLogFile
+
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output 1'
+        'MSBuild clean output 1'
+        'MSBuild output 1'
+        'NuGet output 2'
+        'MSBuild clean output 2'
+        'MSBuild output 2'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCleanIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCleanIfSpecified.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$file = "$directory1\Some solution"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"	
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -NoTimelineLogger -CreateLogFile
+
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output'
+        'MSBuild output'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCreateLogFileIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCreateLogFileIfSpecified.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$file = "$directory1\Some solution"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output no log' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true
+Register-Mock Invoke-MSBuild { 'MSBuild output no log' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation  -MSBuildArguments $msBuildArguments  -Clean -NoTimelineLogger
+
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output'
+        'MSBuild clean output no log'
+        'MSBuild output no log'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsRestoreIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsRestoreIfSpecified.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$file = "$directory1\Some solution"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+Register-Mock Invoke-NuGetRestore
+Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output wrong logfile' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+
+# Act.
+$actual = Invoke-BuildTools -SolutionFiles $file -MSBuildLocation 'Some MSBuild location' -MSBuildArguments 'Some MSBuild arguments' -Clean -NoTimelineLogger -CreateLogFile
+
+# Assert.
+Assert-AreEqual -Expected @(
+        'MSBuild clean output'
+        'MSBuild output'
+    ) -Actual $actual
+
+Assert-WasCalled Invoke-NuGetRestore -Times 0

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1
@@ -1,0 +1,31 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$directory1 = 'Some drive:\Some directory 1'
+$directory2 = 'Some drive:\Some directory 2'
+$file1 = "$directory1\Some solution 1"
+$file2 = "$directory2\Some solution 2"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild with /t:arguments'
+Register-Mock Invoke-NuGetRestore { 'NuGet output 1' } -- -File $file1
+Register-Mock Invoke-NuGetRestore { 'NuGet output 2' } -- -File $file2
+Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1-clean.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file1, $file2 -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean -NoTimelineLogger -CreateLogFile
+
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output 1'
+        'MSBuild clean output 1'
+        'NuGet output 2'
+        'MSBuild clean output 2'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\.. -PassThru
+$env:msBuildDir = 'C:\Some msbuild dir'
+$msBuildPath = "%msBuildDir%"
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+$expectedLoggerPath = ([System.IO.Path]::GetFullPath("$PSScriptRoot\..\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"))
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { $global:LASTEXITCODE = 0 ; 'Some output 1', 'Some output 2' }
+Register-Mock Write-VstsSetResult
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile 'Some project file' -NoTimelineLogger -MSBuildPath $msBuildPath
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -Times 0
+Assert-AreEqual -Expected @(
+        'Some output 1'
+        'Some output 2'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\.. -PassThru
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+$expectedLoggerPath = ([System.IO.Path]::GetFullPath("$PSScriptRoot\..\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"))
+Register-Mock Get-MSBuildPath { $expectedMSBuildPath }
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { $global:LASTEXITCODE = 1 ; 'Some output 1' ; 'Some output 2' }
+Register-Mock Write-VstsSetResult
+Register-Mock Write-VstsLogDetail
+$expectedProjectFile = 'C:\Some solution dir\Some solution file.sln'
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
+Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
+        $script:rootDetailId = $Id
+        return $Id -is [guid] -and
+            $Id -ne [guid]::Empty -and
+            $Type -eq 'Process' -and
+            $Name -eq "MSB_Build0 Some solution file.sln" -and
+            $Progress -eq 0 -and
+            $StartTime -like '????-??-??T??:??:??.*Z' -and
+            $State -eq 'Initialized' -and
+            $AsOutput -eq $true
+    }
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -- -Result Failed -DoNotThrow
+Assert-AreEqual -Expected @(
+        'Some output 1'
+        'Some output 2'
+    ) -Actual $actual
+Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
+        return $Id -eq $script:rootDetailId -and
+            $FinishTime -like '????-??-??T??:??:??.*Z' -and
+            $Progress -eq 100 -and
+            $State -eq 'Completed' -and
+            $Result -eq 'Failed' -and
+            $AsOutput -eq $true
+    }

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
@@ -1,0 +1,29 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\.. -PassThru
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+$expectedLoggerPath = ([System.IO.Path]::GetFullPath("$PSScriptRoot\..\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"))
+Register-Mock Get-MSBuildPath { $expectedMSBuildPath }
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { $global:LASTEXITCODE = 0 ; 'Some output 1' ; 'Some output 2' }
+Register-Mock Write-VstsSetResult
+Register-Mock Write-VstsLogDetail
+$expectedProjectFile = 'C:\Some solution dir\Some solution file.sln'
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimelineLogger
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -Times 0
+Assert-AreEqual -Expected @(
+        'Some output 1'
+        'Some output 2'
+    ) -Actual $actual
+Assert-WasCalled Write-VstsLogDetail -Times 0

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\.. -PassThru
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+$expectedLoggerPath = ([System.IO.Path]::GetFullPath("$PSScriptRoot\..\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"))
+Register-Mock Get-MSBuildPath { $expectedMSBuildPath }
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { $global:LASTEXITCODE = 0 ; 'Some output 1' ; 'Some output 2' }
+Register-Mock Write-VstsSetResult
+Register-Mock Write-VstsLogDetail
+Register-Mock Write-Host
+$expectedProjectFile = 'C:\Some solution dir\Some solution file.sln'
+$expectedLogFile = "$expectedProjectFile.log"
+$expectedLogFileVerbosity = 'diagnostic'
+Register-Mock Test-Path { $false } -- -Path $expectedLogFile
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimelineLogger -LogFile $expectedLogFile -LogFileVerbosity $expectedLogFileVerbosity
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /fl /flp:`"logfile=$expectedLogFile;verbosity=$expectedLogFileVerbosity`" /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -Times 0
+Assert-WasCalled Write-Host -Times 0
+Assert-AreEqual -Expected @(
+        'Some output 1'
+        'Some output 2'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+$module = Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\.. -PassThru
+$expectedMSBuildPath = "C:\Some msbuild dir\msbuild.exe"
+$expectedLoggerPath = ([System.IO.Path]::GetFullPath("$PSScriptRoot\..\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"))
+Register-Mock Get-MSBuildPath { $expectedMSBuildPath }
+Register-Mock Assert-VstsPath
+Register-Mock Get-VstsTaskVariable { "C:\Some agent home directory" } -- -Name Agent.HomeDirectory -Require
+Register-Mock Invoke-VstsTool { $global:LASTEXITCODE = 0 ; 'Some output 1' ; 'Some output 2' }
+Register-Mock Write-VstsSetResult
+Register-Mock Write-VstsLogDetail
+$expectedProjectFile = 'C:\Some solution dir\Some solution file.sln'
+
+# Act.
+$actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile
+
+# Assert.
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
+Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
+Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
+        $script:rootDetailId = $Id
+        return $Id -is [guid] -and
+            $Id -ne [guid]::Empty -and
+            $Type -eq 'Process' -and
+            $Name -eq "MSB_Build0 Some solution file.sln" -and
+            $Progress -eq 0 -and
+            $StartTime -like '????-??-??T??:??:??.*Z' -and
+            $State -eq 'Initialized' -and
+            $AsOutput -eq $true
+    }
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Write-VstsSetResult -Times 0
+Assert-AreEqual -Expected @(
+        'Some output 1'
+        'Some output 2'
+    ) -Actual $actual
+Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
+        return $Id -eq $script:rootDetailId -and
+            $FinishTime -like '????-??-??T??:??:??.*Z' -and
+            $Progress -eq 100 -and
+            $State -eq 'Completed' -and
+            $Result -eq 'Succeeded' -and
+            $AsOutput -eq $true
+    }

--- a/common-npm-packages/MSBuildHelpers/Tests/L0.ts
+++ b/common-npm-packages/MSBuildHelpers/Tests/L0.ts
@@ -1,0 +1,144 @@
+import Q = require('q');
+import assert = require('assert');
+import path = require('path');
+var psm = require('../../../Tests/lib/psRunner');
+var psr = null;
+
+describe('Common-MSBuildHelpers Suite', function () {
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+    before((done) => {
+        if (psm.testSupported()) {
+            psr = new psm.PSRunner();
+            psr.start();
+        }
+
+        done();
+    });
+
+    after(function () {
+        if (psr) {
+            psr.kill();
+        }
+    });
+
+    if (psm.testSupported()) {
+        it('(Format-MSBuildArguments) adds configuration property', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.AddsConfigurationProperty.ps1'), done);
+        })
+        it('(Format-MSBuildArguments) adds maximum CPU count', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.AddsMaximumCpuCount.ps1'), done);
+        })
+        it('(Format-MSBuildArguments) adds MS deploy user agent property', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.AddsMSDeployUserAgentProperty.ps1'), done);
+        })
+        it('(Format-MSBuildArguments) adds platform property', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.AddsPlatformProperty.ps1'), done);
+        })
+        it('(Format-MSBuildArguments) adds VS version property', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.AddsVSVersionProperty.ps1'), done);
+        })
+        it('(Format-MSBuildArguments) rejects invalid characters', (done) => {
+            psr.run(path.join(__dirname, 'Format-MSBuildArguments.RejectsInvalidCharacters.ps1'), done);
+        })
+        it('(Get-SolutionFiles) resolves wildcards', (done) => {
+            psr.run(path.join(__dirname, 'Get-SolutionFiles.ResolvesWildcards.ps1'), done);
+        })
+        it('(Get-SolutionFiles) returns non wildcard solution', (done) => {
+            psr.run(path.join(__dirname, 'Get-SolutionFiles.ReturnsNonWildcardSolution.ps1'), done);
+        })
+        it('(Get-SolutionFiles) throws if no solution', (done) => {
+            psr.run(path.join(__dirname, 'Get-SolutionFiles.ThrowsIfNoSolution.ps1'), done);
+        })
+        it('(Get-SolutionFiles) throws if no solution found', (done) => {
+            psr.run(path.join(__dirname, 'Get-SolutionFiles.ThrowsIfNoSolutionFound.ps1'), done);
+        })
+        it('(Get-VisualStudio 15 caches not found result', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_15_0.CachesNotFoundResult.ps1'), done);
+        })
+        it('(Get-VisualStudio 15) caches result', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_15_0.CachesResult.ps1'), done);
+        })
+        it('(Get-VisualStudio 15) falls back to build tools', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_15_0.FallsBackToBuildTools.ps1'), done);
+        })
+        it('(Get-VisualStudio 15) ignores STDERR', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_15_0.IgnoresStderr.ps1'), done);
+        })
+        it('(Get-VisualStudio 16) caches not found result', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_16_0.CachesNotFoundResult.ps1'), done);
+        })
+        it('(Get-VisualStudio 16) caches result', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_16_0.CachesResult.ps1'), done);
+        })
+        it('(Get-VisualStudio 16) falls back to build tools', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_16_0.FallsBackToBuildTools.ps1'), done);
+        })
+        it('(Get-VisualStudio 16) ignores STDERR', (done) => {
+            psr.run(path.join(__dirname, 'Get-VisualStudio_16_0.IgnoresStderr.ps1'), done);
+        })        
+        it('(Invoke-BuildTools) invokes all tools for all files', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.InvokesAllToolsForAllFiles.ps1'), done);
+        })
+        it('(Invoke-BuildTools) skips clean if specified', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.SkipsCleanIfSpecified.ps1'), done);
+        })
+        it('(Invoke-BuildTools) skips create log file if specified', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.SkipsCreateLogFileIfSpecified.ps1'), done);
+        })
+        it('(Invoke-BuildTools) skips restore if specified', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.SkipsRestoreIfSpecified.ps1'), done);
+        })
+        it('(Invoke-BuildTools) skips second build if clean plus targets provided', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1'), done);
+        })
+        it('(Invoke-MSBuild) combines msbuildexe', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-MSBuild.CombinesMsbuildexe.ps1'), done);
+        })
+        it('(Invoke-MSBuild) fails root timeline detail on exit code', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1'), done);
+        })
+        it('(Invoke-MSBuild) omits timeline detail', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-MSBuild.OmitsTimelineDetail.ps1'), done);
+        })
+        it('(Invoke-MSBuild) skips log file upload if missing', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-MSBuild.SkipsLogUploadIfMissing.ps1'), done);
+        })
+        it('(Invoke-MSBuild) writes root timeline detail', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-MSBuild.WritesRootTimelineDetail.ps1'), done);
+        })
+        it('(Select-MSBuildPath) defaults method to location if location specified', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.DefaultsMethodToLocationIfLocationSpecified.ps1'), done);
+        })
+        it('(Select-MSBuildPath) defaults method to version if no location', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.DefaultsMethodToVersionIfNoLocation.ps1'), done);
+        })
+        it('(Select-MSBuildPath) errors if version not found', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.ErrorsIfVersionNotFound.ps1'), done);
+        })
+        it('(Select-MSBuildPath) falls back from 14', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.FallsBackFrom14.ps1'), done);
+        })
+        it('(Select-MSBuildPath) falls back from 15', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.FallsBackFrom15.ps1'), done);
+        })
+        it('(Select-MSBuildPath) falls back to version if no location specified', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.FallsBackToVersionIfNoLocationSpecified.ps1'), done);
+        })
+        it('(Select-MSBuildPath) falls forward from 12', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.FallsForwardFrom12.ps1'), done);
+        })
+        it('(Select-MSBuildPath) falls forward from 14', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.FallsForwardFrom14.ps1'), done);
+        })
+        it('(Select-MSBuildPath) returns latest version', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.ReturnsLatestVersion.ps1'), done);
+        })
+        it('(Select-MSBuildPath) returns specified location', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.ReturnsSpecifiedLocation.ps1'), done);
+        })
+        it('(Select-MSBuildPath) returns specified version', (done) => {
+            psr.run(path.join(__dirname, 'Select-MSBuildPath.ReturnsSpecifiedVersion.ps1'), done);
+        })
+    }
+});

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.DefaultsMethodToLocationIfLocationSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.DefaultsMethodToLocationIfLocationSpecified.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$method = ''
+$location = 'some location'
+$version = 'some version'
+$architecture = 'some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method $method -Location $location -PreferredVersion $version -Architecture $architecture
+
+# Assert.
+Assert-AreEqual -Expected $location -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.DefaultsMethodToVersionIfNoLocation.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.DefaultsMethodToVersionIfNoLocation.ps1
@@ -1,0 +1,13 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '15.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method '' -Location '' -PreferredVersion '' -Architecture 'Some architecture'
+
+# Assert.
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Get-MSBuildPath
+
+# Act/Assert.
+Assert-Throws { Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '' -Architecture 'Some architecture' }
+Assert-WasCalled Get-MSBuildPath -- -Version '16.0' -Architecture 'Some architecture'
+Assert-WasCalled Get-MSBuildPath -- -Version '15.0' -Architecture 'Some architecture'
+Assert-WasCalled Get-MSBuildPath -- -Version '14.0' -Architecture 'Some architecture'
+Assert-WasCalled Get-MSBuildPath -- -Version '12.0' -Architecture 'Some architecture'
+Assert-WasCalled Get-MSBuildPath -- -Version '4.0' -Architecture 'Some architecture'
+Assert-WasCalled Get-MSBuildPath -Times 5

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '12.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '14.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '14.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '15.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 3
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom16.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom16.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '15.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '16.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 2
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackToVersionIfNoLocationSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackToVersionIfNoLocationSpecified.ps1
@@ -1,0 +1,13 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '15.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Location' -Location '' -PreferredVersion '' -Architecture 'Some architecture'
+
+# Assert.
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '14.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '12.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '15.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '14.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 3
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom15.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom15.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Write-Warning
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '16.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '15.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-WasCalled Write-Warning
+Assert-WasCalled Get-MSBuildPath -Times 2
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsLatestVersion.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsLatestVersion.ps1
@@ -1,0 +1,17 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+foreach ($version in @('', 'latest')) {
+    Unregister-Mock Get-MSBuildPath
+    Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '16.0' -Architecture 'Some architecture'
+
+    # Act.
+    $actual = Select-MSBuildPath -Method 'Version' -Location 'Some input location' -PreferredVersion $version -Architecture 'Some architecture'
+
+    # Assert.
+    Assert-AreEqual -Expected 'Some resolved location' -Actual $actual
+    Assert-WasCalled Get-MSBuildPath -Times 1
+}

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsSpecifiedLocation.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsSpecifiedLocation.ps1
@@ -1,0 +1,12 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Location' -Location 'Some location' -PreferredVersion 'Some version' -Architecture 'Some architecture'
+
+# Assert.
+Assert-AreEqual -Expected 'Some location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsSpecifiedVersion.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsSpecifiedVersion.ps1
@@ -1,0 +1,13 @@
+[cmdletbinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+Register-Mock Get-MSBuildPath { 'Some resolved location' } -- -Version '14.0' -Architecture 'Some architecture'
+
+# Act.
+$actual = Select-MSBuildPath -Method 'Version' -Location 'Some input location' -PreferredVersion '14.0' -Architecture 'Some architecture'
+
+# Assert.
+Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/make.js
+++ b/common-npm-packages/MSBuildHelpers/make.js
@@ -1,0 +1,18 @@
+var path = require('path');
+var util = require('../build-scripts/util');
+
+var buildPath = './_build'
+
+util.rm('-rf', buildPath)
+util.run(path.join(__dirname, 'node_modules/.bin/tsc') + ' --outDir ' + buildPath);
+
+util.cp(path.join(__dirname, 'package.json'), buildPath);
+util.cp(path.join(__dirname, 'package-lock.json'), buildPath);
+util.cp(path.join(__dirname, 'module.json'), buildPath);
+util.cp(path.join(__dirname, '*.ps*'), buildPath);
+
+util.cp('-r', 'Strings', buildPath);
+util.cp('-r', 'Tests', buildPath);
+util.cp('-r', 'node_modules', buildPath);
+util.cp('-r', 'vswhere', buildPath);
+util.cp('-r', 'msbuildlogger', buildPath);

--- a/common-npm-packages/MSBuildHelpers/make.json
+++ b/common-npm-packages/MSBuildHelpers/make.json
@@ -1,0 +1,14 @@
+{
+    "externals": {
+        "archivePackages": [
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/3/msbuildlogger.zip",
+                "dest": "./"
+            },
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip",
+                "dest": "./"
+            }
+        ]
+    }
+}

--- a/common-npm-packages/MSBuildHelpers/module.json
+++ b/common-npm-packages/MSBuildHelpers/module.json
@@ -1,0 +1,13 @@
+{
+    "messages": {
+        "MSB_Build0" : "Build {0}",
+        "MSB_BuildToolNotFound": "MSBuild or xbuild(Mono) were not found on the Mac/Linux agent.",
+        "MSB_DetectedNuGetExtensionsLoaderPath0": "Detected NuGet extensions loader path. Environment variable NUGET_EXTENSIONS_PATH is set to '{0}'.",
+        "MSB_MSBuild15NotFoundionArchitecture0": "MSBuild version '15.0' was not found for architecture '{0}'. Verify the architecture input value is correct and verify Visual Studio 2017 is installed. MSBuild version '15.0' is included when Visual Studio 2017 is installed.",
+        "MSB_MSBuildNotFound": "MSBuild was not found. Try specifying the location to msbuild.exe or install Visual Studio. MSBuild is included when Visual Studio is installed.",
+        "MSB_MSBuildNotFoundVersion0Architecture1": "MSBuild was not found for version '{0}' and architecture '{1}'. Try a different version/architecture combination, specify a location, or install the appropriate version of Visual Studio. MSBuild is included when Visual Studio is installed.",
+        "MSB_RestoreNuGetPackagesDeprecated": "The 'Restore NuGet Packages' option is deprecated. To restore NuGet packages in your build, add a NuGet Tool Installer task to your build definition.",
+        "MSB_SolutionNotFoundUsingSearchPattern0": "Solution not found using search pattern '{0}'.",
+        "MSB_UnableToFindMSBuildVersion0Architecture1FallbackVersion2": "Unable to find MSBuild version '{0}' for architecture '{1}'. Falling back to version '{2}'."
+    }
+}

--- a/common-npm-packages/MSBuildHelpers/msbuildhelpers.ts
+++ b/common-npm-packages/MSBuildHelpers/msbuildhelpers.ts
@@ -1,0 +1,49 @@
+import tl = require('azure-pipelines-task-lib/task');
+
+/**
+ * Finds the tool path for msbuild/xbuild based on specified msbuild version on Mac or Linux agent
+ * @param version 
+ */
+export async function getMSBuildPath(version) {
+    let toolPath: string;
+
+    if (version === '15.0' || version === 'latest') {
+        let msbuildPath: string = tl.which('msbuild', false);
+        if (msbuildPath) {
+            // msbuild found on the agent, check version
+            let msbuildVersion: number;
+
+            let msbuildVersionCheckTool = tl.tool(msbuildPath);
+            msbuildVersionCheckTool.arg(['/version', '/nologo']);
+            msbuildVersionCheckTool.on('stdout', function (data) {
+                if (data) {
+                    let intData = parseInt(data.toString().trim());
+                    if (intData && !isNaN(intData)) {
+                        msbuildVersion = intData;
+                    }
+                }
+            })
+            await msbuildVersionCheckTool.exec();
+
+            if (msbuildVersion) {
+                // found msbuild version on the agent, check if it matches requirements
+                if (msbuildVersion >= 15) {
+                    toolPath = msbuildPath;
+                }
+            }
+        }
+    }
+
+    if (!toolPath) {
+        // either user selected old version of msbuild or we didn't find matching msbuild version on the agent
+        // fallback to xbuild
+        toolPath = tl.which('xbuild', false);
+
+        if (!toolPath) {
+            // failed to find a version of msbuild / xbuild on the agent
+            throw tl.loc('MSB_BuildToolNotFound');
+        }
+    }
+
+    return toolPath;
+}

--- a/common-npm-packages/MSBuildHelpers/package-lock.json
+++ b/common-npm-packages/MSBuildHelpers/package-lock.json
@@ -1,0 +1,418 @@
+{
+  "name": "azure-pipelines-tasks-msbuildhelpers",
+  "version": "2.0.0-preview.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+    },
+    "@types/node": {
+      "version": "10.17.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
+      "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
+    },
+    "@types/qs": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "azure-pipelines-task-lib": {
+      "version": "3.0.6-preview.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.0.tgz",
+      "integrity": "sha512-Fx+7p5GzvYqVXOQI+LhPk56Pio9yBeEyypKZoPI9cQyti8WTVkmJ7YZwn9HRXurftcLumi2Xq+TC3PwnDq5U5Q==",
+      "requires": {
+        "minimatch": "3.0.4",
+        "mockery": "^1.7.0",
+        "q": "^1.5.1",
+        "semver": "^5.1.0",
+        "shelljs": "^0.8.4",
+        "sync-request": "6.1.0",
+        "uuid": "^3.0.1"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "requires": {
+        "asap": "~2.0.6"
+      }
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+      "requires": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      }
+    },
+    "sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+      "requires": {
+        "get-port": "^3.1.0"
+      }
+    },
+    "then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+      "requires": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+        }
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha1-fqfIh3fHI8aB4zv3mIvl0AjQWsI=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/common-npm-packages/MSBuildHelpers/package.json
+++ b/common-npm-packages/MSBuildHelpers/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "azure-pipelines-tasks-msbuildhelpers",
+  "version": "2.0.0-preview.0",
+  "description": "Azure Pipelines tasks MSBuild helpers",
+  "main": "msbuildhelpers.js",
+  "scripts": {
+    "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip ./vswhere && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/3/msbuildlogger.zip ./msbuildlogger &&  node make.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/Microsoft/azure-pipelines-tasks.git"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Microsoft/azure-pipelines-tasks/issues"
+  },
+  "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
+  "dependencies": {
+    "azure-pipelines-task-lib": "^3.0.6-preview.0",
+    "@types/node": "^10.17.0",
+    "@types/mocha": "^5.2.7"
+  },
+  "devDependencies": {
+    "typescript": "4.0.2"
+  }
+}

--- a/common-npm-packages/MSBuildHelpers/tsconfig.json
+++ b/common-npm-packages/MSBuildHelpers/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "target": "ES6",
+        "module": "commonjs",
+        "declaration": true,
+        "noImplicitAny": false,
+        "sourceMap": false
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}


### PR DESCRIPTION
**Task name**: MSBuildHelpers

**Description**: Prepared MSBuildHelpers preview version for publishing to NPM. This is required for Node 10 migration.

This PR is based on [#13962](https://github.com/microsoft/azure-pipelines-tasks/pull/13962)
_Changes applied:_

- Updated packages for Node 10 migration.
- Updated task version to `2.0.0-preview.0`


**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
