### PR TITLE
fix: improve grammar of `ExactVersionNotRecommended` messages

### DIFF
--- a/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -17,5 +17,5 @@
   "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
   "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
   "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-  "loc.messages.ExactVersionNotRecommended": "It is not recommended to specify exact version on Microsoft-Hosted agents. Patch version of Python can be replaced by new one on Hosted agents without notice and build stops to work. it is recommended to specify only major or major and minor version (Example: `3` or `3.6`)"
+  "loc.messages.ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.6`)"
 }

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -77,7 +77,7 @@
         "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
         "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
         "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-        "ExactVersionNotRecommended": "It is not recommended to specify exact version on Microsoft-Hosted agents. Patch version of Python can be replaced by new one on Hosted agents without notice and build stops to work. it is recommended to specify only major or major and minor version (Example: `3` or `3.6`)"
+        "ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.6`)"
     },
     "restrictions": {
         "commands": {

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -14,7 +14,7 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 0,
-        "Minor": 186,
+        "Minor": 188,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -14,7 +14,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 0,
-    "Minor": 186,
+    "Minor": 188,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -12,5 +12,5 @@
   "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
   "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
   "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-  "loc.messages.ExactVersionNotRecommended": "It is not recommended to specify exact version on Microsoft-Hosted agents. Patch version of Ruby can be replaced by new one on Hosted agents without notice and build stops to work. it is recommended to specify only major or major and minor version (Example: `2` or `2.4`)"
+  "loc.messages.ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Ruby can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `2` or `2.4`)"
 }

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 186,
+        "Minor": 188,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -55,7 +55,7 @@
         "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
         "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
         "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-        "ExactVersionNotRecommended": "It is not recommended to specify exact version on Microsoft-Hosted agents. Patch version of Ruby can be replaced by new one on Hosted agents without notice and build stops to work. it is recommended to specify only major or major and minor version (Example: `2` or `2.4`)"
+        "ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Ruby can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `2` or `2.4`)"
     },
     "restrictions": {
         "commands": {

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 186,
+    "Minor": 188,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: `UsePythonVersion` & `UseRubyVersion`

**Description**: Improve the grammatical accurate of the `ExactVersionNotRecommended` message

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
