### PR TITLE
Update js-yaml version in azure-pipelines-tasks-utility-common package

### DIFF
--- a/common-npm-packages/utility-common-v2/package-lock.json
+++ b/common-npm-packages/utility-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-utility-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -145,9 +145,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "form-data": {
       "version": "2.5.1",
@@ -247,12 +247,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "esprima": "^4.0.0"
       }
     },
     "mime-db": {

--- a/common-npm-packages/utility-common-v2/package.json
+++ b/common-npm-packages/utility-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-utility-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Common Library for Azure Rest Calls",
   "repository": {
     "type": "git",
@@ -19,7 +19,7 @@
     "semver": "^5.4.1",
     "azure-pipelines-task-lib": "^3.1.0",
     "azure-pipelines-tool-lib": "^1.0.1",
-    "js-yaml": "3.6.1",
+    "js-yaml": "3.13.1",
     "@types/node": "^10.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changes:

1. Bumped `azure-pipelines-tasks-utility-common` version
2. Upgrade `js-yaml` to version 3.13.1.

**Description**: Versions of js-yaml prior to 3.13.1 are [vulnerable](https://www.npmjs.com/advisories/813) to Code Injection. The load() function may execute arbitrary code injected through a malicious YAML file. 

> Note:
In-the-box tasks which use `utility-common` package don't use functions from` js-yaml`
There is another common package that uses  js-yaml —  kubernetes-common-v2


**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Checked that applied changes work as expected
