### PR TITLE
Fixed localization pipeline issue with already localized strings replaced

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -56,6 +56,10 @@ stages:
         gitHubPrMergeMethod: 'squash'
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    
+    - task: PublishBuildArtifacts@1
+      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      displayName: 'Publish an artifact'
 
     - powershell: |
         node Localize/bump-versions.js


### PR DESCRIPTION
**Description**: Added artifact publishing step to the localization pipeline. This step fixes the issue with unrecognized localized strings.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** [#915](https://github.com/microsoft/build-task-team/issues/915)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
