### PR TITLE
Make DotNetCoreCLI@2's pack command support arguments

### DIFF
--- a/Tasks/DotNetCoreCLIV2/packcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/packcommand.ts
@@ -20,6 +20,8 @@ export async function run(): Promise<void> {
     let nobuild = tl.getBoolInput("nobuild");
     let includeSymbols = tl.getBoolInput("includesymbols");
     let includeSource = tl.getBoolInput("includesource");
+    let additionalArguments = tl.getInput("arguments");
+
     let outputDir = undefined;
 
     try {
@@ -126,7 +128,7 @@ export async function run(): Promise<void> {
         const dotnetPath = tl.which("dotnet", true);
 
         for (const file of filesList) {
-            await dotnetPackAsync(dotnetPath, file, outputDir, nobuild, includeSymbols, includeSource, version, props, verbosity);
+            await dotnetPackAsync(dotnetPath, file, outputDir, nobuild, includeSymbols, includeSource, version, props, verbosity, additionalArguments);
         }
     } catch (err) {
         tl.warning(tl.loc('Net5NugetVersionCompat'));
@@ -135,7 +137,7 @@ export async function run(): Promise<void> {
     }
 }
 
-function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: string, nobuild: boolean, includeSymbols: boolean, includeSource: boolean, version: string, properties: string[], verbosity: string): Q.Promise<number> {
+function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: string, nobuild: boolean, includeSymbols: boolean, includeSource: boolean, version: string, properties: string[], verbosity: string, additionalArguments: string|undefined): Q.Promise<number> {
     let dotnet = tl.tool(dotnetPath);
 
     dotnet.arg("pack");
@@ -175,5 +177,9 @@ function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: str
         dotnet.arg(verbosity);
     }
 
+    if (additionalArguments) {
+        dotnet.line(additionalArguments);
+    }
+    
     return dotnet.exec({ cwd: path.dirname(packageFile) } as IExecOptions);
 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 181,
+        "Minor": 182,
         "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
@@ -120,7 +120,7 @@
             "type": "string",
             "label": "Arguments",
             "defaultValue": "",
-            "visibleRule": "command = build || command = publish || command = run || command = test || command = custom",
+            "visibleRule": "command = build || command = publish || command = run || command = test || command = pack || command = custom",
             "required": false,
             "helpMarkDown": "Arguments to the selected command. For example, build configuration, output folder, runtime. The arguments depend on the command selected."
         },

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 181,
+    "Minor": 182,
     "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",
@@ -120,7 +120,7 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.arguments",
       "defaultValue": "",
-      "visibleRule": "command = build || command = publish || command = run || command = test || command = custom",
+      "visibleRule": "command = build || command = publish || command = run || command = test || command = test || command = custom",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.arguments"
     },

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -120,7 +120,7 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.arguments",
       "defaultValue": "",
-      "visibleRule": "command = build || command = publish || command = run || command = test || command = test || command = custom",
+      "visibleRule": "command = build || command = publish || command = run || command = test || command = pack || command = custom",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.arguments"
     },


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: Make `dotnet pack` support the `arguments` parameter

The original motivation for this change is that I want to set `/p:Version`. The current version of pack sets `/p:PackageVersion` and there is no way to change it. Rather than making a backwards incompatible change to which property is set, I figured adding support for the arguments makes sense since most other commands already do.

**Documentation changes required:** Y

**Added unit tests:** N

I need some guidance to write a test (if required) which verifies that the arguments are passed through.

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
