### PR TITLE
[JenkinsDownloadArtifactsV1] Fix ENOENT when archive folder does not exist

### DIFF
--- a/Tasks/JenkinsDownloadArtifactsV1/jenkinsdownloadartifacts.ts
+++ b/Tasks/JenkinsDownloadArtifactsV1/jenkinsdownloadartifacts.ts
@@ -178,22 +178,25 @@ async function doWork() {
                     }
 
                     var archivePath = path.join(localPathRoot, "archive");
-                    var tempPath = path.join(localPathRoot, uuidv4());
-                    fsExtra.move(archivePath, tempPath)
-                        .then(() => {
-                            fsExtra.copy(tempPath, localPathRoot)
-                                .then(() => {
-                                    fsExtra.remove(tempPath).catch((error) => {
+                    if (tl.exist(archivePath)) {
+                        var tempPath = path.join(localPathRoot, uuidv4());
+                        
+                        fsExtra.move(archivePath, tempPath)
+                            .then(() => {
+                                fsExtra.copy(tempPath, localPathRoot)
+                                    .then(() => {
+                                        fsExtra.remove(tempPath).catch((error) => {
+                                            throw error;
+                                        });
+                                    })
+                                    .catch((error) => {
                                         throw error;
                                     });
-                                })
-                                .catch((error) => {
-                                    throw error;
-                                });
-                        })
-                        .catch((error) => {
-                            throw error;
-                        });
+                            })
+                            .catch((error) => {
+                                throw error;
+                            });
+                    }
                 }
                 else {
                     await getArtifactsFromUrl(artifactQueryUrl, strictSSL, localPathRoot, itemPattern, handler, variables);

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -18,7 +18,7 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 175,
+        "Minor": 182,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 175,
+    "Minor": 182,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
**Task name**: JenkinsDownloadArtifactsV1

**Description**: 
- Previously, downloaded Jenkins archives contained a /archives folder with all artifacts. 
- Contents were then moved from /archives to /\<uuidv4\>, and finally copied to local path root, after which the temp folder was deleted.
- On newest Jenkins versions, downloaded zip archives no longer contain a /archive root folder.
- This fix addresses this issue by verifying the combined path prior to temporary move.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
