### PR TITLE
Parse the build output and share the built image id

### DIFF
--- a/Tasks/DockerV2/Tests/L0.ts
+++ b/Tasks/DockerV2/Tests/L0.ts
@@ -240,6 +240,38 @@ describe("DockerV2 Suite", function () {
         console.log(tr.stderr);
         done();
     });
+
+    it('Docker build should store the id of the image that was built.', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.containerRegistry] = "dockerhubendpoint";
+        process.env[shared.TestEnvVars.repository] = "testuser/standardbuild";
+        process.env[shared.TestEnvVars.command] = shared.CommandTypes.build;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=c834e0094587") != -1, "docker build should have stored the image id.")
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Docker build should store the id of the image that was built with builkit.', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.containerRegistry] = "dockerhubendpoint";
+        process.env[shared.TestEnvVars.repository] = "testuser/buildkit";
+        process.env[shared.TestEnvVars.command] = shared.CommandTypes.build;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=6c3ada3eb420") != -1, "docker build should have stored the image id.")
+        console.log(tr.stderr);
+        done();
+    });
     // // Docker build tests end
 
     // // Docker push tests begin

--- a/Tasks/DockerV2/Tests/TestSetup.ts
+++ b/Tasks/DockerV2/Tests/TestSetup.ts
@@ -108,7 +108,7 @@ a.find[`${DefaultWorkingDirectory}`] = [
 
 a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/testrepo:11 ${BuildContextPath}`] = {
     "code": 0,
-    "stdout": "successfully built image and tagged testuser/testrepo:11."
+    "stdout": "Successfully built c834e0094587\n Successfully tagged testuser/testrepo:11."
 };
 
 a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.ReleaseLabels} -t testuser/testrepo:11 ${BuildContextPath}`] = {

--- a/Tasks/DockerV2/Tests/TestSetup.ts
+++ b/Tasks/DockerV2/Tests/TestSetup.ts
@@ -108,7 +108,7 @@ a.find[`${DefaultWorkingDirectory}`] = [
 
 a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/testrepo:11 ${BuildContextPath}`] = {
     "code": 0,
-    "stdout": "Successfully built c834e0094587\n Successfully tagged testuser/testrepo:11."
+    "stdout": "successfully built image and tagged testuser/testrepo:11."
 };
 
 a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.ReleaseLabels} -t testuser/testrepo:11 ${BuildContextPath}`] = {
@@ -159,6 +159,16 @@ a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabels
 a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabelsWithAddPipelineFalse} -t testuser/testrepo:11 ${BuildContextPath}`] = {
     "code": 0,
     "stdout": "successfully built image and tagged testuser/testrepo:11."
+};
+
+a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/standardbuild:11 ${BuildContextPath}`] = {
+    "code": 0,
+    "stdout": "Successfully built c834e0094587\n Successfully tagged testuser/testrepo:11."
+};
+
+a.exec[`docker build -f ${DockerfilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/buildkit:11 ${BuildContextPath}`] = {
+    "code": 0,
+    "stdout": " => => writing image sha256:6c3ada3eb42094510e0083bba6ae805540e36c96871d7be0c926b2f8cbeea68c\n => => naming to docker.io/library/testuser/buildkit:11"
 };
 
 a.exec[`docker push testuser/testrepo:11`] = {

--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -107,7 +107,7 @@ function getImageIdFromBuildOutput(output: string): string {
     };
 
     const buildKitParser = (text: string): string => {
-        let parsedOutput: string[] = text.match(new RegExp("Writing image sha256:([0-9a-f]{64}): done", 'g'));
+        let parsedOutput: string[] = text.match(new RegExp("writing image sha256:([0-9a-f]{64})", 'g'));
 
         return !parsedOutput || parsedOutput.length == 0
             ? ""

--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -10,18 +10,18 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
     // find dockerfile path
     let dockerfilepath = tl.getInput("Dockerfile", true);
     let dockerFile = fileUtils.findDockerFile(dockerfilepath);
-    
-    if(!tl.exist(dockerFile)) {
+
+    if (!tl.exist(dockerFile)) {
         throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
     }
 
     // get command arguments
     // ignore the arguments input if the command is buildAndPush, as it is ambiguous
     let commandArguments = isBuildAndPushCommand ? "" : dockerCommandUtils.getCommandArguments(tl.getInput("arguments", false));
-    
+
     // get qualified image names by combining container registry(s) and repository
     let repositoryName = tl.getInput("repository");
-    let imageNames: string[] = [];    
+    let imageNames: string[] = [];
     // if container registry is provided, use that
     // else, use the currently logged in registries
     if (tl.getInput("containerRegistry")) {
@@ -48,8 +48,7 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         imageNames.forEach(imageName => {
             if (tags && tags.length > 0) {
                 tags.forEach(tag => {
-                    if(tag)
-                    {
+                    if (tag) {
                         tagArguments.push(imageName + ":" + tag);
                     }
                 });
@@ -70,18 +69,26 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         outputUpdate(taskOutputPath);
 
         const builtImageId = getBuiltImageIdFromDockerBuiltOutput(output);
-        if (builtImageId && builtImageId != ""){
+        if (builtImageId && builtImageId != "") {
             shareBuiltImageId(builtImageId);
         }
     });
 }
 
 function shareBuiltImageId(builtImageId: string) {
+    const IMAGE_SEPARATOR_CHAR: string = ";";
+    const ENV_VARIABLE_MAX_SIZE = 32766;
     let builtImages: string = tl.getVariable("DOCKER_TASK_BUILT_IMAGES");
-    const IMAGE_SEPARATOR_CHAR:string = ";";
 
-    if (builtImages && builtImages != ""){
-        builtImages += `${IMAGE_SEPARATOR_CHAR}${builtImages}`;
+    if (builtImages && builtImages != "") {
+        const newImageId = `${IMAGE_SEPARATOR_CHAR}${builtImages}`;
+
+        if (newImageId.length + builtImages.length > ENV_VARIABLE_MAX_SIZE) {
+            tl.debug("Images id truncated maximum environment variable size reached.")
+            return;
+        }
+
+        builtImages += newImageId;
     }
     else {
         builtImages = builtImageId;
@@ -90,29 +97,29 @@ function shareBuiltImageId(builtImageId: string) {
     tl.setVariable("DOCKER_TASK_BUILT_IMAGES", builtImages);
 }
 
-function getBuiltImageIdFromDockerBuiltOutput(output: string) : string {
-    const standardParser = (text:string): string => {
-        let parsedOutput: string[] = text.match(new RegExp("Successfully built ([0-9a-f]{12})",'g'));
+function getBuiltImageIdFromDockerBuiltOutput(output: string): string {
+    const standardParser = (text: string): string => {
+        let parsedOutput: string[] = text.match(new RegExp("Successfully built ([0-9a-f]{12})", 'g'));
 
         return !parsedOutput || parsedOutput.length == 0
             ? ""
-            : parsedOutput[parsedOutput.length-1].substring(19); // This remove the Succesfully built section
+            : parsedOutput[parsedOutput.length - 1].substring(19); // This remove the Succesfully built section
     };
 
     const buildKitParser = (text: string): string => {
-        let parsedOutput : string[] = text.match(new RegExp("Writing image sha256:([0-9a-f]{64}): done",'g'));
+        let parsedOutput: string[] = text.match(new RegExp("Writing image sha256:([0-9a-f]{64}): done", 'g'));
 
         return !parsedOutput || parsedOutput.length == 0
             ? ""
-            : parsedOutput[parsedOutput.length].substring(21,33); // This remove the section Writing Image Sha256 and takes 12 characters from the Id.
+            : parsedOutput[parsedOutput.length].substring(21, 33); // This remove the section Writing Image Sha256 and takes 12 characters from the Id.
     }
 
     let buildOutputParserFuncs = [standardParser, buildKitParser]
-    for(let parserFunc of buildOutputParserFuncs){
+    for (let parserFunc of buildOutputParserFuncs) {
         const builtImageId = parserFunc(output);
-        if (builtImageId && builtImageId != ""){
+        if (builtImageId && builtImageId != "") {
             return builtImageId;
         }
     }
     return "";
- }
+}

--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -4,7 +4,7 @@ import ContainerConnection from "azure-pipelines-tasks-docker-common-v2/containe
 import * as dockerCommandUtils from "azure-pipelines-tasks-docker-common-v2/dockercommandutils";
 import * as fileUtils from "azure-pipelines-tasks-docker-common-v2/fileutils";
 import * as pipelineUtils from "azure-pipelines-tasks-docker-common-v2/pipelineutils";
-import * as containerUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
+import * as containerImageUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
 import * as utils from "./utils";
 
 export function run(connection: ContainerConnection, outputUpdate: (data: string) => any, isBuildAndPushCommand?: boolean): any {
@@ -69,9 +69,9 @@ export function run(connection: ContainerConnection, outputUpdate: (data: string
         let taskOutputPath = utils.writeTaskOutput("build", output);
         outputUpdate(taskOutputPath);
 
-        const builtImageId = containerUtils.getImageIdFromBuildOutput(output);
-        if (builtImageId && builtImageId != "") {
-            containerUtils.shareBuiltImageId(builtImageId);
+        const builtImageId = containerImageUtils.getImageIdFromBuildOutput(output);
+        if (builtImageId) {
+            containerImageUtils.shareBuiltImageId(builtImageId);
         }
     });
 }

--- a/Tasks/DockerV2/dockerbuild.ts
+++ b/Tasks/DockerV2/dockerbuild.ts
@@ -84,7 +84,7 @@ function shareBuiltImageId(builtImageId: string) {
         const newImageId = `${IMAGE_SEPARATOR_CHAR}${builtImages}`;
 
         if (newImageId.length + builtImages.length > ENV_VARIABLE_MAX_SIZE) {
-            tl.debug("Images id truncated maximum environment variable size reached.")
+            tl.debug("Images id truncated maximum environment variable size reached.");
             return;
         }
 
@@ -111,13 +111,13 @@ function getBuiltImageIdFromDockerBuiltOutput(output: string): string {
 
         return !parsedOutput || parsedOutput.length == 0
             ? ""
-            : parsedOutput[parsedOutput.length].substring(21, 33); // This remove the section Writing Image Sha256 and takes 12 characters from the Id.
+            : parsedOutput[parsedOutput.length - 1].substring(21, 33); // This remove the section Writing Image Sha256 and takes 12 characters from the Id.
     }
 
-    let buildOutputParserFuncs = [standardParser, buildKitParser]
+    let buildOutputParserFuncs = [standardParser, buildKitParser];
     for (let parserFunc of buildOutputParserFuncs) {
         const builtImageId = parserFunc(output);
-        if (builtImageId && builtImageId != "") {
+        if (builtImageId) {
             return builtImageId;
         }
     }

--- a/Tasks/DockerV2/package-lock.json
+++ b/Tasks/DockerV2/package-lock.json
@@ -124,15 +124,15 @@
       }
     },
     "azure-pipelines-tasks-docker-common-v2": {
-      "version": "2.0.1-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-docker-common-v2/-/azure-pipelines-tasks-docker-common-v2-2.0.1-preview.0.tgz",
-      "integrity": "sha512-3hZQQdxY6DJEuM+vXq/UKX13XtPQv4HlTRZ39Ghw/+Q2aTLEFOvrLAYvMM+wS3YHG1ZUT0MXFJpHUlSITvmStg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-docker-common-v2/-/azure-pipelines-tasks-docker-common-v2-2.0.4.tgz",
+      "integrity": "sha512-wVio7xu7oPmkVcwlUmKby79MyCwmN0ookddLdwMI0RyWU/XR3LXALGYWSYf9x+ggr2OxJIzikJRV2wfPx9XCzw==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "3.0.6-preview.0",
+        "azure-pipelines-task-lib": "^3.1.0",
         "del": "2.2.0",
         "q": "1.4.1"
       },
@@ -143,9 +143,9 @@
           "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
         },
         "azure-pipelines-task-lib": {
-          "version": "3.0.6-preview.0",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.0.tgz",
-          "integrity": "sha512-Fx+7p5GzvYqVXOQI+LhPk56Pio9yBeEyypKZoPI9cQyti8WTVkmJ7YZwn9HRXurftcLumi2Xq+TC3PwnDq5U5Q==",
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.2.tgz",
+          "integrity": "sha512-ZafpInsnjHKGemA5l3jwfeaI8jARrIv5aYCn3KPP4iNJHgMG2RtwyFGynIfpkUsHMfzC/370iyLru0NGAuSVWQ==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "^1.7.0",
@@ -164,9 +164,9 @@
           }
         },
         "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -213,9 +213,9 @@
           "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
         },
         "azure-pipelines-task-lib": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.0.tgz",
-          "integrity": "sha512-Q1buvNUxrbW2QQ5FWzspyRxWxjtSMMt0x+yMhMncrrvxSKK0wBIAJgMlzBqlR1mUF6ChL1f0BxNtgtR6sp4MlA==",
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.2.tgz",
+          "integrity": "sha512-ofAdVZcL90Qv6zYcKa1vK3Wnrl2kxoKX/Idvb7RWrqHQzcJlAEjCU4UCB5y6NnSKqRSyVTIhdS6hChphpOaiMQ==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "^1.7.0",

--- a/Tasks/DockerV2/package.json
+++ b/Tasks/DockerV2/package.json
@@ -5,7 +5,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-docker-common-v2": "2.0.1-preview.0",
+    "azure-pipelines-tasks-docker-common-v2": "2.0.4",
     "del": "2.2.0",
     "esprima": "2.7.1",
     "js-yaml": "3.6.1",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 185,
+        "Minor": 187,
         "Patch": 0
     },
     "minimumAgentVersion": "2.172.0",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 185,
+    "Minor": 187,
     "Patch": 0
   },
   "minimumAgentVersion": "2.172.0",


### PR DESCRIPTION
**Task name**: DockerV2

**Description**: After the build finish the task is going to parse the output and share in an env variable the imageId that was built.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14650

**Checklist**:
- [x ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
