### PR TITLE
Create PR in OneLocBuild task only on third week of sprint 

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -57,7 +57,7 @@ stages:
         outDir: '$(Build.ArtifactStagingDirectory)'
         packageSourceAuth: 'patAuth'
         patVariable: '$(OneLocBuildPAT)'
-        isCreatePrSelected: false
+        isCreatePrSelected: $(shouldCreatePR)
         repoType: 'gitHub'
         prSourceBranchPrefix: 'Localize'
         gitHubPatVariable: '$(GitHubPAT)'

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -38,6 +38,7 @@ stages:
           Write-Host "shouldCreatePR was set to false"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($false)"
         }
+        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
       displayName: "Determine the number of the week in the sprint and sprint number"
 
     - powershell: |

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -28,7 +28,7 @@ stages:
       
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
+        if (($env:PR_CREATION_ENABLED -eq 'True') -and (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual')))
         {
           Write-Host "shouldCreatePR was set to true"
           Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -28,8 +28,16 @@ stages:
       
     - powershell: |
         $sprintInfo = Invoke-WebRequest https://whatsprintis.it -Headers @{"Accept"= "application/json"} | ConvertFrom-Json
-        Write-Host "##vso[task.setvariable variable=week]$($sprintInfo.week)"
-        Write-Host "##vso[task.setvariable variable=sprint]$($sprintInfo.sprint)"
+        if (($sprintInfo.week -eq 3) -or ($env:BUILD_REASON -eq 'Manual'))
+        {
+          Write-Host "shouldCreatePR was set to true"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($true)"  
+        }
+        else
+        {
+          Write-Host "shouldCreatePR was set to false"
+          Write-Host "##vso[task.setvariable variable=shouldCreatePR]$($false)"
+        }
       displayName: "Determine the number of the week in the sprint and sprint number"
 
     - powershell: |
@@ -39,10 +47,10 @@ stages:
         git merge origin/master
         git push origin Localization
       displayName: "Sync with master branch"
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
 
     - task: OneLocBuild@2
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       inputs:
         locProj: 'Localize/LocProject.json'
         outDir: '$(Build.ArtifactStagingDirectory)'
@@ -58,7 +66,7 @@ stages:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     
     - task: PublishBuildArtifacts@1
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))
       displayName: 'Publish an artifact'
 
     - powershell: |
@@ -67,7 +75,7 @@ stages:
         git add -A
         git commit -m 'Bumped versions'
       displayName: Bump tasks' and packages' versions
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
         $date= Get-Date -Format "MMddyyyy"
@@ -82,7 +90,7 @@ stages:
         git commit -m "Removing Localize folder"
         git push origin $updateBranch
       displayName: Create and push localization update branch
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
     
     - task: PowerShell@2
       inputs:
@@ -92,7 +100,7 @@ stages:
       env:
         GH_TOKEN: '$(GitHubPAT)'
       displayName: Open a PR
-      condition: and(succeeded(), or(and(eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
+      condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
         $message="Created tasks localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
@@ -101,7 +109,7 @@ stages:
         } | ConvertTo-Json
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about PR opened'
-      condition: and(succeeded(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(succeeded(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
@@ -111,4 +119,4 @@ stages:
         } | ConvertTo-Json
         Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
       displayName: 'Send Slack notification about error'
-      condition: and(failed(), eq(variables['WEEK'], '3'), eq(variables['build.reason'], 'Schedule'))
+      condition: and(failed(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))


### PR DESCRIPTION
Description: This PR should resolve the issue with the incidents on the localization team side caused by missed artifacts in pipeline runs.
In previous behavior we have skipped all the tasks in case it is not the third week of the sprint and artifacts weren't published.

In new behavior, artifacts will be generated every week, but the update of the corresponding branches will only take place on the last week of the sprint. In case of manual run, PR will be created independent of the current week.

Checklist:
- [X] Checked that applied changes work as expected
