### PR TITLE
Fixing graph resource url in Preview version

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-graph.ts
@@ -21,6 +21,8 @@ export class GraphManagementClient extends azureServiceClient.ServiceClient {
 
         if (baseUri) {
             this.baseUri = baseUri;
+        } else {
+            this.baseUri = credentials.activeDirectoryResourceId;
         }
 
         if (options.acceptLanguage) {

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "1.177.0-preview.0",
+  "version": "1.177.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "2.0.0-preview.0",
+  "version": "2.0.0-preview.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-arm-rest-v2

**Description**: Fixing graph resource url in Preview version to support older packer versions

**Documentation changes required:** (Y/N) No

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
