### PR TITLE
Revert Bump version of securefiles-common package in tasks affected by ETIMEDOUT error

### DIFF
--- a/Tasks/AndroidSigningV2/package-lock.json
+++ b/Tasks/AndroidSigningV2/package-lock.json
@@ -51,12 +51,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -75,13 +76,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.4-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
-      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
+      "version": "2.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
+      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -274,6 +275,11 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -415,17 +421,16 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/AndroidSigningV2/package.json
+++ b/Tasks/AndroidSigningV2/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview"
+    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 2,
         "Minor": 180,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "JDK"

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 2,
     "Minor": 180,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "JDK"

--- a/Tasks/AndroidSigningV3/package-lock.json
+++ b/Tasks/AndroidSigningV3/package-lock.json
@@ -51,12 +51,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -75,13 +76,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.4-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
-      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
+      "version": "2.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
+      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -274,6 +275,11 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -415,17 +421,16 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/AndroidSigningV3/package.json
+++ b/Tasks/AndroidSigningV3/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview"
+    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/AndroidSigningV3/task.json
+++ b/Tasks/AndroidSigningV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 180,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "This version of the task uses apksigner instead of jarsigner to sign APKs.",
     "demands": [

--- a/Tasks/AndroidSigningV3/task.loc.json
+++ b/Tasks/AndroidSigningV3/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 3,
     "Minor": 180,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/DownloadSecureFileV1/package-lock.json
+++ b/Tasks/DownloadSecureFileV1/package-lock.json
@@ -20,12 +20,13 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -43,20 +44,20 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "1.179.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.179.0.tgz",
-      "integrity": "sha512-d6ADk/ZyYx4FXZNZo+BXslDtLFquR51amQG76BHhr7kAQR72uCmBZBz5z+il5zMgWXqFxLL1J2LHAXHnk7i69g==",
+      "version": "1.178.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-1.178.0.tgz",
+      "integrity": "sha512-o7s9qbs6CeZICbNkQ0S54DDLY6eytcPSiyiToeC3L9x5k8CtWY9qfX2r641u0q3HxfbwDd1+di2lr8nqwOhCvQ==",
       "requires": {
-        "@types/node": "^10.17.0",
+        "@types/node": "^6.0.0",
         "@types/q": "^1.5.2",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^2.8.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.48",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
-          "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
+          "version": "6.14.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.13.tgz",
+          "integrity": "sha512-J1F0XJ/9zxlZel5ZlbeSuHW2OpabrUAqpFuC2sm2I3by8sERQ8+KCjNKUcq8QHuzpGMWiJpo9ZxeHrqrP2KzQw=="
         }
       }
     },
@@ -92,15 +93,15 @@
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "semver": {
       "version": "5.5.0",
@@ -113,17 +114,16 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/DownloadSecureFileV1/package.json
+++ b/Tasks/DownloadSecureFileV1/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^2.8.0",
-    "azure-pipelines-tasks-securefiles-common": "1.179.0"
+    "azure-pipelines-tasks-securefiles-common": "1.178.0"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/DownloadSecureFileV1/task.json
+++ b/Tasks/DownloadSecureFileV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 180,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/DownloadSecureFileV1/task.loc.json
+++ b/Tasks/DownloadSecureFileV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 180,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/InstallAppleCertificateV2/package-lock.json
+++ b/Tasks/InstallAppleCertificateV2/package-lock.json
@@ -51,12 +51,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -85,13 +86,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.4-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
-      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
+      "version": "2.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
+      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -284,6 +285,11 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -425,17 +431,16 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleCertificateV2/package.json
+++ b/Tasks/InstallAppleCertificateV2/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview",
+    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview",
     "azure-pipelines-tasks-ios-signing-common": "2.0.3-preview",
     "azure-pipelines-task-lib": "^3.0.6-preview.0"
   },

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 180,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
     "runsOn": [

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 180,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "runsOn": [

--- a/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package-lock.json
@@ -51,12 +51,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -85,13 +86,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.4-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
-      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
+      "version": "2.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
+      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       }
     },
@@ -284,6 +285,11 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -425,17 +431,16 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallAppleProvisioningProfileV1/package.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "azure-pipelines-tasks-ios-signing-common": "2.0.3-preview",
-    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview",
+    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0"

--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 180,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 180,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/InstallSSHKeyV0/package-lock.json
+++ b/Tasks/InstallSSHKeyV0/package-lock.json
@@ -51,12 +51,13 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+      "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
       "requires": {
-        "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "os": "0.1.1",
+        "tunnel": "0.0.4",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
@@ -75,13 +76,13 @@
       }
     },
     "azure-pipelines-tasks-securefiles-common": {
-      "version": "2.0.4-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.4-preview.tgz",
-      "integrity": "sha512-ajmSm6lstZ1wDoBiyltyWWmJ0NKWnvcQDpFLIYk+xbT81jctwsgkWLzla07+2BkHHVZtUBNTW05HzyItuBYcYQ==",
+      "version": "2.0.3-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-securefiles-common/-/azure-pipelines-tasks-securefiles-common-2.0.3-preview.tgz",
+      "integrity": "sha512-+kYEeBu+NA9HWFLL+oo1HKv0keqkJUwWI6Zs5wbgy2JC/2evr/hjcU/n2zmURnelEPUtC+H38BlTcReULCfVXw==",
       "requires": {
         "@types/node": "^10.17.0",
         "@types/q": "^1.5.4",
-        "azure-devops-node-api": "10.1.2",
+        "azure-devops-node-api": "7.2.0",
         "azure-pipelines-task-lib": "^3.0.6-preview.0"
       },
       "dependencies": {
@@ -281,6 +282,11 @@
         "wrappy": "1"
       }
     },
+    "os": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+      "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M="
+    },
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
@@ -422,17 +428,16 @@
       }
     },
     "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
       "requires": {
-        "qs": "^6.9.1",
-        "tunnel": "0.0.6",
+        "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },

--- a/Tasks/InstallSSHKeyV0/package.json
+++ b/Tasks/InstallSSHKeyV0/package.json
@@ -21,7 +21,7 @@
     "@types/q": "^1.5.1",
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-securefiles-common": "2.0.4-preview"
+    "azure-pipelines-tasks-securefiles-common": "2.0.3-preview"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/InstallSSHKeyV0/task.json
+++ b/Tasks/InstallSSHKeyV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 180,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent",

--- a/Tasks/InstallSSHKeyV0/task.loc.json
+++ b/Tasks/InstallSSHKeyV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 180,
-    "Patch": 1
+    "Patch": 2
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: AndroidSigningV2, AndroidSigningV3, DownloadSecureFileV1, InstallAppleCertificateV2, InstallAppleProvisioningProfileV1, InstallSSHKeyV0

**Description**: This reverts commit 4719efc259c72e7d1a60811dcd5bd90c33fb176e

**Documentation changes required:** 

**Added unit tests:**

**Attached related issue:** [#585](https://github.com/microsoft/build-task-team/issues/585)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
