### PR TITLE
Update Azure IoT extension to 0.10.11

### DIFF
--- a/Tasks/AzureIoTEdgeV2/constant.ts
+++ b/Tasks/AzureIoTEdgeV2/constant.ts
@@ -28,5 +28,5 @@ export default class Constants {
   public static defaultExecOption = {} as IExecSyncOptions;
   public static UTF8 = "utf8";
   public static outputVariableDeploymentPathKey = "DEPLOYMENT_FILE_PATH";
-  public static azureCliIotExtensionDefaultSource = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.10.10/azure_iot-0.10.10-py3-none-any.whl";
+  public static azureCliIotExtensionDefaultSource = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.10.11/azure_iot-0.10.11-py3-none-any.whl";
 }

--- a/Tasks/AzureIoTEdgeV2/deployimage.ts
+++ b/Tasks/AzureIoTEdgeV2/deployimage.ts
@@ -123,19 +123,6 @@ class azureclitask {
       throw new Error(`View Az Version Error: ${outputStream.content}`);
     }
 
-    // Upgrade setuptools in azcli's private python environment to avoid conflict when installing azure-iot extension
-    // temporary solution until the paho-mqtt error in win2016 goes away 
-    if(tl.osType() === Constants.osTypeWindows)
-    {
-      let pythonExeLocation : string = 'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\CLI2\\python.exe';
-      let setupToolsInstallationCommand = ['-m', 'pip', 'install', '-U', 'setuptools==52.0.0'];
-      let upgradeSetuptoolsResult = tl.execSync(pythonExeLocation, setupToolsInstallationCommand, execOptions);
-      if(upgradeSetuptoolsResult.code !== 0)
-      {
-        throw new Error(`Upgrade setuptools Error: ${outputStream.content}`);
-      }
-    }
-
     let addResult = tl.execSync('az', installCommand, Constants.execSyncSilentOption);
     tl.debug(JSON.stringify(addResult));
     if (addResult.code !== 0) {

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 7
+        "Patch": 8
     },
     "preview": false,
     "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 7
+    "Patch": 8
   },
   "preview": false,
   "showEnvironmentVariables": true,


### PR DESCRIPTION
**Task name**: AzureIoTEdgeV2

**Description**: 
- Update pinned version of Azure IoT CLI extension to 0.10.11 since 0.10.10 is broken from newest Azure CLI update 2.24.0
- Removed temporary setuptools solution for Azure CLI, fix no longer needed

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 
- https://github.com/Azure/azure-iot-cli-extension/issues/357

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
