### PR TITLE
Fixing Packer Build V0 by downgrading arm-rest-v2 version

### DIFF
--- a/Tasks/PackerBuildV0/package.json
+++ b/Tasks/PackerBuildV0/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
     "@types/q": "^1.0.7",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^2.0.0-preview.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "1.178.1",
     "decompress-zip": "0.3.0",
     "moment": "2.21.0",
     "azure-pipelines-task-lib": "^3.0.6-preview.0"

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 176,
+        "Minor": 183,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 176,
+    "Minor": 183,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: Packer Build V0

**Description**: Downgrading one of the dependency (azure-pipelines-tasks-azure-arm-rest-v2)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/AzureDevOps/_queries/edit/1812652/?triage=true

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
