### PR TITLE
Bump version of securefiles-common package in tasks affected by ETIMEDOUT error hotfix

### DIFF
--- a/Tasks/AndroidSigningV2/package-lock.json
+++ b/Tasks/AndroidSigningV2/package-lock.json
@@ -51,13 +51,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -76,13 +75,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.3-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
-      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
+      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -275,11 +274,6 @@
         "wrappy": "1"
       }
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -421,16 +415,17 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/AndroidSigningV2/package.json
+++ b/Tasks/AndroidSigningV2/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview"
+    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 180,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 180,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AndroidSigningV3/package-lock.json
+++ b/Tasks/AndroidSigningV3/package-lock.json
@@ -51,13 +51,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -76,13 +75,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.3-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
-      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
+      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -94,7 +93,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -257,7 +256,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -274,11 +273,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
     },
     "parse-cache-control": {
       "version": "1.0.1",
@@ -421,16 +415,17 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/AndroidSigningV3/package.json
+++ b/Tasks/AndroidSigningV3/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview"
+    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 178,
+        "Minor": 180,
         "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 178,
+    "Minor": 180,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DownloadSecureFileV1/package-lock.json
+++ b/Tasks/DownloadSecureFileV1/package-lock.json
@@ -4,10 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+    },
     "@types/node": {
-      "version": "6.0.117",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.117.tgz",
-      "integrity": "sha512-sihk0SnN8PpiS5ihu5xJQ5ddnURNq4P+XPmW+nORlKkHy21CoZO/IVHK/Wq/l3G8fFW06Fkltgnqx229uPlnRg=="
+      "version": "10.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -15,13 +20,12 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -39,14 +43,21 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.0.0.tgz",
-      "integrity": "sha512-pM3jfj9KdOl34eBQdpb+ThvpLvKGtwfWGcvdrhr2eDk+xNYrgJG/W5WNXTAoPwDNapj2O6JlFOzDo+aHHWP3qQ==",
+      "version": "1.179.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.179.0.tgz",
+      "integrity": "sha512-d6ADk/ZyYx4FXZNZo+BXslDtLFquR51amQG76BHhr7kAQR72uCmBZBz5z+il5zMgWXqFxLL1J2LHAXHnk7i69g==",
       "requires": {
-        "@types/node": "^6.0.0",
+        "@types/node": "^10.17.0",
         "@types/q": "^1.5.2",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^2.8.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
+        }
       }
     },
     "balanced-match": {
@@ -81,15 +92,15 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "semver": {
       "version": "5.5.0",
@@ -102,18 +113,25 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
+    },
+    "typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-downloadsecurefile",
-  "version": "1.179.0",
+  "version": "1.0.0",
   "description": "Azure Pipelines Download Secure File Task",
   "main": "predownloadsecurefile.js",
   "scripts": {

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-downloadsecurefile",
-  "version": "1.0.0",
+  "version": "1.179.0",
   "description": "Azure Pipelines Download Secure File Task",
   "main": "predownloadsecurefile.js",
   "scripts": {

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "@types/node": "^6.0.0",
     "azure-pipelines-task-lib": "^2.8.0",
-    "azure-pipelines-tasks-securefiles-common": "1.178.0"
+    "azure-pipelines-tasks-securefiles-common": "1.179.0"
   }
 }

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -17,8 +17,12 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@types/node": "^6.0.0",
+    "@types/node": "^10.17.0",
+    "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tasks-securefiles-common": "1.179.0"
+  },
+  "devDependencies": {
+    "typescript": "4.0.2"
   }
 }

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 177,
-        "Patch": 1
+        "Minor": 180,
+        "Patch": 0
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 177,
-    "Patch": 1
+    "Minor": 180,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/package-lock.json
+++ b/Tasks/InstallAppleCertificateV2/package-lock.json
@@ -51,13 +51,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -86,13 +85,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.3-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
-      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
+      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -285,11 +284,6 @@
         "wrappy": "1"
       }
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -431,16 +425,17 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleCertificateV2/package.json
+++ b/Tasks/InstallAppleCertificateV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-installapplecertificate",
-  "version": "1.179.0",
+  "version": "1.0.0",
   "description": "Azure Pipelines InstallAppleCertificate Task",
   "main": "preinstallcert.js",
   "scripts": {

--- a/Tasks/InstallAppleCertificateV2/package.json
+++ b/Tasks/InstallAppleCertificateV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-installapplecertificate",
-  "version": "1.0.0",
+  "version": "1.179.0",
   "description": "Azure Pipelines InstallAppleCertificate Task",
   "main": "preinstallcert.js",
   "scripts": {

--- a/Tasks/InstallAppleCertificateV2/package.json
+++ b/Tasks/InstallAppleCertificateV2/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview",
+    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview",
     "azure-pipelines-tasks-ios-signing-common": "2.0.3-preview",
     "azure-pipelines-task-lib": "^3.0.6-preview.0"
   },

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 178,
+        "Minor": 180,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 178,
+    "Minor": 180,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
@@ -51,13 +51,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -86,13 +85,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.3-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
-      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
+      "version": "2.0.4-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
+      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -285,11 +284,6 @@
         "wrappy": "1"
       }
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -431,16 +425,17 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleProvisioningProfileV1/package.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "azure-pipelines-tasks-ios-signing-common": "2.0.3-preview",
-    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview",
+    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0"

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
+        "Minor": 180,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 178,
+    "Minor": 180,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallSSHKeyV0/package-lock.json
+++ b/Tasks/InstallSSHKeyV0/package-lock.json
@@ -4,10 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+    },
     "@types/node": {
-      "version": "6.0.117",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.117.tgz",
-      "integrity": "sha512-sihk0SnN8PpiS5ihu5xJQ5ddnURNq4P+XPmW+nORlKkHy21CoZO/IVHK/Wq/l3G8fFW06Fkltgnqx229uPlnRg=="
+      "version": "10.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
     },
     "@types/q": {
       "version": "1.5.1",
@@ -15,13 +20,12 @@
       "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA=="
     },
     "azure-devops-node-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
-      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
+      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
       "requires": {
-        "os": "0.1.1",
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
       }
     },
@@ -39,16 +43,21 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.0.0.tgz",
-      "integrity": "sha512-pM3jfj9KdOl34eBQdpb+ThvpLvKGtwfWGcvdrhr2eDk+xNYrgJG/W5WNXTAoPwDNapj2O6JlFOzDo+aHHWP3qQ==",
+      "version": "1.179.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.179.0.tgz",
+      "integrity": "sha512-d6ADk/ZyYx4FXZNZo+BXslDtLFquR51amQG76BHhr7kAQR72uCmBZBz5z+il5zMgWXqFxLL1J2LHAXHnk7i69g==",
       "requires": {
-        "@types/node": "^6.0.0",
+        "@types/node": "^10.17.0",
         "@types/q": "^1.5.2",
-        "azure-devops-node-api": "7.2.0",
+        "azure-devops-node-api": "10.1.2",
         "azure-pipelines-task-lib": "^2.8.0"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.48",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
+        },
         "@types/q": {
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
@@ -88,15 +97,15 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
-    "os": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
-      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
-    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "semver": {
       "version": "5.5.0",
@@ -109,18 +118,25 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
       "requires": {
-        "tunnel": "0.0.4",
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
         "underscore": "1.8.3"
       }
+    },
+    "typescript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",

--- a/Tasks/InstallSSHKeyV0/package.json
+++ b/Tasks/InstallSSHKeyV0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-installsshkey",
-  "version": "1.179.0",
+  "version": "1.0.0",
   "description": "Azure Pipelines Install SSK Key Task",
   "main": "preinstallsshkey.js",
   "scripts": {

--- a/Tasks/InstallSSHKeyV0/package.json
+++ b/Tasks/InstallSSHKeyV0/package.json
@@ -17,9 +17,13 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@types/node": "^6.0.0",
+    "@types/node": "^10.17.0",
+    "@types/mocha": "^5.2.7",
     "@types/q": "^1.5.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "azure-pipelines-tasks-securefiles-common": "1.179.0"
+  },
+  "devDependencies": {
+    "typescript": "4.0.2"
   }
 }

--- a/Tasks/InstallSSHKeyV0/package.json
+++ b/Tasks/InstallSSHKeyV0/package.json
@@ -20,6 +20,6 @@
     "@types/node": "^6.0.0",
     "@types/q": "^1.5.1",
     "azure-pipelines-task-lib": "^2.8.0",
-    "azure-pipelines-tasks-securefiles-common": "1.0.0"
+    "azure-pipelines-tasks-securefiles-common": "1.179.0"
   }
 }

--- a/Tasks/InstallSSHKeyV0/package.json
+++ b/Tasks/InstallSSHKeyV0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-installsshkey",
-  "version": "1.0.0",
+  "version": "1.179.0",
   "description": "Azure Pipelines Install SSK Key Task",
   "main": "preinstallsshkey.js",
   "scripts": {

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 175,
+        "Minor": 180,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 180,
+        "Minor": 179,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 175,
+    "Minor": 180,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 180,
+    "Minor": 179,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
**Task name**: AndroidSigningV2, AndroidSigningV3, DownloadSecureFileV1, InstallAppleCertificateV2, InstallAppleProvisioningProfileV1, InstallSSHKeyV0

**Description**: This PR bumping version of securefiles-common to the latest versions to allow using latest version of typed-rest-client which contains handing of ETIMEDOUT error and perfoms retry on it.

Latest version for the tasks that already migrated to Node10: 2.0.4-preview
Latest version for other tasks: 1.179.0

Pipeline runs with updated versions of tasks:
[AndroidSigningV3](https://abtttestorg.visualstudio.com/AndroidSigningTest/_build/results?buildId=2018&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f430846e-c263-498d-8258-8d82152c7eb5)
[AndroidSigningV2](https://abtttestorg.visualstudio.com/AndroidSigningTest/_build/results?buildId=2024&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=3ae6d2b9-5d8d-5ffa-efaf-e046b3587947)
[DownloadSecureFileV1](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=515&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=00c39931-6e12-489c-8a73-bd9a61f2be93)
[InstallAppleCertificateV2, InstallAppleProvisioningProfileV1](https://abtttestorg.visualstudio.com/XcodeBuildTest/_build/results?buildId=2028&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9)
[InstallSSHKeyV0](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=519&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=195f0425-b9fb-4fb0-8ebc-6a88ae18a24f)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [#1795923](https://github.com/microsoft/build-task-team/issues/473), [#1796623](https://github.com/microsoft/build-task-team/issues/480), [#1796303](https://github.com/microsoft/build-task-team/issues/477), [1797489](https://github.com/microsoft/build-task-team/issues/486), [1796304](https://github.com/microsoft/build-task-team/issues/478)

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
