### PR TITLE
Revert changes to use decompress-zip 0.3.0, the version 0.3.3 introdu…

### DIFF
--- a/Tasks/DownloadPackageV0/package-lock.json
+++ b/Tasks/DownloadPackageV0/package-lock.json
@@ -444,9 +444,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "decompress-zip": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
+      "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "requires": {
         "binary": "^0.3.0",
         "graceful-fs": "^4.1.3",

--- a/Tasks/DownloadPackageV0/package.json
+++ b/Tasks/DownloadPackageV0/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^10.17.0",
     "azure-devops-node-api": "10.1.2",
     "azure-pipelines-task-lib": "3.0.6-preview.0",
-    "decompress-zip": "0.3.3",
+    "decompress-zip": "0.3.0",
     "azure-pipelines-tasks-packaging-common": "2.0.0-preview.0",
     "azure-pipelines-tasks-utility-common": "3.0.0-preview.0"
   },

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 182,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 182,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.99.0",

--- a/Tasks/DownloadPackageV1/package-lock.json
+++ b/Tasks/DownloadPackageV1/package-lock.json
@@ -506,9 +506,9 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "decompress-zip": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
+      "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "requires": {
         "binary": "^0.3.0",
         "graceful-fs": "^4.1.3",

--- a/Tasks/DownloadPackageV1/package.json
+++ b/Tasks/DownloadPackageV1/package.json
@@ -23,7 +23,7 @@
     "azure-pipelines-task-lib": "3.0.6-preview.0",
     "azure-pipelines-tasks-packaging-common": "2.0.0-preview.0",
     "azure-pipelines-tasks-utility-common": "3.0.0-preview.0",
-    "decompress-zip": "0.3.3",
+    "decompress-zip": "0.3.0",
     "tar-fs": "1.16.3"
   },
   "devDependencies": {

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 1,
         "Minor": 182,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "Adds support to download Maven, Python, Universal and Npm packages.",

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 182,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
…ced a breaking change

**Task name**: DownloadPackageV0 and DownloadPackageV1

**Description**: Revert changes to use the library decompress-zip 0.3.0 instead of the version 0.3.3

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://developercommunity.visualstudio.com/content/problem/1330882/Error-in-releases-that-pull-from-Azure-D.html

**Checklist**:
- [ x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ x] Checked that applied changes work as expected
