### PR TITLE
Fixing empty output warning

### DIFF
--- a/Tasks/DockerComposeV0/dockercomposeconnection.ts
+++ b/Tasks/DockerComposeV0/dockercomposeconnection.ts
@@ -88,7 +88,7 @@ export default class DockerComposeConnection extends ContainerConnection {
 
         await this.execCommand(command, options);
 
-        return output;
+        return output || '\n';
     }
 
     public createComposeCommand(): tr.ToolRunner {

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 181,
-        "Patch": 1
+        "Minor": 183,
+        "Patch": 0
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 181,
-    "Patch": 1
+    "Minor": 183,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",


### PR DESCRIPTION
**Task name**: DockerComposeV0

**Description**: When command output is empty it results in a warning like:
`##[warning]No data was written into the file /home/vsts/work/_temp/task_outputs/tag_ajinkya599hello-world_1612183887458.log`

Fixing this by adding a newline to the output in such a case.

**Documentation changes required:** Y

**Added unit tests:** N

**Attached related issue:** #12470 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
