### PR TITLE
AzurePowerShellV4/V5 can dynamically download Az modules

### DIFF
--- a/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
@@ -49,6 +49,8 @@ if ($targetAzurePs -eq $latestVersion) {
 }
 Write-Host "## Validating Inputs Complete" 
 
+. $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion "$targetAzurePs" -platform Windows
+
 Write-Host "## Initializing Az module"
 . "$PSScriptRoot\Utility.ps1"
 

--- a/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
@@ -265,9 +265,5 @@ finally {
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
     Remove-EndpointSecrets
     Disconnect-AzureAndClearContext -restrictContext $restrictContext -ErrorAction SilentlyContinue
-
-    # Telemetry
-    $telemetryJsonContent = @{ targetAzurePs = $targetAzurePs } | ConvertTo-Json -Compress
-    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV4]$telemetryJsonContent"
 }
 Write-Host "## Script Execution Complete"

--- a/Tasks/AzurePowerShellV4/Tests/ChecksForPowerShell.ps1
+++ b/Tasks/AzurePowerShellV4/Tests/ChecksForPowerShell.ps1
@@ -19,6 +19,9 @@ Register-Mock Remove-EndpointSecrets
 Register-Mock Disconnect-AzureAndClearContext
 Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV4/Tests/ChecksForPowerShellCore.ps1
+++ b/Tasks/AzurePowerShellV4/Tests/ChecksForPowerShellCore.ps1
@@ -19,6 +19,9 @@ Register-Mock Remove-EndpointSecrets
 Register-Mock Disconnect-AzureAndClearContext
 Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV4/Tests/ChecksForWorkingDirectory.ps1
+++ b/Tasks/AzurePowerShellV4/Tests/ChecksForWorkingDirectory.ps1
@@ -21,6 +21,9 @@ Register-Mock Remove-EndpointSecrets
 Register-Mock Disconnect-AzureAndClearContext
 Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV4/Tests/PerformsBasicFlow.ps1
+++ b/Tasks/AzurePowerShellV4/Tests/PerformsBasicFlow.ps1
@@ -18,6 +18,9 @@ Register-Mock Remove-EndpointSecrets
 Register-Mock Disconnect-AzureAndClearContext
 Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -72,6 +72,10 @@ try {
     $moduleSource = "PSGallery"
 } finally {
     # Telemetry
+    # moduleSource value can be Others(in case of self hosted agents), Folder(when a version is present as folder or
+    # when latest is selected we will use the one latest available as folder), Zip(when the module is available as a zip locally),
+    # GHRelease(when the module zip is downloaded from our GitHub releases management), PSGallery(when we download from PSGallery
+    # using the Save-Module cmdlet).
     $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
     Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV4]$telemetryJsonContent"
 }

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param (
+    [string]
+    $targetVersion,
+
+    [string] [Parameter(Mandatory = $true)] [ValidateSet("Windows", "Linux", "Mac")]
+    $platform
+)
+
+$isWin = $platform -eq "Windows"
+if ($isWin) {
+    . "$PSScriptRoot\Utility.ps1"
+    $isHostedAgent = Test-IsHostedAgentPathPresent
+} else {
+    . "$PSScriptRoot/Utility.ps1"
+    $isHostedAgent = Test-IsHostedAgentPathPresentLinux
+}
+
+if (!$isHostedAgent) {
+    return;
+}
+
+if (!$targetVersion) {
+    return;
+}
+
+if ($isWin) {
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
+} else {
+    $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
+}
+
+if (Test-Path $modulePath) {
+    return;
+}
+
+if ($isWin) {
+    $moduleContainerPath = Get-SavedModuleContainerPath
+} else {
+    $moduleContainerPath = Get-SavedModuleContainerPathLinux
+}
+
+
+$moduleZipPath = $modulePath + ".zip";
+if (Test-Path $moduleZipPath) {
+    Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+    return;
+}
+
+try {
+    $versionsManifest = Invoke-RestMethod -Method Get `
+        -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
+        -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
+    $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
+    (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+    if (Test-Path $moduleZipPath) {
+        Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+        return;
+    }
+} catch {
+
+}
+
+Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -15,20 +15,20 @@ try {
  
     if (!$isHostedAgent) {
         Write-Verbose "Module path not present as expected in hosted agent, skipping step to make module available."
-        $moduleSource = "Others"
+        $moduleSource = "privateAgent"
         return
     }
 
     if (!$targetVersion) {
         Write-Verbose "Latest selected, will make use of the latest available in agent as folder."
-        $moduleSource = "Folder"
+        $moduleSource = "hostedAgentFolder"
         return
     }
 
     $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -isWin $isWin
     if (Test-Path $modulePath) {
         Write-Verbose "Az $targetVersion present at $modulePath as folder."
-        $moduleSource = "Folder"
+        $moduleSource = "hostedAgentFolder"
         return
     }
 
@@ -38,7 +38,7 @@ try {
         Write-Verbose "Az $targetVersion present at $moduleZipPath as zip, expanding it."
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
         Write-Verbose "Zip expanded"
-        $moduleSource = "Zip"
+        $moduleSource = "hostedAgentZip"
         return
     }
 
@@ -47,16 +47,19 @@ try {
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
+        Write-Verbose "Versions manifest downloaded with below content."
+        Write-Verbose $versionsManifest
         $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
         if ($downloadUrlEntity) {
             $downloadUrl = $downloadUrlEntity.files[0].download_url
             Write-Verbose "Downloading Az $targetVersion from GHRelease"
             (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+            Write-Verbose "Download succeeded"
             if (Test-Path $moduleZipPath) {
                 Write-Verbose "Expanding Az $targetVersion downloaded at $moduleZipPath as zip."
                 Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
                 Write-Verbose "Zip expanded"
-                $moduleSource = "GHRelease"
+                $moduleSource = "hostedAgentGHRelease"
                 return
             }
         } else {
@@ -69,12 +72,12 @@ try {
 
     Write-Verbose "Downloading Az $targetVersion from PSGallery."
     Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
-    $moduleSource = "PSGallery"
+    $moduleSource = "hostedAgentPSGallery"
 } finally {
     # Telemetry
-    # moduleSource value can be Others(in case of self hosted agents), Folder(when a version is present as folder or
-    # when latest is selected we will use the one latest available as folder), Zip(when the module is available as a zip locally),
-    # GHRelease(when the module zip is downloaded from our GitHub releases management), PSGallery(when we download from PSGallery
+    # moduleSource value will be privateAgent(in case of self hosted private agents), hostedAgentFolder(when a version is present as folder or
+    # when latest is selected we will use the one latest available as folder), hostedAgentZip(when the module is available as a zip locally),
+    # hostedAgentGHRelease(when the module zip is downloaded from our GitHub releases management), hostedAgentPSGallery(when we download from PSGallery
     # using the Save-Module cmdlet).
     $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
     Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV4]$telemetryJsonContent"

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -47,8 +47,7 @@ try {
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
-        Write-Verbose "Versions manifest downloaded with below content."
-        Write-Verbose $versionsManifest
+        Write-Verbose "Versions manifest downloaded."
         $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
         if ($downloadUrlEntity) {
             $downloadUrl = $downloadUrlEntity.files[0].download_url

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -7,58 +7,72 @@ param (
     $platform
 )
 
-$isWin = $platform -eq "Windows"
-if ($isWin) {
-    . "$PSScriptRoot\Utility.ps1"
-    $isHostedAgent = Test-IsHostedAgentPathPresent
-} else {
-    . "$PSScriptRoot/Utility.ps1"
-    $isHostedAgent = Test-IsHostedAgentPathPresentLinux
-}
-
-if (!$isHostedAgent) {
-    return;
-}
-
-if (!$targetVersion) {
-    return;
-}
-
-if ($isWin) {
-    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
-} else {
-    $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
-}
-
-if (Test-Path $modulePath) {
-    return;
-}
-
-if ($isWin) {
-    $moduleContainerPath = Get-SavedModuleContainerPath
-} else {
-    $moduleContainerPath = Get-SavedModuleContainerPathLinux
-}
-
-
-$moduleZipPath = $modulePath + ".zip";
-if (Test-Path $moduleZipPath) {
-    Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-    return;
-}
-
 try {
-    $versionsManifest = Invoke-RestMethod -Method Get `
-        -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
-        -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
-    $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
-    (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+    $isWin = $platform -eq "Windows"
+    if ($isWin) {
+        . "$PSScriptRoot\Utility.ps1"
+        $isHostedAgent = Test-IsHostedAgentPathPresent
+    } else {
+        . "$PSScriptRoot/Utility.ps1"
+        $isHostedAgent = Test-IsHostedAgentPathPresentLinux
+    }
+
+    if (!$isHostedAgent) {
+        $moduleSource = "Others"
+        return
+    }
+
+    if (!$targetVersion) {
+        $moduleSource = "Folder"
+        return
+    }
+
+    if ($isWin) {
+        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
+    } else {
+        $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
+    }
+
+    if (Test-Path $modulePath) {
+        $moduleSource = "Folder"
+        return
+    }
+
+    if ($isWin) {
+        $moduleContainerPath = Get-SavedModuleContainerPath
+    } else {
+        $moduleContainerPath = Get-SavedModuleContainerPathLinux
+    }
+
+
+    $moduleZipPath = $modulePath + ".zip";
     if (Test-Path $moduleZipPath) {
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-        return;
+        $moduleSource = "Zip"
+        return
     }
-} catch {
 
+    try {
+        $versionsManifest = Invoke-RestMethod -Method Get `
+            -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
+            -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
+        $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
+        (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+        if (Test-Path $moduleZipPath) {
+            Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+            $moduleSource = "GHRelease"
+            return
+        }
+    } catch {
+        Write-Verbose "Failed to download from GHRelease"
+        Write-Verbose $_
+    }
+
+    Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
+    $moduleSource = "PSGallery"
+} finally {
+    # Telemetry
+    $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
+    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV4]$telemetryJsonContent"
+    Write-Host $telemetryJsonContent
 }
-
-Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -42,6 +42,8 @@ try {
         return
     }
 
+    Write-Host "Az version $targetVersion not avaiable locally on the agent. Downloading dynamically."
+
     try {
         Write-Verbose "Getting versions manifest from GHRelease."
         $versionsManifest = Invoke-RestMethod -Method Get `

--- a/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV4/TryMakingModuleAvailable.ps1
@@ -9,70 +9,69 @@ param (
 
 try {
     $isWin = $platform -eq "Windows"
-    if ($isWin) {
-        . "$PSScriptRoot\Utility.ps1"
-        $isHostedAgent = Test-IsHostedAgentPathPresent
-    } else {
-        . "$PSScriptRoot/Utility.ps1"
-        $isHostedAgent = Test-IsHostedAgentPathPresentLinux
-    }
 
+    . (Join-Path $PSScriptRoot "Utility.ps1")
+    $isHostedAgent = Test-IsHostedAgentPathPresent -isWin $isWin
+ 
     if (!$isHostedAgent) {
+        Write-Verbose "Module path not present as expected in hosted agent, skipping step to make module available."
         $moduleSource = "Others"
         return
     }
 
     if (!$targetVersion) {
+        Write-Verbose "Latest selected, will make use of the latest available in agent as folder."
         $moduleSource = "Folder"
         return
     }
 
-    if ($isWin) {
-        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
-    } else {
-        $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
-    }
-
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -isWin $isWin
     if (Test-Path $modulePath) {
+        Write-Verbose "Az $targetVersion present at $modulePath as folder."
         $moduleSource = "Folder"
         return
     }
 
-    if ($isWin) {
-        $moduleContainerPath = Get-SavedModuleContainerPath
-    } else {
-        $moduleContainerPath = Get-SavedModuleContainerPathLinux
-    }
-
-
+    $moduleContainerPath = Get-SavedModuleContainerPath -isWin $isWin
     $moduleZipPath = $modulePath + ".zip";
     if (Test-Path $moduleZipPath) {
+        Write-Verbose "Az $targetVersion present at $moduleZipPath as zip, expanding it."
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+        Write-Verbose "Zip expanded"
         $moduleSource = "Zip"
         return
     }
 
     try {
+        Write-Verbose "Getting versions manifest from GHRelease."
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
-        $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
-        (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
-        if (Test-Path $moduleZipPath) {
-            Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-            $moduleSource = "GHRelease"
-            return
+        $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
+        if ($downloadUrlEntity) {
+            $downloadUrl = $downloadUrlEntity.files[0].download_url
+            Write-Verbose "Downloading Az $targetVersion from GHRelease"
+            (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+            if (Test-Path $moduleZipPath) {
+                Write-Verbose "Expanding Az $targetVersion downloaded at $moduleZipPath as zip."
+                Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+                Write-Verbose "Zip expanded"
+                $moduleSource = "GHRelease"
+                return
+            }
+        } else {
+            Write-Verbose "Az $targetVersion not present in versions manifest from GHRelease"
         }
     } catch {
         Write-Verbose "Failed to download from GHRelease"
         Write-Verbose $_
     }
 
+    Write-Verbose "Downloading Az $targetVersion from PSGallery."
     Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
     $moduleSource = "PSGallery"
 } finally {
     # Telemetry
     $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
     Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV4]$telemetryJsonContent"
-    Write-Host $telemetryJsonContent
 }

--- a/Tasks/AzurePowerShellV4/Utility.ps1
+++ b/Tasks/AzurePowerShellV4/Utility.ps1
@@ -1,35 +1,45 @@
 function Get-SavedModuleContainerPath {
-    return $env:SystemDrive + "\Modules";
-}
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
 
-function Get-SavedModuleContainerPathLinux {
-    return "/usr/share";
+    if ($isWin) {
+        return $env:SystemDrive + "\Modules";
+    } else {
+        return "/usr/share";
+    }
 }
 
 function Test-IsHostedAgentPathPresent {
-    $containerPath = Get-SavedModuleContainerPath;
-    return Test-Path "$containerPath\az_*"
-}
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
 
-function Test-IsHostedAgentPathPresentLinux {
-    $containerPath = Get-SavedModuleContainerPathLinux;
-    return Test-Path "$containerPath/az_*"
+    $containerPath = Get-SavedModuleContainerPath -isWin $isWin
+    return Test-Path (Join-Path $containerPath "az_*")
 }
 
 function Get-SavedModulePath {
     [CmdletBinding()]
-    param([string] $azurePowerShellVersion)
-    $savedModulePath = (Get-SavedModuleContainerPath) + "\az_" + $azurePowerShellVersion;
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $azurePowerShellVersion,
+
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
+
+    $savedModulePath = Join-Path (Get-SavedModuleContainerPath -isWin $isWin) "az_$azurePowerShellVersion"
     Write-Verbose "The value of the module path is: $savedModulePath"
     return $savedModulePath 
-}
-
-function Get-SavedModulePathLinux {
-    [CmdletBinding()]
-    param([string] $azurePowerShellVersion)
-    $savedModulePath =  (Get-SavedModuleContainerPathLinux) + "/az_" + $azurePowerShellVersion;
-    Write-Verbose "The value of the module path is: $savedModulePath"
-    return $savedModulePath
 }
 
 function Expand-ModuleZip {
@@ -61,7 +71,7 @@ function Update-PSModulePathForHostedAgent {
     param([string] $targetAzurePs)
     try {
         if ($targetAzurePs) {
-            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs
+            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs -isWin $true
         }
         else {
             $hostedAgentAzModulePath = Get-LatestModule -patternToMatch "^az_[0-9]+\.[0-9]+\.[0-9]+$" -patternToExtract "[0-9]+\.[0-9]+\.[0-9]+$"
@@ -78,7 +88,7 @@ function Update-PSModulePathForHostedAgentLinux {
     param([string] $targetAzurePs)
     try {
         if ($targetAzurePs) {
-            $hostedAgentAzModulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetAzurePs
+            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs -isWin $false
             if(!(Test-Path $hostedAgentAzModulePath)) {
                 Write-Verbose "No module path found with this name"
                 throw ("Could not find the module path with given version.")

--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -148,7 +148,6 @@ async function run() {
         if (stderrFailure) {
             tl.setResult(tl.TaskResult.Failed, tl.loc('JS_Stderr'));
         }
-        telemetry.emitTelemetry("TaskHub", "AzurePowerShellV4", { targetAzurePs });
         console.log("## Script Execution Complete"); 
     }
     catch (err) {

--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -64,6 +64,10 @@ async function run() {
         console.log("## Initializing Az module");
         console.log(tl.loc('GeneratingScript'));
         let contents: string[] = [];
+
+        const makeModuleAvailableScriptPath = path.join(path.resolve(__dirname), 'TryMakingModuleAvailable.ps1');
+        contents.push(`${makeModuleAvailableScriptPath} -targetVersion '${targetAzurePs}' -platform Linux`);
+
         let azFilePath = path.join(path.resolve(__dirname), 'InitializeAz.ps1');
         contents.push(`$ErrorActionPreference = '${_vsts_input_errorActionPreference}'`);
         if(targetAzurePs == "") {

--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -36,6 +36,8 @@ async function run() {
         let serviceName = tl.getInput('ConnectedServiceNameARM',/*required*/true);
         let endpointObject= await new AzureRMEndpoint(serviceName).getEndpoint();
         let input_workingDirectory = tl.getPathInput('workingDirectory', /*required*/ true, /*check*/ true);
+        let isDebugEnabled = (process.env['SYSTEM_DEBUG'] || "").toLowerCase() === "true";
+
         // string constants
         let otherVersion = "OtherVersion"
 
@@ -64,6 +66,10 @@ async function run() {
         console.log("## Initializing Az module");
         console.log(tl.loc('GeneratingScript'));
         let contents: string[] = [];
+
+        if (isDebugEnabled) {
+            contents.push("$VerbosePreference = 'continue'");
+        }
 
         const makeModuleAvailableScriptPath = path.join(path.resolve(__dirname), 'TryMakingModuleAvailable.ps1');
         contents.push(`${makeModuleAvailableScriptPath} -targetVersion '${targetAzurePs}' -platform Linux`);

--- a/Tasks/AzurePowerShellV4/make.json
+++ b/Tasks/AzurePowerShellV4/make.json
@@ -30,6 +30,12 @@
                     }
                 ]
             }
+        ],
+        "archivePackages": [
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+                "dest": "./"
+            }
         ]
     }
 }

--- a/Tasks/AzurePowerShellV4/package-lock.json
+++ b/Tasks/AzurePowerShellV4/package-lock.json
@@ -135,6 +135,36 @@
         "uuid": "^3.3.2"
       }
     },
+    "azure-pipelines-tool-lib": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
+      "requires": {
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "azure-pipelines-task-lib": "^2.8.0",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "1.0.9",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "tunnel": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+        },
+        "typed-rest-client": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -509,6 +539,11 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
@@ -581,6 +616,11 @@
           "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
         }
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "topo": {
       "version": "1.1.0",

--- a/Tasks/AzurePowerShellV4/package-lock.json
+++ b/Tasks/AzurePowerShellV4/package-lock.json
@@ -119,48 +119,20 @@
         "azure-pipelines-tool-lib": "1.0.0-preview.0",
         "js-yaml": "3.6.1",
         "semver": "^5.4.1"
-      }
-    },
-    "azure-pipelines-tool-lib": {
-      "version": "1.0.0-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.0-preview.0.tgz",
-      "integrity": "sha512-Ao4A/r7q6qTTeDqa40U9/58kw5uC6r29cTJ7386uMSl7RgNu19ja+nN0Tnvl6dQTCjajMjqiT+UADuDi5zhucw==",
-      "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^3.0.6-preview.0",
-        "semver": "^5.7.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.7.3",
-        "uuid": "^3.3.2"
-      }
-    },
-    "azure-pipelines-tool-lib": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
-      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
-      "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.0.1",
-        "azure-pipelines-task-lib": "^2.8.0",
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "1.0.9",
-        "uuid": "^3.0.1"
       },
       "dependencies": {
-        "tunnel": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
-        },
-        "typed-rest-client": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
-          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+        "azure-pipelines-tool-lib": {
+          "version": "1.0.0-preview.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.0-preview.0.tgz",
+          "integrity": "sha512-Ao4A/r7q6qTTeDqa40U9/58kw5uC6r29cTJ7386uMSl7RgNu19ja+nN0Tnvl6dQTCjajMjqiT+UADuDi5zhucw==",
           "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
+            "@types/semver": "^5.3.0",
+            "@types/uuid": "^3.4.5",
+            "azure-pipelines-task-lib": "^3.0.6-preview.0",
+            "semver": "^5.7.0",
+            "semver-compare": "^1.0.0",
+            "typed-rest-client": "^1.7.3",
+            "uuid": "^3.3.2"
           }
         }
       }
@@ -539,11 +511,6 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
-    },
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
@@ -616,11 +583,6 @@
           "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
         }
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "topo": {
       "version": "1.1.0",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 184,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 184,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -62,6 +62,8 @@ try
         $contents += "`$VerbosePreference = 'continue'"
     }
 
+    $contents += ". $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion '$targetAzurePs' -platform Windows"
+
     $CoreAzArgument = $null;
     if ($targetAzurePs) {
         $CoreAzArgument = "-endpoint '$endpoint' -targetAzurePs $targetAzurePs"

--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -46,6 +46,8 @@ if ($targetAzurePs -eq $latestVersion) {
     throw (Get-VstsLocString -Key InvalidAzurePsVersion -ArgumentList $targetAzurePs)
 }
 
+. $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion "$targetAzurePs" -platform Windows
+
 . "$PSScriptRoot\Utility.ps1"
 
 $serviceName = Get-VstsInput -Name ConnectedServiceNameARM -Require
@@ -61,8 +63,6 @@ try
     if ($env:system_debug -eq "true") {
         $contents += "`$VerbosePreference = 'continue'"
     }
-
-    $contents += ". $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion '$targetAzurePs' -platform Windows"
 
     $CoreAzArgument = $null;
     if ($targetAzurePs) {
@@ -171,8 +171,4 @@ finally {
     Import-Module $PSScriptRoot\ps_modules\VstsAzureHelpers_
     Remove-EndpointSecrets
     Disconnect-AzureAndClearContext -ErrorAction SilentlyContinue
-
-    # Telemetry
-    $telemetryJsonContent = @{ targetAzurePs = $targetAzurePs } | ConvertTo-Json -Compress
-    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV5]$telemetryJsonContent"
 }

--- a/Tasks/AzurePowerShellV5/Tests/ChecksForPowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/Tests/ChecksForPowerShell.ps1
@@ -21,6 +21,9 @@ Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
 Register-Mock Write-VstsTaskError
 Register-Mock Write-VstsSetResult
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV5/Tests/ChecksForPowerShellCore.ps1
+++ b/Tasks/AzurePowerShellV5/Tests/ChecksForPowerShellCore.ps1
@@ -21,6 +21,9 @@ Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
 Register-Mock Write-VstsTaskError
 Register-Mock Write-VstsSetResult
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV5/Tests/ChecksForWorkingDirectory.ps1
+++ b/Tasks/AzurePowerShellV5/Tests/ChecksForWorkingDirectory.ps1
@@ -23,6 +23,9 @@ Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
 Register-Mock Write-VstsTaskError
 Register-Mock Write-VstsSetResult
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV5/Tests/PerformsBasicFlow.ps1
+++ b/Tasks/AzurePowerShellV5/Tests/PerformsBasicFlow.ps1
@@ -20,6 +20,9 @@ Register-Mock Assert-VstsPath
 Register-Mock Invoke-VstsTool { }
 Register-Mock Write-VstsTaskError
 Register-Mock Write-VstsSetResult
+Register-Mock Expand-ModuleZip
+Register-Mock Invoke-RestMethod
+Register-Mock Save-Module
 
 # Act.
 $actual = & $PSScriptRoot\..\AzurePowerShell.ps1

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -7,58 +7,71 @@ param (
     $platform
 )
 
-$isWin = $platform -eq "Windows"
-if ($isWin) {
-    . "$PSScriptRoot\Utility.ps1"
-    $isHostedAgent = Test-IsHostedAgentPathPresent
-} else {
-    . "$PSScriptRoot/Utility.ps1"
-    $isHostedAgent = Test-IsHostedAgentPathPresentLinux
-}
-
-if (!$isHostedAgent) {
-    return;
-}
-
-if (!$targetVersion) {
-    return;
-}
-
-if ($isWin) {
-    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
-} else {
-    $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
-}
-
-if (Test-Path $modulePath) {
-    return;
-}
-
-if ($isWin) {
-    $moduleContainerPath = Get-SavedModuleContainerPath
-} else {
-    $moduleContainerPath = Get-SavedModuleContainerPathLinux
-}
-
-
-$moduleZipPath = $modulePath + ".zip";
-if (Test-Path $moduleZipPath) {
-    Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-    return;
-}
-
 try {
-    $versionsManifest = Invoke-RestMethod -Method Get `
-        -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
-        -Uri "https://api.github.com/repos/amit-avit/az-ps-module-versions/contents/versions-manifest.json"
-    $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
-    (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+    $isWin = $platform -eq "Windows"
+    if ($isWin) {
+        . "$PSScriptRoot\Utility.ps1"
+        $isHostedAgent = Test-IsHostedAgentPathPresent
+    } else {
+        . "$PSScriptRoot/Utility.ps1"
+        $isHostedAgent = Test-IsHostedAgentPathPresentLinux
+    }
+
+    if (!$isHostedAgent) {
+        $moduleSource = "Others"
+        return
+    }
+
+    if (!$targetVersion) {
+        $moduleSource = "Folder"
+        return
+    }
+
+    if ($isWin) {
+        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
+    } else {
+        $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
+    }
+
+    if (Test-Path $modulePath) {
+        $moduleSource = "Folder"
+        return
+    }
+
+    if ($isWin) {
+        $moduleContainerPath = Get-SavedModuleContainerPath
+    } else {
+        $moduleContainerPath = Get-SavedModuleContainerPathLinux
+    }
+
+
+    $moduleZipPath = $modulePath + ".zip";
     if (Test-Path $moduleZipPath) {
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-        return;
+        $moduleSource = "Zip"
+        return
     }
-} catch {
 
+    try {
+        $versionsManifest = Invoke-RestMethod -Method Get `
+            -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
+            -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
+        $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
+        (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+        if (Test-Path $moduleZipPath) {
+            Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+            $moduleSource = "GHRelease"
+            return
+        }
+    } catch {
+        Write-Verbose "Failed to download from GHRelease"
+        Write-Verbose $_
+    }
+
+    Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
+    $moduleSource = "PSGallery"
+} finally {
+    # Telemetry
+    $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
+    Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV5]$telemetryJsonContent"
 }
-
-Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -15,20 +15,20 @@ try {
  
     if (!$isHostedAgent) {
         Write-Verbose "Module path not present as expected in hosted agent, skipping step to make module available."
-        $moduleSource = "Others"
+        $moduleSource = "privateAgent"
         return
     }
 
     if (!$targetVersion) {
         Write-Verbose "Latest selected, will make use of the latest available in agent as folder."
-        $moduleSource = "Folder"
+        $moduleSource = "hostedAgentFolder"
         return
     }
 
     $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -isWin $isWin
     if (Test-Path $modulePath) {
         Write-Verbose "Az $targetVersion present at $modulePath as folder."
-        $moduleSource = "Folder"
+        $moduleSource = "hostedAgentFolder"
         return
     }
 
@@ -38,7 +38,7 @@ try {
         Write-Verbose "Az $targetVersion present at $moduleZipPath as zip, expanding it."
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
         Write-Verbose "Zip expanded"
-        $moduleSource = "Zip"
+        $moduleSource = "hostedAgentZip"
         return
     }
 
@@ -47,16 +47,19 @@ try {
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
+        Write-Verbose "Versions manifest downloaded with below content."
+        Write-Verbose $versionsManifest
         $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
         if ($downloadUrlEntity) {
             $downloadUrl = $downloadUrlEntity.files[0].download_url
             Write-Verbose "Downloading Az $targetVersion from GHRelease"
             (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+            Write-Verbose "Download succeeded"
             if (Test-Path $moduleZipPath) {
                 Write-Verbose "Expanding Az $targetVersion downloaded at $moduleZipPath as zip."
                 Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
                 Write-Verbose "Zip expanded"
-                $moduleSource = "GHRelease"
+                $moduleSource = "hostedAgentGHRelease"
                 return
             }
         } else {
@@ -69,9 +72,13 @@ try {
 
     Write-Verbose "Downloading Az $targetVersion from PSGallery."
     Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
-    $moduleSource = "PSGallery"
+    $moduleSource = "hostedAgentPSGallery"
 } finally {
     # Telemetry
+    # moduleSource value will be privateAgent(in case of self hosted private agents), hostedAgentFolder(when a version is present as folder or
+    # when latest is selected we will use the one latest available as folder), hostedAgentZip(when the module is available as a zip locally),
+    # hostedAgentGHRelease(when the module zip is downloaded from our GitHub releases management), hostedAgentPSGallery(when we download from PSGallery
+    # using the Save-Module cmdlet).
     $telemetryJsonContent = @{ targetAzurePs = $targetVersion; moduleSource = $moduleSource } | ConvertTo-Json -Compress
     Write-Host "##vso[telemetry.publish area=TaskHub;feature=AzurePowerShellV5]$telemetryJsonContent"
 }

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -47,8 +47,7 @@ try {
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
-        Write-Verbose "Versions manifest downloaded with below content."
-        Write-Verbose $versionsManifest
+        Write-Verbose "Versions manifest downloaded."
         $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
         if ($downloadUrlEntity) {
             $downloadUrl = $downloadUrlEntity.files[0].download_url

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -42,6 +42,8 @@ try {
         return
     }
 
+    Write-Host "Az version $targetVersion not avaiable locally on the agent. Downloading dynamically."
+
     try {
         Write-Verbose "Getting versions manifest from GHRelease."
         $versionsManifest = Invoke-RestMethod -Method Get `

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param (
+    [string]
+    $targetVersion,
+
+    [string] [Parameter(Mandatory = $true)] [ValidateSet("Windows", "Linux", "Mac")]
+    $platform
+)
+
+$isWin = $platform -eq "Windows"
+if ($isWin) {
+    . "$PSScriptRoot\Utility.ps1"
+    $isHostedAgent = Test-IsHostedAgentPathPresent
+} else {
+    . "$PSScriptRoot/Utility.ps1"
+    $isHostedAgent = Test-IsHostedAgentPathPresentLinux
+}
+
+if (!$isHostedAgent) {
+    return;
+}
+
+if (!$targetVersion) {
+    return;
+}
+
+if ($isWin) {
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
+} else {
+    $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
+}
+
+if (Test-Path $modulePath) {
+    return;
+}
+
+if ($isWin) {
+    $moduleContainerPath = Get-SavedModuleContainerPath
+} else {
+    $moduleContainerPath = Get-SavedModuleContainerPathLinux
+}
+
+
+$moduleZipPath = $modulePath + ".zip";
+if (Test-Path $moduleZipPath) {
+    Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+    return;
+}
+
+try {
+    $versionsManifest = Invoke-RestMethod -Method Get `
+        -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
+        -Uri "https://api.github.com/repos/amit-avit/az-ps-module-versions/contents/versions-manifest.json"
+    $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
+    (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+    if (Test-Path $moduleZipPath) {
+        Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+        return;
+    }
+} catch {
+
+}
+
+Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop

--- a/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
+++ b/Tasks/AzurePowerShellV5/TryMakingModuleAvailable.ps1
@@ -9,65 +9,65 @@ param (
 
 try {
     $isWin = $platform -eq "Windows"
-    if ($isWin) {
-        . "$PSScriptRoot\Utility.ps1"
-        $isHostedAgent = Test-IsHostedAgentPathPresent
-    } else {
-        . "$PSScriptRoot/Utility.ps1"
-        $isHostedAgent = Test-IsHostedAgentPathPresentLinux
-    }
 
+    . (Join-Path $PSScriptRoot "Utility.ps1")
+    $isHostedAgent = Test-IsHostedAgentPathPresent -isWin $isWin
+ 
     if (!$isHostedAgent) {
+        Write-Verbose "Module path not present as expected in hosted agent, skipping step to make module available."
         $moduleSource = "Others"
         return
     }
 
     if (!$targetVersion) {
+        Write-Verbose "Latest selected, will make use of the latest available in agent as folder."
         $moduleSource = "Folder"
         return
     }
 
-    if ($isWin) {
-        $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion
-    } else {
-        $modulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetVersion
-    }
-
+    $modulePath = Get-SavedModulePath -azurePowerShellVersion $targetVersion -isWin $isWin
     if (Test-Path $modulePath) {
+        Write-Verbose "Az $targetVersion present at $modulePath as folder."
         $moduleSource = "Folder"
         return
     }
 
-    if ($isWin) {
-        $moduleContainerPath = Get-SavedModuleContainerPath
-    } else {
-        $moduleContainerPath = Get-SavedModuleContainerPathLinux
-    }
-
-
+    $moduleContainerPath = Get-SavedModuleContainerPath -isWin $isWin
     $moduleZipPath = $modulePath + ".zip";
     if (Test-Path $moduleZipPath) {
+        Write-Verbose "Az $targetVersion present at $moduleZipPath as zip, expanding it."
         Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+        Write-Verbose "Zip expanded"
         $moduleSource = "Zip"
         return
     }
 
     try {
+        Write-Verbose "Getting versions manifest from GHRelease."
         $versionsManifest = Invoke-RestMethod -Method Get `
             -Headers @{ "Accept" = "application/vnd.github.VERSION.raw" } `
             -Uri "https://api.github.com/repos/Azure/az-ps-module-versions/contents/versions-manifest.json"
-        $downloadUrl = ($versionsManifest | Where-Object version -eq $targetVersion).files[0].download_url
-        (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
-        if (Test-Path $moduleZipPath) {
-            Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
-            $moduleSource = "GHRelease"
-            return
+        $downloadUrlEntity = $versionsManifest | Where-Object version -eq $targetVersion
+        if ($downloadUrlEntity) {
+            $downloadUrl = $downloadUrlEntity.files[0].download_url
+            Write-Verbose "Downloading Az $targetVersion from GHRelease"
+            (New-Object System.Net.WebClient).DownloadFile($downloadUrl, $moduleZipPath)
+            if (Test-Path $moduleZipPath) {
+                Write-Verbose "Expanding Az $targetVersion downloaded at $moduleZipPath as zip."
+                Expand-ModuleZip -zipPath $moduleZipPath -destination $moduleContainerPath -isWin $isWin
+                Write-Verbose "Zip expanded"
+                $moduleSource = "GHRelease"
+                return
+            }
+        } else {
+            Write-Verbose "Az $targetVersion not present in versions manifest from GHRelease"
         }
     } catch {
         Write-Verbose "Failed to download from GHRelease"
         Write-Verbose $_
     }
 
+    Write-Verbose "Downloading Az $targetVersion from PSGallery."
     Save-Module -Path $modulePath -Name Az -RequiredVersion $targetVersion -Force -ErrorAction Stop
     $moduleSource = "PSGallery"
 } finally {

--- a/Tasks/AzurePowerShellV5/Utility.ps1
+++ b/Tasks/AzurePowerShellV5/Utility.ps1
@@ -1,35 +1,45 @@
 function Get-SavedModuleContainerPath {
-    return $env:SystemDrive + "\Modules";
-}
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
 
-function Get-SavedModuleContainerPathLinux {
-    return "/usr/share";
+    if ($isWin) {
+        return $env:SystemDrive + "\Modules";
+    } else {
+        return "/usr/share";
+    }
 }
 
 function Test-IsHostedAgentPathPresent {
-    $containerPath = Get-SavedModuleContainerPath;
-    return Test-Path "$containerPath\az_*"
-}
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
 
-function Test-IsHostedAgentPathPresentLinux {
-    $containerPath = Get-SavedModuleContainerPathLinux;
-    return Test-Path "$containerPath/az_*"
+    $containerPath = Get-SavedModuleContainerPath -isWin $isWin
+    return Test-Path (Join-Path $containerPath "az_*")
 }
 
 function Get-SavedModulePath {
     [CmdletBinding()]
-    param([string] $azurePowerShellVersion)
-    $savedModulePath = (Get-SavedModuleContainerPath) + "\az_" + $azurePowerShellVersion;
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $azurePowerShellVersion,
+
+        [Parameter(Mandatory = $true)]
+        [bool]
+        $isWin
+    )
+
+    $savedModulePath = Join-Path (Get-SavedModuleContainerPath -isWin $isWin) "az_$azurePowerShellVersion"
     Write-Verbose "The value of the module path is: $savedModulePath"
     return $savedModulePath 
-}
-
-function Get-SavedModulePathLinux {
-    [CmdletBinding()]
-    param([string] $azurePowerShellVersion)
-    $savedModulePath =  (Get-SavedModuleContainerPathLinux) + "/az_" + $azurePowerShellVersion;
-    Write-Verbose "The value of the module path is: $savedModulePath"
-    return $savedModulePath
 }
 
 function Expand-ModuleZip {
@@ -61,7 +71,7 @@ function Update-PSModulePathForHostedAgent {
     param([string] $targetAzurePs)
     try {
         if ($targetAzurePs) {
-            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs
+            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs -isWin $true
         }
         else {
             $hostedAgentAzModulePath = Get-LatestModule -patternToMatch "^az_[0-9]+\.[0-9]+\.[0-9]+$" -patternToExtract "[0-9]+\.[0-9]+\.[0-9]+$"
@@ -78,7 +88,7 @@ function Update-PSModulePathForHostedAgentLinux {
     param([string] $targetAzurePs)
     try {
         if ($targetAzurePs) {
-            $hostedAgentAzModulePath = Get-SavedModulePathLinux -azurePowerShellVersion $targetAzurePs
+            $hostedAgentAzModulePath = Get-SavedModulePath -azurePowerShellVersion $targetAzurePs -isWin $false
             if(!(Test-Path $hostedAgentAzModulePath)) {
                 Write-Verbose "No module path found with this name"
                 throw ("Could not find the module path with given version.")

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -148,7 +148,6 @@ async function run() {
         if (stderrFailure) {
             tl.setResult(tl.TaskResult.Failed, tl.loc('JS_Stderr'));
         }
-        telemetry.emitTelemetry('TaskHub', 'AzurePowerShellV5', { targetAzurePs });
     }
     catch (err) {
         tl.setResult(tl.TaskResult.Failed, err.message || 'run() failed');

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -36,6 +36,7 @@ async function run() {
         let serviceName = tl.getInput('ConnectedServiceNameARM',/*required*/true);
         let endpointObject= await new AzureRMEndpoint(serviceName).getEndpoint();
         let input_workingDirectory = tl.getPathInput('workingDirectory', /*required*/ true, /*check*/ true);
+        let isDebugEnabled = (process.env['SYSTEM_DEBUG'] || "").toLowerCase() === "true";
 
         // string constants
         let otherVersion = "OtherVersion"
@@ -63,6 +64,10 @@ async function run() {
         // Generate the script contents.
         console.log(tl.loc('GeneratingScript'));
         let contents: string[] = [];
+
+        if (isDebugEnabled) {
+            contents.push("$VerbosePreference = 'continue'");
+        }
 
         const makeModuleAvailableScriptPath = path.join(path.resolve(__dirname), 'TryMakingModuleAvailable.ps1');
         contents.push(`${makeModuleAvailableScriptPath} -targetVersion '${targetAzurePs}' -platform Linux`);

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -63,6 +63,10 @@ async function run() {
         // Generate the script contents.
         console.log(tl.loc('GeneratingScript'));
         let contents: string[] = [];
+
+        const makeModuleAvailableScriptPath = path.join(path.resolve(__dirname), 'TryMakingModuleAvailable.ps1');
+        contents.push(`${makeModuleAvailableScriptPath} -targetVersion '${targetAzurePs}' -platform Linux`);
+
         let azFilePath = path.join(path.resolve(__dirname), 'InitializeAz.ps1');
         contents.push(`$ErrorActionPreference = '${_vsts_input_errorActionPreference}'`); 
         if(targetAzurePs == "") {

--- a/Tasks/AzurePowerShellV5/make.json
+++ b/Tasks/AzurePowerShellV5/make.json
@@ -30,6 +30,12 @@
                     }
                 ]
             }
+        ],
+        "archivePackages": [
+            {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/1/7zip.zip",
+                "dest": "./"
+            }
         ]
     }
 }

--- a/Tasks/AzurePowerShellV5/package-lock.json
+++ b/Tasks/AzurePowerShellV5/package-lock.json
@@ -128,6 +128,36 @@
         "uuid": "^3.3.2"
       }
     },
+    "azure-pipelines-tool-lib": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
+      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
+      "requires": {
+        "@types/semver": "^5.3.0",
+        "@types/uuid": "^3.0.1",
+        "azure-pipelines-task-lib": "^2.8.0",
+        "semver": "^5.3.0",
+        "semver-compare": "^1.0.0",
+        "typed-rest-client": "1.0.9",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "tunnel": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+        },
+        "typed-rest-client": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
+          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+          "requires": {
+            "tunnel": "0.0.4",
+            "underscore": "1.8.3"
+          }
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -495,6 +525,11 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
@@ -560,6 +595,11 @@
           "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
         }
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "topo": {
       "version": "1.1.0",

--- a/Tasks/AzurePowerShellV5/package-lock.json
+++ b/Tasks/AzurePowerShellV5/package-lock.json
@@ -112,48 +112,20 @@
         "azure-pipelines-tool-lib": "1.0.0-preview.0",
         "js-yaml": "3.6.1",
         "semver": "^5.4.1"
-      }
-    },
-    "azure-pipelines-tool-lib": {
-      "version": "1.0.0-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.0-preview.0.tgz",
-      "integrity": "sha512-Ao4A/r7q6qTTeDqa40U9/58kw5uC6r29cTJ7386uMSl7RgNu19ja+nN0Tnvl6dQTCjajMjqiT+UADuDi5zhucw==",
-      "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^3.0.6-preview.0",
-        "semver": "^5.7.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.7.3",
-        "uuid": "^3.3.2"
-      }
-    },
-    "azure-pipelines-tool-lib": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-0.12.0.tgz",
-      "integrity": "sha512-JAlFvMTtEXISrnJY/kgq0LecLi089RqXRf/gMsXYbflmzszklkc+LUJpR0A7NDmJ+9/MWpKY/ZX+Q/zirYa7gw==",
-      "requires": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.0.1",
-        "azure-pipelines-task-lib": "^2.8.0",
-        "semver": "^5.3.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "1.0.9",
-        "uuid": "^3.0.1"
       },
       "dependencies": {
-        "tunnel": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
-        },
-        "typed-rest-client": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.0.9.tgz",
-          "integrity": "sha512-iOdwgmnP/tF6Qs+oY4iEtCf/3fnCDl7Gy9LGPJ4E3M4Wj3uaSko15FVwbsaBmnBqTJORnXBWVY5306D4HH8oiA==",
+        "azure-pipelines-tool-lib": {
+          "version": "1.0.0-preview.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.0-preview.0.tgz",
+          "integrity": "sha512-Ao4A/r7q6qTTeDqa40U9/58kw5uC6r29cTJ7386uMSl7RgNu19ja+nN0Tnvl6dQTCjajMjqiT+UADuDi5zhucw==",
           "requires": {
-            "tunnel": "0.0.4",
-            "underscore": "1.8.3"
+            "@types/semver": "^5.3.0",
+            "@types/uuid": "^3.4.5",
+            "azure-pipelines-task-lib": "^3.0.6-preview.0",
+            "semver": "^5.7.0",
+            "semver-compare": "^1.0.0",
+            "typed-rest-client": "^1.7.3",
+            "uuid": "^3.3.2"
           }
         }
       }
@@ -525,11 +497,6 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
     },
-    "semver-compare": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
-    },
     "shelljs": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
@@ -595,11 +562,6 @@
           "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
         }
       }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "topo": {
       "version": "1.1.0",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 184,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 184,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [


### PR DESCRIPTION
**Task name**: AzurePowerShellV4 and V5

**Description**: If Az module is present as folder then proceed else if present as zip then unzip and proceed else download from GH releases else if download failed then download from PSGallery using Save-Module cmdlet.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

**Validations**:
- Validated the changes in windows and linux hosted agents.
- For both the platforms tried dynamic loading from:
  - folder with latest
  - folder with specific version
  - unzipping if present as zip instead of folder
  - download from GH releases
  - download from PSGallery