### PR TITLE
Added enhancements to the localization pipeline

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -26,10 +26,9 @@ stages:
       displayName: 'npm install'
       
     - powershell: |
-        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
-        $sprint = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).sprint
-        Write-Host "##vso[task.setvariable variable=week]$week"
-        Write-Host "##vso[task.setvariable variable=sprint]$sprint"
+        $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
+        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
+        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
       displayName: "Determine the number of the week in the sprint and sprint number"
 
     - powershell: |
@@ -90,15 +89,21 @@ stages:
       condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
-        $body = '{"text": "Created tasks localization update PR. Someone please approve/merge it. :please-puss-in-boots:' + $env:PR_LINK + ' "}'
+        $message="Created tasks localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $body = '{"text": "Something went wrong while creating tasks localization update PR. Build: ' + $buildUrl + '"}'
+        $message="Something went wrong while creating tasks localization update PR. Build: $buildUrl"
+        $body = [PSCustomObject]@{
+          text = $message
+        } | ConvertTo-Json
+
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
       condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
-

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -2,6 +2,14 @@ name: $(Date:MMddyy)$(Rev:.rrrr)
 
 trigger: none
 
+schedules:
+- cron: 0 8 * * Mon # mm HH DD MM DW
+  displayName: Localization update
+  branches:
+    include: 
+    - Localization
+  always: true
+
 stages:
 - stage: __default
   jobs:
@@ -9,7 +17,32 @@ stages:
     pool:
       vmImage: windows-latest
     steps:
+
+    - checkout: self
+      persistCredentials: true
+
+    - powershell: |
+        npm install
+      displayName: 'npm install'
+      
+    - powershell: |
+        $week = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).week
+        $sprint = (Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json).sprint
+        Write-Host "##vso[task.setvariable variable=week]$week"
+        Write-Host "##vso[task.setvariable variable=sprint]$sprint"
+      displayName: "Determine the number of the week in the sprint and sprint number"
+
+    - powershell: |
+        git config --global user.email "$(github_email)"
+        git config --global user.name "$(username)"
+        git checkout -b Localization origin/Localization
+        git merge origin/master
+        git push origin Localization
+      displayName: "Sync with master branch"
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+
     - task: OneLocBuild@2
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -19,10 +52,53 @@ stages:
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'
-        isAutoCompletePrSelected: false
+        isAutoCompletePrSelected: true
       env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: drop'
+    - powershell: |
+        node Localize/bump-versions.js
+        
+        git add -A
+        git commit -m 'Bumped versions'
+      displayName: Bump tasks' and packages' versions
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+
+    - powershell: |
+        $date= Get-Date -Format "MMddyyyy"
+        $updateBranch="Localization-update_$date"
+        echo "##vso[task.setvariable variable=updateBranch]$updateBranch"
+
+        git checkout -b $updateBranch
+
+        Remove-Item -Recurse -Force Localize
+
+        git add -A
+        git commit -m "Removing Localize folder"
+        git push origin $updateBranch
+      displayName: Create and push localization update branch
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+    
+    - task: PowerShell@2
+      inputs:
+        filePath: 'ci/open-pullrequest.ps1'
+        arguments: "-SourceBranch $(updateBranch)"
+        failOnStderr: true
+      env:
+        GH_TOKEN: '$(GitHubPAT)'
+      displayName: Open a PR
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+
+    - powershell: |
+        $body = '{"text": "Created tasks localization update PR. Someone please approve/merge it. :please-puss-in-boots:' + $env:PR_LINK + ' "}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification about PR opened'
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+
+    - powershell: |
+        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+        $body = '{"text": "Something went wrong while creating tasks localization update PR. Build: ' + $buildUrl + '"}'
+        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send Slack notification about error'
+      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
 

--- a/ci/open-pullrequest.ps1
+++ b/ci/open-pullrequest.ps1
@@ -1,4 +1,8 @@
-param($SourceBranch) 
+param(
+    [Parameter(Mandatory)]
+    [string]
+    $SourceBranch
+) 
 
 function Get-PullRequest() {
     $prInfo = (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)


### PR DESCRIPTION
**Task name**: Localization pipeline definition

**Description**: 
Added schedule trigger to run the localization pipeline on the third week of a sprint on Mondays at 8 a.m. UTC,
Added Slack notifications about successful and failed builds.
Added a script that automatically bumps tasks and common packages versions.
Added a script that creates a PR to the master branch with localization updates.

The pipeline is going to have the following flow:
Checkout `Localization` branch -> merge `master` into `Localization` and push changes -> OneLocBuild task gathers localization strings and commit them (auto-merge a PR) to the `Localization` -> bump versions of tasks and packages with localization affected ->create a new branch -> commit and push bumped versions -> open a PR to the master branch.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#875](https://github.com/microsoft/build-task-team/issues/875)