### PR TITLE
Porting azure-pipelines-tasks-azure-arm-rest-v2 fix in 1.178.1 to preview npm package branch

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
@@ -21,6 +21,8 @@ export class GraphManagementClient extends azureServiceClient.ServiceClient {
 
         if (baseUri) {
             this.baseUri = baseUri;
+        } else {
+            this.baseUri = credentials.activeDirectoryResourceId;
         }
 
         if (options.acceptLanguage) {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-pipelines-tasks-azure-arm-rest-v2

**Description**: Porting azure-pipelines-tasks-azure-arm-rest-v2 fix in 1.178.1 to preview npm package branch

**Documentation changes required:** (N) <Please mark if documentation changes are required>

**Added unit tests:** (N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
