### PR TITLE
Fixed assigning of classDirectories - read only property issue

### DIFF
--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -21,7 +21,7 @@ def jacocoIncludes = [${includeFilter}]
 subprojects {
     jacocoTestReport {
         doFirst {
-            classDirectories = fileTree(dir: "${classFileDirectory}").exclude(jacocoExcludes).include(jacocoIncludes)
+            classDirectories.setFrom fileTree(dir: "${classFileDirectory}").exclude(jacocoExcludes).include(jacocoIncludes)
         }
 
         reports {

--- a/common-npm-packages/codecoverage-tools/package-lock.json
+++ b/common-npm-packages/codecoverage-tools/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "1.177.0",
+  "version": "1.181.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/codecoverage-tools/package.json
+++ b/common-npm-packages/codecoverage-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-codecoverage-tools",
-  "version": "1.177.0",
+  "version": "1.181.0",
   "author": "Microsoft Corporation",
   "description": "VSTS Tasks Code Coverage Tools",
   "license": "MIT",


### PR DESCRIPTION
**Task name**: GradleV2 - codecoverage-tools package update

**Description**: fixed assigning of classDirectories property when code coverage is enabled - to avoid 'can't assign read only property' error.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14130

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it - n/a since this is a package update
- [ ] Checked that applied changes work as expected - in progress
