### PR TITLE
Porting RunFromPackage fix from common

### DIFF
--- a/common-npm-packages/AzureRmDeploy-common/azure-arm-rest/azure-arm-app-service-kudu.ts
+++ b/common-npm-packages/AzureRmDeploy-common/azure-arm-rest/azure-arm-app-service-kudu.ts
@@ -458,9 +458,13 @@ export class Kudu {
         httpRequest.method = 'POST';
         httpRequest.uri = this._client.getRequestUri(`/api/zipdeploy`, queryParameters);
         httpRequest.body = fs.createReadStream(webPackage);
-
+        let requestOptions = new webClient.WebRequestOptions();
+        //Bydefault webclient.sendRequest retries for  [408, 409, 500, 502, 503, 504] as suggested by appservice team for zipdeploy api 
+        //408 and 409 should not be retried as it will never turn into success
+        requestOptions.retriableStatusCodes = [500, 502, 503, 504];
+        requestOptions.retryIntervalInSeconds = 5;
         try {
-            let response = await this._client.beginRequest(httpRequest, null, 'application/octet-stream');
+            let response = await this._client.beginRequest(httpRequest, requestOptions, 'application/octet-stream');
             tl.debug(`ZIP Deploy response: ${JSON.stringify(response)}`);
             if(response.statusCode == 200) {
                 tl.debug('Deployment passed');
@@ -633,17 +637,16 @@ export class Kudu {
     }
 
     private _getFormattedError(error: any) {
-        if(error && error.statusCode) {
-            return `${error.statusMessage} (CODE: ${error.statusCode})`;
-        }
-        else if(error && error.message) {
+        if(error && error.message) {
             if(error.statusCode) {
                 error.message = `${typeof error.message.valueOf() == 'string' ? error.message : error.message.Code + " - " + error.message.Message } (CODE: ${error.statusCode})`
             }
 
             return error.message;
         }
-
+        if(error && error.statusCode) {
+            return `${error.statusMessage} (CODE: ${error.statusCode})`;
+        }
         return error;
     }
 }

--- a/common-npm-packages/AzureRmDeploy-common/operations/KuduServiceUtility.ts
+++ b/common-npm-packages/AzureRmDeploy-common/operations/KuduServiceUtility.ts
@@ -123,13 +123,15 @@ export class KuduServiceUtility {
     public async deployUsingRunFromZip(packagePath: string, customMessage?: any) : Promise<void> {
         try {
             console.log(tl.loc('PackageDeploymentInitiated'));
-
+            //zipdeploy async api ref: https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url#asynchronous-zip-deployment
             let queryParameters: Array<string> = [
+                'isAsync=true',
                 'deployer=' +   VSTS_DEPLOY
             ];
             var deploymentMessage = this._getUpdateHistoryRequest(null, null, customMessage).message;
             queryParameters.push('message=' + encodeURIComponent(deploymentMessage));
-            await this._appServiceKuduService.zipDeploy(packagePath, queryParameters);
+            let deploymentDetails = await this._appServiceKuduService.zipDeploy(packagePath, queryParameters);
+            await this._processDeploymentResponse(deploymentDetails);
             console.log(tl.loc('PackageDeploymentSuccess'));
             console.log("NOTE: Run From Package makes wwwroot read-only, so you will receive an error when writing files to this directory.");
         }

--- a/common-npm-packages/AzureRmDeploy-common/package-lock.json
+++ b/common-npm-packages/AzureRmDeploy-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/AzureRmDeploy-common/package.json
+++ b/common-npm-packages/AzureRmDeploy-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: AzureRmDeploy-Common

**Description**: Porting fix https://github.com/microsoft/azure-pipelines-tasks/pull/14251 from common folder to common-npm-packages 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/14201

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
