### PR TITLE
Revert "[InstallAppleProvisioningProfileV1] Add restrictions"

### DIFF
--- a/Tasks/InstallAppleProvisioningProfileV1/task.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 184,
+        "Minor": 181,
         "Patch": 0
     },
     "runsOn": [
@@ -23,7 +23,7 @@
     "demands": [
         "xcode"
     ],
-    "minimumAgentVersion": "2.182.1",
+    "minimumAgentVersion": "2.116.0",
     "instanceNameFormat": "Install an Apple provisioning profile",
     "inputs": [
         {
@@ -91,18 +91,6 @@
         "Node10": {
             "target": "postinstallprovprofile.js",
             "argumentFormat": ""
-        }
-    },
-    "restrictions": {
-        "commands": {
-            "mode": "restricted"
-        },
-        "settableVariables": {
-            "allowed": [
-                "provisioningProfileUuid",
-                "provisioningProfileName",
-                "APPLE_PROV_PROFILE_UUID"
-            ]
         }
     },
     "messages": {

--- a/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
+++ b/Tasks/InstallAppleProvisioningProfileV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 184,
+    "Minor": 181,
     "Patch": 0
   },
   "runsOn": [
@@ -23,7 +23,7 @@
   "demands": [
     "xcode"
   ],
-  "minimumAgentVersion": "2.182.1",
+  "minimumAgentVersion": "2.116.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
     {
@@ -91,18 +91,6 @@
     "Node10": {
       "target": "postinstallprovprofile.js",
       "argumentFormat": ""
-    }
-  },
-  "restrictions": {
-    "commands": {
-      "mode": "restricted"
-    },
-    "settableVariables": {
-      "allowed": [
-        "provisioningProfileUuid",
-        "provisioningProfileName",
-        "APPLE_PROV_PROFILE_UUID"
-      ]
     }
   },
   "messages": {


### PR DESCRIPTION
Reverts microsoft/azure-pipelines-tasks#14519

Revert the following changes:

*Changes*: 
- Added `restrictions` block to `task.json`
- Fixed `minimumAgentVersion` property in `task.json`
