### PR TITLE
[packaging-common] Fixed mock helpers

### DIFF
--- a/common-npm-packages/packaging-common/Tests/ArtifactToolMockHelper.ts
+++ b/common-npm-packages/packaging-common/Tests/ArtifactToolMockHelper.ts
@@ -1,7 +1,7 @@
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 
 export function registerArtifactToolUtilitiesMock(tmr: tmrm.TaskMockRunner, toolPath: string) {
-    tmr.registerMock('packaging-common/universal/ArtifactToolUtilities', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/universal/ArtifactToolUtilities', {
         getArtifactToolFromService: function(serviceUri, accessToken, toolName) {
             return toolPath;
         },
@@ -13,7 +13,7 @@ export function registerArtifactToolUtilitiesMock(tmr: tmrm.TaskMockRunner, tool
 
 export function registerArtifactToolRunnerMock(tmr: tmrm.TaskMockRunner) {
     var mtt = require('azure-pipelines-task-lib/mock-toolrunner');
-    tmr.registerMock('packaging-common/universal/ArtifactToolRunner', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/universal/ArtifactToolRunner', {
         getOptions: function() {
             return {
                 cwd: process.cwd(),

--- a/common-npm-packages/packaging-common/Tests/MockHelper.ts
+++ b/common-npm-packages/packaging-common/Tests/MockHelper.ts
@@ -41,6 +41,6 @@ export function registerLocationHelpersMock(tmr: tmrm.TaskMockRunner) {
         RegistryType: {npm: 1, NuGetV2: 2, NuGetV3: 3, PyPiSimple: 4, PyPiUpload: 5}
     };
 
-    tmr.registerMock('packaging-common/locationUtilities', mockLocationUtils);
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/locationUtilities', mockLocationUtils);
     tmr.registerMock('../locationUtilities', mockLocationUtils);
 }

--- a/common-npm-packages/packaging-common/Tests/NuGetMockHelper.ts
+++ b/common-npm-packages/packaging-common/Tests/NuGetMockHelper.ts
@@ -3,7 +3,7 @@ import tmrm = require('azure-pipelines-task-lib/mock-run');
 import {VersionInfo} from '../pe-parser/VersionResource'
 	
 export function registerNugetToolGetterMock(tmr: tmrm.TaskMockRunner) {
-    tmr.registerMock('packaging-common/nuget/NuGetToolGetter', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/NuGetToolGetter', {
         getNuGet: function(versionSpec) {
             return "c:\\from\\tool\\installer\\nuget.exe";
         },
@@ -23,7 +23,7 @@ export function registerNugetToolGetterMock(tmr: tmrm.TaskMockRunner) {
 }
 
 export function registerNugetToolGetterMockUnix(tmr: tmrm.TaskMockRunner) {
-    tmr.registerMock('packaging-common/nuget/NuGetToolGetter', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/NuGetToolGetter', {
         getNuGet: function(versionSpec) {
             return '~/myagent/_work/_tasks/NuGet/nuget.exe';
         },
@@ -43,7 +43,7 @@ export function registerNugetToolGetterMockUnix(tmr: tmrm.TaskMockRunner) {
 }
 
 export function registerNugetUtilityMock(tmr: tmrm.TaskMockRunner, projectFile: string[]) {
-    tmr.registerMock('packaging-common/nuget/Utility', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/Utility', {
         getPatternsArrayFromInput: function(input) {
             return [input];
         },
@@ -81,7 +81,7 @@ export function registerNugetUtilityMock(tmr: tmrm.TaskMockRunner, projectFile: 
 }
 
 export function registerNugetUtilityMockUnix(tmr: tmrm.TaskMockRunner, projectFile: string[]) {
-    tmr.registerMock('packaging-common/nuget/Utility', {
+    tmr.registerMock('azure-pipelines-tasks-packaging-common/nuget/Utility', {
         getPatternsArrayFromInput: function(input) {
             return [input];
         },

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Azure Pipelines Packaging Tasks Common",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
**Task name**: packaging-common

**Description**: Fixed issue with tests failed for dependent tasks.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** Required for [#348](https://github.com/microsoft/build-task-team/issues/348) and PR #14063

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
