### PR TITLE
Added variable to force enable download zip option on windows

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -277,7 +277,7 @@ async function main(): Promise<void> {
                 if (artifact.resource.type.toLowerCase() === "container") {
                     var handler = new webHandlers.PersonalAccessTokenCredentialHandler(accessToken);
                     // this variable uses to force enable zip download option, it is used only in test purpose and shouldn't be used for other reasons
-                    const forceEnableZipDownloadOption = tl.getVariable("FORCE_ENABLE_ZIP_DOWNLOAD");
+                    const forceEnableZipDownloadOption = tl.getVariable("DownloadBuildArtifacts.ForceEnableDownloadZipForCanary");
                     const forceEnableZipDownloadOptionBool = forceEnableZipDownloadOption ? forceEnableZipDownloadOption.toLowerCase() == 'true' : false;
                     var isPullRequestFork = tl.getVariable("SYSTEM.PULLREQUEST.ISFORK");
                     var isPullRequestForkBool = isPullRequestFork ? isPullRequestFork.toLowerCase() == 'true' : false;

--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -289,7 +289,7 @@ async function main(): Promise<void> {
                         isZipDownloadDisabledBool = true;
                     }
 
-                    if ((!isZipDownloadDisabledBool && isWin && isPullRequestForkBool) || (isWin && forceEnableZipDownloadOptionBool)) {
+                    if (isWin && ((!isZipDownloadDisabledBool && isPullRequestForkBool) || forceEnableZipDownloadOptionBool)) {
                         const operationName: string = `Download zip - ${artifact.name}`;
 
                         const handlerConfig: IContainerHandlerZipConfig = { ...config, projectId, buildId, handler, endpointUrl };

--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -276,6 +276,9 @@ async function main(): Promise<void> {
 
                 if (artifact.resource.type.toLowerCase() === "container") {
                     var handler = new webHandlers.PersonalAccessTokenCredentialHandler(accessToken);
+                    // this variable uses to force enable zip download option, it is used only in test purpose and shouldn't be used for other reasons
+                    const forceEnableZipDownloadOption = tl.getVariable("FORCE_ENABLE_ZIP_DOWNLOAD");
+                    const forceEnableZipDownloadOptionBool = forceEnableZipDownloadOption ? forceEnableZipDownloadOption.toLowerCase() == 'true' : false;
                     var isPullRequestFork = tl.getVariable("SYSTEM.PULLREQUEST.ISFORK");
                     var isPullRequestForkBool = isPullRequestFork ? isPullRequestFork.toLowerCase() == 'true' : false;
                     var isZipDownloadDisabled = tl.getVariable("SYSTEM.DisableZipDownload");
@@ -286,7 +289,7 @@ async function main(): Promise<void> {
                         isZipDownloadDisabledBool = true;
                     }
 
-                    if (!isZipDownloadDisabledBool && isWin && isPullRequestForkBool) {
+                    if ((!isZipDownloadDisabledBool && isWin && isPullRequestForkBool) || (isWin && forceEnableZipDownloadOptionBool)) {
                         const operationName: string = `Download zip - ${artifact.name}`;
 
                         const handlerConfig: IContainerHandlerZipConfig = { ...config, projectId, buildId, handler, endpointUrl };

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 188,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 188,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {


### PR DESCRIPTION
**Task name**: DownloadBuildArtifactsV0

**Description**: Added env variable to force enable downloading of zip archive by the task in tests purpose.

**Documentation changes required:** (Y/N)  N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
