### PR TITLE
[PublishBuildArtifactsV1, DownloadBuildArtifactsV0] Add optional input to store artifacts as tar archives

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/en-US/resources.resjson
@@ -35,6 +35,8 @@
   "loc.input.help.checkDownloadedFiles": "If checked, this build task will check that all files are fully downloaded.",
   "loc.input.label.retryDownloadCount": "Retry count",
   "loc.input.help.retryDownloadCount": "Optional number of times to retry downloading a build artifact if the download fails.",
+  "loc.input.label.extractTars": "Extract all files that are stored inside tar archives",
+  "loc.input.help.extractTars": "Enable this option to extract all downloaded files that have .tar extension. This is helpful because you need to pack your artifact files into tar if you want to preserve Unix file permissions.",
   "loc.messages.DownloadArtifacts": "Downloading artifact %s from: %s",
   "loc.messages.DownloadingArtifactsForBuild": "Downloading artifacts for build: %s",
   "loc.messages.LinkedArtifactCount": "Linked artifacts count:  %s",
@@ -59,5 +61,6 @@
   "loc.messages.BeginArtifactItemsIntegrityCheck": "Starting artifact items integrity check",
   "loc.messages.CorruptedArtifactItemsList": "The following items are not passed integrity check:",
   "loc.messages.IntegrityCheckNotPassed": "Artifact items integrity check failed",
-  "loc.messages.IntegrityCheckPassed": "Artifact items integrity check successfully finished"
+  "loc.messages.IntegrityCheckPassed": "Artifact items integrity check successfully finished",
+  "loc.messages.NoTarsFound": "No tar archives were found to extract"
 }

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 183,
+        "Minor": 185,
         "Patch": 0
     },
     "groups": [
@@ -196,6 +196,14 @@
             "groupName": "advanced",
             "required": false,
             "helpMarkDown": "Optional number of times to retry downloading a build artifact if the download fails."
+        },
+        {
+            "name": "extractTars",
+            "type": "boolean",
+            "label": "Extract all files that are stored inside tar archives",
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Enable this option to extract all downloaded files that have .tar extension. This is helpful because you need to pack your artifact files into tar if you want to preserve Unix file permissions."
         }
     ],
     "dataSourceBindings": [
@@ -278,7 +286,8 @@
         "BeginArtifactItemsIntegrityCheck": "Starting artifact items integrity check",
         "CorruptedArtifactItemsList": "The following items are not passed integrity check:",
         "IntegrityCheckNotPassed": "Artifact items integrity check failed",
-        "IntegrityCheckPassed": "Artifact items integrity check successfully finished"
+        "IntegrityCheckPassed": "Artifact items integrity check successfully finished",
+        "NoTarsFound": "No tar archives were found to extract"
     },
     "outputVariables": [
         {

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 183,
+    "Minor": 185,
     "Patch": 0
   },
   "groups": [
@@ -196,6 +196,14 @@
       "groupName": "advanced",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.retryDownloadCount"
+    },
+    {
+      "name": "extractTars",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.extractTars",
+      "groupName": "advanced",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.extractTars"
     }
   ],
   "dataSourceBindings": [
@@ -278,7 +286,8 @@
     "BeginArtifactItemsIntegrityCheck": "ms-resource:loc.messages.BeginArtifactItemsIntegrityCheck",
     "CorruptedArtifactItemsList": "ms-resource:loc.messages.CorruptedArtifactItemsList",
     "IntegrityCheckNotPassed": "ms-resource:loc.messages.IntegrityCheckNotPassed",
-    "IntegrityCheckPassed": "ms-resource:loc.messages.IntegrityCheckPassed"
+    "IntegrityCheckPassed": "ms-resource:loc.messages.IntegrityCheckPassed",
+    "NoTarsFound": "ms-resource:loc.messages.NoTarsFound"
   },
   "outputVariables": [
     {

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -18,6 +18,8 @@
   "loc.input.help.ParallelCount": "Enter the degree of parallelism, or number of threads used, to perform the copy. The value must be at least 1 and not greater than 128.",
   "loc.input.label.FileCopyOptions": "File copy options",
   "loc.input.help.FileCopyOptions": "Pass additional options to the Robocopy command.",
+  "loc.input.label.StoreAsTar": "Tar the artifact before uploading",
+  "loc.input.help.StoreAsTar": "Add all files from the publish path to a tar archive before uploading. This allows you to preserve the UNIX file permissions.",
   "loc.messages.ErrorFileShareLinux": "Publishing artifacts from a Linux or macOS agent to a file share is not supported. Change the artifact type to `Azure Pipelines` or use a Windows agent.",
   "loc.messages.ErrorHostTypeNotSupported": "This task must run in a build to publish artifacts to Azure Pipelines.",
   "loc.messages.PublishBuildArtifactsFailed": "Publishing build artifacts failed with an error: %s",

--- a/Tasks/PublishBuildArtifactsV1/Tests/L0.ts
+++ b/Tasks/PublishBuildArtifactsV1/Tests/L0.ts
@@ -145,4 +145,30 @@ describe('PublishBuildArtifactsV1 Suite', function () {
         assert(testRunner.invokedToolCount === 0, 'should exit before running PublishBuildArtifacts');
         done();
     });
+
+    it('Add a single file to tar before uploading', (done: Mocha.Done) => {
+        const testPath: string = path.join(__dirname, 'L0StoreFileAsTar.js');
+        const testRunner = new MockTestRunner(testPath);
+        testRunner.run();
+
+        assert(testRunner.stderr.length === 0, 'should not have written to stderr. error: ' + testRunner.stderr);
+        assert(testRunner.succeeded, 'task should have succeeded');
+        assert(testRunner.stdOutContained('test stdout from bash: tar file'), 'should have run bash tar');
+        const artifactPath: string = path.join(process.cwd(), 'drop.tar.gz');
+        assert(testRunner.stdOutContained(`##vso[artifact.upload artifacttype=container;artifactname=drop;containerfolder=drop;localpath=${artifactPath};]${artifactPath}`))
+        done();
+    });
+
+    it('Add a folder to tar before uploading', (done: Mocha.Done) => {
+        const testPath: string = path.join(__dirname, 'L0StoreFolderAsTar.js');
+        const testRunner = new MockTestRunner(testPath);
+        testRunner.run();
+
+        assert(testRunner.stderr.length === 0, 'should not have written to stderr. error: ' + testRunner.stderr);
+        assert(testRunner.succeeded, 'task should have succeeded');
+        assert(testRunner.stdOutContained('test stdout from bash: tar folder'), 'should have run bash tar');
+        const artifactPath: string = path.join(process.cwd(), 'drop.tar.gz');
+        assert(testRunner.stdOutContained(`##vso[artifact.upload artifacttype=container;artifactname=drop;containerfolder=drop;localpath=${artifactPath};]${artifactPath}`))
+        done();
+    });
 });

--- a/Tasks/PublishBuildArtifactsV1/Tests/L0StoreFileAsTar.ts
+++ b/Tasks/PublishBuildArtifactsV1/Tests/L0StoreFileAsTar.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+
+import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
+import * as MockToolRunner from 'azure-pipelines-task-lib/mock-toolrunner';
+
+import { goodAnswers } from './goodAnswers';
+
+const taskPath: string = path.join(__dirname, '..', 'publishbuildartifacts.js');
+const taskRunner = new TaskMockRunner(taskPath);
+
+taskRunner.setInput('PathtoPublish', 'C:\\bin\\release\\file.exe');
+taskRunner.setInput('ArtifactName', 'drop');
+taskRunner.setInput('ArtifactType', 'Container');
+taskRunner.setInput('StoreAsTar', 'true');
+
+process.env['AGENT_TEMPDIRECTORY'] = process.cwd();
+
+taskRunner.setAnswers(goodAnswers);
+
+taskRunner.registerMock('azure-pipelines-task-lib/toolrunner', MockToolRunner);
+
+taskRunner.run();

--- a/Tasks/PublishBuildArtifactsV1/Tests/L0StoreFolderAsTar.ts
+++ b/Tasks/PublishBuildArtifactsV1/Tests/L0StoreFolderAsTar.ts
@@ -1,0 +1,22 @@
+import * as path from 'path';
+
+import { TaskMockRunner } from 'azure-pipelines-task-lib/mock-run';
+import * as MockToolRunner from 'azure-pipelines-task-lib/mock-toolrunner';
+
+import { goodAnswers } from './goodAnswers';
+
+const taskPath: string = path.join(__dirname, '..', 'publishbuildartifacts.js');
+const taskRunner = new TaskMockRunner(taskPath);
+
+taskRunner.setInput('PathtoPublish', 'C:\\bin\\release');
+taskRunner.setInput('ArtifactName', 'drop');
+taskRunner.setInput('ArtifactType', 'Container');
+taskRunner.setInput('StoreAsTar', 'true');
+
+process.env['AGENT_TEMPDIRECTORY'] = process.cwd();
+
+taskRunner.setAnswers(goodAnswers);
+
+taskRunner.registerMock('azure-pipelines-task-lib/toolrunner', MockToolRunner);
+
+taskRunner.run();

--- a/Tasks/PublishBuildArtifactsV1/Tests/goodAnswers.ts
+++ b/Tasks/PublishBuildArtifactsV1/Tests/goodAnswers.ts
@@ -2,11 +2,15 @@ import * as path from 'path';
 import { TaskLibAnswers } from 'azure-pipelines-task-lib/mock-answer';
 
 export const goodAnswers: TaskLibAnswers = {
+  'which': {
+    'bash': 'path/to/bash'
+  },
   'checkPath': {
     '/bin/release': true,
     'C:\\bin\\release\\': true,
     'C:\\bin\\release': true,
-    'C:\\bin\\release\\file.exe': true
+    'C:\\bin\\release\\file.exe': true,
+    'path/to/bash': true
   },
   'exec': {
     [`powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command & \'${path.resolve(__dirname, '..', 'Invoke-Robocopy.ps1')}\' -Source \'C:\\bin\\release\' -Target \'\\\\UNCShare\\subdir\\drop\' -ParallelCount 1`]: {
@@ -26,6 +30,16 @@ export const goodAnswers: TaskLibAnswers = {
     },
     [`powershell.exe -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command & \'${path.resolve(__dirname, '..', 'Invoke-Robocopy.ps1')}\' -Source \'C:\\bin\\release\' -Target \'\\\\UNCShare\\drop\\.\' -ParallelCount 1 -File \'file.exe\'`]: {
       'stdout': 'test stdout from robocopy (copy a single file)',
+      'stderr': '',
+      'code': 0
+    },
+    [`path/to/bash tar czvf ${path.join(process.cwd(), 'drop.tar.gz')} C:\\bin\\release\\file.exe`]: {
+      'stdout': 'test stdout from bash: tar file',
+      'stderr': '',
+      'code': 0
+    },
+    [`path/to/bash tar czvf ${path.join(process.cwd(), 'drop.tar.gz')} C:\\bin\\release`]: {
+      'stdout': 'test stdout from bash: tar folder',
       'stderr': '',
       'code': 0
     }

--- a/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
@@ -43,6 +43,19 @@ let pathToRobocopyPSString = (filePath: string) => {
     return `'${result}'`;
 }
 
+function createTarArchive(filesPath: string, artifactName: string) {
+    const bash: tr.ToolRunner = tl.tool(tl.which('bash', true));
+    const outputFilePath: string = path.join(tl.getVariable('Agent.TempDirectory'), `${artifactName}.tar.gz`);
+    bash.arg(['tar', 'czvf', outputFilePath, filesPath]);
+    const tarExecResult: tr.IExecSyncResult = bash.execSync();
+
+    if (tarExecResult.error || tarExecResult.code !== 0) {
+        throw new Error("Couldn't add artifact files to a tar archive");
+    }
+
+    return outputFilePath;
+}
+
 function getPathToUpload(
     pathToPublish: string,
     shouldStoreAsTar: boolean,
@@ -52,16 +65,7 @@ function getPathToUpload(
         return pathToPublish;
     }
 
-    const bash: tr.ToolRunner = tl.tool(tl.which('bash', true));
-    const outputFilePath: string = path.join(tl.getVariable('Agent.TempDirectory'), `${artifactName}.tar.gz`);
-    bash.arg(['tar', 'czvf', outputFilePath, pathToPublish]);
-    const tarExecResult: tr.IExecSyncResult = bash.execSync();
-
-    if (tarExecResult.error || tarExecResult.code !== 0) {
-        throw new Error("Couldn't add artifact files to a tar archive");
-    }
-
-    return outputFilePath;
+    return createTarArchive(pathToPublish, artifactName);
 }
 
 async function run() {

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -92,6 +92,15 @@
             "required": false,
             "helpMarkDown": "Pass additional options to the Robocopy command.",
             "visibleRule": "ArtifactType = FilePath"
+        },
+        {
+            "name": "StoreAsTar",
+            "type": "boolean",
+            "label": "Tar the artifact before uploading",
+            "defaultValue": "false",
+            "groupName": "advanced",
+            "required": false,
+            "helpMarkDown": "Add all files from the publish path to a tar archive before uploading. This allows you to preserve the UNIX file permissions."
         }
     ],
     "instanceNameFormat": "Publish Artifact: $(ArtifactName)",

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 183,
+        "Minor": 185,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishBuildArtifactsV1/task.loc.json
+++ b/Tasks/PublishBuildArtifactsV1/task.loc.json
@@ -92,6 +92,15 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.FileCopyOptions",
       "visibleRule": "ArtifactType = FilePath"
+    },
+    {
+      "name": "StoreAsTar",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.StoreAsTar",
+      "defaultValue": "false",
+      "groupName": "advanced",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.StoreAsTar"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/PublishBuildArtifactsV1/task.loc.json
+++ b/Tasks/PublishBuildArtifactsV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 183,
+    "Minor": 185,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: PublishBuildArtifactsV1, DownloadBuildArtifactsV0

**Description**: Currently artifacts don't store Unix file permissions. The solution we've decided to implement is to add the option to store artifacts as tar archives, which store permissions.

**Documentation changes required:** Yes

**Added unit tests:** Yes

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/6364

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected - still need more tests. Currently we have these successful pipelines:
- [preserve file permissions windows](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=789&view=results)
- [don't preserve file permissions windows](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=790&view=results)
- [preserve file permissions ubuntu](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=792&view=results)
- [don't preserve file permissions ubuntu](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=791&view=results)
- [preserve file permissions macos](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=793&view=results)
- [don't preserve file permissions macos](https://dev.azure.com/v-dshmelev/playground/_build/results?buildId=794&view=results)
