### PR TITLE
Added secondary location check for pbxProject

### DIFF
--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 185,
+        "Minor": 188,
         "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8 - 11. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 185,
+    "Minor": 188,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/XcodeV5/xcodeutils.ts
+++ b/Tasks/XcodeV5/xcodeutils.ts
@@ -148,8 +148,15 @@ function getPbxProjectPath(workspace: string) {
         if (pathExistsAsFile(pbxProjectPath)) {
             return pbxProjectPath;
         }
+
+        tl.debug("Corresponding pbxProject file doesn't exist: " + pbxProjectPath + ", checking alternative location");
+        
+        let altPbxProjectPath = workspace.trim().toLowerCase().replace('.xcworkspace', '.xcodeproj/project.pbxproj');
+        if (pathExistsAsFile(altPbxProjectPath)) {
+            return altPbxProjectPath;
+        }
         else {
-            tl.debug("Corresponding pbxProject file doesn't exist: " + pbxProjectPath);
+            tl.debug("Corresponding pbxProject file doesn't exist at alternative location: " + altPbxProjectPath);
         }
     }
 }


### PR DESCRIPTION
**Task name**: XcodeV5

**Description**: Adds a fallback check for pbxproj file. The current check looks for a location I have need seen in a Xcode project. I was hesitant to remove as it was coded for a reason, so I added a fall back location should work for most projects

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N, I would, but can't get project to build

**Attached related issue:** (Y/N) #14577 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
