### PR TITLE
Sharing the image id that was built V0

### DIFF
--- a/Tasks/DockerV0/Tests/L0.ts
+++ b/Tasks/DockerV0/Tests/L0.ts
@@ -250,4 +250,34 @@ describe('Docker Suite', function() {
         console.log(tr.stderr);
         done();
     });
+
+    it('Docker build should store the id of the image that was built.', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.imageName] = "testuser/standardbuild:11";
+        process.env[shared.TestEnvVars.action] = shared.ActionTypes.buildImage;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=c834e0094587") != -1, "docker build should have stored the image id.")
+        console.log(tr.stderr);
+        done();
+    });
+
+    it('Docker build should store the id of the image that was built with builkit.', (done:Mocha.Done) => {
+        let tp = path.join(__dirname, 'TestSetup.js');
+        process.env[shared.TestEnvVars.imageName] = "testuser/buildkit:11";
+        process.env[shared.TestEnvVars.action] = shared.ActionTypes.buildImage;
+        let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        tr.run();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool one time. actual: ' + tr.invokedToolCount);
+        assert(tr.stderr.length == 0 || tr.errorIssues.length, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdout.indexOf("set DOCKER_TASK_BUILT_IMAGES=6c3ada3eb420") != -1, "docker build should have stored the image id.")
+        console.log(tr.stderr);
+        done();
+    });
 });

--- a/Tasks/DockerV0/Tests/TestSetup.ts
+++ b/Tasks/DockerV0/Tests/TestSetup.ts
@@ -115,7 +115,15 @@ a.exec[`docker build -f ${DockerFilePath} -t test/test:2 -t test/test:6`] = {
     "code": 0,
     "stdout": "successfully build test/test:2 and test/test:6 image"
 };
+a.exec[`docker build -f ${DockerFilePath} -t testuser/standardbuild:11`] = {
+    "code": 0,
+    "stdout": "Successfully built c834e0094587\n Successfully tagged testuser/testrepo:11."
+};
 
+a.exec[`docker build -f ${DockerFilePath} -t testuser/buildkit:11`] = {
+    "code": 0,
+    "stdout": " => => writing image sha256:6c3ada3eb42094510e0083bba6ae805540e36c96871d7be0c926b2f8cbeea68c\n => => naming to docker.io/library/testuser/buildkit:11"
+};
 tr.setAnswers(<any>a);
 
 // Create mock for fs module

--- a/Tasks/DockerV0/containerbuild.ts
+++ b/Tasks/DockerV0/containerbuild.ts
@@ -72,5 +72,10 @@ export function run(connection: ContainerConnection): any {
     return connection.execCommand(command).then(() => {
         let taskOutputPath = utils.writeTaskOutput("build", output);
         tl.setVariable("DockerOutputPath", taskOutputPath);
+
+        const builtImageId = imageUtils.getImageIdFromBuildOutput(output);
+        if (builtImageId && builtImageId != "") {
+            imageUtils.shareBuiltImageId(builtImageId);
+        }
     });
 }

--- a/Tasks/DockerV0/containerbuild.ts
+++ b/Tasks/DockerV0/containerbuild.ts
@@ -74,7 +74,7 @@ export function run(connection: ContainerConnection): any {
         tl.setVariable("DockerOutputPath", taskOutputPath);
 
         const builtImageId = imageUtils.getImageIdFromBuildOutput(output);
-        if (builtImageId && builtImageId != "") {
+        if (builtImageId) {
             imageUtils.shareBuiltImageId(builtImageId);
         }
     });

--- a/Tasks/DockerV0/npm-shrinkwrap.json
+++ b/Tasks/DockerV0/npm-shrinkwrap.json
@@ -101,15 +101,15 @@
       }
     },
     "azure-pipelines-tasks-docker-common-v2": {
-      "version": "2.0.1-preview.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-docker-common-v2/-/azure-pipelines-tasks-docker-common-v2-2.0.1-preview.0.tgz",
-      "integrity": "sha512-3hZQQdxY6DJEuM+vXq/UKX13XtPQv4HlTRZ39Ghw/+Q2aTLEFOvrLAYvMM+wS3YHG1ZUT0MXFJpHUlSITvmStg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-docker-common-v2/-/azure-pipelines-tasks-docker-common-v2-2.0.4.tgz",
+      "integrity": "sha512-wVio7xu7oPmkVcwlUmKby79MyCwmN0ookddLdwMI0RyWU/XR3LXALGYWSYf9x+ggr2OxJIzikJRV2wfPx9XCzw==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "3.0.6-preview.0",
+        "azure-pipelines-task-lib": "^3.1.0",
         "del": "2.2.0",
         "q": "1.4.1"
       },
@@ -118,6 +118,27 @@
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
           "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.2.tgz",
+          "integrity": "sha512-ZafpInsnjHKGemA5l3jwfeaI8jARrIv5aYCn3KPP4iNJHgMG2RtwyFGynIfpkUsHMfzC/370iyLru0NGAuSVWQ==",
+          "requires": {
+            "minimatch": "3.0.4",
+            "mockery": "^1.7.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.4",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          },
+          "dependencies": {
+            "q": {
+              "version": "1.5.1",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+              "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+            }
+          }
         }
       }
     },

--- a/Tasks/DockerV0/package.json
+++ b/Tasks/DockerV0/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "del": "2.2.0",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-docker-common-v2": "2.0.1-preview.0",
+    "azure-pipelines-tasks-docker-common-v2": "2.0.4",
     "esprima": "2.7.1",
     "js-yaml": "3.6.1"
   },

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 187,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 187,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",


### PR DESCRIPTION
**Task name**:  DockerV0

**Description**: Share the imageId that was built in the common env variable

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/14650

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
