### PR TITLE
Modified courtesy push pipeline to avoid fails

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -95,8 +95,16 @@ steps:
       # Build the release branch name
       $currentSprint = (Invoke-WebRequest https://whatsprintis.it/sprint -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).sprint
       $releaseBranch = "releases/m" + $currentSprint
-      # Push branch to git
+      # add config entry to avoid errors while pulling
+      git config  user.email "bot@courtesy.com"
+      git config  user.name "Courtesy Bot"
+      # Pull commits from remote and push branch to git
       git checkout -b $releaseBranch
+      Write-Host 'Trying to pull the remote branch:'
+      git pull https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
+      if (-not $?) {
+        Write-Host 'Failed to pull the remote branch. This is expected if the remote branch doesn't exist.
+      }
       git push https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
     condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'), eq(variables['COURTESY_PUSH'], 'true'))
     displayName: Push release branch

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -95,16 +95,19 @@ steps:
       # Build the release branch name
       $currentSprint = (Invoke-WebRequest https://whatsprintis.it/sprint -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).sprint
       $releaseBranch = "releases/m" + $currentSprint
+
       # add config entry to avoid errors while pulling
-      git config  user.email "bot@courtesy.com"
-      git config  user.name "Courtesy Bot"
+      git config --global user.email "$(username)@microsoft.com"
+      git config --global user.name "$(username)"
+
       # Pull commits from remote and push branch to git
       git checkout -b $releaseBranch
-      Write-Host 'Trying to pull the remote branch:'
+      Write-Host 'Trying to pull the remote branch..'
       git pull https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
       if (-not $?) {
         Write-Host 'Failed to pull the remote branch. This is expected if the remote branch doesn't exist.
       }
+      Write-Host 'Trying to push to the remote branch..'
       git push https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
     condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'), eq(variables['COURTESY_PUSH'], 'true'))
     displayName: Push release branch

--- a/ci/courtesy-push.yml
+++ b/ci/courtesy-push.yml
@@ -14,6 +14,7 @@ steps:
 
 - script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps\.nuget\externals\UnifiedDependencies.xml IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
   displayName: 'Update unified deps'
+  condition: and(succeeded(), eq(variables['WEEK'], '3'))
 
 - task: NuGetAuthenticate@0
   inputs:


### PR DESCRIPTION
**Task name**: Courtesy-push

**Description**: 
- Added condition to the `courtesy-push.js` invocation step to avoid build failing if a build starts on the first or the second week.
- Added `git pull` command to avoid build failing if any commits are pushed to a release branch before a sprint ends. A build will fail if there're conflicts.

**Documentation changes required:** No

**Attached related issue:** [#14230](https://github.com/microsoft/azure-pipelines-tasks/issues/14230)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
