### PR TITLE
[Common packages preview] VSBuildV1 - default logger switch - applied changes to common package

### DIFF
--- a/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
@@ -106,7 +106,7 @@ function Invoke-MSBuild {
 
         if($IsDefaultLoggerEnabled) {
             # Hook up the custom logger.
-            $loggerAssembly = "$PSScriptRoot\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
+            $loggerAssembly = "$PSScriptRoot\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
             Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
             $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
         }

--- a/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
@@ -11,7 +11,8 @@ function Invoke-BuildTools {
         [switch]$Clean,
         [switch]$NoTimelineLogger,
         [switch]$CreateLogFile,
-        [string]$LogFileVerbosity)
+        [string]$LogFileVerbosity,
+        [switch]$IsDefaultLoggerEnabled = $true)
 
     Trace-VstsEnteringInvocation $MyInvocation
     try {
@@ -30,7 +31,7 @@ function Invoke-BuildTools {
                 if ($CreateLogFile) {
                     $splat["LogFile"] = "$file-clean.log"
                 }
-                Invoke-MSBuild -ProjectFile $file -Targets Clean -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
+                Invoke-MSBuild -ProjectFile $file -Targets Clean -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger -IsDefaultLoggerEnabled:$IsDefaultLoggerEnabled @splat
             }
 
             # If we cleaned and passed /t targets, we don't need to run them again
@@ -38,7 +39,7 @@ function Invoke-BuildTools {
                 if ($CreateLogFile) {
                     $splat["LogFile"] = "$file.log"
                 }
-                Invoke-MSBuild -ProjectFile $file -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger @splat
+                Invoke-MSBuild -ProjectFile $file -MSBuildPath $MSBuildLocation -AdditionalArguments $MSBuildArguments -NoTimelineLogger:$NoTimelineLogger -IsDefaultLoggerEnabled:$IsDefaultLoggerEnabled @splat
             }
         }
     } finally {
@@ -59,7 +60,8 @@ function Invoke-MSBuild {
         [string]$LogFileVerbosity,
         [switch]$NoTimelineLogger,
         [string]$MSBuildPath, # TODO: Switch MSBuildPath to mandatory. Both callers (MSBuild and VSBuild task) throw prior to reaching here if MSBuild cannot be resolved.
-        [string]$AdditionalArguments)
+        [string]$AdditionalArguments,
+        [switch]$IsDefaultLoggerEnabled = $true)
 
     Trace-VstsEnteringInvocation $MyInvocation
     try {
@@ -102,10 +104,12 @@ function Invoke-MSBuild {
         # Store the solution folder so we can provide solution-relative paths (for now) for the project events.
         $solutionDirectory = [System.IO.Path]::GetDirectoryName($ProjectFile)
 
-        # Hook up the custom logger.
-        $loggerAssembly = "$PSScriptRoot\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
-        Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
-        $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
+        if($IsDefaultLoggerEnabled) {
+            # Hook up the custom logger.
+            $loggerAssembly = "$PSScriptRoot\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
+            Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
+            $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
+        }
 
         # Append additional arguments.
         if ($AdditionalArguments) {

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
@@ -2,7 +2,7 @@
 param()
 
 # Arrange.
-. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
 Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
 $directory = 'Some drive:\Some directory'
 $file = "$directory\Some solution"

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$directory = 'Some drive:\Some directory'
+$file = "$directory\Some solution"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+
+Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
+Register-Mock Invoke-MSBuild { 'MSBuild disabled logger output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled:$true -LogFile: "$file.log"
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -NoTimelineLogger -CreateLogFile
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output'
+        'MSBuild disabled logger output'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
@@ -2,7 +2,7 @@
 param()
 
 # Arrange.
-. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
 Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
 $directory = 'Some drive:\Some directory'
 $file = "$directory\Some solution"

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
@@ -1,0 +1,21 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
+$directory = 'Some drive:\Some directory'
+$file = "$directory\Some solution"
+$msBuildLocation = 'Some MSBuild location'
+$msBuildArguments = 'Some MSBuild arguments'
+
+Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
+Register-Mock Invoke-MSBuild { 'MSBuild disabled logger output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled:$false -LogFile: "$file.log"
+
+# Act.
+$actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -NoTimelineLogger -CreateLogFile -IsDefaultLoggerEnabled:$false
+# Assert.
+Assert-AreEqual -Expected @(
+        'NuGet output'
+        'MSBuild disabled logger output'
+    ) -Actual $actual

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.InvokesAllToolsForAllFiles.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.InvokesAllToolsForAllFiles.ps1
@@ -12,12 +12,12 @@ $msBuildLocation = 'Some MSBuild location'
 $msBuildArguments = 'Some MSBuild arguments'
 Register-Mock Invoke-NuGetRestore { 'NuGet output 1' } -- -File $file1
 Register-Mock Invoke-NuGetRestore { 'NuGet output 2' } -- -File $file2
-Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"
-Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1-clean.log"	
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2-clean.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"	
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1-clean.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2.log"
 
 # Act.
 $actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file1, $file2 -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean -NoTimelineLogger -CreateLogFile

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCleanIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCleanIfSpecified.ps1
@@ -8,8 +8,8 @@ $file = "$directory1\Some solution"
 $msBuildLocation = 'Some MSBuild location'
 $msBuildArguments = 'Some MSBuild arguments'
 Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
-Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"	
 
 # Act.
 $actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -NoTimelineLogger -CreateLogFile

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCreateLogFileIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsCreateLogFileIfSpecified.ps1
@@ -8,10 +8,10 @@ $file = "$directory1\Some solution"
 $msBuildLocation = 'Some MSBuild location'
 $msBuildArguments = 'Some MSBuild arguments'
 Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
-Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output no log' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true
-Register-Mock Invoke-MSBuild { 'MSBuild output no log' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true
-Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output no log' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true
+Register-Mock Invoke-MSBuild { 'MSBuild output no log' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"
 
 # Act.
 $actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file -MSBuildLocation $msBuildLocation  -MSBuildArguments $msBuildArguments  -Clean -NoTimelineLogger

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsRestoreIfSpecified.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsRestoreIfSpecified.ps1
@@ -9,9 +9,9 @@ $msBuildLocation = 'Some MSBuild location'
 $msBuildArguments = 'Some MSBuild arguments'
 Register-Mock Invoke-NuGetRestore
 Register-Mock Invoke-NuGetRestore { 'NuGet output' } -- -File $file
-Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file-clean.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output wrong logfile' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output' } -- -ProjectFile $file -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output wrong logfile' } -- -ProjectFile $file -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file.log"
 
 # Act.
 $actual = Invoke-BuildTools -SolutionFiles $file -MSBuildLocation 'Some MSBuild location' -MSBuildArguments 'Some MSBuild arguments' -Clean -NoTimelineLogger -CreateLogFile

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1
@@ -12,12 +12,12 @@ $msBuildLocation = 'Some MSBuild location'
 $msBuildArguments = 'Some MSBuild with /t:arguments'
 Register-Mock Invoke-NuGetRestore { 'NuGet output 1' } -- -File $file1
 Register-Mock Invoke-NuGetRestore { 'NuGet output 2' } -- -File $file2
-Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"
-Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1-clean.log"	
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2-clean.log"
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file1.log"	
-Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 1' } -- -ProjectFile $file1 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1.log"
+Register-Mock Invoke-MSBuild { 'MSBuild output 2' } -- -ProjectFile $file2 -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1-clean.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2-clean.log"
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 1 wrong logfile' } -- -ProjectFile $file1 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file1.log"	
+Register-Mock Invoke-MSBuild { 'MSBuild clean output 2 wrong logfile' } -- -ProjectFile $file2 -Targets Clean -MSBuildPath $msBuildLocation -AdditionalArguments $msBuildArguments -NoTimelineLogger: $true -IsDefaultLoggerEnabled: $true -LogFile: "$file2.log"
 
 # Act.
 $actual = Invoke-BuildTools -NuGetRestore -SolutionFiles $file1, $file2 -MSBuildLocation $msBuildLocation -MSBuildArguments $msBuildArguments -Clean -NoTimelineLogger -CreateLogFile

--- a/common-npm-packages/MSBuildHelpers/Tests/L0.ts
+++ b/common-npm-packages/MSBuildHelpers/Tests/L0.ts
@@ -92,6 +92,12 @@ describe('Common-MSBuildHelpers Suite', function () {
         it('(Invoke-BuildTools) skips second build if clean plus targets provided', (done) => {
             psr.run(path.join(__dirname, 'Invoke-BuildTools.SkipsSecondBuildIfCleanPlusTargetsProvided.ps1'), done);
         })
+        it('(Invoke-BuildTools) default logger is enabled by default', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1'), done);
+        })
+        it('(Invoke-BuildTools) disables default logger', (done) => {
+            psr.run(path.join(__dirname, 'Invoke-BuildTools.DisableDefaultLogger.ps1'), done);
+        })
         it('(Invoke-MSBuild) combines msbuildexe', (done) => {
             psr.run(path.join(__dirname, 'Invoke-MSBuild.CombinesMsbuildexe.ps1'), done);
         })

--- a/common-npm-packages/MSBuildHelpers/package-lock.json
+++ b/common-npm-packages/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/MSBuildHelpers/package.json
+++ b/common-npm-packages/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {


### PR DESCRIPTION
**Task name**: None (MSBuildHelpers common package)

**Description**: added parameter to disable default logger for Invoke-BuildTools function.

**Documentation changes required:** N

**Added unit tests:** added tests, amended existing.

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14255

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it - bumped package version
- [x] Checked that applied changes work as expected
