### PR TITLE
Adding null check for tag input in DockerV2

### DIFF
--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -51,7 +51,10 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         imageNames.forEach(imageName => {
             if (tags && tags.length > 0) {
                 tags.forEach(tag => {
-                    tagArguments.push(imageName + ":" + tag);
+                    if(tag)
+                    {
+                        tagArguments.push(imageName + ":" + tag);
+                    }
                 });
             }
             else {

--- a/Tasks/DockerV2/dockerpush.ts
+++ b/Tasks/DockerV2/dockerpush.ts
@@ -22,15 +22,17 @@ function pushMultipleImages(connection: ContainerConnection, imageNames: string[
         imageNames.forEach(imageName => {
             if (tags && tags.length > 0) {
                 tags.forEach(tag => {
-                    let imageNameWithTag = imageName + ":" + tag;
-                    tl.debug("Pushing ImageNameWithTag: " + imageNameWithTag);
-                    if (promise) {
-                        promise = promise.then(() => {
-                            return dockerCommandUtils.push(connection, imageNameWithTag, commandArguments, onCommandOut)
-                        });
-                    }
-                    else {
-                        promise = dockerCommandUtils.push(connection, imageNameWithTag, commandArguments, onCommandOut);
+                    if (tag) {
+                        let imageNameWithTag = imageName + ":" + tag;
+                        tl.debug("Pushing ImageNameWithTag: " + imageNameWithTag);
+                        if (promise) {
+                            promise = promise.then(() => {
+                                return dockerCommandUtils.push(connection, imageNameWithTag, commandArguments, onCommandOut)
+                            });
+                        }
+                        else {
+                            promise = dockerCommandUtils.push(connection, imageNameWithTag, commandArguments, onCommandOut);
+                        }
                     }
                 });
             }

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 181,
-        "Patch": 0
+        "Patch": 2
     },
     "minimumAgentVersion": "2.172.0",
     "demands": [],

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 181,
-    "Patch": 0
+    "Patch": 2
   },
   "minimumAgentVersion": "2.172.0",
   "demands": [],


### PR DESCRIPTION
**Task name**: DockerV2

**Description**: Whitespaces are not trimmed in the newer versions of azure-pipelines-task-lib after [this](https://github.com/microsoft/azure-pipelines-task-lib/commit/ea7cfd92c86568620a761ab092d0bcc4816ed074#diff-8c0d3606f5533debbaff6b9bb823728034f2bac6694ef72adecb402da0664d25) commit. We updated the version of this library in the last deployment and that's why it started breaking some of the pipelines. Adding a null check for tag fixes the issue.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
