### PR TITLE
feat: implement `suppressExactVersionWarning` parameter

### DIFF
--- a/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -6,6 +6,8 @@
   "loc.group.displayName.advanced": "Advanced",
   "loc.input.label.versionSpec": "Version spec",
   "loc.input.help.versionSpec": "Version range or exact version of a Python version to use, using semver's version range syntax. [More information](https://go.microsoft.com/fwlink/?LinkID=2006180)",
+  "loc.input.label.suppressExactVersionWarning": "Suppress exact version warning",
+  "loc.input.help.suppressExactVersionWarning": "Suppress the warning about using an exact version.",
   "loc.input.label.addToPath": "Add to PATH",
   "loc.input.help.addToPath": "Whether to prepend the retrieved Python version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.input.label.architecture": "Architecture",

--- a/Tasks/UsePythonVersionV0/Tests/L0_usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/Tests/L0_usepythonversion.ts
@@ -46,7 +46,8 @@ it('sets PATH correctly on Linux', async function () {
     const parameters = {
         versionSpec: '3.6',
         addToPath: true,
-        architecture: 'x64'
+        architecture: 'x64',
+        suppressExactVersionWarning: false
     };
 
     await uut.usePythonVersion(parameters, Platform.Linux);
@@ -77,7 +78,8 @@ it('sets PATH correctly on Windows', async function () {
     const parameters = {
         versionSpec: '3.6',
         addToPath: true,
-        architecture: 'x64'
+        architecture: 'x64',
+        suppressExactVersionWarning: false
     };
 
     await uut.usePythonVersion(parameters, Platform.Windows);

--- a/Tasks/UsePythonVersionV0/main.ts
+++ b/Tasks/UsePythonVersionV0/main.ts
@@ -8,10 +8,12 @@ import { usePythonVersion } from './usepythonversion';
     try {
         task.setResourcePath(path.join(__dirname, 'task.json'));
         const versionSpec = task.getInput('versionSpec', true);
+        const suppressExactVersionWarning = task.getBoolInput('suppressExactVersionWarning', false);
         const addToPath = task.getBoolInput('addToPath', true);
         const architecture = task.getInput('architecture', true);
         await usePythonVersion({
             versionSpec,
+            suppressExactVersionWarning,
             addToPath,
             architecture
         },
@@ -19,6 +21,7 @@ import { usePythonVersion } from './usepythonversion';
         task.setResult(task.TaskResult.Succeeded, "");
         telemetry.emitTelemetry('TaskHub', 'UsePythonVersionV0', {
             versionSpec,
+            suppressExactVersionWarning,
             addToPath,
             architecture
         });

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -36,6 +36,14 @@
             "helpMarkDown": "Version range or exact version of a Python version to use, using semver's version range syntax. [More information](https://go.microsoft.com/fwlink/?LinkID=2006180)"
         },
         {
+            "name": "suppressExactVersionWarning",
+            "type": "boolean",
+            "label": "ms-resource:loc.input.label.suppressExactVersionWarning",
+            "required": false,
+            "defaultValue": "false",
+            "helpMarkDown": "ms-resource:loc.input.help.suppressExactVersionWarning"
+        },
+        {
             "name": "addToPath",
             "type": "boolean",
             "label": "Add to PATH",

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -14,7 +14,7 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 0,
-        "Minor": 193,
+        "Minor": 197,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -14,7 +14,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 0,
-    "Minor": 193,
+    "Minor": 197,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -36,6 +36,14 @@
       "helpMarkDown": "ms-resource:loc.input.help.versionSpec"
     },
     {
+      "name": "suppressExactVersionWarning",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.suppressExactVersionWarning",
+      "required": false,
+      "defaultValue": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.suppressExactVersionWarning"
+    },
+    {
       "name": "addToPath",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.addToPath",

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -12,6 +12,7 @@ import { desugarDevVersion, pythonVersionToSemantic, isExactVersion } from './ve
 
 interface TaskParameters {
     versionSpec: string,
+    suppressExactVersionWarning: boolean,
     addToPath: boolean,
     architecture: string
 }
@@ -90,7 +91,7 @@ async function useCpythonVersion(parameters: Readonly<TaskParameters>, platform:
     const semanticVersionSpec = pythonVersionToSemantic(desugaredVersionSpec);
     task.debug(`Semantic version spec of ${parameters.versionSpec} is ${semanticVersionSpec}`);
 
-    if (isExactVersion(semanticVersionSpec)) {
+    if (!parameters.suppressExactVersionWarning && isExactVersion(semanticVersionSpec)) {
         task.warning(task.loc('ExactVersionNotRecommended'));
     }
 

--- a/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseRubyVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -5,6 +5,8 @@
   "loc.instanceNameFormat": "Use Ruby $(versionSpec)",
   "loc.input.label.versionSpec": "Version spec",
   "loc.input.help.versionSpec": "Version range or exact version of a Ruby version to use.",
+  "loc.input.label.suppressExactVersionWarning": "Suppress exact version warning",
+  "loc.input.help.suppressExactVersionWarning": "Suppress the warning about using an exact version.",
   "loc.input.label.addToPath": "Add to PATH",
   "loc.input.help.addToPath": "Prepend the retrieved Ruby version to the PATH environment variable to make it available in subsequent tasks or scripts without using the output variable.",
   "loc.messages.ListAvailableVersions": "Available versions:",

--- a/Tasks/UseRubyVersionV0/main.ts
+++ b/Tasks/UseRubyVersionV0/main.ts
@@ -7,14 +7,17 @@ import { useRubyVersion, getPlatform } from './userubyversion';
     try {
         task.setResourcePath(path.join(__dirname, 'task.json'));
         const versionSpec = task.getInput('versionSpec', true) || '';
+        const suppressExactVersionWarning = task.getBoolInput('suppressExactVersionWarning', false);
         const addToPath = task.getBoolInput('addToPath', true);
         await useRubyVersion({
             versionSpec,
+            suppressExactVersionWarning,
             addToPath
         }, getPlatform());
         task.setResult(task.TaskResult.Succeeded, '');
         telemetry.emitTelemetry('TaskHub', 'UseRubyVersionV0', {
             versionSpec,
+            suppressExactVersionWarning,
             addToPath
         });
     } catch (error) {

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 193,
+        "Minor": 197,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UseRubyVersionV0/task.json
+++ b/Tasks/UseRubyVersionV0/task.json
@@ -29,6 +29,14 @@
             "helpMarkDown": "Version range or exact version of a Ruby version to use."
         },
         {
+            "name": "suppressExactVersionWarning",
+            "type": "boolean",
+            "label": "ms-resource:loc.input.label.suppressExactVersionWarning",
+            "required": false,
+            "defaultValue": "false",
+            "helpMarkDown": "ms-resource:loc.input.help.suppressExactVersionWarning"
+        },
+        {
             "name": "addToPath",
             "type": "boolean",
             "label": "Add to PATH",

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 193,
+    "Minor": 197,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/UseRubyVersionV0/task.loc.json
+++ b/Tasks/UseRubyVersionV0/task.loc.json
@@ -29,6 +29,14 @@
       "helpMarkDown": "ms-resource:loc.input.help.versionSpec"
     },
     {
+      "name": "suppressExactVersionWarning",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.suppressExactVersionWarning",
+      "required": false,
+      "defaultValue": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.suppressExactVersionWarning"
+    },
+    {
       "name": "addToPath",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.addToPath",

--- a/Tasks/UseRubyVersionV0/userubyversion.ts
+++ b/Tasks/UseRubyVersionV0/userubyversion.ts
@@ -19,7 +19,7 @@ export enum Platform {
 export function isExactVersion(versionSpec: string) {
     const semanticVersion = semver.coerce(versionSpec);
     return semanticVersion && semanticVersion.patch;
-} 
+}
 
 export function getPlatform(): Platform {
     switch (process.platform) {
@@ -32,11 +32,12 @@ export function getPlatform(): Platform {
 
 interface TaskParameters {
     readonly versionSpec: string;
+    readonly suppressExactVersionWarning: boolean;
     readonly addToPath: boolean;
 }
 
 export async function useRubyVersion(parameters: TaskParameters, platform: Platform): Promise<void> {
-    if (isExactVersion(parameters.versionSpec)) {
+    if (!parameters.suppressExactVersionWarning && isExactVersion(parameters.versionSpec)) {
         task.warning(task.loc('ExactVersionNotRecommended'));
     }
     const toolName: string = 'Ruby';


### PR DESCRIPTION
**Task name**: `UseRubyVersion` & `UsePythonVersion`

**Description**: This allows explicitly suppressing the "exact version not recommended" warning that these tasks currently show if you use an exact version.

This makes sense in situations where the version is being tracked in the repo in a way that tools (i.e `bundler`) will enforce, and you want the point of failure to be on the setup task in the event a version is not available to an agent rather than the tooling (since the latter is the more correct place to fail, given the failure will always happen even if you were using non-exact versions for the task).

**Documentation changes required:** Y

**Added unit tests:** N

**Attached related issue:** fixes #14869

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
