### PR TITLE
Bumped version of azure-devops-node-api in preview version of azure-pipelines-tasks-securefiles-common package

### DIFF
--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.3-preview",
+  "version": "2.0.4-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "@types/node": {
-      "version": "10.17.44",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
-      "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
+      "version": "10.17.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.47.tgz",
+      "integrity": "sha512-YZ1mMAdUPouBZCdeugjV8y1tqqr28OyL8DYbH5ePCfe9zcXtvbh1wDBy7uzlHkXo3Qi07kpzXfvycvrkby/jXw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -46,13 +46,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -213,9 +212,9 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "is-core-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.0.0.tgz",
-      "integrity": "sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -258,11 +257,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
     },
     "parse-cache-control": {
       "version": "1.0.1",
@@ -325,11 +319,11 @@
       }
     },
     "resolve": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-      "integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "requires": {
-        "is-core-module": "^2.0.0",
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -405,16 +399,17 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
     },
@@ -424,9 +419,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "underscore": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-<<<<<<< HEAD
   "version": "2.0.4-preview",
-=======
-  "version": "2.0.3-preview",
->>>>>>> 2e71c120c... Added sockettimeout argument (#13799)
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
+<<<<<<< HEAD
   "version": "2.0.4-preview",
+=======
+  "version": "2.0.3-preview",
+>>>>>>> 2e71c120c... Added sockettimeout argument (#13799)
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.3-preview",
+  "version": "2.0.4-preview",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/q": "^1.5.4",
-    "azure-devops-node-api": "7.2.0",
+    "azure-devops-node-api": "10.1.2",
     "azure-pipelines-task-lib": "^3.0.6-preview.0"
   },
   "devDependencies": {

--- a/common-npm-packages/securefiles-common/securefiles-common.ts
+++ b/common-npm-packages/securefiles-common/securefiles-common.ts
@@ -7,17 +7,19 @@ import { IRequestOptions } from "azure-devops-node-api/interfaces/common/VsoBase
 export class SecureFileHelpers {
     serverConnection: WebApi;
 
-    constructor(retryCount?: number) {
+    constructor(retryCount?: number, socketTimeout?: number) {
         const serverUrl: string = tl.getVariable('System.TeamFoundationCollectionUri');
         const serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         const authHandler = getPersonalAccessTokenHandler(serverCreds);
 
         const maxRetries = retryCount && retryCount >= 0 ? retryCount : 5; // Default to 5 if not specified
         tl.debug('Secure file retry count set to: ' + maxRetries);
+
         const proxy = tl.getHttpProxyConfiguration();
         let options: IRequestOptions = {
             allowRetries: true,
-            maxRetries
+            maxRetries,
+            socketTimeout
         };
 
         if (proxy) {


### PR DESCRIPTION
**Task name**: azure-pipelines-tasks-securefiles-common

**Description**: Bumps to the latest version of azure-devops-node-api package as [here](https://github.com/microsoft/azure-pipelines-tasks/pull/13988), as one of the affected tasks is already migrated on node10,  we need to bump preview version of the package as well to fix the bug with ETIMEDOUT. 
This PR also adding missed property for setting socketTimeout in SecureFileHelpers constructor.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) [#1795923](https://github.com/microsoft/build-task-team/issues/473), [#1796623](https://github.com/microsoft/build-task-team/issues/480), [#1796303](https://github.com/microsoft/build-task-team/issues/477), [#1796304](https://github.com/microsoft/build-task-team/issues/478)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
