### PR TITLE
Adds validation before call trim on container image

### DIFF
--- a/Tasks/KubernetesManifestV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesManifestV0/Strings/resources.resjson/en-US/resources.resjson
@@ -91,5 +91,6 @@
   "loc.messages.InvalidBaselineAndCanaryReplicas": "Invalid value for replica count.",
   "loc.messages.InvalidTimeoutValue": "Invalid value for timeout. Enter a valid number.",
   "loc.messages.RolloutStatusTimedout": "Rollout status check failed.",
-  "loc.messages.EnvironmentLink": "For more information, go to %s"
+  "loc.messages.EnvironmentLink": "For more information, go to %s",
+  "loc.messages.NullContainerImage": "Container image is null."
 }

--- a/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
+++ b/Tasks/KubernetesManifestV0/src/utils/KubernetesObjectUtility.ts
@@ -353,7 +353,12 @@ function updateContainers(containers: any[], images: string[]) {
         return containers;
     }
     containers.forEach((container) => {
-        const imageName: string = extractImageName(container.image.trim());
+        let containerImage = container.image;
+        if (!containerImage) {
+            throw (tl.loc('NullContainerImage'));
+        }
+
+        const imageName: string = extractImageName(containerImage.trim());
         images.forEach(image => {
             if (extractImageName(image) === imageName) {
                 container.image = image;


### PR DESCRIPTION
**Task name**: KubernetesManifestV0

**Description**: Adds validation to container image before calling trim on it

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y #14216

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
