### PR TITLE
[ArchiveFilesV2]Change default value for sevenZipCompression option

### DIFF
--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -19,7 +19,7 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 2,
-        "Minor": 186,
+        "Minor": 188,
         "Patch": 0
     },
     "groups": [
@@ -67,7 +67,7 @@
             "type": "pickList",
             "label": "7z compression",
             "required": false,
-            "defaultValue": "5",
+            "defaultValue": "normal",
             "helpMarkDown": "Optionally choose a compression level, or choose <b>`None`</b> to create an uncompressed 7z file.",
             "groupName": "archive",
             "visibleRule": "archiveType = 7z",

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -19,7 +19,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 2,
-    "Minor": 186,
+    "Minor": 188,
     "Patch": 0
   },
   "groups": [
@@ -67,7 +67,7 @@
       "type": "pickList",
       "label": "ms-resource:loc.input.label.sevenZipCompression",
       "required": false,
-      "defaultValue": "5",
+      "defaultValue": "normal",
       "helpMarkDown": "ms-resource:loc.input.help.sevenZipCompression",
       "groupName": "archive",
       "visibleRule": "archiveType = 7z",


### PR DESCRIPTION
**Task name**: ArchiveFilesV2

**Description**: Changed default value for sevenZipCompression option

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
