### PR TITLE
[UseRubyVersionV0] Update dependencies (port to m184)

### DIFF
--- a/Tasks/UsePythonVersionV0/Tests/L0.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0.ts
@@ -6,7 +6,7 @@ import * as task from 'azure-pipelines-task-lib/task';
 import { MockTestRunner } from 'azure-pipelines-task-lib/mock-test';
 
 function didSetVariable(testRunner: MockTestRunner, variableName: string, variableValue: string): boolean {
-    return testRunner.stdOutContained(`##vso[task.setvariable variable=${variableName};issecret=false;]${variableValue}`);
+    return testRunner.stdOutContained(`##vso[task.setvariable variable=${variableName};isOutput=false;issecret=false;]${variableValue}`);
 }
 
 function didPrependPath(testRunner: MockTestRunner, toolPath: string): boolean {

--- a/Tasks/UsePythonVersionV0/Tests/package-lock.json
+++ b/Tasks/UsePythonVersionV0/Tests/package-lock.json
@@ -14,7 +14,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "requires": {
         "samsam": "1.3.0"

--- a/Tasks/UsePythonVersionV0/package-lock.json
+++ b/Tasks/UsePythonVersionV0/package-lock.json
@@ -36,9 +36,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
     },
     "@types/semver": {
       "version": "5.5.0",
@@ -69,9 +69,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-pipelines-task-lib": {
-      "version": "3.0.6-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.0.tgz",
-      "integrity": "sha512-Fx+7p5GzvYqVXOQI+LhPk56Pio9yBeEyypKZoPI9cQyti8WTVkmJ7YZwn9HRXurftcLumi2Xq+TC3PwnDq5U5Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.0.tgz",
+      "integrity": "sha512-9L+uG3dxwr/orjFy8tWa2fti+2weiRAdsKVtXINfIpLKFSAHS9tKOpupS53CgBJzQxFf5HfZwNeiUTv+/dBPpA==",
       "requires": {
         "minimatch": "3.0.4",
         "mockery": "^1.7.0",
@@ -83,25 +83,25 @@
       }
     },
     "azure-pipelines-tasks-utility-common": {
-      "version": "3.0.0-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.0.0-preview.0.tgz",
-      "integrity": "sha512-1MfpkIY7WzoqomufJ4lZf1j6LJiYzbTMqD5L3n90IhxORdmOnB65byYkz9OtuXfLdCmxXyQprMxNdhsLjjynYQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.0.2.tgz",
+      "integrity": "sha512-9L6ETcAGWrSEXBsPbbavwp3qi1WxWTbG6OeeYPyUsZsASn3HDc/QMAcmUfsyPmvteIeiIz7JN8DxGFVZlkUBbw==",
       "requires": {
         "@types/node": "^10.17.0",
-        "azure-pipelines-task-lib": "^3.0.6-preview.0",
-        "azure-pipelines-tool-lib": "1.0.0-preview.0",
-        "js-yaml": "3.6.1",
+        "azure-pipelines-task-lib": "^3.1.0",
+        "azure-pipelines-tool-lib": "^1.0.1",
+        "js-yaml": "3.13.1",
         "semver": "^5.4.1"
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "1.0.0-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.0-preview.0.tgz",
-      "integrity": "sha512-Ao4A/r7q6qTTeDqa40U9/58kw5uC6r29cTJ7386uMSl7RgNu19ja+nN0Tnvl6dQTCjajMjqiT+UADuDi5zhucw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.1.tgz",
+      "integrity": "sha512-LonIQs/y0fDmrged2PDHMox8UHQuRrTs388gwBP1axgx4aU/vV/73e7v8tY/++kBF4sDCFea8ZrNxoYSSzRCtQ==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^3.0.6-preview.0",
+        "azure-pipelines-task-lib": "^3.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.7.3",
@@ -126,6 +126,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -167,9 +176,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "form-data": {
       "version": "2.5.1",
@@ -190,6 +199,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-port": {
       "version": "3.2.0",
@@ -216,6 +235,11 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "http-basic": {
       "version": "8.1.3",
@@ -269,25 +293,25 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "js-yaml": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
-        "esprima": "^2.6.0"
+        "esprima": "^4.0.0"
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.46.0"
       }
     },
     "minimatch": {
@@ -302,6 +326,11 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
     },
     "once": {
       "version": "1.4.0",
@@ -345,9 +374,12 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.0.tgz",
+      "integrity": "sha512-yjACOWijC6L/kmPZZAsVBNY2zfHSIbpdpL977quseu56/8BZ2LoF5axK2bGhbzhVKt7V9xgWTtpyLbxwIoER0Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -372,11 +404,11 @@
       }
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -403,6 +435,16 @@
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
     },
     "sprintf-js": {
@@ -467,9 +509,9 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.3.tgz",
+      "integrity": "sha512-gJoH7RE3trY77Bf5MNezVV+21O/WMmt9ps7w1bjFyLxrQqDymDWJSDacem1eM6R86zFM0FlE07F8dOupLmKLmQ==",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",

--- a/Tasks/UsePythonVersionV0/package.json
+++ b/Tasks/UsePythonVersionV0/package.json
@@ -26,9 +26,9 @@
     "@types/node": "^10.17.0",
     "@types/q": "^1.0.7",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-utility-common": "^3.0.0-preview.0",
-    "azure-pipelines-tool-lib": "^1.0.0-preview.0"
+    "azure-pipelines-task-lib": "^3.1.0",
+    "azure-pipelines-tasks-utility-common": "^3.0.2",
+    "azure-pipelines-tool-lib": "^1.0.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 183,
+        "Minor": 185,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 183,
+    "Minor": 185,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: UseRubyVersionV0

**Description**: Update dependencies:
* Updated azure-pipelines-task-lib and azure-pipelines-tool-lib not to use preview versions
* Upgraded azure-pipelines-tasks-utility-common to 3.0.2 version to solve js-yaml volnurabilitiy 

Original [PR](https://github.com/microsoft/azure-pipelines-tasks/pull/14628) to master

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected