### PR TITLE
Fix for unzipping archives with lot of files (#13958)

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -93,9 +93,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary": {
       "version": "0.3.0",
@@ -125,12 +125,12 @@
       }
     },
     "buffer": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
@@ -300,9 +300,9 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 178,
-        "Patch": 1
+        "Minor": 179,
+        "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 178,
-    "Patch": 1
+    "Minor": 179,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/Common/webdeployment-common-v2/make.json
+++ b/Tasks/Common/webdeployment-common-v2/make.json
@@ -11,6 +11,10 @@
                 "archiveName": "MSDeploy.zip",
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/MSDeploy/3.6/M142/MSDeploy.zip",
                 "dest": "./"
+            },
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+                "dest": "./"
             }
         ]
     }

--- a/Tasks/Common/webdeployment-common-v2/npm-shrinkwrap.json
+++ b/Tasks/Common/webdeployment-common-v2/npm-shrinkwrap.json
@@ -9,14 +9,14 @@
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.2.0.tgz",
       "integrity": "sha1-+1xq9UQ7P6akJjRHU7rSp7REqt0=",
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
-        "readable-stream": "2.3.4",
-        "tar-stream": "1.5.5",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.1.0"
       },
       "dependencies": {
         "archiver-utils": {
@@ -24,12 +24,12 @@
           "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lazystream": "1.0.0",
-            "lodash": "4.17.5",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.4"
+            "glob": "^7.0.0",
+            "graceful-fs": "^4.1.0",
+            "lazystream": "^1.0.0",
+            "lodash": "^4.8.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           }
         },
         "async": {
@@ -37,7 +37,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.5"
+            "lodash": "^4.14.0"
           }
         },
         "balanced-match": {
@@ -50,7 +50,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "^2.0.5"
           }
         },
         "brace-expansion": {
@@ -58,7 +58,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -72,10 +72,10 @@
           "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
           "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "crc32-stream": "2.0.0",
-            "normalize-path": "2.1.1",
-            "readable-stream": "2.3.4"
+            "buffer-crc32": "^0.2.1",
+            "crc32-stream": "^2.0.0",
+            "normalize-path": "^2.0.0",
+            "readable-stream": "^2.0.0"
           }
         },
         "concat-map": {
@@ -93,8 +93,8 @@
           "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
           "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
           "requires": {
-            "crc": "3.5.0",
-            "readable-stream": "2.3.4"
+            "crc": "^3.4.4",
+            "readable-stream": "^2.0.0"
           }
         },
         "end-of-stream": {
@@ -102,7 +102,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "fs.realpath": {
@@ -115,12 +115,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -133,8 +133,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -152,7 +152,7 @@
           "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
           "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "requires": {
-            "readable-stream": "2.3.4"
+            "readable-stream": "^2.0.5"
           }
         },
         "lodash": {
@@ -165,7 +165,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "normalize-path": {
@@ -173,7 +173,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "once": {
@@ -181,7 +181,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "path-is-absolute": {
@@ -199,13 +199,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -213,7 +213,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "tar-stream": {
@@ -221,10 +221,10 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
           "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
           "requires": {
-            "bl": "1.2.1",
-            "end-of-stream": "1.4.1",
-            "readable-stream": "2.3.4",
-            "xtend": "4.0.1"
+            "bl": "^1.0.0",
+            "end-of-stream": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "util-deprecate": {
@@ -247,10 +247,10 @@
           "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
           "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
           "requires": {
-            "archiver-utils": "1.3.0",
-            "compress-commons": "1.2.2",
-            "lodash": "4.17.5",
-            "readable-stream": "2.3.4"
+            "archiver-utils": "^1.3.0",
+            "compress-commons": "^1.2.0",
+            "lodash": "^4.8.0",
+            "readable-stream": "^2.0.0"
           }
         }
       }
@@ -261,11 +261,11 @@
       "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
       "requires": {
         "minimatch": "3.0.4",
-        "mockery": "1.7.0",
-        "q": "1.4.1",
-        "semver": "5.7.0",
-        "shelljs": "0.3.0",
-        "uuid": "3.3.2"
+        "mockery": "^1.7.0",
+        "q": "^1.1.2",
+        "semver": "^5.1.0",
+        "shelljs": "^0.3.0",
+        "uuid": "^3.0.1"
       }
     },
     "balanced-match": {
@@ -278,7 +278,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -297,12 +297,12 @@
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "requires": {
-        "binary": "0.3.0",
-        "graceful-fs": "4.1.11",
-        "mkpath": "0.1.0",
-        "nopt": "3.0.6",
-        "q": "1.4.1",
-        "readable-stream": "1.1.14",
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
         "touch": "0.0.3"
       },
       "dependencies": {
@@ -316,8 +316,8 @@
           "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
           "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
           "requires": {
-            "buffers": "0.1.1",
-            "chainsaw": "0.1.0"
+            "buffers": "~0.1.1",
+            "chainsaw": "~0.1.0"
           }
         },
         "buffers": {
@@ -330,7 +330,7 @@
           "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
           "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
           "requires": {
-            "traverse": "0.3.9"
+            "traverse": ">=0.3.0 <0.4"
           }
         },
         "core-util-is": {
@@ -363,7 +363,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "readable-stream": {
@@ -371,10 +371,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -387,7 +387,7 @@
           "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
           "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
           "requires": {
-            "nopt": "1.0.10"
+            "nopt": "~1.0.10"
           },
           "dependencies": {
             "nopt": {
@@ -395,7 +395,7 @@
               "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
               "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             }
           }
@@ -417,7 +417,7 @@
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.0.tgz",
       "integrity": "sha512-SJJUrmDgXP0gkUzgErfkaeD+pugM8GYxerTALQa1gTUb5W1wrC4k07GZU+QNZd7MpFqJSYWXTQSUy8Ps03hx5Q==",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "minimatch": {
@@ -425,7 +425,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mockery": {
@@ -473,8 +473,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.13.tgz",
       "integrity": "sha1-+EQ+B0Oeb/ktmVKPSbvTScyfMGs=",
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": ">=2.4.6"
       },
       "dependencies": {
         "sax": {
@@ -488,6 +488,11 @@
           "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
       }
+    },
+    "xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
     }
   }
 }

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "instanceNameFormat": "File Transform: $(Package)",

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -17,8 +17,8 @@
     ],
     "version": {
         "Major": 2,
-        "Minor": 0,
-        "Patch": 9
+        "Minor": 179,
+        "Patch": 0
     },
     "preview": "true",
     "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 0,
-    "Patch": 9
+    "Minor": 179,
+    "Patch": 0
   },
   "preview": "true",
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
Issue: If any option File Transforms or Variable Substitution is enabled, the zip package is extracted to perform the selected operation when source type is zip. The task uses decompress-zip node module to perform the extraction and for packages with lot of files, the module fails with EMFILE error.
Fix: Instead of using the decompress-zip module for extraction, changed it to consume tools 7zip for windows and unzip for non-windows agents.

**Task name**: AzureRmWebAppDeploymentV4

**Description**: Cherry picking changes from master to release 179 branch. Details above.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #4127 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
