### PR TITLE
ArtifactEngine version bumped up in DownloadBuildArtifacts task

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/package-lock.json
+++ b/Tasks/DownloadBuildArtifactsV0/package-lock.json
@@ -41,9 +41,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "artifact-engine": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.0.tgz",
-      "integrity": "sha512-MerSYnKYOn7dzT4cEShfDmDPQYAHqrNNEcPlaodg0QKUGElH9d/DLXwYqKZqoB6fqXkOpXpGRGxmQ77DtvkKHA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.1.tgz",
+      "integrity": "sha512-Ppo+LCZYnWaXZYSm3FZZcRAVs9MqkWBQR19qUEdVGDjhNeTaszBRVl3TH3dzTYeIIkskyzXX8VN92cyFNC09Wg==",
       "requires": {
         "azure-pipelines-task-lib": "^3.1.0",
         "handlebars": "4.7.7",

--- a/Tasks/DownloadBuildArtifactsV0/package.json
+++ b/Tasks/DownloadBuildArtifactsV0/package.json
@@ -21,7 +21,7 @@
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.1.0",
     "azure-devops-node-api": "7.2.0",
-    "artifact-engine": "1.0.0",
+    "artifact-engine": "1.0.1",
     "decompress-zip": "0.3.3"
   },
   "devDependencies": {

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 188,
-        "Patch": 2
+        "Patch": 3
     },
     "groups": [
         {

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 188,
-    "Patch": 2
+    "Patch": 3
   },
   "groups": [
     {


### PR DESCRIPTION
**Task name**: DownloadBuildArtifacts

**Description**: `ArtifactEngine` had a bug with download size zero value which displayed in `DownloadBuildArtifacts` task logs.  The bug has been fixed in [this Pull Request](https://github.com/microsoft/azure-pipelines-extensions/pull/956) so now we need to bump up the `ArtifactEngine` version in the `DownloadBuildArtifacts` task to resolve the [Related issue](https://github.com/microsoft/build-task-team/issues/1142).

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

DownloadBuildArtifacts task logs **before** changes:

![image](https://user-images.githubusercontent.com/61472718/119036369-56b93a00-b9b9-11eb-8986-b2b9c6ca854b.png)

DownloadBuildArtifacts task logs **after** changes:

![image](https://user-images.githubusercontent.com/61472718/119037555-cbd93f00-b9ba-11eb-9494-44e2106a2699.png)