### PR TITLE
Docker V0 and V1 store build output in temp file

### DIFF
--- a/Tasks/DockerV0/Tests/L0.ts
+++ b/Tasks/DockerV0/Tests/L0.ts
@@ -1,3 +1,4 @@
+import * as os from "os";
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
@@ -234,6 +235,18 @@ describe('Docker Suite', function() {
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t ajgtestacr1.azurecr.io/test/test:2`) != -1, "docker build should run");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Runs successfully for docker build and populate ouput variable correctly', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.action] = shared.ActionTypes.buildImage;
+        tr.run();
+
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`set DockerOutputPath=${path.join(os.tmpdir(),"task_outputs","build")}`) != -1, "docker build should update DockerOutputPath env variable.")
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV0/Tests/L0.ts
+++ b/Tasks/DockerV0/Tests/L0.ts
@@ -246,7 +246,7 @@ describe('Docker Suite', function() {
         tr.run();
 
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`set DockerOutputPath=${path.join(os.tmpdir(),"task_outputs","build")}`) != -1, "docker build should update DockerOutputPath env variable.")
+        assert(tr.stdout.indexOf("set DockerOutputPath=") != -1, "docker build should set DockerOutputPath env variable.")
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV0/containerbuild.ts
+++ b/Tasks/DockerV0/containerbuild.ts
@@ -63,5 +63,11 @@ export function run(connection: ContainerConnection): any {
         context = tl.getPathInput("context");
     }
     command.arg(context);
+
+    command.on("stdout", data => {
+        let taskOutputPath = utils.writeTaskOutput("build", data);
+        tl.setVariable("DockerOutputPath", taskOutputPath);
+    });
+
     return connection.execCommand(command);
 }

--- a/Tasks/DockerV0/containerbuild.ts
+++ b/Tasks/DockerV0/containerbuild.ts
@@ -64,10 +64,13 @@ export function run(connection: ContainerConnection): any {
     }
     command.arg(context);
 
+    let output: string = "";
     command.on("stdout", data => {
-        let taskOutputPath = utils.writeTaskOutput("build", data);
-        tl.setVariable("DockerOutputPath", taskOutputPath);
+        output += data;
     });
 
-    return connection.execCommand(command);
+    return connection.execCommand(command).then(() => {
+        let taskOutputPath = utils.writeTaskOutput("build", output);
+        tl.setVariable("DockerOutputPath", taskOutputPath);
+    });
 }

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 183,
+        "Minor": 187,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 181,
+        "Minor": 183,
         "Patch": 0
     },
     "demands": [],
@@ -325,6 +325,10 @@
         {
             "name": "DockerOutput",
             "description": "Stores the output of the docker command"
+        },
+        {
+            "name": "DockerOutputPath",
+            "description": "The path of the file(s) which contains the output of the build command." 
         }
     ],
     "instanceNameFormat": "$(action)",

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -328,7 +328,7 @@
         },
         {
             "name": "DockerOutputPath",
-            "description": "The path of the file(s) which contains the output of the build command." 
+            "description": "The path of the file which contains the output of the build command." 
         }
     ],
     "instanceNameFormat": "$(action)",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 183,
+    "Minor": 187,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 181,
+    "Minor": 183,
     "Patch": 0
   },
   "demands": [],
@@ -325,6 +325,10 @@
     {
       "name": "DockerOutput",
       "description": "Stores the output of the docker command"
+    },
+    {
+      "name": "DockerOutputPath",
+      "description": "The path of the file(s) which contains the output of the build command."
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -328,7 +328,7 @@
     },
     {
       "name": "DockerOutputPath",
-      "description": "The path of the file(s) which contains the output of the build command."
+      "description": "The path of the file which contains the output of the build command."
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DockerV0/utils.ts
+++ b/Tasks/DockerV0/utils.ts
@@ -4,6 +4,9 @@ import * as fs from "fs";
 import ContainerConnection from "azure-pipelines-tasks-docker-common-v2/containerconnection";
 import * as sourceUtils from "azure-pipelines-tasks-docker-common-v2/sourceutils";
 import * as imageUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
+import * as fileutils from "azure-pipelines-tasks-docker-common-v2/fileutils";
+import * as path from "path";
+import * as os from "os";
 
 export function getImageNames(): string[] {
     let imageNamesFilePath = tl.getPathInput("imageNamesPath", /* required */ true, /* check exists */ true);
@@ -80,6 +83,28 @@ export function getImageMappings(connection: ContainerConnection, imageNames: st
     });
 
     return sourceToTargetMapping;
+}
+
+
+function getTaskOutputDir(command: string): string {
+    let tempDirectory = tl.getVariable('agent.tempDirectory') || os.tmpdir();
+    let taskOutputDir = path.join(tempDirectory, "task_outputs");
+    return taskOutputDir;
+}
+
+export function writeTaskOutput(commandName: string, output: string): string {
+    let taskOutputDir = getTaskOutputDir(commandName);
+    if (!fs.existsSync(taskOutputDir)) {
+        fs.mkdirSync(taskOutputDir);
+    }
+
+    let outputFileName = commandName + "_" + Date.now() + ".txt";
+    let taskOutputPath = path.join(taskOutputDir, outputFileName);
+    if (fileutils.writeFileSync(taskOutputPath, output) == 0) {
+        tl.warning(tl.loc('NoDataWrittenOnFile', taskOutputPath));
+    }
+    
+    return taskOutputPath;
 }
 
 interface ImageInfo {

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -390,7 +390,7 @@ describe('Docker Suite', function() {
         tr.run();
 
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`set DockerOutputPath=${path.join(os.tmpdir(),"task_outputs","build")}`) != -1, "docker build should update DockerOutputPath env variable.")
+        assert(tr.stdout.indexOf("set DockerOutputPath=") != -1, "docker build should set DockerOutputPath env variable.")
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import * as os from "os";
 import * as assert from 'assert';
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import tl = require('azure-pipelines-task-lib');
@@ -378,6 +379,18 @@ describe('Docker Suite', function() {
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t ajgtestacr1.azurecr.io/test/test:2`) != -1, "docker build should run");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Runs successfully for docker build and populate ouput variable correctly', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        tr.run();
+
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`set DockerOutputPath=${path.join(os.tmpdir(),"task_outputs","build")}`) != -1, "docker build should update DockerOutputPath env variable.")
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV1/containerbuild.ts
+++ b/Tasks/DockerV1/containerbuild.ts
@@ -66,5 +66,11 @@ export function run(connection: ContainerConnection): any {
         context = tl.getPathInput("buildContext");
     }
     command.arg(context);
+
+    command.on("stdout", data => {
+        let taskOutputPath = utils.writeTaskOutput("build", data);
+        tl.setVariable("DockerOutputPath", taskOutputPath);
+    });
+
     return connection.execCommand(command);
 }

--- a/Tasks/DockerV1/containerbuild.ts
+++ b/Tasks/DockerV1/containerbuild.ts
@@ -67,10 +67,13 @@ export function run(connection: ContainerConnection): any {
     }
     command.arg(context);
 
+    let output: string = "";
     command.on("stdout", data => {
-        let taskOutputPath = utils.writeTaskOutput("build", data);
-        tl.setVariable("DockerOutputPath", taskOutputPath);
+        output += data;
     });
 
-    return connection.execCommand(command);
+    return connection.execCommand(command).then(() => {
+        let taskOutputPath = utils.writeTaskOutput("build", output);
+        tl.setVariable("DockerOutputPath", taskOutputPath);
+    });
 }

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -368,7 +368,7 @@
         },
         {
             "name": "DockerOutputPath",
-            "description": "The path of the file(s) which contains the output of the build command." 
+            "description": "The path of the file which contains the output of the build command." 
         }
     ],
     "instanceNameFormat": "$(command)",

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 183,
+        "Minor": 187,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 181,
+        "Minor": 183,
         "Patch": 0
     },
     "demands": [],
@@ -365,6 +365,10 @@
         {
             "name": "DockerOutput",
             "description": "Stores the output of the docker command"
+        },
+        {
+            "name": "DockerOutputPath",
+            "description": "The path of the file(s) which contains the output of the build command." 
         }
     ],
     "instanceNameFormat": "$(command)",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 183,
+    "Minor": 187,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 181,
+    "Minor": 183,
     "Patch": 0
   },
   "demands": [],
@@ -365,6 +365,10 @@
     {
       "name": "DockerOutput",
       "description": "Stores the output of the docker command"
+    },
+    {
+      "name": "DockerOutputPath",
+      "description": "The path of the file(s) which contains the output of the build command."
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -368,7 +368,7 @@
     },
     {
       "name": "DockerOutputPath",
-      "description": "The path of the file(s) which contains the output of the build command."
+      "description": "The path of the file which contains the output of the build command."
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/DockerV1/utils.ts
+++ b/Tasks/DockerV1/utils.ts
@@ -4,6 +4,9 @@ import * as fs from "fs";
 import ContainerConnection from "azure-pipelines-tasks-docker-common-v2/containerconnection";
 import * as sourceUtils from "azure-pipelines-tasks-docker-common-v2/sourceutils";
 import * as imageUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
+import * as fileutils from "azure-pipelines-tasks-docker-common-v2/fileutils";
+import * as path from "path";
+import * as os from "os";
 
 export function getImageNames(): string[] {
     let imageNamesFilePath = tl.getPathInput("imageNamesPath", /* required */ true, /* check exists */ true);
@@ -71,6 +74,29 @@ export function getImageMappings(connection: ContainerConnection, imageNames: st
 
     return sourceToTargetMapping;
 }
+
+
+function getTaskOutputDir(command: string): string {
+    let tempDirectory = tl.getVariable('agent.tempDirectory') || os.tmpdir();
+    let taskOutputDir = path.join(tempDirectory, "task_outputs");
+    return taskOutputDir;
+}
+
+export function writeTaskOutput(commandName: string, output: string): string {
+    let taskOutputDir = getTaskOutputDir(commandName);
+    if (!fs.existsSync(taskOutputDir)) {
+        fs.mkdirSync(taskOutputDir);
+    }
+
+    let outputFileName = commandName + "_" + Date.now() + ".txt";
+    let taskOutputPath = path.join(taskOutputDir, outputFileName);
+    if (fileutils.writeFileSync(taskOutputPath, output) == 0) {
+        tl.warning(tl.loc('NoDataWrittenOnFile', taskOutputPath));
+    }
+    
+    return taskOutputPath;
+}
+
 
 interface ImageInfo {
     /**


### PR DESCRIPTION
**Task name**:  Docker

**Description**: the build command is going to store the output of docker in a temp file and is going to store its path in an output variable

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14537

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
