### PR TITLE
Fixed the downloadArchive script for common packages

### DIFF
--- a/common-npm-packages/build-scripts/downloadArchive.js
+++ b/common-npm-packages/build-scripts/downloadArchive.js
@@ -102,6 +102,9 @@ const archiveUrl = args[0];
 const dest = args[1];
 
 const targetPath = downloadArchive(archiveUrl, path.join('../_download', dest));
+if (!fs.existsSync(dest)) {
+    util.mkdir('-p', dest);
+}
 util.cp('-rf', path.join(targetPath, '*'), dest);
 
 exports.downloadArchive=downloadArchive;

--- a/common-npm-packages/build-scripts/downloadArchive.js
+++ b/common-npm-packages/build-scripts/downloadArchive.js
@@ -102,6 +102,6 @@ const archiveUrl = args[0];
 const dest = args[1];
 
 const targetPath = downloadArchive(archiveUrl, path.join('../_download', dest));
-util.cp('-r', targetPath, dest);
+util.cp('-rf', path.join(targetPath, '*'), dest);
 
 exports.downloadArchive=downloadArchive;


### PR DESCRIPTION
**Task name**: Common packages build script

**Description**: Added `*` wildcard to the `cp()` source path parameter to avoid creating a subfolder at the destination path with the same name as the source folder has. It also fixes bug with copying to the current folder (`./`).

**Before:** a downloaded archive was unpacked to a wrong path containing a redundant subfolder in the case when the destination folder exists on Windows. It was unpacked wrong on macOS and Ubuntu in any case.

**After:** a downloaded archive is extracted to a specified folder as it's expected in any case.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#451](https://github.com/microsoft/build-task-team/issues/451)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
