### PR TITLE
Removing kubernetes-common resource path from task code

### DIFF
--- a/Tasks/KubernetesManifestV0/src/run.ts
+++ b/Tasks/KubernetesManifestV0/src/run.ts
@@ -13,7 +13,6 @@ import { reject } from './actions/reject';
 import { createSecret } from './actions/createSecret';
 
 tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
-tl.setResourcePath(path.join(__dirname, '..', 'node_modules/azure-pipelines-tasks-kubernetes-common-v2/module.json'));
 
 function run(): Promise<void> {
     const action = tl.getInput('action');

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 181,
+        "Minor": 182,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 181,
+    "Minor": 182,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: KubernetesManifestV0

**Description**: Removing kubernetes-common resource path from task code. This is already present in the common package used by this task. Currently it gives a warning in pipeline logs:
```
##[warning]Resource file has already set to: /home/vsts/work/_tasks/KubernetesManifest_dee316a2-586f-4def-be79-488a1f503dfe/0.181.0/node_modules/azure-pipelines-tasks-kubernetes-common-v2/module.json
```

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
