### PR TITLE
Allow cross domain authentication in securefiles-common

### DIFF
--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.4-preview",
+  "version": "2.0.5-preview",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.4-preview",
+  "version": "2.0.5-preview",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {

--- a/common-npm-packages/securefiles-common/securefiles-common.ts
+++ b/common-npm-packages/securefiles-common/securefiles-common.ts
@@ -10,7 +10,7 @@ export class SecureFileHelpers {
     constructor(retryCount?: number, socketTimeout?: number) {
         const serverUrl: string = tl.getVariable('System.TeamFoundationCollectionUri');
         const serverCreds: string = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
-        const authHandler = getPersonalAccessTokenHandler(serverCreds);
+        const authHandler = getPersonalAccessTokenHandler(serverCreds, true);
 
         const maxRetries = retryCount && retryCount >= 0 ? retryCount : 5; // Default to 5 if not specified
         tl.debug('Secure file retry count set to: ' + maxRetries);


### PR DESCRIPTION
**Task name**: securefiles-common

**Description**: Added passing of allowCrossOriginAuthentication with true value, to prevent *The user '' is not authorized to access this resource.* error

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [#473](https://github.com/microsoft/build-task-team/issues/473)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected

Pipeline runs to demonstrate parameter behaviour:
 * Old behaviour (Parameter was not passed): [Run](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=801&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f07a7720-a39e-43dc-a7d7-ae3b1271d99e)
 * New behaviour (Parameter is passing with true value) : [Run](https://dev.azure.com/v-niezz-testorg/TestProject/_build/results?buildId=796&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=23e653f5-0b05-5890-4740-8f3b4e477afc)