### PR TITLE
Applied command restrictions to UseRubyVersionV0 task

### DIFF
--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -62,7 +62,7 @@
             "mode": "restricted"
         },
         "settableVariables": {
-            "allowed": ["rubyLocation"]
+            "allowed": ["rubyLocation", "PATH"]
         }
     }
 }

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -13,11 +13,11 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 182,
+        "Minor": 184,
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.115.0",
+    "minimumAgentVersion": "2.182.1",
     "instanceNameFormat": "Use Ruby $(versionSpec)",
     "inputs": [
         {
@@ -56,5 +56,13 @@
         "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
         "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
         "ExactVersionNotRecommended": "It is not recommended to specify exact version on Microsoft-Hosted agents. Patch version of Ruby can be replaced by new one on Hosted agents without notice and build stops to work. it is recommended to specify only major or major and minor version (Example: `2` or `2.4`)"
+    },
+    "restrictions": {
+        "commands": {
+            "mode": "restricted"
+        },
+        "settableVariables": {
+            "allowed": ["rubyLocation"]
+        }
     }
 }

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -13,11 +13,11 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 182,
+    "Minor": 184,
     "Patch": 0
   },
   "demands": [],
-  "minimumAgentVersion": "2.115.0",
+  "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
     {
@@ -56,5 +56,13 @@
     "ToolNotFoundSelfHosted": "ms-resource:loc.messages.ToolNotFoundSelfHosted",
     "VersionNotFound": "ms-resource:loc.messages.VersionNotFound",
     "ExactVersionNotRecommended": "ms-resource:loc.messages.ExactVersionNotRecommended"
+  },
+  "restrictions": {
+      "commands": {
+          "mode": "restricted"
+      },
+      "settableVariables": {
+          "allowed": ["rubyLocation"]
+      }
   }
 }

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -58,11 +58,14 @@
     "ExactVersionNotRecommended": "ms-resource:loc.messages.ExactVersionNotRecommended"
   },
   "restrictions": {
-      "commands": {
-          "mode": "restricted"
-      },
-      "settableVariables": {
-          "allowed": ["rubyLocation"]
-      }
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": [
+        "rubyLocation",
+        "PATH"
+      ]
+    }
   }
 }


### PR DESCRIPTION
**Task name**: UseRubyVersionV0

**Description**: applied command restrictions. Added rubyLocation and PATH as allowed - since they could be changed during task execution.

Original [PR](https://github.com/microsoft/azure-pipelines-tasks/pull/14510)

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected - checked that there is no warnings/error during execution. Checked that variables are being set up
