### PR TITLE
Update VstsAzureRestHelpers_.psm1

### DIFF
--- a/Tasks/Common/VstsAzureRestHelpers_/VstsAzureRestHelpers_.psm1
+++ b/Tasks/Common/VstsAzureRestHelpers_/VstsAzureRestHelpers_.psm1
@@ -744,19 +744,19 @@ function Get-AzureSqlDatabaseServerResourceId {
         [Object] [Parameter(Mandatory = $true)] $endpoint,
         [Object] [Parameter(Mandatory = $true)] $accessToken)
 
-    $serverType = "Microsoft.Sql/servers"
+    $apiVersion = "2019-06-01-preview"
     $subscriptionId = $endpoint.Data.SubscriptionId.ToLower()
 
-    Write-Verbose "[Azure Rest Call] Get Resource Groups"
+    Write-Verbose "[Azure Rest Call] Get Azure Sql Servers"
     $method = "GET"
-    $uri = "$($endpoint.Url)/subscriptions/$subscriptionId/resources?api-version=$apiVersion"
+    $uri = "$($endpoint.Url)/subscriptions/$subscriptionId/providers/Microsoft.Sql/servers?api-version=$apiVersion"
     $headers = @{Authorization = ("{0} {1}" -f $accessToken.token_type, $accessToken.access_token) }
 
     do {
         Write-Verbose "Fetching Resources from $uri"
         $ResourceDetails = Invoke-RestMethod -Uri $uri -Method $method -Headers $headers -ContentType $script:jsonContentType
         foreach ($resourceDetail in $ResourceDetails.Value) {
-            if ($resourceDetail.name -eq $serverName -and $resourceDetail.type -eq $serverType) {
+            if ($resourceDetail.name -eq $serverName) {
                 return $resourceDetail.id
             }
         }

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 178,
-        "Patch": 2
+        "Minor": 184,
+        "Patch": 0
     },
     "demands": [
         "sqlpackage"


### PR DESCRIPTION
switch the api call to use a more reliable uri to avoid issues highlighted here: https://stackoverflow.com/questions/66442375/can-an-azure-sql-server-be-unavailable-unreachable-for-a-period-of-time-after

**Task name**: SqlAzureDacpacDeploymentV1

**Description**: Switched ~/Tasks/Common/VstsAzureRestHelpers_/VstsAzureRestHelpers_.psm1 > Get-AzureSqlDatabaseServerResourceId function to use [sql servers list](https://docs.microsoft.com/en-us/rest/api/sql/servers/list api) call instead of [resources list](https://docs.microsoft.com/en-us/rest/api/resources/resources/list). The previous uri would often fail to return newly created sql servers for extended periods of time despite the server being available and queryable. 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [https://stackoverflow.com/questions/66442375/can-an-azure-sql-server-be-unavailable-unreachable-for-a-period-of-time-after](https://stackoverflow.com/questions/66442375/can-an-azure-sql-server-be-unavailable-unreachable-for-a-period-of-time-after)

**Checklist**:
- [ x ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
