### PR TITLE
Add ability to export IPA from existing xcarchive (feature request #14771)

### DIFF
--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -97,5 +97,6 @@
   "loc.messages.NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`.",
   "loc.messages.XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed.",
   "loc.messages.XcodeRequiresMac": "Using Xcode requires a macOS agent. Building with Xcode on Linux or Windows is not supported by Apple.",
-  "loc.messages.UsingDefaultSimulator": "Using default simulator: %s."
+  "loc.messages.UsingDefaultSimulator": "Using default simulator: %s.",
+  "loc.messages.NoValidActionSpecified": "Either packageApp must be true or an action specified"
 }

--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -70,6 +70,8 @@
   "loc.input.help.publishJUnitResults": "Specify whether to publish JUnit test results to Azure Pipelines. This requires xcpretty to be enabled to generate JUnit test results.",
   "loc.input.label.testRunTitle": "Test run title",
   "loc.input.help.testRunTitle": "Title of the test run when publishing JUnit test results to Azure Pipelines.",
+  "loc.input.label.skipArchiveAction": "Skip Archiving",
+  "loc.input.help.skipArchiveAction": "Indicate whether `xcodebuild archive` should be executed before exporting the IPA.",
   "loc.messages.SignIdNotFound": "Failed to find the iOS signing identity. Verify that signing and provisioning information is provided.",
   "loc.messages.TempKeychainSetupFailed": "Failed to add the temporary keychain to the keychains search path.",
   "loc.messages.ProvProfileDetailsNotFound": "Failed to find details for the provisioning profile: %s",

--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -797,4 +797,30 @@ describe('Xcode L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
         done();
     });
+
+    it('export ipa without archiving', function (done: MochaDone) {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        let tp = path.join(__dirname, 'L0ExportOnly.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        //version
+        assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
+
+        //export prep
+        assert(tr.ran("/usr/libexec/PlistBuddy -c Clear _XcodeTaskExportOptions.plist"),
+            'PlistBuddy Clear should have run. An empty exportOptions plist should be used when there\'s not an embedded provisioning profile.');
+
+        //export        
+        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/myscheme.xcarchive'
+            + ' -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
+
+        assert(tr.invokedToolCount == 3, 'should have run xcodebuild version, plistbuddy clear, and xcodebuild exportArchive');
+        assert(tr.stderr.length == 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        done();
+    });    
 });

--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -775,5 +775,26 @@ describe('Xcode L0 Suite', function () {
         assert(tr.invokedToolCount === 4, 'Should have ran 4 command lines.');
 
         done();
-    });    
+    });
+    
+    it('add archivePath when actions include archive', function (done: MochaDone) {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        let tp = path.join(__dirname, 'L0XcodeAddArchivePathForArchiveAction.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        //version
+        assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
+
+        //archive
+        assert(tr.ran('/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) ' +
+                '-workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme archive -archivePath /user/build/myscheme'),
+            'xcodebuild for archiving the ios project/workspace should have been run.');
+        assert(tr.invokedToolCount == 2, 'should have run xcodebuild version and xcodebuild archive');
+        assert(tr.stderr.length == 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        done();
+    });
 });

--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -139,7 +139,7 @@ describe('Xcode L0 Suite', function () {
 
         tr.run();
 
-        assert(tr.stdout.search(/Input required: actions/) > 0, 'Error should be shown if actions are not specified.');
+        assert(tr.stdout.search(/##vso\[task.issue type=error;\]Error: loc_mock_NoValidActionSpecified/) > 0, 'Error should be shown if actions are not specified.');
         assert(tr.failed, 'task should have failed');
         done();
     });
@@ -757,4 +757,23 @@ describe('Xcode L0 Suite', function () {
 
         done();
     });
+
+    it('packageApp without actions', function (done: MochaDone) {
+        this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+
+        const tp = path.join(__dirname, 'L0TaskNoActionsRequiredWhenPackaging.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        //export
+        assert(tr.ran('/home/bin/xcodebuild -exportArchive -archivePath /user/build/myscheme.xcarchive'
+            + ' -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist'),
+            'xcodebuild exportArchive should have been run to export the IPA from the .xcarchive');
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.invokedToolCount === 4, 'Should have ran 4 command lines.');
+
+        done();
+    });    
 });

--- a/Tasks/XcodeV5/Tests/L0ExportOnly.ts
+++ b/Tasks/XcodeV5/Tests/L0ExportOnly.ts
@@ -1,0 +1,96 @@
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'xcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+process.env['HOME'] = '/users/test'; //replace with mock of setVariable when task-lib has the support
+
+tr.setInput('actions', '');
+tr.setInput('packageApp', 'true');
+tr.setInput('skipArchiveAction', 'true');
+tr.setInput('signingOption', 'default');
+tr.setInput('signingIdentity', '');
+tr.setInput('provisioningProfileUuid', '');
+tr.setInput('args', '');
+tr.setInput('cwd', '/user/build');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+tr.setInput('publishJUnitResults', 'false');
+tr.setInput('archivePath', '/user/build/myscheme.xcarchive');
+tr.setInput('exportPath', '/user/build');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "xcodebuild": "/home/bin/xcodebuild",
+        "security": "/usr/bin/security",
+        "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
+        "rm": "/bin/rm"
+    },
+    "checkPath" : {
+        "/home/bin/xcodebuild": true,
+        "/usr/bin/security": true,
+        "/usr/libexec/PlistBuddy": true,
+        "/bin/rm": true,
+    },
+    "findMatch": {
+        "**/*.xcodeproj/*.xcworkspace": [
+          "/user/build/fun.xcodeproj/project.xcworkspace"
+        ],
+        "**/*.xcarchive": [
+            "/user/build/myscheme.xcarchive"
+        ],
+        "**/embedded.mobileprovision": [
+            "/user/build/myscheme.xcarchive/Products/myscheme.app/embedded.mobileprovision"
+        ]
+    },
+    "exec": {
+        "/home/bin/xcodebuild -version": {
+          "code": 0,
+          "stdout": "Xcode 7.2.1"
+        },
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/myscheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+          "code": 0,
+          "stdout": "xcodebuild output here"
+        },
+        "/usr/libexec/PlistBuddy -c Clear _XcodeTaskExportOptions.plist": {
+            "code": 0,
+            "stdout": "plist initialized output here"
+        },
+        "/usr/libexec/PlistBuddy -c Add method string app-store _XcodeTaskExportOptions.plist": {
+            "code": 0,
+            "stdout": "plist add output here"
+        },
+        "/usr/libexec/PlistBuddy -c Print ProvisionsAllDevices _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": "ProvisionsAllDevices not found"
+        },
+        "/usr/libexec/PlistBuddy -c Print Entitlements:get-task-allow _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "false"
+        },
+        "/usr/libexec/PlistBuddy -c Print ProvisionedDevices _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": "ProvisionedDevices not found"
+        },
+        "/usr/libexec/PlistBuddy -c Print Entitlements:com.apple.developer.icloud-container-environment _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": ":com.apple.developer.icloud-container-environment, Does Not Exist"
+        },
+        "/bin/rm -f _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "delete output here"
+        },
+        "/usr/bin/security cms -D -i /user/build/testScheme.xcarchive/Products/testScheme.app/embedded.mobileprovision": {
+            "code": 0,
+            "stdout": "prov profile details here"
+        }
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/XcodeV5/Tests/L0TaskNoActionsRequiredWhenPackaging.ts
+++ b/Tasks/XcodeV5/Tests/L0TaskNoActionsRequiredWhenPackaging.ts
@@ -1,0 +1,103 @@
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'xcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+process.env['HOME'] = '/users/test'; //replace with mock of setVariable when task-lib has the support
+
+tr.setInput('actions', '');
+tr.setInput('configuration', '$(Configuration)');
+tr.setInput('sdk', '$(SDK)');
+tr.setInput('xcWorkspacePath', '**/*.xcodeproj/*.xcworkspace');
+tr.setInput('scheme', 'myscheme');
+tr.setInput('packageApp', 'true');
+tr.setInput('signingOption', 'default');
+tr.setInput('signingIdentity', '');
+tr.setInput('provisioningProfileUuid', '');
+tr.setInput('args', '');
+tr.setInput('cwd', '/user/build');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+tr.setInput('publishJUnitResults', 'false');
+tr.setInput('archivePath', '/user/build');
+tr.setInput('exportPath', '/user/build');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "xcodebuild": "/home/bin/xcodebuild",
+        "security": "/usr/bin/security",
+        "/usr/libexec/PlistBuddy": "/usr/libexec/PlistBuddy",
+        "rm": "/bin/rm"
+    },
+    "checkPath" : {
+        "/home/bin/xcodebuild": true,
+        "/usr/bin/security": true,
+        "/usr/libexec/PlistBuddy": true,
+        "/bin/rm": true,
+    },
+    "findMatch": {
+        "**/*.xcodeproj/*.xcworkspace": [
+          "/user/build/fun.xcodeproj/project.xcworkspace"
+        ],
+        "**/*.xcarchive": [
+            "/user/build/myscheme.xcarchive"
+        ],
+        "**/embedded.mobileprovision": [
+            "/user/build/myscheme.xcarchive/Products/myscheme.app/embedded.mobileprovision"
+        ]
+    },
+    "exec": {
+        "/home/bin/xcodebuild -version": {
+          "code": 0,
+          "stdout": "Xcode 7.2.1"
+        },
+        "/home/bin/xcodebuild -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme archive -sdk $(SDK) -configuration $(Configuration) -archivePath /user/build/myscheme": {
+          "code": 0,
+          "stdout": "xcodebuild output here"
+        },
+        "/home/bin/xcodebuild -exportArchive -archivePath /user/build/myscheme.xcarchive -exportPath /user/build -exportOptionsPlist _XcodeTaskExportOptions.plist": {
+          "code": 0,
+          "stdout": "xcodebuild output here"
+        },
+        "/usr/libexec/PlistBuddy -c Clear _XcodeTaskExportOptions.plist": {
+            "code": 0,
+            "stdout": "plist initialized output here"
+        },
+        "/usr/libexec/PlistBuddy -c Add method string app-store _XcodeTaskExportOptions.plist": {
+            "code": 0,
+            "stdout": "plist add output here"
+        },
+        "/usr/libexec/PlistBuddy -c Print ProvisionsAllDevices _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": "ProvisionsAllDevices not found"
+        },
+        "/usr/libexec/PlistBuddy -c Print Entitlements:get-task-allow _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "false"
+        },
+        "/usr/libexec/PlistBuddy -c Print ProvisionedDevices _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": "ProvisionedDevices not found"
+        },
+        "/usr/libexec/PlistBuddy -c Print Entitlements:com.apple.developer.icloud-container-environment _xcodetasktmp.plist": {
+            "code": 1,
+            "stdout": ":com.apple.developer.icloud-container-environment, Does Not Exist"
+        },
+        "/bin/rm -f _xcodetasktmp.plist": {
+            "code": 0,
+            "stdout": "delete output here"
+        },
+        "/usr/bin/security cms -D -i /user/build/testScheme.xcarchive/Products/testScheme.app/embedded.mobileprovision": {
+            "code": 0,
+            "stdout": "prov profile details here"
+        }
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/XcodeV5/Tests/L0XcodeAddArchivePathForArchiveAction.ts
+++ b/Tasks/XcodeV5/Tests/L0XcodeAddArchivePathForArchiveAction.ts
@@ -1,0 +1,62 @@
+
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'xcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+process.env['HOME'] = '/users/test'; //replace with mock of setVariable when task-lib has the support
+
+// Xcode task defaults used for version 5
+tr.setInput('actions', 'archive');
+tr.setInput('configuration', '$(Configuration)');
+tr.setInput('sdk', '$(SDK)');
+tr.setInput('xcWorkspacePath', '**/*.xcodeproj/*.xcworkspace');
+tr.setInput('scheme', 'myscheme');
+tr.setInput('packageApp', 'false');
+tr.setInput('signingOption', 'default');
+tr.setInput('signingIdentity', '');
+tr.setInput('provisioningProfileUuid', '');
+tr.setInput('args', '');
+tr.setInput('cwd', '/user/build');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+tr.setInput('publishJUnitResults', 'false');
+tr.setInput('archivePath', '/user/build');
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "xcodebuild": "/home/bin/xcodebuild"
+    },
+    "checkPath" : {
+        "/home/bin/xcodebuild": true
+    },
+    "getVariable": {
+        "build.sourcesDirectory": "/user/build",
+        "HOME": "/users/test"
+    },
+    "findMatch": {
+        "**/*.xcodeproj/*.xcworkspace": [
+          "/user/build/fun.xcodeproj/project.xcworkspace"
+        ],
+        "**/*.app": [
+          "/user/build/output/$(SDK)/$(Configuration)/build.sym/Release.iphoneos/fun.app"
+        ]
+    },
+    "exec": {
+        "/home/bin/xcodebuild -version": {
+          "code": 0,
+          "stdout": "Xcode 7.2.1"
+        },
+        "/home/bin/xcodebuild -sdk $(SDK) -configuration $(Configuration) -workspace /user/build/fun.xcodeproj/project.xcworkspace -scheme myscheme archive -archivePath /user/build/myscheme": {
+          "code": 0,
+          "stdout": "xcodebuild output here"
+        }
+    }
+};
+tr.setAnswers(a);
+
+tr.run();
+

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -126,7 +126,7 @@
       "required": false,
       "helpMarkDown": "(Optional) Specify a directory where created archives should be placed.",
       "groupName": "package",
-      "visibleRule": "packageApp == true"
+      "visibleRule": "packageApp == true || actions.includes('archive')"
     },
     {
       "name": "exportPath",

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -48,7 +48,7 @@
       "type": "string",
       "label": "Actions",
       "defaultValue": "build",
-      "required": true,
+      "required": false,
       "helpMarkDown": "Enter a space-delimited list of actions. Some valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build."
     },
     {
@@ -409,6 +409,7 @@
     "NoDestinationPlatformWarning": "UI tests must be run against a simulator or a connected device. In the Xcode task, set `Destination platform` to a value other than `Default`.",
     "XcprettyNotInstalled": "xcpretty is not installed on the build server. xcodebuild raw output will be shown. Publishing test results will fail if xcpretty is not installed.",
     "XcodeRequiresMac": "Using Xcode requires a macOS agent. Building with Xcode on Linux or Windows is not supported by Apple.",
-    "UsingDefaultSimulator": "Using default simulator: %s."
+    "UsingDefaultSimulator": "Using default simulator: %s.",
+    "NoValidActionSpecified": "ms-resource:loc.messages.NoValidActionSpecified"
   }
 }

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -359,6 +359,16 @@
       "groupName": "advanced",
       "helpMarkDown": "Title of the test run when publishing JUnit test results to Azure Pipelines.",
       "visibleRule": "publishJUnitResults == true"
+    },
+    {
+        "name": "skipArchiveAction",
+        "type": "boolean",
+        "label": "Skip Archiving",
+        "defaultValue": false,
+        "required": false,
+        "helpMarkDown": "Indicate whether `xcodebuild archive` should be executed before exporting the IPA.",
+        "groupName": "package",
+        "visibleRule": "packageApp == true"
     }
   ],
   "execution": {

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -48,7 +48,7 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.actions",
       "defaultValue": "build",
-      "required": true,
+      "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.actions"
     },
     {
@@ -409,6 +409,7 @@
     "NoDestinationPlatformWarning": "ms-resource:loc.messages.NoDestinationPlatformWarning",
     "XcprettyNotInstalled": "ms-resource:loc.messages.XcprettyNotInstalled",
     "XcodeRequiresMac": "ms-resource:loc.messages.XcodeRequiresMac",
-    "UsingDefaultSimulator": "ms-resource:loc.messages.UsingDefaultSimulator"
+    "UsingDefaultSimulator": "ms-resource:loc.messages.UsingDefaultSimulator",
+    "NoValidActionSpecified": "ms-resource:loc.messages.NoValidActionSpecified"
   }
 }

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -359,6 +359,16 @@
       "groupName": "advanced",
       "helpMarkDown": "ms-resource:loc.input.help.testRunTitle",
       "visibleRule": "publishJUnitResults == true"
+    },
+    {
+      "name": "skipArchiveAction",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.skipArchiveAction",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.skipArchiveAction",
+      "groupName": "package",
+      "visibleRule": "packageApp == true"
     }
   ],
   "execution": {

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -126,7 +126,7 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.archivePath",
       "groupName": "package",
-      "visibleRule": "packageApp == true"
+      "visibleRule": "packageApp == true || actions.includes('archive')"
     },
     {
       "name": "exportPath",

--- a/Tasks/XcodeV5/xcode.ts
+++ b/Tasks/XcodeV5/xcode.ts
@@ -250,6 +250,16 @@ async function run() {
             xcb.argIf(xcode_provProfileSpecifier, xcode_provProfileSpecifier);
             xcb.argIf(xcode_devTeam, xcode_devTeam);
 
+            if (actions.includes('archive') && !createIPA) {
+                let archivePath: string = tl.getInput('archivePath');
+                if (archivePath && !archivePath.endsWith('.xcarchive')) {
+                    archivePath = tl.resolve(archivePath, scheme);
+                }
+
+                xcb.argIf(archivePath, ['-archivePath', archivePath]);
+    
+            }
+            
             //--- Enable Xcpretty formatting ---
             if (useXcpretty && !tl.which('xcpretty')) {
                 // user wants to enable xcpretty but it is not installed, fallback to xcodebuild raw output


### PR DESCRIPTION
**Task name**: Xcode

**Description**: Adds ability to export IPA from existing xcarchive. I have split the PR into 3 commits, each can be separated out into their own PR if necessary:

1. Made the action parameter option when the packageApp is true
2. Move the archivePath parameter to the advanced section. Made visible when packageApp is true or archive is listed as an action. Add archivePath to the command line args when archive is listed as an action
3. Add parameter skipArchivingAction to allow skipping of archive when packageApp is true

**Documentation changes required:** Yes. I updated some of the documentation, but it should be reviewed

**Added unit tests:** Yes

**Attached related issue:** #14771 
**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
