### PR TITLE
Added skip_app_build option to AzureStaticWebAppV0 task

### DIFF
--- a/Tasks/AzureStaticWebAppV0/index.ts
+++ b/Tasks/AzureStaticWebAppV0/index.ts
@@ -27,6 +27,7 @@ async function run() {
         const apiLocation: string = tl.getInput('api_location', false) || "";
         const apiBuildCommand: string = tl.getInput('api_build_command', false) || "";
         const routesLocation: string = tl.getInput('routes_location', false) || "";
+        const skipAppBuild: string = tl.getInput('skip_app_build', false) || "";
         
         process.env['SWA_APP_LOCATION'] = appLocation;
         process.env['SWA_APP_BUILD_COMMAND'] = appBuildCommand;
@@ -35,6 +36,7 @@ async function run() {
         process.env['SWA_API_BUILD_COMMAND'] = apiBuildCommand;
         process.env['SWA_ROUTES_LOCATION'] = routesLocation;
         process.env['SWA_DEPLOYMENT_CLIENT'] = deploymentClient;
+        process.env['SWA_SKIP_APP_BUILD'] = skipAppBuild;
 
         const options = {
             failOnStdErr: false,

--- a/Tasks/AzureStaticWebAppV0/launch-docker.sh
+++ b/Tasks/AzureStaticWebAppV0/launch-docker.sh
@@ -8,6 +8,7 @@ params=()
 [[ ! -z "$SWA_API_LOCATION" ]] && params+=(-e "INPUT_API_LOCATION=$SWA_API_LOCATION")
 [[ ! -z "$SWA_API_BUILD_COMMAND" ]] && params+=(-e "INPUT_API_BUILD_COMMAND=$SWA_API_BUILD_COMMAND")
 [[ ! -z "$SWA_ROUTES_LOCATION" ]] && params+=(-e "INPUT_ROUTES_LOCATION=$SWA_ROUTES_LOCATION")
+[[ ! -z "$SWA_SKIP_APP_BUILD" ]] && params+=(-e "INPUT_SKIP_APP_BUILD=$SWA_SKIP_APP_BUILD")
 
 docker run \
     -e INPUT_AZURE_STATIC_WEB_APPS_API_TOKEN="$azure_static_web_apps_api_token" \

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -68,6 +68,14 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Directory location where the routes.json file can be found in the source code"
+    },
+    {
+      "name": "skip_app_build",
+      "type": "boolean",
+      "label": "Skip App Build",
+      "defaultValue": "false",
+      "required": false,
+      "helpMarkDown": "Skips the build step for the application source code if set to true"
     }
   ],
   "execution": {

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "0",
-    "Minor": "1",
+    "Minor": "187",
     "Patch": "0"
   },
   "preview": true,


### PR DESCRIPTION
**Task name**: AzureStaticWebAppV0

**Description**: In order to use Approvals and checks with the Deployment job, I needed the option to not run the build. It is already supported GitHub Actions.

https://github.com/Azure/static-web-apps-deploy/pull/8

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
