### PR TITLE
windows semicolon fix

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/sql/MysqlClient.ts
+++ b/Tasks/AzureMysqlDeploymentV1/sql/MysqlClient.ts
@@ -125,7 +125,7 @@ export class MysqlClient implements ISqlClient {
             fileSourceArgument = " -e" + '"' + this._azureMysqlTaskParameter.getSqlInline() + '"';
         }
         else {
-            fileSourceArgument = ` -e "source ${packageUtility.PackageUtility.getPackagePath(this._azureMysqlTaskParameter.getSqlFile())};"`;
+            fileSourceArgument = ` -e "source ${packageUtility.PackageUtility.getPackagePath(this._azureMysqlTaskParameter.getSqlFile()).replace(/\\/g, '/')};"`;
         }
        
         return  fileSourceArgument;       

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 182,
-        "Patch": 1
+        "Minor": 183,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 182,
-    "Patch": 1
+    "Minor": 183,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",


### PR DESCRIPTION
**Task name**: AzureMysqlDeploymentV1

**Description**: Task fails for below combination

Windows Agent + Mysql script file selection
Task fails because of having semi-colon (;) following the MySQL Script file path. converted file path to unix format

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/14352

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
