### PR TITLE
VSTest: Use Hydra when the diagnosticsEnabled feature is enabled

### DIFF
--- a/Tasks/VsTestV2/runvstest.ts
+++ b/Tasks/VsTestV2/runvstest.ts
@@ -56,9 +56,7 @@ async function execute() {
             const inputDataContract = inputParser.parseInputsForNonDistributedTestRun();
             const enableHydra = isHydraFlowToBeEnabled(inputDataContract);
 
-            if (enableHydra || inputDataContract.EnableSingleAgentAPIFlow || (inputDataContract.ExecutionSettings
-                && inputDataContract.ExecutionSettings.RerunSettings
-                && inputDataContract.ExecutionSettings.RerunSettings.RerunFailedTests)) {
+            if (enableHydra || inputDataContract.EnableSingleAgentAPIFlow) {
                 if (enableApiExecution) {
                     console.log('================== API Execution =====================');
                     inputDataContract.ExecutionSettings.TestPlatformExecutionMode = 'api';
@@ -108,6 +106,22 @@ function isHydraFlowToBeEnabled(inputDataContract: InputDataContract) {
                 !== path.join(tl.getVariable(AgentVariables.AGENT_TEMPDIRECTORY), 'TestResults').toLowerCase()) {
 
             tl.debug('Enabling Hydra flow since the override results directory feature is being used.');
+            return true;
+        }
+
+        if (inputDataContract.ExecutionSettings
+            && inputDataContract.ExecutionSettings.RerunSettings
+            && inputDataContract.ExecutionSettings.RerunSettings.RerunFailedTests) {
+
+            tl.debug('Enabling Hydra flow since the rerun feature is being used.');
+            return true;
+        }
+
+        if (inputDataContract.ExecutionSettings
+            && inputDataContract.ExecutionSettings.DiagnosticsSettings
+            && inputDataContract.ExecutionSettings.DiagnosticsSettings.Enabled) {
+
+            tl.debug('Enabling Hydra flow since the diagnostic feature is being used.');
             return true;
         }
 

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 170,
-        "Patch": 1
+        "Minor": 183,
+        "Patch": 0
     },
     "demands": [
         "vstest"


### PR DESCRIPTION
**Task name**: VSTest@2

**Description**: 
Resolves an issue where a task with diagnosticsEnabled would not capture memory dumps on abort unless another hydra-enabling feature was also configured, like the Rerun tests on failure. It seems the root cause is that the diagnostic requires a runsettings change and the old codepath doesn't generate it dynamically.

I also moved the "Rerun enabled" check to be with the others in isHydraFlowToBeEnabled.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
