### PR TITLE
Fix for Download GitHub Release failed request 400

### DIFF
--- a/Tasks/DownloadGitHubReleaseV0/main.ts
+++ b/Tasks/DownloadGitHubReleaseV0/main.ts
@@ -145,7 +145,7 @@ async function main(): Promise<void> {
             canHandleAuthentication: () => false,
             handleAuthentication: () => { },
             prepareRequest: (options) => {
-                if (options.host.indexOf("amazonaws") == -1) {
+                if (options.host.indexOf("X-Amz-Algorithm") == -1) {
                     options.headers['Authorization'] = 'Bearer ' + token;
                 }
                 else {

--- a/Tasks/DownloadGitHubReleaseV0/main.ts
+++ b/Tasks/DownloadGitHubReleaseV0/main.ts
@@ -145,7 +145,8 @@ async function main(): Promise<void> {
             canHandleAuthentication: () => false,
             handleAuthentication: () => { },
             prepareRequest: (options) => {
-                if (options.host.indexOf("X-Amz-Algorithm") == -1) {
+                //To handle single auth being used at a time, add Auth header only when X-AMZ is not used
+                if (options.host.indexOf("amazonaws") == -1 && options.path.indexOf("X-Amz-Algorithm") == -1) {
                     options.headers['Authorization'] = 'Bearer ' + token;
                 }
                 else {

--- a/Tasks/DownloadGitHubReleaseV0/task.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 160,
-        "Patch": 2
+        "Patch": 3
     },
     "minimumAgentVersion": "1.99.0",
     "instanceNameFormat": "Download GitHub Release",

--- a/Tasks/DownloadGitHubReleaseV0/task.loc.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.loc.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 160,
-    "Patch": 2
+    "Patch": 3
   },
   "minimumAgentVersion": "1.99.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: DownloadGitHubRelease

**Description**: Github is fronting their user release content via http://github-releases.githubusercontent.com instead of *.s3.amazonaws.com. It resulted in auth header error:
Only one auth mechanism allowed; only the X-Amz-Algorithm query parameter, Signature query string parameter or the Authorization header should be specified<
**Documentation changes required:** N

**Added unit tests:**  N

**Attached related issue:**  https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/1812170, https://github.com/microsoft/azure-pipelines-tasks/issues/14309

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
