### PR TITLE
Update CltTasksUtility.ps1 for QuickPerfTest Task

### DIFF
--- a/Tasks/QuickPerfTestV1/CltTasksUtility.ps1
+++ b/Tasks/QuickPerfTestV1/CltTasksUtility.ps1
@@ -1,7 +1,18 @@
 function InvokeRestMethod($headers, $contentType, $uri , $method= "Get", $body)
 {
 	$ServicePoint = [System.Net.ServicePointManager]::FindServicePoint($uri)
-	$result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $global:RestTimeout -Uri $uri -Method $method -Headers $headers -Body $body
+	try
+	{
+   		$result = Invoke-RestMethod -ContentType "application/json" -UserAgent $global:userAgent -TimeoutSec $restTimeout -Uri $uri -Method $method -Headers $headers -Body $body
+    	}
+        catch
+	{
+    		Write-Host "An error occurred:"
+    		$errorObject = ConvertFrom-Json -InputObject $_.ErrorDetails
+    		$errorMessage = $errorObject.message
+    		Write-Error $errorMessage
+        	throw "Error occurred while calling API: $method $uri. Please check error messages for more details."
+    	}
 	$ServicePoint.CloseConnectionGroup("")
 	return $result
 }

--- a/Tasks/QuickPerfTestV1/task.json
+++ b/Tasks/QuickPerfTestV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 0,
-        "Patch": 41
+        "Minor": 186,
+        "Patch": 0
     },
     "deprecated": true,
     "demands": [

--- a/Tasks/QuickPerfTestV1/task.loc.json
+++ b/Tasks/QuickPerfTestV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 0,
-    "Patch": 41
+    "Minor": 186,
+    "Patch": 0
   },
   "deprecated": true,
   "demands": [


### PR DESCRIPTION
**Task name**: QuickPerTestV1

**Description**: Catching proper error message and displaying so that customer knows that service is now shutdown.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) []([https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1831804])

Logs for cltabc account where cltshutdown is enabled:
![image](https://user-images.githubusercontent.com/9054199/114714910-2e05ab00-9d50-11eb-953b-25364b5b0628.png)

Logs for clttestsu0 account where cltshutdown is disabled :
![image](https://user-images.githubusercontent.com/9054199/114713810-1e399700-9d4f-11eb-9307-312cc1e9816b.png)


**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
