### PR TITLE
[Port to master]: Fixing DockerV0 and DockerV1 issue - Cannot read property 'retrieveSecret' of undefined

### DIFF
--- a/Tasks/DockerV0/make.json
+++ b/Tasks/DockerV0/make.json
@@ -1,2 +1,10 @@
 {
+    "rm": [
+        {
+            "items": [
+                "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib"
+            ],
+            "options": "-Rf"
+        }
+    ]
 }

--- a/Tasks/DockerV0/task.json
+++ b/Tasks/DockerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 187,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "preview": "false",

--- a/Tasks/DockerV0/task.loc.json
+++ b/Tasks/DockerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 187,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerV1/make.json
+++ b/Tasks/DockerV1/make.json
@@ -1,2 +1,10 @@
 {
+    "rm": [
+        {
+            "items": [
+                "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib"
+            ],
+            "options": "-Rf"
+        }
+    ]
 }

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 187,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [],
     "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 187,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: DockerV0, DockerV1

**Description**: Fixing the error: Cannot read property 'retrieveSecret' of undefined. This got introduced with the recent checkins that pulled in the latest version of docker-common-v2. This resulted in conflicting versions of azure-pipelines-task-lib.
FIX: Remove the azure-pipelines-task-lib module brought-in by docker-common-v2 dependency.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) NA

**Attached related issue:** (Y/N) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
