### PR TITLE
Annotate base image info in docker v1

### DIFF
--- a/Tasks/DockerV0/Tests/L0.ts
+++ b/Tasks/DockerV0/Tests/L0.ts
@@ -21,7 +21,6 @@ describe('Docker Suite', function() {
         delete process.env[shared.TestEnvVars.additionalImageTags];
         delete process.env[shared.TestEnvVars.enforceDockerNamingConvention];
         delete process.env[shared.TestEnvVars.memory];
-        delete process.env[shared.TestEnvVars.addBaseImageData];
     });
     after(function () {
     });

--- a/Tasks/DockerV0/Tests/L0.ts
+++ b/Tasks/DockerV0/Tests/L0.ts
@@ -21,6 +21,7 @@ describe('Docker Suite', function() {
         delete process.env[shared.TestEnvVars.additionalImageTags];
         delete process.env[shared.TestEnvVars.enforceDockerNamingConvention];
         delete process.env[shared.TestEnvVars.memory];
+        delete process.env[shared.TestEnvVars.addBaseImageData];
     });
     after(function () {
     });

--- a/Tasks/DockerV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DockerV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,6 +9,8 @@
   "loc.group.displayName.advanced": "Advanced Options",
   "loc.input.label.containerregistrytype": "Container registry type",
   "loc.input.help.containerregistrytype": "Select 'Azure Container Registry' to connect to it by using an Azure Service Connection. Select 'Container registry' to connect to Docker Hub or any other private container registry.",
+  "loc.input.label.addBaseImageData": "Add base image metadata to image(s)",
+  "loc.input.help.addBaseImageData": "By default base image data like base image name and digest are added which helps with traceability. You can opt out of this default behavior by using this input.",
   "loc.input.label.dockerRegistryEndpoint": "Docker registry service connection",
   "loc.input.help.dockerRegistryEndpoint": "Select a Docker registry service connection. Required for commands that need to authenticate with a registry.",
   "loc.input.label.azureSubscriptionEndpoint": "Azure subscription",

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -160,21 +160,6 @@ describe('Docker Suite', function() {
         done();
     });
 
-    it('Docker build should add labels with base image info', (done:Mocha.Done) => {
-        let tp = path.join(__dirname, 'TestSetup.js');
-        process.env[shared.TestEnvVars.imageName] = "testuser/imagewithannotations:11";
-        process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
-        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-        tr.run();
-
-        assert(tr.invokedToolCount == 3, 'should have invoked tool three time. actual: ' + tr.invokedToolCount);
-        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
-        assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest} -t testuser/imagewithannotations:11`) != -1, "docker build should run");
-        console.log(tr.stderr);
-        done();
-    });
-
     it('Runs successfully for docker run image', (done:Mocha.Done) => {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
@@ -413,6 +398,7 @@ describe('Docker Suite', function() {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.succeeded, 'task should have succeeded');
@@ -446,7 +432,22 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=6c3ada3eb420") != -1, "docker build should have stored the image id.")
+        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=6c3ada3eb420") != -1, "docker build should have stored the image id.");
+        console.log(tr.stderr);
+        done();
+    });
+    
+    it('Docker build should add labels with base image info', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.imageName] = "testuser/imagewithannotations:11";
+        process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 3, 'should have invoked tool three time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t testuser/imagewithannotations:11 ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest}`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -39,7 +39,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -55,7 +55,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2 -m 2GB`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2 -m 2GB`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -72,7 +72,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -106,7 +106,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -123,7 +123,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2 -t test/test`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2 -t test/test`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -139,7 +139,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test:testtag -t test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test:testtag -t test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -155,7 +155,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2`) != -1, "docker build should run with correct arguments");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2`) != -1, "docker build should run with correct arguments");
         console.log(tr.stderr);
         done();
     });
@@ -370,7 +370,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -389,7 +389,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t ajgtestacr1.azurecr.io/test/test:2`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} -t ajgtestacr1.azurecr.io/test/test:2`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -447,7 +447,7 @@ describe('Docker Suite', function() {
         assert(tr.invokedToolCount == 3, 'should have invoked tool three time. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
-        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t testuser/imagewithannotations:11 ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest}`) != -1, "docker build should run");
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest} -t testuser/imagewithannotations:11`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -24,6 +24,7 @@ describe('Docker Suite', function() {
         delete process.env[shared.TestEnvVars.tagMultipleImages];
         delete process.env[shared.TestEnvVars.arguments];
         delete process.env[shared.TestEnvVars.qualifySourceImageName];
+        delete process.env[shared.TestEnvVars.addBaseImageData];
     });
     after(function () {
     });
@@ -32,6 +33,7 @@ describe('Docker Suite', function() {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -47,6 +49,7 @@ describe('Docker Suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.memoryLimit] = "2GB";
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -63,6 +66,7 @@ describe('Docker Suite', function() {
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.imageName] = 'test/Te st:2';
         process.env[shared.TestEnvVars.enforceDockerNamingConvention] = 'true';
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -79,6 +83,7 @@ describe('Docker Suite', function() {
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.imageName] = 'test/Te st:2';
         process.env[shared.TestEnvVars.enforceDockerNamingConvention] = 'false';
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -95,6 +100,7 @@ describe('Docker Suite', function() {
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.imageName] = 'test/Test:2';
         process.env[shared.TestEnvVars.enforceDockerNamingConvention] = 'true';
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -111,6 +117,7 @@ describe('Docker Suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.includeLatestTag] = "true";
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -126,6 +133,7 @@ describe('Docker Suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.arguments] = "-t test:testtag";
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
@@ -141,12 +149,28 @@ describe('Docker Suite', function() {
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.arguments] = "-t test:tag1\n-t test:tag2\n-t test:tag3";
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
 
         assert(tr.invokedToolCount == 1, 'should have invoked tool one times. actual: ' + tr.invokedToolCount);
         assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2`) != -1, "docker build should run with correct arguments");
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Docker build should add labels with base image info', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.imageName] = "testuser/imagewithannotations:11";
+        process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 3, 'should have invoked tool three time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf(`[command]docker build -f ${shared.formatPath("dir1/DockerFile")} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest} -t testuser/imagewithannotations:11`) != -1, "docker build should run");
         console.log(tr.stderr);
         done();
     });
@@ -354,6 +378,7 @@ describe('Docker Suite', function() {
         let tp = path.join(__dirname, 'TestSetup.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         process.env[shared.TestEnvVars.containerType] = shared.ContainerTypes.AzureContainerRegistry;
         tr.run();
 
@@ -371,6 +396,7 @@ describe('Docker Suite', function() {
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
         process.env[shared.TestEnvVars.containerType] = shared.ContainerTypes.AzureContainerRegistry;
         process.env[shared.TestEnvVars.qualifyImageName] = "true";
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         tr.run();
         
         //console.log(tr.stdout);

--- a/Tasks/DockerV1/Tests/L0.ts
+++ b/Tasks/DockerV1/Tests/L0.ts
@@ -411,6 +411,7 @@ describe('Docker Suite', function() {
         let tp = path.join(__dirname, 'TestSetup.js');
         process.env[shared.TestEnvVars.imageName] = "testuser/standardbuild:11";
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -426,6 +427,7 @@ describe('Docker Suite', function() {
         let tp = path.join(__dirname, 'TestSetup.js');
         process.env[shared.TestEnvVars.imageName] = "testuser/buildkit:11";
         process.env[shared.TestEnvVars.command] = shared.CommandTypes.buildImage;
+        process.env[shared.TestEnvVars.addBaseImageData] = "false";
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 

--- a/Tasks/DockerV1/Tests/TestSetup.ts
+++ b/Tasks/DockerV1/Tests/TestSetup.ts
@@ -156,11 +156,11 @@ a.exec[`docker images`] = {
     "code": 0,
     "stdout": "Listed images successfully."
 };
-a.exec[`docker build -f ${DockerFilePath} -t testuser/standardbuild:11`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/standardbuild:11`] = {
     "code": 0,
     "stdout": "Successfully built c834e0094587\n Successfully tagged testuser/testrepo:11."
 };
-a.exec[`docker build -f ${DockerFilePath} -t testuser/buildkit:11`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t testuser/buildkit:11`] = {
     "code": 0,
     "stdout": " => => writing image sha256:6c3ada3eb42094510e0083bba6ae805540e36c96871d7be0c926b2f8cbeea68c\n => => naming to docker.io/library/testuser/buildkit:11"
 };

--- a/Tasks/DockerV1/Tests/TestSetup.ts
+++ b/Tasks/DockerV1/Tests/TestSetup.ts
@@ -27,12 +27,14 @@ tr.setInput('memoryLimit', process.env[shared.TestEnvVars.memoryLimit] || '');
 tr.setInput('pushMultipleImages', process.env[shared.TestEnvVars.pushMultipleImages] || "false");
 tr.setInput('tagMultipleImages', process.env[shared.TestEnvVars.tagMultipleImages] || "false");
 tr.setInput('arguments', process.env[shared.TestEnvVars.arguments] || '');
+tr.setInput ('addBaseImageData', process.env[shared.TestEnvVars.addBaseImageData] || "true");
 
 console.log("Inputs have been set");
 
+process.env["SYSTEM_HOSTTYPE"] = "__hostType__";
 process.env["RELEASE_RELEASENAME"] = "Release-1";
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  DefaultWorkingDirectory;
-process.env["SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"] = "https://abc.visualstudio.com/";
+process.env["SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"] = shared.teamFoundationCollectionURI;
 process.env["SYSTEM_SERVERTYPE"] = "hosted";
 process.env["ENDPOINT_AUTH_dockerhubendpoint"] = "{\"parameters\":{\"username\":\"test\", \"password\":\"regpassword\", \"email\":\"test@microsoft.com\",\"registry\":\"https://index.docker.io/v1/\"},\"scheme\":\"UsernamePassword\"}";
 process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";
@@ -79,27 +81,27 @@ let a = {
 // Add extra answer definitions that need to be dynamically generated
 a.exist[DockerFilePath] = true;
 
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -m 2GB`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -m 2GB ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/Te st:2`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test/Te st:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 1,
     "stdout": "test/Te st:2 not valid imagename"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build test/test image with latest tag"
 };
-a.exec[`docker build -f ${DockerFilePath} -t ajgtestacr1.azurecr.io/test/test:2`] = {
+a.exec[`docker build -f ${DockerFilePath} -t ajgtestacr1.azurecr.io/test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build ajgtestacr1.azurecr.io/test/test image with latest tag"
 };
-a.exec[`docker build -f ${DockerFilePath} -t ${shared.ImageNamesFileImageName}`] = {
+a.exec[`docker build -f ${DockerFilePath} -t ${shared.ImageNamesFileImageName} ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0
 };
 a.exec[`docker tag test/test:2 ajgtestacr1.azurecr.io/test/test:2`] = {
@@ -123,15 +125,15 @@ a.exec[`docker run --rm ${shared.ImageNamesFileImageName}`] = {
 a.exec[`docker push ${shared.ImageNamesFileImageName}`] = {
     "code": 0
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test:6`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test:6 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 and test/test:6 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test:testtag -t test/test:2`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test:testtag -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 and -t test:testtag image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2`] = {
+a.exec[`docker build -f ${DockerFilePath} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
     "code": 0,
     "stdout": "successfully built and tagged test/test:2, test:tag1, test:tag2 and test:tag3"
 };
@@ -162,7 +164,7 @@ a.exec[`docker build -f ${DockerFilePath} -t testuser/buildkit:11`] = {
     "code": 0,
     "stdout": " => => writing image sha256:6c3ada3eb42094510e0083bba6ae805540e36c96871d7be0c926b2f8cbeea68c\n => => naming to docker.io/library/testuser/buildkit:11"
 };
-a.exec[`docker build -f ${DockerFilePath} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest} -t testuser/imagewithannotations:11`] = {
+a.exec[`docker build -f ${DockerFilePath} -t testuser/imagewithannotations:11 ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest}`] = {
     "code": 0,
     "stdout": "successfully built image and tagged testuser/imagewithannotations:11."
 };

--- a/Tasks/DockerV1/Tests/TestSetup.ts
+++ b/Tasks/DockerV1/Tests/TestSetup.ts
@@ -81,27 +81,27 @@ let a = {
 // Add extra answer definitions that need to be dynamically generated
 a.exist[DockerFilePath] = true;
 
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -m 2GB ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2 -m 2GB`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/Te st:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test/Te st:2`] = {
     "code": 1,
     "stdout": "test/Te st:2 not valid imagename"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2 -t test/test`] = {
     "code": 0,
     "stdout": "successfully build test/test image with latest tag"
 };
-a.exec[`docker build -f ${DockerFilePath} -t ajgtestacr1.azurecr.io/test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t ajgtestacr1.azurecr.io/test/test:2`] = {
     "code": 0,
     "stdout": "successfully build ajgtestacr1.azurecr.io/test/test image with latest tag"
 };
-a.exec[`docker build -f ${DockerFilePath} -t ${shared.ImageNamesFileImageName} ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t ${shared.ImageNamesFileImageName}`] = {
     "code": 0
 };
 a.exec[`docker tag test/test:2 ajgtestacr1.azurecr.io/test/test:2`] = {
@@ -125,15 +125,15 @@ a.exec[`docker run --rm ${shared.ImageNamesFileImageName}`] = {
 a.exec[`docker push ${shared.ImageNamesFileImageName}`] = {
     "code": 0
 };
-a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test:6 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test/test:2 -t test/test:6`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 and test/test:6 image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test:testtag -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test:testtag -t test/test:2`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 and -t test:testtag image"
 };
-a.exec[`docker build -f ${DockerFilePath} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2 ${shared.DockerCommandArgs.BuildLabels}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} -t test:tag1 -t test:tag2 -t test:tag3 -t test/test:2`] = {
     "code": 0,
     "stdout": "successfully built and tagged test/test:2, test:tag1, test:tag2 and test:tag3"
 };
@@ -164,7 +164,7 @@ a.exec[`docker build -f ${DockerFilePath} -t testuser/buildkit:11`] = {
     "code": 0,
     "stdout": " => => writing image sha256:6c3ada3eb42094510e0083bba6ae805540e36c96871d7be0c926b2f8cbeea68c\n => => naming to docker.io/library/testuser/buildkit:11"
 };
-a.exec[`docker build -f ${DockerFilePath} -t testuser/imagewithannotations:11 ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest}`] = {
+a.exec[`docker build -f ${DockerFilePath} ${shared.DockerCommandArgs.BuildLabels} --label ${shared.BaseImageLabels.name} --label ${shared.BaseImageLabels.digest} -t testuser/imagewithannotations:11`] = {
     "code": 0,
     "stdout": "successfully built image and tagged testuser/imagewithannotations:11."
 };

--- a/Tasks/DockerV1/Tests/TestShared.ts
+++ b/Tasks/DockerV1/Tests/TestShared.ts
@@ -40,6 +40,12 @@ export let BaseImageLabels = {
     name:"image.base.ref.name=ubuntu",
     digest:"image.base.digest=sha256:826f70e0ac33e99a72cf20fb0571245a8fee52d68cb26d8bc58e53bfa65dcdfa"
 };
+
+export let teamFoundationCollectionURI = "https://abc.visualstudio.com/";
+
+export let DockerCommandArgs = {
+    BuildLabels: `--label com.visualstudio.abc.image.system.teamfoundationcollectionuri=${teamFoundationCollectionURI}`,
+}
 /**
  * Formats the given path to be appropriate for the operating system.
  * @param canonicalPath A non-rooted path using a forward slash (/) as a directory separator.

--- a/Tasks/DockerV1/Tests/TestShared.ts
+++ b/Tasks/DockerV1/Tests/TestShared.ts
@@ -12,7 +12,8 @@ export let TestEnvVars = {
     pushMultipleImages: "__pushMultipleImages__",
     tagMultipleImages: "__tagMultipleImages__",
     arguments: "__arguments__",
-    qualifySourceImageName: "__qualifySourceImageName__"
+    qualifySourceImageName: "__qualifySourceImageName__",
+    addBaseImageData: "addBaseImageData"
 };
 
 export let OperatingSystems = {
@@ -34,6 +35,11 @@ export let ContainerTypes = {
 
 export let ImageNamesFileImageName = "test_image";
 
+export let BaseImageName = "ubuntu";
+export let BaseImageLabels = {
+    name:"image.base.ref.name=ubuntu",
+    digest:"image.base.digest=sha256:826f70e0ac33e99a72cf20fb0571245a8fee52d68cb26d8bc58e53bfa65dcdfa"
+};
 /**
  * Formats the given path to be appropriate for the operating system.
  * @param canonicalPath A non-rooted path using a forward slash (/) as a directory separator.

--- a/Tasks/DockerV1/containerbuild.ts
+++ b/Tasks/DockerV1/containerbuild.ts
@@ -1,5 +1,6 @@
 "use strict";
 
+import * as fs from "fs";
 import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as dockerCommandUtils from "azure-pipelines-tasks-docker-common-v2/dockercommandutils";
@@ -10,6 +11,11 @@ import * as sourceUtils from "azure-pipelines-tasks-docker-common-v2/sourceutils
 import * as imageUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
 import * as utils from "./utils";
 
+interface ImageAnnotations {
+    BaseImageName: string,
+    BaseImageDigest: string
+}
+
 export function run(connection: ContainerConnection): any {
     var command = connection.createCommand();
     command.arg("build");
@@ -19,6 +25,11 @@ export function run(connection: ContainerConnection): any {
 
     if (!tl.exist(dockerFile)) {
         throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
+    }
+
+    let imageAnnotations: ImageAnnotations = null;
+    if (isBaseImageLabelAnnotationEnabled()) {
+        imageAnnotations = GetImageAnnotation(connection, dockerFile);
     }
 
     command.arg(["-f", dockerFile]);
@@ -81,4 +92,134 @@ export function run(connection: ContainerConnection): any {
             imageUtils.shareBuiltImageId(builtImageId);
         }
     });
+}
+
+function GetImageAnnotation(connection: ContainerConnection, dockerFilePath: string): ImageAnnotations {
+    let imageAnnotations: ImageAnnotations = {
+        BaseImageName: "",
+        BaseImageDigest: ""
+    };
+
+    imageAnnotations.BaseImageName = getBaseImageName(dockerFilePath);
+
+    if (imageAnnotations.BaseImageName && imageAnnotations.BaseImageName != "") {
+        imageAnnotations.BaseImageDigest = getImageDigest(connection, imageAnnotations.BaseImageName);
+    }
+
+    return imageAnnotations;
+}
+
+
+function getBaseImageName(dockerFilePath: string): string {
+    // This method takes into consideration multi-stage dockerfiles, it tries to find the final
+    // base image for the container.
+
+    try {
+        const dockerFileContent = fs.readFileSync(dockerFilePath, 'utf-8');
+
+        if (!dockerFileContent || dockerFileContent == "") {
+            return "";
+        }
+
+        var lines = dockerFileContent.split(/[\r?\n]/);
+        var tagToImageNameMapping: Map<string, string> = new Map<string, string>();
+        var baseImage = "";
+        for (var i = 0; i < lines.length; i++) {
+            var index = lines[i].toUpperCase().indexOf("FROM");
+            if (index == -1) {
+                continue;
+            }
+
+            var nameComponents = lines[i].substring(index + 4).toLowerCase().split(" as ");
+            var prospectImageName = nameComponents[0].trim()
+            if (nameComponents.length > 1) {
+                var tag = nameComponents[1].trim()
+                if (tagToImageNameMapping.has(prospectImageName)) {
+                    tagToImageNameMapping.set(tag, tagToImageNameMapping.get(prospectImageName));
+                } else {
+                    tagToImageNameMapping.set(tag, prospectImageName);
+                }
+                baseImage = tagToImageNameMapping.get(tag);
+            } else {
+                baseImage = tagToImageNameMapping.has(prospectImageName)
+                    ? tagToImageNameMapping.get(prospectImageName)
+                    : prospectImageName
+            }
+        }
+        return baseImage.includes("$") // In this case the base image has an argument and we don't know what it is its real value
+            ? ""
+            : baseImage
+    } catch (error) {
+        tl.debug(`An error was found getting the base image for the docker file ${dockerFilePath}. ${error.message}`);
+        return "";
+    }
+}
+
+function getImageDigest(connection: ContainerConnection, imageName: string,): string {
+    try {
+        pullImage(connection, imageName);
+        let inspectObj = inspectImage(connection, imageName);
+
+        if (!inspectObj) {
+            return "";
+        }
+
+        let repoDigests: string[] = inspectObj.RepoDigests
+
+        if (repoDigests.length == 0) {
+            tl.debug(`No digests where found for image: ${imageName}`);
+            return "";
+        }
+
+        if (repoDigests.length > 1) {
+            tl.debug(`Multiple digests where found for image: ${imageName}`);
+            return "";
+        }
+
+        return repoDigests[0].split("@")[1]
+    } catch (error) {
+        tl.debug(`An exception was thrown getting the image digest for ${imageName}, the error was ${error.message}`)
+        return "";
+    }
+}
+
+function pullImage(connection: ContainerConnection, imageName: string) {
+    let pullCommand = connection.createCommand();
+    pullCommand.arg("pull");
+    pullCommand.arg([imageName]);
+    let pullResult = pullCommand.execSync();
+
+    if (pullResult.stderr && pullResult.stderr != "") {
+        tl.debug(`An error was found pulling the image ${imageName}, the command output was ${pullResult.stderr}`);
+    }
+}
+
+function inspectImage(connection: ContainerConnection, imageName): any {
+    let inspectCommand = connection.createCommand();
+    inspectCommand.arg("inspect");
+    inspectCommand.arg([imageName]);
+    let inspectResult = inspectCommand.execSync();
+
+    if (inspectResult.stderr && inspectResult.stderr != "") {
+        tl.debug(`An error was found inspecting the image ${imageName}, the command output was ${inspectResult.stderr}`);
+        return null;
+    }
+
+    let inspectObj = JSON.parse(inspectResult.stdout);
+
+    if (!inspectObj || inspectObj.length == 0) {
+        tl.debug(`Inspecting the image ${imageName} produced no results.`);
+        return null;
+    }
+
+    return inspectObj[0]
+}
+
+function isBaseImageLabelAnnotationEnabled(): boolean {
+    const controlVariable = tl.getVariable("addBaseImageData")
+    if (!controlVariable) {
+        return true;
+    }
+
+    return controlVariable.toLocaleLowerCase() !== 'false';
 }

--- a/Tasks/DockerV1/containerbuild.ts
+++ b/Tasks/DockerV1/containerbuild.ts
@@ -11,11 +11,6 @@ import * as sourceUtils from "azure-pipelines-tasks-docker-common-v2/sourceutils
 import * as imageUtils from "azure-pipelines-tasks-docker-common-v2/containerimageutils";
 import * as utils from "./utils";
 
-interface ImageAnnotations {
-    BaseImageName: string,
-    BaseImageDigest: string
-}
-
 export function run(connection: ContainerConnection): any {
     var command = connection.createCommand();
     command.arg("build");
@@ -25,11 +20,6 @@ export function run(connection: ContainerConnection): any {
 
     if (!tl.exist(dockerFile)) {
         throw new Error(tl.loc('ContainerDockerFileNotFound', dockerfilepath));
-    }
-
-    let imageAnnotations: ImageAnnotations = null;
-    if (isBaseImageLabelAnnotationEnabled()) {
-        imageAnnotations = GetImageAnnotation(connection, dockerFile);
     }
 
     command.arg(["-f", dockerFile]);
@@ -69,6 +59,13 @@ export function run(connection: ContainerConnection): any {
         command.arg(["-m", memoryLimit]);
     }
 
+    const addBaseImageInfo = tl.getBoolInput("addBaseImageData");
+    const labelsArgument = pipelineUtils.getDefaultLabels(false, addBaseImageInfo, dockerFile, connection);
+
+    labelsArgument.forEach(label => {
+        command.arg(["--label", label]);
+    });
+
     var context: string;
     var useDefaultContext = tl.getBoolInput("useDefaultContext");
     if (useDefaultContext) {
@@ -92,134 +89,4 @@ export function run(connection: ContainerConnection): any {
             imageUtils.shareBuiltImageId(builtImageId);
         }
     });
-}
-
-function GetImageAnnotation(connection: ContainerConnection, dockerFilePath: string): ImageAnnotations {
-    let imageAnnotations: ImageAnnotations = {
-        BaseImageName: "",
-        BaseImageDigest: ""
-    };
-
-    imageAnnotations.BaseImageName = getBaseImageName(dockerFilePath);
-
-    if (imageAnnotations.BaseImageName && imageAnnotations.BaseImageName != "") {
-        imageAnnotations.BaseImageDigest = getImageDigest(connection, imageAnnotations.BaseImageName);
-    }
-
-    return imageAnnotations;
-}
-
-
-function getBaseImageName(dockerFilePath: string): string {
-    // This method takes into consideration multi-stage dockerfiles, it tries to find the final
-    // base image for the container.
-
-    try {
-        const dockerFileContent = fs.readFileSync(dockerFilePath, 'utf-8');
-
-        if (!dockerFileContent || dockerFileContent == "") {
-            return "";
-        }
-
-        var lines = dockerFileContent.split(/[\r?\n]/);
-        var tagToImageNameMapping: Map<string, string> = new Map<string, string>();
-        var baseImage = "";
-        for (var i = 0; i < lines.length; i++) {
-            var index = lines[i].toUpperCase().indexOf("FROM");
-            if (index == -1) {
-                continue;
-            }
-
-            var nameComponents = lines[i].substring(index + 4).toLowerCase().split(" as ");
-            var prospectImageName = nameComponents[0].trim()
-            if (nameComponents.length > 1) {
-                var tag = nameComponents[1].trim()
-                if (tagToImageNameMapping.has(prospectImageName)) {
-                    tagToImageNameMapping.set(tag, tagToImageNameMapping.get(prospectImageName));
-                } else {
-                    tagToImageNameMapping.set(tag, prospectImageName);
-                }
-                baseImage = tagToImageNameMapping.get(tag);
-            } else {
-                baseImage = tagToImageNameMapping.has(prospectImageName)
-                    ? tagToImageNameMapping.get(prospectImageName)
-                    : prospectImageName
-            }
-        }
-        return baseImage.includes("$") // In this case the base image has an argument and we don't know what it is its real value
-            ? ""
-            : baseImage
-    } catch (error) {
-        tl.debug(`An error was found getting the base image for the docker file ${dockerFilePath}. ${error.message}`);
-        return "";
-    }
-}
-
-function getImageDigest(connection: ContainerConnection, imageName: string,): string {
-    try {
-        pullImage(connection, imageName);
-        let inspectObj = inspectImage(connection, imageName);
-
-        if (!inspectObj) {
-            return "";
-        }
-
-        let repoDigests: string[] = inspectObj.RepoDigests
-
-        if (repoDigests.length == 0) {
-            tl.debug(`No digests where found for image: ${imageName}`);
-            return "";
-        }
-
-        if (repoDigests.length > 1) {
-            tl.debug(`Multiple digests where found for image: ${imageName}`);
-            return "";
-        }
-
-        return repoDigests[0].split("@")[1]
-    } catch (error) {
-        tl.debug(`An exception was thrown getting the image digest for ${imageName}, the error was ${error.message}`)
-        return "";
-    }
-}
-
-function pullImage(connection: ContainerConnection, imageName: string) {
-    let pullCommand = connection.createCommand();
-    pullCommand.arg("pull");
-    pullCommand.arg([imageName]);
-    let pullResult = pullCommand.execSync();
-
-    if (pullResult.stderr && pullResult.stderr != "") {
-        tl.debug(`An error was found pulling the image ${imageName}, the command output was ${pullResult.stderr}`);
-    }
-}
-
-function inspectImage(connection: ContainerConnection, imageName): any {
-    let inspectCommand = connection.createCommand();
-    inspectCommand.arg("inspect");
-    inspectCommand.arg([imageName]);
-    let inspectResult = inspectCommand.execSync();
-
-    if (inspectResult.stderr && inspectResult.stderr != "") {
-        tl.debug(`An error was found inspecting the image ${imageName}, the command output was ${inspectResult.stderr}`);
-        return null;
-    }
-
-    let inspectObj = JSON.parse(inspectResult.stdout);
-
-    if (!inspectObj || inspectObj.length == 0) {
-        tl.debug(`Inspecting the image ${imageName} produced no results.`);
-        return null;
-    }
-
-    return inspectObj[0]
-}
-
-function isBaseImageLabelAnnotationEnabled(): boolean {
-    const controlVariable = tl.getVariable("addBaseImageData")
-    if (!controlVariable) {
-        return true;
-    }
-
-    return controlVariable.toLocaleLowerCase() !== 'false';
 }

--- a/Tasks/DockerV1/containerbuild.ts
+++ b/Tasks/DockerV1/containerbuild.ts
@@ -29,6 +29,13 @@ export function run(connection: ContainerConnection): any {
         pipelineUtils.addDefaultLabelArgs(command);
     }
 
+    const addBaseImageInfo = tl.getBoolInput("addBaseImageData");
+    const labelsArgument = pipelineUtils.getDefaultLabels(false, addBaseImageInfo, dockerFile, connection);
+
+    labelsArgument.forEach(label => {
+        command.arg(["--label", label]);
+    });
+
     var commandArguments = dockerCommandUtils.getCommandArguments(tl.getInput("arguments", false));
 
     command.line(commandArguments);
@@ -58,13 +65,6 @@ export function run(connection: ContainerConnection): any {
     if (memoryLimit) {
         command.arg(["-m", memoryLimit]);
     }
-
-    const addBaseImageInfo = tl.getBoolInput("addBaseImageData");
-    const labelsArgument = pipelineUtils.getDefaultLabels(false, addBaseImageInfo, dockerFile, connection);
-
-    labelsArgument.forEach(label => {
-        command.arg(["--label", label]);
-    });
 
     var context: string;
     var useDefaultContext = tl.getBoolInput("useDefaultContext");

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -52,6 +52,14 @@
             "helpMarkDown": "Select 'Azure Container Registry' to connect to it by using an Azure Service Connection. Select 'Container registry' to connect to Docker Hub or any other private container registry."
         },
         {
+            "name": "addBaseImageData",
+            "type": "boolean",
+            "label": "Add base image metadata to image(s)",
+            "groupName": "commands",
+            "defaultValue": "true",
+            "helpMarkDown": "By default base image data like base image name and digest are added which helps with traceability. You can opt out of this default behavior by using this input."
+        },
+        {
             "name": "dockerRegistryEndpoint",
             "type": "connectedService:dockerregistry",
             "label": "Docker registry service connection",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -52,6 +52,14 @@
       "helpMarkDown": "ms-resource:loc.input.help.containerregistrytype"
     },
     {
+      "name": "addBaseImageData",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.addBaseImageData",
+      "groupName": "commands",
+      "defaultValue": "true",
+      "helpMarkDown": "ms-resource:loc.input.help.addBaseImageData"
+    },
+    {
       "name": "dockerRegistryEndpoint",
       "type": "connectedService:dockerregistry",
       "label": "ms-resource:loc.input.label.dockerRegistryEndpoint",


### PR DESCRIPTION
**Task name**: DockerV1

**Description**: Add the base image name and base image digest as labels during docker build.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14650

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
