### PR TITLE
Add support for retryOnNullOrException in MockHelper

### DIFF
--- a/Tasks/Common/packaging-common/Tests/MockHelper.ts
+++ b/Tasks/Common/packaging-common/Tests/MockHelper.ts
@@ -37,6 +37,9 @@ export function registerLocationHelpersMock(tmr: tmrm.TaskMockRunner) {
         retryOnExceptionHelper: async function<T>(action: () => Promise<T>, maxTries: number, retryIntervalInMilliseconds: number) {
             return await action();
         },
+        retryOnNullOrExceptionHelper: async function<T>(action: () => Promise<T>, maxTries: number, retryIntervalInMilliseconds: number) {
+            return await action();
+        },
         ProtocolType: {NuGet: 1, Npm: 2, Maven: 3, PyPi: 4},
         RegistryType: {npm: 1, NuGetV2: 2, NuGetV3: 3, PyPiSimple: 4, PyPiUpload: 5}
     };

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Azure Pipelines Packaging Tasks Common",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
**Task name**: azure-pipeline-tasks-packaging-common

**Description**: MockHelper needed updating for use in consuming tests

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1825800

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
