### PR TITLE
Fixed GoV0 task friendly name for different locales

### DIFF
--- a/Tasks/GoV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Ir",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "Obtenga, compile o pruebe una aplicación Go o ejecute un comando Go personalizado.",
   "loc.instanceNameFormat": "go $(comando)",

--- a/Tasks/GoV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Aller à",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "Récupérer, générer ou tester une application Go, ou exécuter une commande Go personnalisée",
   "loc.instanceNameFormat": "go $(commande)",

--- a/Tasks/GoV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Vai",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "Consente di scaricare, compilare o testare un'applicazione Go oppure di eseguire un comando Go personalizzato",
   "loc.instanceNameFormat": "go $(command)",

--- a/Tasks/GoV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "이동",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[이 작업에 대한 자세한 정보](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "Go 애플리케이션을 다운로드, 빌드 또는 테스트하거나 사용자 지정 Go 명령을 실행합니다.",
   "loc.instanceNameFormat": "go $(명령)",

--- a/Tasks/GoV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "转到",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[详细了解此任务](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "获取、生成或测试 Go 应用程序，或者运行自定义 Go 命令",
   "loc.instanceNameFormat": "go $(command)",

--- a/Tasks/GoV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/GoV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "移至",
+  "loc.friendlyName": "Go",
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=867582)",
   "loc.description": "取得、建置或測試 Go 應用程式，或執行自訂 Go 命令",
   "loc.instanceNameFormat": "go $(command)",

--- a/Tasks/GoV0/task.json
+++ b/Tasks/GoV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 4,
-        "Patch": 1
+        "Patch": 2
     },
     "runsOn": [
         "Agent",

--- a/Tasks/GoV0/task.loc.json
+++ b/Tasks/GoV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 4,
-    "Patch": 1
+    "Patch": 2
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: GoV0

**Description**: fixed task friendly name for different locales - from localized string to 'Go'.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
