### PR TITLE
Add base image info labels to common package

### DIFF
--- a/common-npm-packages/docker-common-v2/containerimageutils.ts
+++ b/common-npm-packages/docker-common-v2/containerimageutils.ts
@@ -1,6 +1,7 @@
 "use strict";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as fs from 'fs';
+import ContainerConnection from "./containerconnection";
 
 export function hasRegistryComponent(imageName: string): boolean {
     var periodIndex = imageName.indexOf("."),
@@ -73,3 +74,124 @@ export function getResourceName(image: string, digest: string) {
     
     return "https://" + registry  + namespace  + repository + "@sha256:" + digest;
   }
+
+export function getFinalBaseImageName(dockerFilePath: string): string {
+    // This method takes into consideration multi-stage dockerfiles, it tries to find the final
+    // base image for the container.
+    // ex:
+    // FROM ubuntu:16.04 as builder
+    //
+    // FROM builder as base
+    // RUN echo 'test'
+    //
+    // FROM base
+    // RUN echo 'test2'
+    // 
+    // This code is going to return ubuntu:16.04
+
+    try {
+        const dockerFileContent = fs.readFileSync(dockerFilePath, 'utf-8');
+
+        if (!dockerFileContent || dockerFileContent == "") {
+            return "";
+        }
+
+        var lines = dockerFileContent.split(/[\r?\n]/);
+        var tagToImageNameMapping: Map<string, string> = new Map<string, string>();
+        var baseImage = "";
+        for (var i = 0; i < lines.length; i++) {
+            var index = lines[i].toUpperCase().indexOf("FROM");
+            if (index == -1) {
+                continue;
+            }
+
+            var nameComponents = lines[i].substring(index + 4).toLowerCase().split(" as ");
+            var prospectImageName = nameComponents[0].trim();
+            if (nameComponents.length > 1) {
+                var tag = nameComponents[1].trim();
+                if (tagToImageNameMapping.has(prospectImageName)) {
+                    tagToImageNameMapping.set(tag, tagToImageNameMapping.get(prospectImageName));
+                } else {
+                    tagToImageNameMapping.set(tag, prospectImageName);
+                }
+                baseImage = tagToImageNameMapping.get(tag);
+            } else {
+                baseImage = tagToImageNameMapping.has(prospectImageName)
+                    ? tagToImageNameMapping.get(prospectImageName)
+                    : prospectImageName;
+            }
+        }
+        return baseImage.includes("$") // In this case the base image has an argument and we don't know what it is its real value
+            ? ""
+            : baseImage;
+    } catch (error) {
+        tl.debug(`An error was found getting the base image for the docker file ${dockerFilePath}. ${error.message}`);
+        return "";
+    }
+}
+
+export function getImageDigest(connection: ContainerConnection, imageName: string,): string {
+    try {
+        pullImage(connection, imageName);
+        let inspectObj = inspectImage(connection, imageName);
+
+        if (!inspectObj) {
+            return "";
+        }
+
+        let repoDigests: string[] = inspectObj.RepoDigests;
+
+        if (repoDigests.length == 0) {
+            tl.debug(`No digests were found for image: ${imageName}`);
+            return "";
+        }
+
+        if (repoDigests.length > 1) {
+            tl.debug(`Multiple digests were found for image: ${imageName}`);
+            return "";
+        }
+
+        return repoDigests[0].split("@")[1];
+    } catch (error) {
+        tl.debug(`An exception was thrown getting the image digest for ${imageName}, the error was ${error.message}`)
+        return "";
+    }
+}
+
+function pullImage(connection: ContainerConnection, imageName: string) {
+    let pullCommand = connection.createCommand();
+    pullCommand.arg("pull");
+    pullCommand.arg(imageName);
+    let pullResult = pullCommand.execSync();
+
+    if (pullResult.stderr && pullResult.stderr != "") {
+        tl.debug(`An error was found pulling the image ${imageName}, the command output was ${pullResult.stderr}`);
+    }
+}
+
+function inspectImage(connection: ContainerConnection, imageName): any {
+    try {
+        let inspectCommand = connection.createCommand();
+        inspectCommand.arg("inspect");
+        inspectCommand.arg(imageName);
+        let inspectResult = inspectCommand.execSync();
+
+        if (inspectResult.stderr && inspectResult.stderr != "") {
+            tl.debug(`An error was found inspecting the image ${imageName}, the command output was ${inspectResult.stderr}`);
+            return null;
+        }
+
+        let inspectObj = JSON.parse(inspectResult.stdout);
+
+        if (!inspectObj || inspectObj.length == 0) {
+            tl.debug(`Inspecting the image ${imageName} produced no results.`);
+            return null;
+        }
+
+        return inspectObj[0];
+    } catch (error) {
+        tl.debug(`An error ocurred running the inspect command: ${error.message}`);
+        return null;
+    }
+}
+

--- a/common-npm-packages/docker-common-v2/containerimageutils.ts
+++ b/common-npm-packages/docker-common-v2/containerimageutils.ts
@@ -61,6 +61,7 @@ export function getBaseImageName(dockerFileContent: string): string {
         var lines = dockerFileContent.split(/[\r?\n]/);
         var aliasToImageNameMapping: Map<string, string> = new Map<string, string>();
         var baseImage = "";
+
         for (var i = 0; i < lines.length; i++) {
             var index = lines[i].toUpperCase().indexOf("FROM");
             if (index == -1) {
@@ -69,13 +70,16 @@ export function getBaseImageName(dockerFileContent: string): string {
 
             var nameComponents = lines[i].substring(index + 4).toLowerCase().split(" as ");
             var prospectImageName = nameComponents[0].trim();
+
             if (nameComponents.length > 1) {
                 var alias = nameComponents[1].trim();
+
                 if (aliasToImageNameMapping.has(prospectImageName)) {
                     aliasToImageNameMapping.set(alias, aliasToImageNameMapping.get(prospectImageName));
                 } else {
                     aliasToImageNameMapping.set(alias, prospectImageName);
                 }
+
                 baseImage = aliasToImageNameMapping.get(alias);
             } else {
                 baseImage = aliasToImageNameMapping.has(prospectImageName)
@@ -83,11 +87,11 @@ export function getBaseImageName(dockerFileContent: string): string {
                     : prospectImageName;
             }
         }
-        return baseImage.includes("$") // In this case the base image has an argument and we don't know what it is its real value
+        return baseImage.includes("$") // In this case the base image has an argument and we don't know what its real value is
             ? null
             : baseImage;
     } catch (error) {
-        tl.debug(`An error was found getting the base image name. ${error.message}`);
+        tl.debug(`An error ocurred getting the base image name. ${error.message}`);
         return null;
     }
 }

--- a/common-npm-packages/docker-common-v2/package-lock.json
+++ b/common-npm-packages/docker-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-docker-common-v2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/docker-common-v2/package.json
+++ b/common-npm-packages/docker-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-docker-common-v2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Common Library for Azure Rest Calls",
   "repository": {
     "type": "git",

--- a/common-npm-packages/docker-common-v2/pipelineutils.ts
+++ b/common-npm-packages/docker-common-v2/pipelineutils.ts
@@ -4,6 +4,8 @@ import * as tl from "azure-pipelines-task-lib/task";
 import * as URL from 'url';
 import * as util from "util";
 import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
+import ContainerConnection from "./containerconnection";
+import * as containerUtils from "./containerimageutils";
 
 function addLabelArgs(command: ToolRunner, labels: string[]) {
     labels.forEach(label => {
@@ -17,6 +19,11 @@ function addLabel(hostName: string, labelName: string, variableName: string, lab
         let label = util.format("%s.image.%s=%s", hostName, labelName, labelValue);
         labels.push(label);
     }
+}
+
+function addLabelWithValue(labelName: string, labelValue: string, labels: string[]): void {
+    let label = util.format("%s=%s", labelName, labelValue);
+    labels.push(label);
 }
 
 function addCommonLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
@@ -38,11 +45,31 @@ function addBuildLabels(hostName: string, labels: string[], addPipelineData?: bo
     }
 }
 
-function addReleaseLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {    
+function addReleaseLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
     addLabel(hostName, "release.releaseid", "RELEASE_RELEASEID", labels);
     if (addPipelineData) {
         addLabel(hostName, "release.definitionname", "RELEASE_DEFINITIONNAME", labels);
         addLabel(hostName, "release.releaseweburl", "RELEASE_RELEASEWEBURL", labels);
+    }
+}
+
+function addBaseImageLabels(connection: ContainerConnection, labels: string[], dockerFilePath: string): void {
+    const baseImageName = containerUtils.getFinalBaseImageName(dockerFilePath);
+    if (!baseImageName) {
+        tl.debug("No base image name was found.");
+        return;
+    }
+
+    addLabelWithValue("image.base.ref.name", baseImageName, labels);
+
+    if (!connection) {
+        tl.debug("Image digest couldn't be extracted because no connection was found.");
+        return;
+    }
+
+    const baseImageDigest = containerUtils.getImageDigest(connection, baseImageName);
+    if (baseImageDigest) {
+        addLabelWithValue("image.base.digest", baseImageDigest, labels);
     }
 }
 
@@ -67,7 +94,7 @@ export function addDefaultLabelArgs(command: ToolRunner): void {
     addLabelArgs(command, labels);
 }
 
-export function getDefaultLabels(addPipelineData?: boolean): string[] {
+export function getDefaultLabels(addPipelineData?: boolean, addBaseImageData?: boolean, dockerFilePath?: string, connection?: ContainerConnection): string[] {
     let labels: string[] = [];
     let hostName = getReverseDNSName();
     if (hostName) {
@@ -81,5 +108,12 @@ export function getDefaultLabels(addPipelineData?: boolean): string[] {
         }
     }
 
+    if (addBaseImageData) {
+        try {
+            addBaseImageLabels(connection, labels, dockerFilePath)
+        } catch (error) {
+            tl.debug(`An error ocurred getting the base image lables ${error.message}`);
+        }
+    }
     return labels;
 }

--- a/common-npm-packages/docker-common-v2/pipelineutils.ts
+++ b/common-npm-packages/docker-common-v2/pipelineutils.ts
@@ -54,9 +54,8 @@ function addReleaseLabels(hostName: string, labels: string[], addPipelineData?: 
 }
 
 function addBaseImageLabels(connection: ContainerConnection, labels: string[], dockerFilePath: string): void {
-    const baseImageName = containerUtils.getFinalBaseImageName(dockerFilePath);
+    const baseImageName = containerUtils.getBaseImageNameFromDockerFile(dockerFilePath);
     if (!baseImageName) {
-        tl.debug("No base image name was found.");
         return;
     }
 


### PR DESCRIPTION
**Task name**:  docker-common-packages-v2

**Description**:  Added methods to get the last base image name and the image digest.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
