### PR TITLE
Removed SPN ObjectId Fetching step

### DIFF
--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -33,7 +33,6 @@ describe('PackerBuild Suite V1', function() {
         delete process.env["__packer_exists__"] ;
         delete process.env["__packer_fix_fails__"] ;
         delete process.env["__packer_validate_fails__"] ;
-        delete process.env["__spnObjectId_not_exists__"] ;
 
         done();
     });
@@ -241,22 +240,6 @@ describe('PackerBuild Suite V1', function() {
             assert(tr.stdout.indexOf("packer fix -validate=false") != -1, "packer fix command not called");
             assert(tr.stdout.indexOf("writing to file F:\\somedir\\tempdir\\100\\default.windows.template-fixed.json content: { \"some-key\": \"some-value\" }") != -1, "packer validate command not called");
             done();
-        });
-
-        it('Should fetch SPN object id if service endpoint does not contain it', (done:MochaDone) => {
-            process.env["__spnObjectId_not_exists__"] = "true";
-            let tp = path.join(__dirname, 'L0Windows.js');
-            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-            tr.run();
-            process.env["__spnObjectId_not_exists__"] = "false";
-
-            runValidations(() => {
-                assert(tr.invokedToolCount == 4, 'should have invoked tool four times. actual: ' + tr.invokedToolCount);
-                assert(tr.succeeded, 'task should have succeeded');
-                assert(tr.stdout.indexOf("loc_mock_FetchingSPNDetailsRemotely") != -1, "SPN object should be fetched");
-                assert(tr.stdout.indexOf("loc_mock_FetchedSPNDetailsRemotely") != -1, "SPN object should be fetched");
-            }, tr, done);
-
         });
 
         it('Should cleanup temp template folder', (done:MochaDone) => {

--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -55,7 +55,7 @@ describe('PackerBuild Suite V1', function() {
         it('Writes packer var file successfully for windows template', (done:MochaDone) => {
             let tp = path.join(__dirname, 'L0Windows.js');
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-            let match1 = 'writing to file C:\\somefolder\\somevarfile.json content: {"subscription_id":"sId","client_id":"spId","client_secret":"spKey","tenant_id":"tenant","object_id":"oId"}';
+            let match1 = 'writing to file C:\\somefolder\\somevarfile.json content: {"subscription_id":"sId","client_id":"spId","client_secret":"spKey","tenant_id":"tenant"}';
             let match2 = 'writing to file C:\\somefolder\\somevarfile.json content: {"resource_group":"testrg","storage_account":"teststorage","image_publisher":"MicrosoftWindowsServer","image_offer":"WindowsServer","image_sku":"2012-R2-Datacenter","location":"South India","capture_name_prefix":"Release-1","skip_clean":"true","script_relative_path":"dir3\\\\somedir\\\\deploy.ps1","package_path":"C:\\\\dir1\\\\somedir\\\\dir2","package_name":"dir2","script_arguments":"-target \\"subdir 1\\" -shouldFail false"}';
             tr.run();
 
@@ -119,7 +119,7 @@ describe('PackerBuild Suite V1', function() {
             let tp = path.join(__dirname, 'L0WindowsCustomImage.js');
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
             let match1 = 'writing to file C:\\somefolder\\somevarfile.json content: {"resource_group":"testrg","storage_account":"teststorage","image_url":"https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/vsts-buildimagetask/Release-1-osDisk.2d175222-b257-405f-a07f-0af4dc4b3dc4.vhd","location":"South India","capture_name_prefix":"Release-1","skip_clean":"true","script_relative_path":"dir3\\\\somedir\\\\deploy.ps1","package_path":"C:\\\\dir1\\\\somedir\\\\dir2","package_name":"dir2","script_arguments":"-target \\"subdir 1\\" -shouldFail false"}';
-            let match2 = 'writing to file C:\\somefolder\\somevarfile.json content: {"subscription_id":"sId","client_id":"spId","client_secret":"spKey","tenant_id":"tenant","object_id":"oId"}';
+            let match2 = 'writing to file C:\\somefolder\\somevarfile.json content: {"subscription_id":"sId","client_id":"spId","client_secret":"spKey","tenant_id":"tenant"}';
             tr.run();
 
             assert(tr.invokedToolCount == 4, 'should have invoked tool four times. actual: ' + tr.invokedToolCount);

--- a/Tasks/PackerBuildV1/Tests/L0Linux.ts
+++ b/Tasks/PackerBuildV1/Tests/L0Linux.ts
@@ -29,7 +29,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV1/Tests/L0LinuxBuiltinTemplateAdditionalParameters.ts
@@ -29,7 +29,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0LinuxCustomImage.ts
+++ b/Tasks/PackerBuildV1/Tests/L0LinuxCustomImage.ts
@@ -30,7 +30,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0LinuxInstallPacker.ts
+++ b/Tasks/PackerBuildV1/Tests/L0LinuxInstallPacker.ts
@@ -31,7 +31,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0LinuxManaged.ts
+++ b/Tasks/PackerBuildV1/Tests/L0LinuxManaged.ts
@@ -31,7 +31,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0Parser.ts
+++ b/Tasks/PackerBuildV1/Tests/L0Parser.ts
@@ -28,7 +28,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0Windows.ts
+++ b/Tasks/PackerBuildV1/Tests/L0Windows.ts
@@ -30,17 +30,12 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_URL_AzureRMSpn"] = "https://management.azure.com/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";
 process.env["RELEASE_RELEASENAME"] = "Release-1";
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  DefaultWorkingDirectory;
-
-if(process.env["__spnObjectId_not_exists__"] === "true") {
-    delete process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"];
-}
 
 // provide answers for task mock
 let a: any = <any>{

--- a/Tasks/PackerBuildV1/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsBuiltinTemplateAdditionalParameters.ts
@@ -29,7 +29,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0WindowsCustomImage.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsCustomImage.ts
@@ -30,7 +30,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0WindowsFail.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsFail.ts
@@ -30,7 +30,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0WindowsInstallPacker.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsInstallPacker.ts
@@ -29,7 +29,6 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";

--- a/Tasks/PackerBuildV1/Tests/L0WindowsManaged.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsManaged.ts
@@ -32,17 +32,12 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
 process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
 process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
-process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"] =  "oId";
 process.env["ENDPOINT_URL_AzureRMSpn"] = "https://management.azure.com/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
 process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";
 process.env["RELEASE_RELEASENAME"] = "Release-1";
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  DefaultWorkingDirectory;
-
-if(process.env["__spnObjectId_not_exists__"] === "true") {
-    delete process.env["ENDPOINT_DATA_AzureRMSpn_SPNOBJECTID"];
-}
 
 // provide answers for task mock
 let a: any = <any>{

--- a/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
+++ b/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
@@ -1,12 +1,8 @@
 "use strict";
 
-import azureGraph = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-graph');
-import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common");
-
 import * as tl from "azure-pipelines-task-lib/task";
 import * as constants from "./constants";
 import * as definitions from "./definitions"
-import TaskParameters from "./taskParameters"
 
 // Provider for all template variables related to azure SPN. Reads service endpoint to get all necessary details.
 export default class AzureSpnTemplateVariablesProvider implements definitions.ITemplateVariablesProvider {
@@ -37,36 +33,7 @@ export default class AzureSpnTemplateVariablesProvider implements definitions.IT
         this._spnVariables.set(constants.TemplateVariableClientSecretName, tl.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalkey', false));
         this._spnVariables.set(constants.TemplateVariableTenantIdName, tl.getEndpointAuthorizationParameter(connectedService, 'tenantid', false));
 
-
-        var spnObjectId = tl.getEndpointDataParameter(connectedService, "spnObjectId", true);
-        // if we are creating windows VM and SPN object-id is not available in service endpoint, fetch it from Graph endpoint
-        // NOP for nix
-        if(!spnObjectId && taskParameters.osType.toLowerCase().match(/^win/)) {
-            spnObjectId = await this.getServicePrincipalObjectId(await taskParameters.graphCredentialsPromise);
-        }
-
-        this._spnVariables.set(constants.TemplateVariableObjectIdName, spnObjectId);
-
         return this._spnVariables;
-    }
-
-    private async getServicePrincipalObjectId(graphCredentials: msRestAzure.ApplicationTokenCredentials): Promise<string> {
-        console.log(tl.loc("FetchingSPNDetailsRemotely", graphCredentials.getClientId()));
-        var client = new azureGraph.GraphManagementClient(graphCredentials);
-        var servicePrincipal = null;
-        try {
-            servicePrincipal = await client.servicePrincipals.GetServicePrincipal(null);
-        } catch (error) {
-            throw tl.loc("FailedToFetchSPNDetailsRemotely", error.message);
-        }
-
-        var spnObjectId: string = "";
-        if(!!servicePrincipal && !!servicePrincipal.objectId) {
-            spnObjectId = servicePrincipal.objectId;
-        }
-
-        console.log(tl.loc("FetchedSPNDetailsRemotely", spnObjectId));
-        return spnObjectId;
     }
 
     private _spnVariables: Map<string, string>;

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 176,
+        "Minor": 183,
         "Patch": 0
     },
     "demands": [],
@@ -341,9 +341,6 @@
         "ParsingAdditionalBuilderParameters": "Parsing additional builder parameters json.",
         "ParsingTemplateFileContentFailed": "Unable to parse json content from template file %s with error: %s.",
         "ParsingCustomTemplateParameters": "Parsing custom template parameters json.",
-        "FetchingSPNDetailsRemotely": "Fetching SPN details for app ID %s from the Azure AD graph service connection...",
-        "FetchedSPNDetailsRemotely": "Fetched SPN details successfully. ObjectId: %s",
-        "FailedToFetchSPNDetailsRemotely": "Could not fetch SPN details from the graph service connection. Error: %s.",
         "GetArtifactItemsNotSupported": "Get artifact items not supported, invalid code path",
         "CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode": "Could not fetch access token for Managed Service Principal. Please configure Managed Service Identity (MSI) for virtual machine 'https://aka.ms/azure-msi-docs'. Status code: %s, status message: %s",
         "CouldNotFetchAccessTokenforMSIStatusCode": "Could not fetch access token for Managed Service Principal. Status code: %s, status message: %s",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 176,
+    "Minor": 183,
     "Patch": 0
   },
   "demands": [],
@@ -341,9 +341,6 @@
     "ParsingAdditionalBuilderParameters": "ms-resource:loc.messages.ParsingAdditionalBuilderParameters",
     "ParsingTemplateFileContentFailed": "ms-resource:loc.messages.ParsingTemplateFileContentFailed",
     "ParsingCustomTemplateParameters": "ms-resource:loc.messages.ParsingCustomTemplateParameters",
-    "FetchingSPNDetailsRemotely": "ms-resource:loc.messages.FetchingSPNDetailsRemotely",
-    "FetchedSPNDetailsRemotely": "ms-resource:loc.messages.FetchedSPNDetailsRemotely",
-    "FailedToFetchSPNDetailsRemotely": "ms-resource:loc.messages.FailedToFetchSPNDetailsRemotely",
     "GetArtifactItemsNotSupported": "ms-resource:loc.messages.GetArtifactItemsNotSupported",
     "CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode": "ms-resource:loc.messages.CouldNotFetchAccessTokenforMSIDueToMSINotConfiguredProperlyStatusCode",
     "CouldNotFetchAccessTokenforMSIStatusCode": "ms-resource:loc.messages.CouldNotFetchAccessTokenforMSIStatusCode",


### PR DESCRIPTION
**Task name**: PackerBuildV1

**Description**: Removed fetching ObjectId step as its not a compulsory parameter for Hashicorp Packer

**Documentation changes required:** (Y/N) No

**Added unit tests:** (Y/N) Removed tests and test parameters related to SPN ObjectId

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/AzureDevOps/_queries/edit/1812652/?triage=true

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
