### PR TITLE
VSBuildV1 - msbuildhelpers fixed typo

### DIFF
--- a/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
@@ -106,7 +106,7 @@ function Invoke-MSBuild {
 
         if($IsDefaultLoggerEnabled) {
             # Hook up the custom logger.
-            $loggerAssembly = "$PSScriptRoot\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
+            $loggerAssembly = "$PSScriptRoot\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
             Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
             $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
         }

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DefaultLoggerEnabledByDefault.ps1
@@ -2,7 +2,7 @@
 param()
 
 # Arrange.
-. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
 Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
 $directory = 'Some drive:\Some directory'
 $file = "$directory\Some solution"

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-BuildTools.DisableDefaultLogger.ps1
@@ -2,7 +2,7 @@
 param()
 
 # Arrange.
-. $PSScriptRoot\..\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
 Microsoft.PowerShell.Core\Import-Module $PSScriptRoot\..
 $directory = 'Some drive:\Some directory'
 $file = "$directory\Some solution"


### PR DESCRIPTION
**Task name**: VSBuildV1

**Description**: Fixed typos - loggerAssembly path, several other paths in tests.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14255

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it - n/a for package, since package has not been published yet
- [x] Checked that applied changes work as expected - checked that path is valid now
