### PR TITLE
AzurePowerShellV2/3 can use Azure and AzureRM modules as zip

### DIFF
--- a/Tasks/AzurePowerShellV2/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV2/AzurePowerShell.ps1
@@ -70,6 +70,8 @@ catch
    Write-Verbose "Unable to get the authScheme $error" 
 }
 
+. $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion $targetAzurePs
+
 Update-PSModulePathForHostedAgent -targetAzurePs $targetAzurePs -authScheme $authScheme
 
 try {

--- a/Tasks/AzurePowerShellV2/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV2/AzurePowerShell.ps1
@@ -144,8 +144,4 @@ finally {
 
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
     Disconnect-AzureAndClearContext -authScheme $authScheme -ErrorAction SilentlyContinue
-
-    # Telemetry
-    $telemetryJsonContent = @{ targetAzurePs = $targetAzurePs } | ConvertTo-Json -Compress
-    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV2]$telemetryJsonContent"
 }

--- a/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
@@ -4,36 +4,68 @@ param (
     $targetVersion
 )
 
-. "$PSScriptRoot\Utility.ps1"
-$moduleContainerPath = Get-SavedModuleContainerPath
+try {
+    . "$PSScriptRoot\Utility.ps1"
+    $moduleContainerPath = Get-SavedModuleContainerPath
 
-if (-not(Test-Path -Path $moduleContainerPath)) {
-    Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
-    return;
-}
-
-if (!$targetVersion) {
-    Write-Verbose "Latest module selected which will be available as folder."
-    return;
-}
-
-# value for classic
-@($false, $true).ForEach({
-    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
-    if (Test-Path -Path $modulePath) {
-        Write-Verbose "Module available as folder at $modulePath"
+    if (-not(Test-Path -Path $moduleContainerPath)) {
+        $classicModuleSource = "privateAgent"
+        $nonClassicModuleSource = "privateAgent"
+        Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
         return;
     }
 
-    $moduleZipPath = $modulePath + ".zip";
-    if (-not(Test-Path -Path $moduleZipPath)) {
-        Write-Verbose "Module zip not available to unzip at $moduleZipPath"
+    if (!$targetVersion) {
+        $classicModuleSource = "hostedAgentFolder"
+        $nonClassicModuleSource = "hostedAgentFolder"
+        Write-Verbose "Latest module selected which will be available as folder."
         return;
     }
 
-    Write-Verbose "Extracting zip $moduleZipPath"
-    $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
-    $command = "$PSScriptRoot\7zip\7z.exe"
-    &$command @parameter
-    Write-Verbose "Extraction complete"
-})
+    # value for classic
+    @($false, $true).ForEach({
+        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
+        if (Test-Path -Path $modulePath) {
+            if ($_) {
+                $classicModuleSource = "hostedAgentFolder"
+            } else {
+                $nonClassicModuleSource = "hostedAgentFolder"
+            }
+
+            Write-Verbose "Module available as folder at $modulePath"
+            return;
+        }
+
+        $moduleZipPath = $modulePath + ".zip";
+        if (-not(Test-Path -Path $moduleZipPath)) {
+            if ($_) {
+                $classicModuleSource = "hostedAgentOthers"
+            } else {
+                $nonClassicModuleSource = "hostedAgentOthers"
+            }
+
+            Write-Verbose "Module zip not available to unzip at $moduleZipPath"
+            return;
+        }
+
+        if ($_) {
+            $classicModuleSource = "hostedAgentZip"
+        } else {
+            $nonClassicModuleSource = "hostedAgentZip"
+        }
+
+        Write-Verbose "Extracting zip $moduleZipPath"
+        $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
+        $command = "$PSScriptRoot\7zip\7z.exe"
+        &$command @parameter
+        Write-Verbose "Extraction complete"
+    })
+} finally {
+    # Telemetry
+    $telemetryJsonContent = @{
+        targetAzurePs = $targetVersion;
+        classicModuleSource = $classicModuleSource;
+        nonClassicModuleSource = $nonClassicModuleSource
+    } | ConvertTo-Json -Compress
+    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV2]$telemetryJsonContent"
+}

--- a/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param (
+    [string]
+    $targetVersion
+)
+
+. "$PSScriptRoot\Utility.ps1"
+$moduleContainerPath = Get-SavedModuleContainerPath
+
+if (-not(Test-Path -Path $moduleContainerPath)) {
+    return;
+}
+
+if (!$targetVersion) {
+    return;
+}
+
+# value for classic
+@($false, $true).ForEach({
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
+    if (Test-Path -Path $modulePath) {
+        return;
+    }
+
+    $moduleZipPath = $modulePath + ".zip";
+    if (-not(Test-Path -Path $moduleZipPath)) {
+        return;
+    }
+
+    $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
+    $command = "$PSScriptRoot\7zip\7z.exe"
+    &$command @parameter
+})

--- a/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV2/TryMakingModuleAvailable.ps1
@@ -8,10 +8,12 @@ param (
 $moduleContainerPath = Get-SavedModuleContainerPath
 
 if (-not(Test-Path -Path $moduleContainerPath)) {
+    Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
     return;
 }
 
 if (!$targetVersion) {
+    Write-Verbose "Latest module selected which will be available as folder."
     return;
 }
 
@@ -19,15 +21,19 @@ if (!$targetVersion) {
 @($false, $true).ForEach({
     $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
     if (Test-Path -Path $modulePath) {
+        Write-Verbose "Module available as folder at $modulePath"
         return;
     }
 
     $moduleZipPath = $modulePath + ".zip";
     if (-not(Test-Path -Path $moduleZipPath)) {
+        Write-Verbose "Module zip not available to unzip at $moduleZipPath"
         return;
     }
 
+    Write-Verbose "Extracting zip $moduleZipPath"
     $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
     $command = "$PSScriptRoot\7zip\7z.exe"
     &$command @parameter
+    Write-Verbose "Extraction complete"
 })

--- a/Tasks/AzurePowerShellV2/Utility.ps1
+++ b/Tasks/AzurePowerShellV2/Utility.ps1
@@ -2,16 +2,20 @@ $rollForwardTable = @{
     "5.0.0" = "5.1.1";
 };
 
+function Get-SavedModuleContainerPath {
+    return $env:SystemDrive + "\Modules";
+}
+
 function Get-SavedModulePath {
     [CmdletBinding()]
     param([string] $azurePowerShellVersion,
           [switch] $Classic)
     
     if($Classic -eq $true) {
-        return $($env:SystemDrive + "\Modules\Azure_" + $azurePowerShellVersion)
+        return (Get-SavedModuleContainerPath) + "\Azure_" + $azurePowerShellVersion;
     }
     else {
-        return $($env:SystemDrive + "\Modules\AzureRm_" + $azurePowerShellVersion)
+        return (Get-SavedModuleContainerPath) + "\AzureRm_" + $azurePowerShellVersion;
     }
 }
 

--- a/Tasks/AzurePowerShellV2/make.json
+++ b/Tasks/AzurePowerShellV2/make.json
@@ -30,6 +30,12 @@
                     }
                 ]
             }
+        ],
+        "archivePackages": [
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+                "dest": "./"
+            }
         ]
     }
 }

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 179,
-        "Patch": 1
+        "Minor": 184,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 179,
-    "Patch": 1
+    "Minor": 184,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV3/AzurePowerShell.ps1
@@ -76,6 +76,8 @@ catch
    Write-Verbose "Unable to get the authScheme $error" 
 }
 
+. $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion $targetAzurePs
+
 Update-PSModulePathForHostedAgent -targetAzurePs $targetAzurePs -authScheme $authScheme
 
 # troubleshoot link

--- a/Tasks/AzurePowerShellV3/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV3/AzurePowerShell.ps1
@@ -181,7 +181,3 @@ finally {
 }
 Write-Host "## Script Execution Complete"
 Disconnect-AzureAndClearContext -authScheme $authScheme -ErrorAction SilentlyContinue
-
-# Telemetry
-$telemetryJsonContent = @{ targetAzurePs = $targetAzurePs } | ConvertTo-Json -Compress
-Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV3]$telemetryJsonContent"

--- a/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param (
+    [string]
+    $targetVersion
+)
+
+. "$PSScriptRoot\Utility.ps1"
+$moduleContainerPath = Get-SavedModuleContainerPath
+
+if (-not(Test-Path -Path $moduleContainerPath)) {
+    return;
+}
+
+if (!$targetVersion) {
+    return;
+}
+
+# value for classic
+@($false, $true).ForEach({
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
+    if (Test-Path -Path $modulePath) {
+        return;
+    }
+
+    $moduleZipPath = $modulePath + ".zip";
+    if (-not(Test-Path -Path $moduleZipPath)) {
+        return;
+    }
+
+    $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
+    $command = "$PSScriptRoot\7zip\7z.exe"
+    &$command @parameter
+})

--- a/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
@@ -8,10 +8,12 @@ param (
 $moduleContainerPath = Get-SavedModuleContainerPath
 
 if (-not(Test-Path -Path $moduleContainerPath)) {
+    Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
     return;
 }
 
 if (!$targetVersion) {
+    Write-Verbose "Latest module selected which will be available as folder."
     return;
 }
 
@@ -19,15 +21,19 @@ if (!$targetVersion) {
 @($false, $true).ForEach({
     $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
     if (Test-Path -Path $modulePath) {
+        Write-Verbose "Module available as folder at $modulePath"
         return;
     }
 
     $moduleZipPath = $modulePath + ".zip";
     if (-not(Test-Path -Path $moduleZipPath)) {
+        Write-Verbose "Module zip not available to unzip at $moduleZipPath"
         return;
     }
 
+    Write-Verbose "Extracting zip $moduleZipPath"
     $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
     $command = "$PSScriptRoot\7zip\7z.exe"
     &$command @parameter
+    Write-Verbose "Extraction complete"
 })

--- a/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV3/TryMakingModuleAvailable.ps1
@@ -4,36 +4,68 @@ param (
     $targetVersion
 )
 
-. "$PSScriptRoot\Utility.ps1"
-$moduleContainerPath = Get-SavedModuleContainerPath
+try {
+    . "$PSScriptRoot\Utility.ps1"
+    $moduleContainerPath = Get-SavedModuleContainerPath
 
-if (-not(Test-Path -Path $moduleContainerPath)) {
-    Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
-    return;
-}
-
-if (!$targetVersion) {
-    Write-Verbose "Latest module selected which will be available as folder."
-    return;
-}
-
-# value for classic
-@($false, $true).ForEach({
-    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
-    if (Test-Path -Path $modulePath) {
-        Write-Verbose "Module available as folder at $modulePath"
+    if (-not(Test-Path -Path $moduleContainerPath)) {
+        $classicModuleSource = "privateAgent"
+        $nonClassicModuleSource = "privateAgent"
+        Write-Verbose "Folder layout not as per hosted agent, considering self hosted agent skipping module unzip logic."
         return;
     }
 
-    $moduleZipPath = $modulePath + ".zip";
-    if (-not(Test-Path -Path $moduleZipPath)) {
-        Write-Verbose "Module zip not available to unzip at $moduleZipPath"
+    if (!$targetVersion) {
+        $classicModuleSource = "hostedAgentFolder"
+        $nonClassicModuleSource = "hostedAgentFolder"
+        Write-Verbose "Latest module selected which will be available as folder."
         return;
     }
 
-    Write-Verbose "Extracting zip $moduleZipPath"
-    $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
-    $command = "$PSScriptRoot\7zip\7z.exe"
-    &$command @parameter
-    Write-Verbose "Extraction complete"
-})
+    # value for classic
+    @($false, $true).ForEach({
+        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -Classic:$_;
+        if (Test-Path -Path $modulePath) {
+            if ($_) {
+                $classicModuleSource = "hostedAgentFolder"
+            } else {
+                $nonClassicModuleSource = "hostedAgentFolder"
+            }
+
+            Write-Verbose "Module available as folder at $modulePath"
+            return;
+        }
+
+        $moduleZipPath = $modulePath + ".zip";
+        if (-not(Test-Path -Path $moduleZipPath)) {
+            if ($_) {
+                $classicModuleSource = "hostedAgentOthers"
+            } else {
+                $nonClassicModuleSource = "hostedAgentOthers"
+            }
+
+            Write-Verbose "Module zip not available to unzip at $moduleZipPath"
+            return;
+        }
+
+        if ($_) {
+            $classicModuleSource = "hostedAgentZip"
+        } else {
+            $nonClassicModuleSource = "hostedAgentZip"
+        }
+
+        Write-Verbose "Extracting zip $moduleZipPath"
+        $parameter = @("x", "-o$moduleContainerPath", "$moduleZipPath")
+        $command = "$PSScriptRoot\7zip\7z.exe"
+        &$command @parameter
+        Write-Verbose "Extraction complete"
+    })
+} finally {
+    # Telemetry
+    $telemetryJsonContent = @{
+        targetAzurePs = $targetVersion;
+        classicModuleSource = $classicModuleSource;
+        nonClassicModuleSource = $nonClassicModuleSource
+    } | ConvertTo-Json -Compress
+    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV3]$telemetryJsonContent"
+}

--- a/Tasks/AzurePowerShellV3/Utility.ps1
+++ b/Tasks/AzurePowerShellV3/Utility.ps1
@@ -2,16 +2,20 @@ $rollForwardTable = @{
     "5.0.0" = "5.1.1";
 };
 
+function Get-SavedModuleContainerPath {
+    return $env:SystemDrive + "\Modules";
+}
+
 function Get-SavedModulePath {
     [CmdletBinding()]
     param([string] $azurePowerShellVersion,
           [switch] $Classic)
     
     if($Classic -eq $true) {
-        return $($env:SystemDrive + "\Modules\Azure_" + $azurePowerShellVersion)
+        return (Get-SavedModuleContainerPath) + "\Azure_" + $azurePowerShellVersion;
     }
     else {
-        return $($env:SystemDrive + "\Modules\AzureRm_" + $azurePowerShellVersion)
+        return (Get-SavedModuleContainerPath) + "\AzureRm_" + $azurePowerShellVersion;
     }
 }
 

--- a/Tasks/AzurePowerShellV3/make.json
+++ b/Tasks/AzurePowerShellV3/make.json
@@ -30,6 +30,12 @@
                     }
                 ]
             }
+        ],
+        "archivePackages": [
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+                "dest": "./"
+            }
         ]
     }
 }

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 179,
-        "Patch": 1
+        "Minor": 184,
+        "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 179,
-    "Patch": 1
+    "Minor": 184,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
**Task name**: AzurePowerShellV2 and V3

**Description**: If Azure or AzureRM powershell module is available as zip in `C:\Modules\` instead of folder then the task would be able to make use of that by extracting the zip.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
