### PR TITLE
Add restrictions for ArchiveFilesV2, DeleteFilesV1, ExtractFilesV1

### DIFF
--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -16,6 +16,7 @@
         "DeploymentGroup"
     ],
     "demands": [],
+    "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 2,
         "Minor": 185,

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -138,6 +138,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "Filename": "files=%s",
         "TarExists": "Intermediate tar: %s already exists.  Attempting to add files to it.",

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -19,7 +19,7 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 2,
-        "Minor": 185,
+        "Minor": 186,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -19,7 +19,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 2,
-    "Minor": 185,
+    "Minor": 186,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -16,6 +16,7 @@
     "DeploymentGroup"
   ],
   "demands": [],
+  "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 2,
     "Minor": 185,

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -138,6 +138,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "Filename": "ms-resource:loc.messages.Filename",
     "TarExists": "ms-resource:loc.messages.TarExists",

--- a/Tasks/DeleteFilesV1/task.json
+++ b/Tasks/DeleteFilesV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 185,
+        "Minor": 186,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DeleteFilesV1/task.json
+++ b/Tasks/DeleteFilesV1/task.json
@@ -20,7 +20,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.92.0",
+    "minimumAgentVersion": "2.182.1",
     "groups": [
         {
             "name": "advanced",

--- a/Tasks/DeleteFilesV1/task.json
+++ b/Tasks/DeleteFilesV1/task.json
@@ -70,6 +70,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "CantDeleteFiles": "Couldn't delete one or more files",
         "SkippingSymbolStore": "Skipping delete for symbol store file share: %s",

--- a/Tasks/DeleteFilesV1/task.loc.json
+++ b/Tasks/DeleteFilesV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 185,
+    "Minor": 186,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DeleteFilesV1/task.loc.json
+++ b/Tasks/DeleteFilesV1/task.loc.json
@@ -70,6 +70,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "CantDeleteFiles": "ms-resource:loc.messages.CantDeleteFiles",
     "SkippingSymbolStore": "ms-resource:loc.messages.SkippingSymbolStore",

--- a/Tasks/DeleteFilesV1/task.loc.json
+++ b/Tasks/DeleteFilesV1/task.loc.json
@@ -20,7 +20,7 @@
     "Patch": 0
   },
   "demands": [],
-  "minimumAgentVersion": "1.92.0",
+  "minimumAgentVersion": "2.182.1",
   "groups": [
     {
       "name": "advanced",

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -16,6 +16,7 @@
         "DeploymentGroup"
     ],
     "demands": [],
+    "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 1,
         "Minor": 184,

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -19,8 +19,8 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 1,
-        "Minor": 184,
-        "Patch": 1
+        "Minor": 186,
+        "Patch": 0
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -20,7 +20,7 @@
     "version": {
         "Major": 1,
         "Minor": 184,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Extract files $(message)",
     "inputs": [

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -74,6 +74,14 @@
             "argumentFormat": ""
         }
     },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": []
+        }
+    },
     "messages": {
         "ExtractDirFailedinFindFiles": "Specified archive: %s can not be extracted because it is a directory.",
         "ExtractNotFileFailed": "Specified archive: %s can not be extracted because it is not a file.",

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -74,6 +74,14 @@
       "argumentFormat": ""
     }
   },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
+    }
+  },
   "messages": {
     "ExtractDirFailedinFindFiles": "ms-resource:loc.messages.ExtractDirFailedinFindFiles",
     "ExtractNotFileFailed": "ms-resource:loc.messages.ExtractNotFileFailed",

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 1,
     "Minor": 184,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -16,6 +16,7 @@
     "DeploymentGroup"
   ],
   "demands": [],
+  "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 1,
     "Minor": 184,

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -19,8 +19,8 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 1,
-    "Minor": 184,
-    "Patch": 1
+    "Minor": 186,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [


### PR DESCRIPTION
**Task name**: ArchiveFilesV2, DeleteFilesV1, ExtractFilesV1

**Description**: added restrictions.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected - verified sanity scenarios for tasks, checked that setting of prohibited variables is not allowed for one of the tasks
