### PR TITLE
Fix pot - unzip using PS tool

### DIFF
--- a/common-npm-packages/webdeployment-common-v2/package-lock.json
+++ b/common-npm-packages/webdeployment-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-webdeployment-common",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/webdeployment-common-v2/package.json
+++ b/common-npm-packages/webdeployment-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-webdeployment-common",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Common Lib for MSDeploy Utility",
   "repository": {
     "type": "git",

--- a/common-npm-packages/webdeployment-common-v2/ziputility.ts
+++ b/common-npm-packages/webdeployment-common-v2/ziputility.ts
@@ -9,15 +9,12 @@ var archiver = require('archiver');
 
 const deleteDir = (path: string) => tl.exist(path) && tl.rmRF(path);
 
-const extractWindowsZip = async (fromFile: string, toDir: string, usePowerShell?: boolean) => {
-
-    // The behaviour of this environment variable should not be relied on. This is experimental.
-    let forceUse7Zip: string = process.env['ADO_FORCE_USE_7ZIP'] || 'false'
-    tl.debug(`ADO_FORCE_USE_7ZIP = '${forceUse7Zip}'`)
-    if (usePowerShell && forceUse7Zip.toLowerCase() !== 'true') {
+const extractWindowsZip = async (fromFile: string, toDir: string, usePowerShell?: boolean) => {    
+    let forceUsePSUnzip: string = process.env['ADO_FORCE_USE_PSUNZIP'] || 'false'
+    tl.debug(`ADO_FORCE_USE_PSUNZIP = '${forceUsePSUnzip}'`)
+    if (forceUsePSUnzip.toLowerCase() === 'true') {
         await extractUsingPowerShell(fromFile, toDir);
-    }
-    else {
+    } else {
         await extractUsing7zip(fromFile, toDir);
     }
 }
@@ -106,17 +103,6 @@ const extractUsingUnzip = async (fromFile: string, toDir: string) => {
         .exec();
 }
 
-const isMSBuildPackageZip = async (packageZipPath: string): Promise<boolean> => {
-    let pacakgeComponent = await getArchivedEntries(packageZipPath);
-    if (((pacakgeComponent["entries"].indexOf("parameters.xml") > -1) || (pacakgeComponent["entries"].indexOf("Parameters.xml") > -1)) && 
-        ((pacakgeComponent["entries"].indexOf("systemInfo.xml") > -1) || (pacakgeComponent["entries"].indexOf("systeminfo.xml") > -1)
-        || (pacakgeComponent["entries"].indexOf("SystemInfo.xml") > -1))) {
-        return true;
-    }
-
-    return false;
-}
-
 export async function unzip(zipFileLocation: string, unzipDirLocation: string) {
     deleteDir(unzipDirLocation);
     
@@ -125,8 +111,7 @@ export async function unzip(zipFileLocation: string, unzipDirLocation: string) {
 
     tl.debug('extracting ' + zipFileLocation + ' to ' + unzipDirLocation);    
     if (isWin) {
-        let isMSBuildPackage = await isMSBuildPackageZip(zipFileLocation);
-        await extractWindowsZip(zipFileLocation, unzipDirLocation, isMSBuildPackage);
+        await extractWindowsZip(zipFileLocation, unzipDirLocation);
     } 
     else{
         await extractUsingUnzip(zipFileLocation, unzipDirLocation);


### PR DESCRIPTION
Fix pot - In case of Msbuild packaged, if "ADO_FORCE_USE_PSUNZIP" pipeline variable is set, then make use of PS tooling for unzipping the package. Default unzip will be using 7 zip