### PR TITLE
Hotfix: Update Azure IoT extension to 0.10.11

### DIFF
--- a/Tasks/AzureIoTEdgeV2/constant.ts
+++ b/Tasks/AzureIoTEdgeV2/constant.ts
@@ -28,5 +28,5 @@ export default class Constants {
   public static defaultExecOption = {} as IExecSyncOptions;
   public static UTF8 = "utf8";
   public static outputVariableDeploymentPathKey = "DEPLOYMENT_FILE_PATH";
-  public static azureCliIotExtensionDefaultSource = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.10.10/azure_iot-0.10.10-py3-none-any.whl";
+  public static azureCliIotExtensionDefaultSource = "https://github.com/Azure/azure-iot-cli-extension/releases/download/v0.10.11/azure_iot-0.10.11-py3-none-any.whl";
 }

--- a/Tasks/AzureIoTEdgeV2/deployimage.ts
+++ b/Tasks/AzureIoTEdgeV2/deployimage.ts
@@ -123,19 +123,6 @@ class azureclitask {
       throw new Error(`View Az Version Error: ${outputStream.content}`);
     }
 
-    // Upgrade setuptools in azcli's private python environment to avoid conflict when installing azure-iot extension
-    // temporary solution until the paho-mqtt error in win2016 goes away 
-    if(tl.osType() === Constants.osTypeWindows)
-    {
-      let pythonExeLocation : string = 'C:\\Program Files (x86)\\Microsoft SDKs\\Azure\\CLI2\\python.exe';
-      let setupToolsInstallationCommand = ['-m', 'pip', 'install', '-U', 'setuptools==52.0.0'];
-      let upgradeSetuptoolsResult = tl.execSync(pythonExeLocation, setupToolsInstallationCommand, execOptions);
-      if(upgradeSetuptoolsResult.code !== 0)
-      {
-        throw new Error(`Upgrade setuptools Error: ${outputStream.content}`);
-      }
-    }
-
     let addResult = tl.execSync('az', installCommand, Constants.execSyncSilentOption);
     tl.debug(JSON.stringify(addResult));
     if (addResult.code !== 0) {

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 7
+        "Patch": 8
     },
     "preview": false,
     "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 7
+    "Patch": 8
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/DownloadBuildArtifactsV0/package-lock.json
+++ b/Tasks/DownloadBuildArtifactsV0/package-lock.json
@@ -41,9 +41,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "artifact-engine": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.0.tgz",
-      "integrity": "sha512-MerSYnKYOn7dzT4cEShfDmDPQYAHqrNNEcPlaodg0QKUGElH9d/DLXwYqKZqoB6fqXkOpXpGRGxmQ77DtvkKHA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.1.tgz",
+      "integrity": "sha512-Ppo+LCZYnWaXZYSm3FZZcRAVs9MqkWBQR19qUEdVGDjhNeTaszBRVl3TH3dzTYeIIkskyzXX8VN92cyFNC09Wg==",
       "requires": {
         "azure-pipelines-task-lib": "^3.1.0",
         "handlebars": "4.7.7",

--- a/Tasks/DownloadBuildArtifactsV0/package.json
+++ b/Tasks/DownloadBuildArtifactsV0/package.json
@@ -21,7 +21,7 @@
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.1.0",
     "azure-devops-node-api": "7.2.0",
-    "artifact-engine": "1.0.0",
+    "artifact-engine": "1.0.1",
     "decompress-zip": "0.3.3"
   },
   "devDependencies": {

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 188,
-        "Patch": 2
+        "Patch": 3
     },
     "groups": [
         {

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 188,
-    "Patch": 2
+    "Patch": 3
   },
   "groups": [
     {

--- a/Tasks/JavaToolInstallerV0/package-lock.json
+++ b/Tasks/JavaToolInstallerV0/package-lock.json
@@ -50,15 +50,16 @@
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
             "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
         },
-        "ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
         },
         "argparse": {
             "version": "1.0.10",
@@ -69,26 +70,117 @@
             }
         },
         "artifact-engine": {
-            "version": "0.1.29",
-            "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-0.1.29.tgz",
-            "integrity": "sha512-Pg7Gyqfy2cu/Ctam4mdA9GczVQOBTFCqCqdUKoaq9XyA2c1zWmkKYTfa4LxbudGryjmePYern1O6OnnZHZkpew==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.0.tgz",
+            "integrity": "sha512-MerSYnKYOn7dzT4cEShfDmDPQYAHqrNNEcPlaodg0QKUGElH9d/DLXwYqKZqoB6fqXkOpXpGRGxmQ77DtvkKHA==",
             "requires": {
-                "azure-pipelines-task-lib": "2.8.0",
-                "handlebars": "4.0.14",
+                "azure-pipelines-task-lib": "^3.1.0",
+                "handlebars": "4.7.7",
                 "minimatch": "3.0.2",
                 "tunnel": "0.0.4"
             },
             "dependencies": {
+                "@sinonjs/formatio": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+                    "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+                    "requires": {
+                        "samsam": "1.3.0"
+                    }
+                },
+                "@types/concat-stream": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+                    "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "@types/form-data": {
+                    "version": "0.0.33",
+                    "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+                    "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "@types/minimatch": {
+                    "version": "2.0.29",
+                    "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
+                    "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o="
+                },
+                "@types/mocha": {
+                    "version": "5.2.7",
+                    "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+                    "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+                },
+                "@types/mockery": {
+                    "version": "1.4.29",
+                    "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
+                    "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U="
+                },
+                "@types/node": {
+                    "version": "10.17.51",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+                    "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+                },
+                "@types/qs": {
+                    "version": "6.9.6",
+                    "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+                    "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+                },
+                "@types/xml2js": {
+                    "version": "0.4.8",
+                    "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+                    "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "asap": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+                    "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+                },
+                "assert": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+                    "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+                    "requires": {
+                        "util": "0.10.3"
+                    }
+                },
+                "assertion-error": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+                    "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+                },
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                    "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+                },
                 "azure-pipelines-task-lib": {
-                    "version": "2.8.0",
-                    "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
-                    "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.0.tgz",
+                    "integrity": "sha512-9L+uG3dxwr/orjFy8tWa2fti+2weiRAdsKVtXINfIpLKFSAHS9tKOpupS53CgBJzQxFf5HfZwNeiUTv+/dBPpA==",
                     "requires": {
                         "minimatch": "3.0.4",
                         "mockery": "^1.7.0",
-                        "q": "^1.1.2",
+                        "q": "^1.5.1",
                         "semver": "^5.1.0",
-                        "shelljs": "^0.3.0",
+                        "shelljs": "^0.8.4",
+                        "sync-request": "6.1.0",
                         "uuid": "^3.0.1"
                     },
                     "dependencies": {
@@ -99,8 +191,3206 @@
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
+                        },
+                        "mockery": {
+                            "version": "1.7.0",
+                            "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+                            "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
                         }
                     }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                    "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+                },
+                "brace-expansion": {
+                    "version": "1.1.8",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                    "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "buffer-from": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+                    "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+                },
+                "chai": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+                    "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+                    "requires": {
+                        "assertion-error": "^1.0.1",
+                        "deep-eql": "^0.1.3",
+                        "type-detect": "^1.0.0"
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+                    "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+                },
+                "combined-stream": {
+                    "version": "1.0.8",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+                    "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "commander": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+                    "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+                },
+                "concat-stream": {
+                    "version": "1.6.2",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+                    "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                        }
+                    }
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                    "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+                },
+                "debug": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+                    "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+                    "requires": {
+                        "ms": "0.6.2"
+                    }
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+                },
+                "deep-eql": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+                    "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+                    "requires": {
+                        "type-detect": "0.1.1"
+                    },
+                    "dependencies": {
+                        "type-detect": {
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                            "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+                        }
+                    }
+                },
+                "deep-equal": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                    "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                },
+                "diff": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+                    "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+                    "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+                },
+                "form-data": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "formatio": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+                    "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+                    "requires": {
+                        "samsam": "1.x"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                    "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+                },
+                "function-bind": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+                },
+                "get-port": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+                    "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+                },
+                "glob": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+                    "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+                    "requires": {
+                        "graceful-fs": "~2.0.0",
+                        "inherits": "2",
+                        "minimatch": "~0.2.11"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "0.2.14",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                            "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+                            "requires": {
+                                "lru-cache": "2",
+                                "sigmund": "~1.0.0"
+                            }
+                        }
+                    }
+                },
+                "graceful-fs": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+                    "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+                },
+                "growl": {
+                    "version": "1.8.1",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+                    "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg="
+                },
+                "handlebars": {
+                    "version": "4.7.7",
+                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+                    "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+                    "requires": {
+                        "minimist": "^1.2.5",
+                        "neo-async": "^2.6.0",
+                        "source-map": "^0.6.1",
+                        "uglify-js": "^3.1.4",
+                        "wordwrap": "^1.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+                    "requires": {
+                        "function-bind": "^1.1.1"
+                    }
+                },
+                "http-basic": {
+                    "version": "8.1.3",
+                    "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+                    "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+                    "requires": {
+                        "caseless": "^0.12.0",
+                        "concat-stream": "^1.6.2",
+                        "http-response-object": "^3.0.1",
+                        "parse-cache-control": "^1.0.1"
+                    }
+                },
+                "http-response-object": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+                    "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+                    "requires": {
+                        "@types/node": "^10.0.3"
+                    }
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                    "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "ini": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+                    "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+                },
+                "interpret": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+                },
+                "is-core-module": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+                    "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "jade": {
+                    "version": "0.26.3",
+                    "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                    "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+                    "requires": {
+                        "commander": "0.6.1",
+                        "mkdirp": "0.3.0"
+                    },
+                    "dependencies": {
+                        "commander": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+                            "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+                        },
+                        "mkdirp": {
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+                            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+                        }
+                    }
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+                },
+                "just-extend": {
+                    "version": "1.1.27",
+                    "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+                    "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+                    "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+                },
+                "lodash.get": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+                    "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+                },
+                "lolex": {
+                    "version": "2.7.0",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+                    "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg=="
+                },
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                },
+                "mime-db": {
+                    "version": "1.46.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+                    "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+                },
+                "mime-types": {
+                    "version": "2.1.29",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+                    "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+                    "requires": {
+                        "mime-db": "1.46.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                    "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
+                    "requires": {
+                        "brace-expansion": "^1.0.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+                },
+                "mkdirp": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                    "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                        }
+                    }
+                },
+                "mocha": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.3.3.tgz",
+                    "integrity": "sha1-lkiMSb/XHYalGMuUHikag/SNiFY=",
+                    "requires": {
+                        "commander": "2.3.0",
+                        "debug": "2.0.0",
+                        "diff": "1.4.0",
+                        "escape-string-regexp": "1.0.2",
+                        "glob": "3.2.3",
+                        "growl": "1.8.1",
+                        "jade": "0.26.3",
+                        "mkdirp": "0.5.0",
+                        "supports-color": "1.2.0"
+                    }
+                },
+                "mocha-tap-reporter": {
+                    "version": "0.1.3",
+                    "resolved": "https://registry.npmjs.org/mocha-tap-reporter/-/mocha-tap-reporter-0.1.3.tgz",
+                    "integrity": "sha1-Emy70vggZJXnKxWZFNOXuOoXoig=",
+                    "requires": {
+                        "mocha": "*"
+                    }
+                },
+                "mockery": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+                    "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+                },
+                "native-promise-only": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+                    "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+                },
+                "nconf": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+                    "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+                    "requires": {
+                        "async": "^1.4.0",
+                        "ini": "^1.3.0",
+                        "secure-keys": "^1.0.0",
+                        "yargs": "^3.19.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+                        },
+                        "cliui": {
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                            "requires": {
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
+                            }
+                        },
+                        "window-size": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+                            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+                        },
+                        "yargs": {
+                            "version": "3.32.0",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+                            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+                            "requires": {
+                                "camelcase": "^2.0.1",
+                                "cliui": "^3.0.3",
+                                "decamelize": "^1.1.1",
+                                "os-locale": "^1.4.0",
+                                "string-width": "^1.0.1",
+                                "window-size": "^0.1.4",
+                                "y18n": "^3.2.0"
+                            }
+                        }
+                    }
+                },
+                "neo-async": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+                    "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+                },
+                "nise": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.1.tgz",
+                    "integrity": "sha512-9JX3YwoIt3kS237scmSSOpEv7vCukVzLfwK0I0XhocDSHUANid8ZHnLEULbbSkfeMn98B2y5kphIWzZUylESRQ==",
+                    "requires": {
+                        "@sinonjs/formatio": "^2.0.0",
+                        "just-extend": "^1.1.27",
+                        "lolex": "^2.3.2",
+                        "path-to-regexp": "^1.7.0",
+                        "text-encoding": "^0.6.4"
+                    }
+                },
+                "nock": {
+                    "version": "9.1.0",
+                    "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.0.tgz",
+                    "integrity": "sha512-u9QOLOZP0DlcKzmAzCuX5PRsIhbiRJupR7hJn1cCCT7VW3ZKUrEH/oxGEtVA8Xbu4EmzH9d/VK0x/3FxCGRrRg==",
+                    "requires": {
+                        "chai": ">=1.9.2 <4.0.0",
+                        "debug": "^2.2.0",
+                        "deep-equal": "^1.0.0",
+                        "json-stringify-safe": "^5.0.1",
+                        "lodash": "~4.17.2",
+                        "mkdirp": "^0.5.0",
+                        "propagate": "0.4.0",
+                        "qs": "^6.0.2",
+                        "semver": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                        }
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                    "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+                },
+                "nyc": {
+                    "version": "11.9.0",
+                    "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+                    "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+                    "requires": {
+                        "archy": "^1.0.0",
+                        "arrify": "^1.0.1",
+                        "caching-transform": "^1.0.0",
+                        "convert-source-map": "^1.5.1",
+                        "debug-log": "^1.0.1",
+                        "default-require-extensions": "^1.0.0",
+                        "find-cache-dir": "^0.1.1",
+                        "find-up": "^2.1.0",
+                        "foreground-child": "^1.5.3",
+                        "glob": "^7.0.6",
+                        "istanbul-lib-coverage": "^1.1.2",
+                        "istanbul-lib-hook": "^1.1.0",
+                        "istanbul-lib-instrument": "^1.10.0",
+                        "istanbul-lib-report": "^1.1.3",
+                        "istanbul-lib-source-maps": "^1.2.3",
+                        "istanbul-reports": "^1.4.0",
+                        "md5-hex": "^1.2.0",
+                        "merge-source-map": "^1.1.0",
+                        "micromatch": "^3.1.10",
+                        "mkdirp": "^0.5.0",
+                        "resolve-from": "^2.0.0",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.1",
+                        "spawn-wrap": "^1.4.2",
+                        "test-exclude": "^4.2.0",
+                        "yargs": "11.1.0",
+                        "yargs-parser": "^8.0.0"
+                    },
+                    "dependencies": {
+                        "align-text": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
+                            }
+                        },
+                        "amdefine": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        },
+                        "ansi-styles": {
+                            "version": "2.2.1",
+                            "bundled": true
+                        },
+                        "append-transform": {
+                            "version": "0.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "default-require-extensions": "^1.0.0"
+                            }
+                        },
+                        "archy": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "arr-diff": {
+                            "version": "4.0.0",
+                            "bundled": true
+                        },
+                        "arr-flatten": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "arr-union": {
+                            "version": "3.1.0",
+                            "bundled": true
+                        },
+                        "array-unique": {
+                            "version": "0.3.2",
+                            "bundled": true
+                        },
+                        "arrify": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "assign-symbols": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "async": {
+                            "version": "1.5.2",
+                            "bundled": true
+                        },
+                        "atob": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        },
+                        "babel-code-frame": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "requires": {
+                                "chalk": "^1.1.3",
+                                "esutils": "^2.0.2",
+                                "js-tokens": "^3.0.2"
+                            }
+                        },
+                        "babel-generator": {
+                            "version": "6.26.1",
+                            "bundled": true,
+                            "requires": {
+                                "babel-messages": "^6.23.0",
+                                "babel-runtime": "^6.26.0",
+                                "babel-types": "^6.26.0",
+                                "detect-indent": "^4.0.0",
+                                "jsesc": "^1.3.0",
+                                "lodash": "^4.17.4",
+                                "source-map": "^0.5.7",
+                                "trim-right": "^1.0.1"
+                            }
+                        },
+                        "babel-messages": {
+                            "version": "6.23.0",
+                            "bundled": true,
+                            "requires": {
+                                "babel-runtime": "^6.22.0"
+                            }
+                        },
+                        "babel-runtime": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "requires": {
+                                "core-js": "^2.4.0",
+                                "regenerator-runtime": "^0.11.0"
+                            }
+                        },
+                        "babel-template": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "requires": {
+                                "babel-runtime": "^6.26.0",
+                                "babel-traverse": "^6.26.0",
+                                "babel-types": "^6.26.0",
+                                "babylon": "^6.18.0",
+                                "lodash": "^4.17.4"
+                            }
+                        },
+                        "babel-traverse": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "requires": {
+                                "babel-code-frame": "^6.26.0",
+                                "babel-messages": "^6.23.0",
+                                "babel-runtime": "^6.26.0",
+                                "babel-types": "^6.26.0",
+                                "babylon": "^6.18.0",
+                                "debug": "^2.6.8",
+                                "globals": "^9.18.0",
+                                "invariant": "^2.2.2",
+                                "lodash": "^4.17.4"
+                            }
+                        },
+                        "babel-types": {
+                            "version": "6.26.0",
+                            "bundled": true,
+                            "requires": {
+                                "babel-runtime": "^6.26.0",
+                                "esutils": "^2.0.2",
+                                "lodash": "^4.17.4",
+                                "to-fast-properties": "^1.0.3"
+                            }
+                        },
+                        "babylon": {
+                            "version": "6.18.0",
+                            "bundled": true
+                        },
+                        "balanced-match": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "base": {
+                            "version": "0.11.2",
+                            "bundled": true,
+                            "requires": {
+                                "cache-base": "^1.0.1",
+                                "class-utils": "^0.3.5",
+                                "component-emitter": "^1.2.1",
+                                "define-property": "^1.0.0",
+                                "isobject": "^3.0.1",
+                                "mixin-deep": "^1.2.0",
+                                "pascalcase": "^0.1.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^1.0.0"
+                                    }
+                                },
+                                "is-accessor-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^1.0.0",
+                                        "is-data-descriptor": "^1.0.0",
+                                        "kind-of": "^6.0.2"
+                                    }
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "brace-expansion": {
+                            "version": "1.1.11",
+                            "bundled": true,
+                            "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                            }
+                        },
+                        "braces": {
+                            "version": "2.3.2",
+                            "bundled": true,
+                            "requires": {
+                                "arr-flatten": "^1.1.0",
+                                "array-unique": "^0.3.2",
+                                "extend-shallow": "^2.0.1",
+                                "fill-range": "^4.0.0",
+                                "isobject": "^3.0.1",
+                                "repeat-element": "^1.1.2",
+                                "snapdragon": "^0.8.1",
+                                "snapdragon-node": "^2.0.1",
+                                "split-string": "^3.0.2",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "builtin-modules": {
+                            "version": "1.1.1",
+                            "bundled": true
+                        },
+                        "cache-base": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "collection-visit": "^1.0.0",
+                                "component-emitter": "^1.2.1",
+                                "get-value": "^2.0.6",
+                                "has-value": "^1.0.0",
+                                "isobject": "^3.0.1",
+                                "set-value": "^2.0.0",
+                                "to-object-path": "^0.3.0",
+                                "union-value": "^1.0.0",
+                                "unset-value": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "caching-transform": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "md5-hex": "^1.2.0",
+                                "mkdirp": "^0.5.1",
+                                "write-file-atomic": "^1.1.4"
+                            }
+                        },
+                        "camelcase": {
+                            "version": "1.2.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "center-align": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "align-text": "^0.1.3",
+                                "lazy-cache": "^1.0.3"
+                            }
+                        },
+                        "chalk": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
+                            }
+                        },
+                        "class-utils": {
+                            "version": "0.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "arr-union": "^3.1.0",
+                                "define-property": "^0.2.5",
+                                "isobject": "^3.0.0",
+                                "static-extend": "^0.1.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "cliui": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
+                                "wordwrap": "0.0.2"
+                            },
+                            "dependencies": {
+                                "wordwrap": {
+                                    "version": "0.0.2",
+                                    "bundled": true,
+                                    "optional": true
+                                }
+                            }
+                        },
+                        "code-point-at": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "collection-visit": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "map-visit": "^1.0.0",
+                                "object-visit": "^1.0.0"
+                            }
+                        },
+                        "commondir": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "component-emitter": {
+                            "version": "1.2.1",
+                            "bundled": true
+                        },
+                        "concat-map": {
+                            "version": "0.0.1",
+                            "bundled": true
+                        },
+                        "convert-source-map": {
+                            "version": "1.5.1",
+                            "bundled": true
+                        },
+                        "copy-descriptor": {
+                            "version": "0.1.1",
+                            "bundled": true
+                        },
+                        "core-js": {
+                            "version": "2.5.6",
+                            "bundled": true
+                        },
+                        "cross-spawn": {
+                            "version": "4.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "lru-cache": "^4.0.1",
+                                "which": "^1.2.9"
+                            }
+                        },
+                        "debug": {
+                            "version": "2.6.9",
+                            "bundled": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        },
+                        "debug-log": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "decamelize": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "decode-uri-component": {
+                            "version": "0.2.0",
+                            "bundled": true
+                        },
+                        "default-require-extensions": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "strip-bom": "^2.0.0"
+                            }
+                        },
+                        "define-property": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.2",
+                                "isobject": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "is-accessor-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^1.0.0",
+                                        "is-data-descriptor": "^1.0.0",
+                                        "kind-of": "^6.0.2"
+                                    }
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "detect-indent": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "repeating": "^2.0.0"
+                            }
+                        },
+                        "error-ex": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-arrayish": "^0.2.1"
+                            }
+                        },
+                        "escape-string-regexp": {
+                            "version": "1.0.5",
+                            "bundled": true
+                        },
+                        "esutils": {
+                            "version": "2.0.2",
+                            "bundled": true
+                        },
+                        "execa": {
+                            "version": "0.7.0",
+                            "bundled": true,
+                            "requires": {
+                                "cross-spawn": "^5.0.1",
+                                "get-stream": "^3.0.0",
+                                "is-stream": "^1.1.0",
+                                "npm-run-path": "^2.0.0",
+                                "p-finally": "^1.0.0",
+                                "signal-exit": "^3.0.0",
+                                "strip-eof": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "cross-spawn": {
+                                    "version": "5.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "lru-cache": "^4.0.1",
+                                        "shebang-command": "^1.2.0",
+                                        "which": "^1.2.9"
+                                    }
+                                }
+                            }
+                        },
+                        "expand-brackets": {
+                            "version": "2.1.4",
+                            "bundled": true,
+                            "requires": {
+                                "debug": "^2.3.3",
+                                "define-property": "^0.2.5",
+                                "extend-shallow": "^2.0.1",
+                                "posix-character-classes": "^0.1.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "assign-symbols": "^1.0.0",
+                                "is-extendable": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "is-extendable": {
+                                    "version": "1.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-plain-object": "^2.0.4"
+                                    }
+                                }
+                            }
+                        },
+                        "extglob": {
+                            "version": "2.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "array-unique": "^0.3.2",
+                                "define-property": "^1.0.0",
+                                "expand-brackets": "^2.1.4",
+                                "extend-shallow": "^2.0.1",
+                                "fragment-cache": "^0.2.1",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^1.0.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                },
+                                "is-accessor-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^1.0.0",
+                                        "is-data-descriptor": "^1.0.0",
+                                        "kind-of": "^6.0.2"
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "fill-range": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "extend-shallow": "^2.0.1",
+                                "is-number": "^3.0.0",
+                                "repeat-string": "^1.6.1",
+                                "to-regex-range": "^2.1.0"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "find-cache-dir": {
+                            "version": "0.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "commondir": "^1.0.1",
+                                "mkdirp": "^0.5.1",
+                                "pkg-dir": "^1.0.0"
+                            }
+                        },
+                        "find-up": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "locate-path": "^2.0.0"
+                            }
+                        },
+                        "for-in": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "foreground-child": {
+                            "version": "1.5.6",
+                            "bundled": true,
+                            "requires": {
+                                "cross-spawn": "^4",
+                                "signal-exit": "^3.0.0"
+                            }
+                        },
+                        "fragment-cache": {
+                            "version": "0.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "map-cache": "^0.2.2"
+                            }
+                        },
+                        "fs.realpath": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "get-caller-file": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        },
+                        "get-value": {
+                            "version": "2.0.6",
+                            "bundled": true
+                        },
+                        "glob": {
+                            "version": "7.1.2",
+                            "bundled": true,
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "globals": {
+                            "version": "9.18.0",
+                            "bundled": true
+                        },
+                        "graceful-fs": {
+                            "version": "4.1.11",
+                            "bundled": true
+                        },
+                        "handlebars": {
+                            "version": "4.0.11",
+                            "bundled": true,
+                            "requires": {
+                                "async": "^1.4.0",
+                                "optimist": "^0.6.1",
+                                "source-map": "^0.4.4",
+                                "uglify-js": "^2.6"
+                            },
+                            "dependencies": {
+                                "source-map": {
+                                    "version": "0.4.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "amdefine": ">=0.0.4"
+                                    }
+                                }
+                            }
+                        },
+                        "has-ansi": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        },
+                        "has-flag": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "has-value": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "get-value": "^2.0.6",
+                                "has-values": "^1.0.0",
+                                "isobject": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "has-values": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-number": "^3.0.0",
+                                "kind-of": "^4.0.0"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^3.0.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-buffer": "^1.1.5"
+                                            }
+                                        }
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "hosted-git-info": {
+                            "version": "2.6.0",
+                            "bundled": true
+                        },
+                        "imurmurhash": {
+                            "version": "0.1.4",
+                            "bundled": true
+                        },
+                        "inflight": {
+                            "version": "1.0.6",
+                            "bundled": true,
+                            "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                            }
+                        },
+                        "inherits": {
+                            "version": "2.0.3",
+                            "bundled": true
+                        },
+                        "invariant": {
+                            "version": "2.2.4",
+                            "bundled": true,
+                            "requires": {
+                                "loose-envify": "^1.0.0"
+                            }
+                        },
+                        "invert-kv": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            }
+                        },
+                        "is-arrayish": {
+                            "version": "0.2.1",
+                            "bundled": true
+                        },
+                        "is-buffer": {
+                            "version": "1.1.6",
+                            "bundled": true
+                        },
+                        "is-builtin-module": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "builtin-modules": "^1.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "0.1.6",
+                            "bundled": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "5.1.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "is-extendable": {
+                            "version": "0.1.1",
+                            "bundled": true
+                        },
+                        "is-finite": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "is-number": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            }
+                        },
+                        "is-odd": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-number": "^4.0.0"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "4.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "is-plain-object": {
+                            "version": "2.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "isobject": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "is-stream": {
+                            "version": "1.1.0",
+                            "bundled": true
+                        },
+                        "is-utf8": {
+                            "version": "0.2.1",
+                            "bundled": true
+                        },
+                        "is-windows": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "isexe": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true
+                        },
+                        "istanbul-lib-coverage": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "istanbul-lib-hook": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "append-transform": "^0.4.0"
+                            }
+                        },
+                        "istanbul-lib-instrument": {
+                            "version": "1.10.1",
+                            "bundled": true,
+                            "requires": {
+                                "babel-generator": "^6.18.0",
+                                "babel-template": "^6.16.0",
+                                "babel-traverse": "^6.18.0",
+                                "babel-types": "^6.18.0",
+                                "babylon": "^6.18.0",
+                                "istanbul-lib-coverage": "^1.2.0",
+                                "semver": "^5.3.0"
+                            }
+                        },
+                        "istanbul-lib-report": {
+                            "version": "1.1.3",
+                            "bundled": true,
+                            "requires": {
+                                "istanbul-lib-coverage": "^1.1.2",
+                                "mkdirp": "^0.5.1",
+                                "path-parse": "^1.0.5",
+                                "supports-color": "^3.1.2"
+                            },
+                            "dependencies": {
+                                "supports-color": {
+                                    "version": "3.2.3",
+                                    "bundled": true,
+                                    "requires": {
+                                        "has-flag": "^1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-lib-source-maps": {
+                            "version": "1.2.3",
+                            "bundled": true,
+                            "requires": {
+                                "debug": "^3.1.0",
+                                "istanbul-lib-coverage": "^1.1.2",
+                                "mkdirp": "^0.5.1",
+                                "rimraf": "^2.6.1",
+                                "source-map": "^0.5.3"
+                            },
+                            "dependencies": {
+                                "debug": {
+                                    "version": "3.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ms": "2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "istanbul-reports": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "handlebars": "^4.0.3"
+                            }
+                        },
+                        "js-tokens": {
+                            "version": "3.0.2",
+                            "bundled": true
+                        },
+                        "jsesc": {
+                            "version": "1.3.0",
+                            "bundled": true
+                        },
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "bundled": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        },
+                        "lazy-cache": {
+                            "version": "1.0.4",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "lcid": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "invert-kv": "^1.0.0"
+                            }
+                        },
+                        "load-json-file": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^2.2.0",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0",
+                                "strip-bom": "^2.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-locate": "^2.0.0",
+                                "path-exists": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "path-exists": {
+                                    "version": "3.0.0",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "lodash": {
+                            "version": "4.17.10",
+                            "bundled": true
+                        },
+                        "longest": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "loose-envify": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "requires": {
+                                "js-tokens": "^3.0.0"
+                            }
+                        },
+                        "lru-cache": {
+                            "version": "4.1.3",
+                            "bundled": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            }
+                        },
+                        "map-cache": {
+                            "version": "0.2.2",
+                            "bundled": true
+                        },
+                        "map-visit": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "object-visit": "^1.0.0"
+                            }
+                        },
+                        "md5-hex": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "md5-o-matic": "^0.1.1"
+                            }
+                        },
+                        "md5-o-matic": {
+                            "version": "0.1.1",
+                            "bundled": true
+                        },
+                        "mem": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "mimic-fn": "^1.0.0"
+                            }
+                        },
+                        "merge-source-map": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "source-map": "^0.6.1"
+                            },
+                            "dependencies": {
+                                "source-map": {
+                                    "version": "0.6.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "micromatch": {
+                            "version": "3.1.10",
+                            "bundled": true,
+                            "requires": {
+                                "arr-diff": "^4.0.0",
+                                "array-unique": "^0.3.2",
+                                "braces": "^2.3.1",
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "extglob": "^2.0.4",
+                                "fragment-cache": "^0.2.1",
+                                "kind-of": "^6.0.2",
+                                "nanomatch": "^1.2.9",
+                                "object.pick": "^1.3.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "mimic-fn": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "bundled": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        },
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true
+                        },
+                        "mixin-deep": {
+                            "version": "1.3.1",
+                            "bundled": true,
+                            "requires": {
+                                "for-in": "^1.0.2",
+                                "is-extendable": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "is-extendable": {
+                                    "version": "1.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-plain-object": "^2.0.4"
+                                    }
+                                }
+                            }
+                        },
+                        "mkdirp": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "requires": {
+                                "minimist": "0.0.8"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "nanomatch": {
+                            "version": "1.2.9",
+                            "bundled": true,
+                            "requires": {
+                                "arr-diff": "^4.0.0",
+                                "array-unique": "^0.3.2",
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "fragment-cache": "^0.2.1",
+                                "is-odd": "^2.0.0",
+                                "is-windows": "^1.0.2",
+                                "kind-of": "^6.0.2",
+                                "object.pick": "^1.3.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "arr-diff": {
+                                    "version": "4.0.0",
+                                    "bundled": true
+                                },
+                                "array-unique": {
+                                    "version": "0.3.2",
+                                    "bundled": true
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "normalize-package-data": {
+                            "version": "2.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "hosted-git-info": "^2.1.4",
+                                "is-builtin-module": "^1.0.0",
+                                "semver": "2 || 3 || 4 || 5",
+                                "validate-npm-package-license": "^3.0.1"
+                            }
+                        },
+                        "npm-run-path": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "path-key": "^2.0.0"
+                            }
+                        },
+                        "number-is-nan": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "object-assign": {
+                            "version": "4.1.1",
+                            "bundled": true
+                        },
+                        "object-copy": {
+                            "version": "0.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "copy-descriptor": "^0.1.0",
+                                "define-property": "^0.2.5",
+                                "kind-of": "^3.0.3"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "object-visit": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "isobject": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "object.pick": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "isobject": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "once": {
+                            "version": "1.4.0",
+                            "bundled": true,
+                            "requires": {
+                                "wrappy": "1"
+                            }
+                        },
+                        "optimist": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "requires": {
+                                "minimist": "~0.0.1",
+                                "wordwrap": "~0.0.2"
+                            }
+                        },
+                        "os-homedir": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "os-locale": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "execa": "^0.7.0",
+                                "lcid": "^1.0.0",
+                                "mem": "^1.1.0"
+                            }
+                        },
+                        "p-finally": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "p-limit": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-try": "^1.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-limit": "^1.1.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "parse-json": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "error-ex": "^1.2.0"
+                            }
+                        },
+                        "pascalcase": {
+                            "version": "0.1.1",
+                            "bundled": true
+                        },
+                        "path-exists": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "pinkie-promise": "^2.0.0"
+                            }
+                        },
+                        "path-is-absolute": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "path-key": {
+                            "version": "2.0.1",
+                            "bundled": true
+                        },
+                        "path-parse": {
+                            "version": "1.0.5",
+                            "bundled": true
+                        },
+                        "path-type": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.2",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
+                            }
+                        },
+                        "pify": {
+                            "version": "2.3.0",
+                            "bundled": true
+                        },
+                        "pinkie": {
+                            "version": "2.0.4",
+                            "bundled": true
+                        },
+                        "pinkie-promise": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "pinkie": "^2.0.0"
+                            }
+                        },
+                        "pkg-dir": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "find-up": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "path-exists": "^2.0.0",
+                                        "pinkie-promise": "^2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "posix-character-classes": {
+                            "version": "0.1.1",
+                            "bundled": true
+                        },
+                        "pseudomap": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "read-pkg": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "load-json-file": "^1.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^1.0.0"
+                            }
+                        },
+                        "read-pkg-up": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "find-up": "^1.0.0",
+                                "read-pkg": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "find-up": {
+                                    "version": "1.1.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "path-exists": "^2.0.0",
+                                        "pinkie-promise": "^2.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "regenerator-runtime": {
+                            "version": "0.11.1",
+                            "bundled": true
+                        },
+                        "regex-not": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "extend-shallow": "^3.0.2",
+                                "safe-regex": "^1.1.0"
+                            }
+                        },
+                        "repeat-element": {
+                            "version": "1.1.2",
+                            "bundled": true
+                        },
+                        "repeat-string": {
+                            "version": "1.6.1",
+                            "bundled": true
+                        },
+                        "repeating": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-finite": "^1.0.0"
+                            }
+                        },
+                        "require-directory": {
+                            "version": "2.1.1",
+                            "bundled": true
+                        },
+                        "require-main-filename": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "resolve-from": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "resolve-url": {
+                            "version": "0.2.1",
+                            "bundled": true
+                        },
+                        "ret": {
+                            "version": "0.1.15",
+                            "bundled": true
+                        },
+                        "right-align": {
+                            "version": "0.1.3",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "align-text": "^0.1.1"
+                            }
+                        },
+                        "rimraf": {
+                            "version": "2.6.2",
+                            "bundled": true,
+                            "requires": {
+                                "glob": "^7.0.5"
+                            }
+                        },
+                        "safe-regex": {
+                            "version": "1.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "ret": "~0.1.10"
+                            }
+                        },
+                        "semver": {
+                            "version": "5.5.0",
+                            "bundled": true
+                        },
+                        "set-blocking": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "set-value": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "extend-shallow": "^2.0.1",
+                                "is-extendable": "^0.1.1",
+                                "is-plain-object": "^2.0.3",
+                                "split-string": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "shebang-command": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "shebang-regex": "^1.0.0"
+                            }
+                        },
+                        "shebang-regex": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "signal-exit": {
+                            "version": "3.0.2",
+                            "bundled": true
+                        },
+                        "slide": {
+                            "version": "1.1.6",
+                            "bundled": true
+                        },
+                        "snapdragon": {
+                            "version": "0.8.2",
+                            "bundled": true,
+                            "requires": {
+                                "base": "^0.11.1",
+                                "debug": "^2.2.0",
+                                "define-property": "^0.2.5",
+                                "extend-shallow": "^2.0.1",
+                                "map-cache": "^0.2.2",
+                                "source-map": "^0.5.6",
+                                "source-map-resolve": "^0.5.0",
+                                "use": "^3.1.0"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "snapdragon-node": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "define-property": "^1.0.0",
+                                "isobject": "^3.0.0",
+                                "snapdragon-util": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^1.0.0"
+                                    }
+                                },
+                                "is-accessor-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^1.0.0",
+                                        "is-data-descriptor": "^1.0.0",
+                                        "kind-of": "^6.0.2"
+                                    }
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "snapdragon-util": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^3.2.0"
+                            }
+                        },
+                        "source-map": {
+                            "version": "0.5.7",
+                            "bundled": true
+                        },
+                        "source-map-resolve": {
+                            "version": "0.5.1",
+                            "bundled": true,
+                            "requires": {
+                                "atob": "^2.0.0",
+                                "decode-uri-component": "^0.2.0",
+                                "resolve-url": "^0.2.1",
+                                "source-map-url": "^0.4.0",
+                                "urix": "^0.1.0"
+                            }
+                        },
+                        "source-map-url": {
+                            "version": "0.4.0",
+                            "bundled": true
+                        },
+                        "spawn-wrap": {
+                            "version": "1.4.2",
+                            "bundled": true,
+                            "requires": {
+                                "foreground-child": "^1.5.6",
+                                "mkdirp": "^0.5.0",
+                                "os-homedir": "^1.0.1",
+                                "rimraf": "^2.6.2",
+                                "signal-exit": "^3.0.2",
+                                "which": "^1.3.0"
+                            }
+                        },
+                        "spdx-correct": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "spdx-expression-parse": "^3.0.0",
+                                "spdx-license-ids": "^3.0.0"
+                            }
+                        },
+                        "spdx-exceptions": {
+                            "version": "2.1.0",
+                            "bundled": true
+                        },
+                        "spdx-expression-parse": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "spdx-exceptions": "^2.1.0",
+                                "spdx-license-ids": "^3.0.0"
+                            }
+                        },
+                        "spdx-license-ids": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        },
+                        "split-string": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "extend-shallow": "^3.0.0"
+                            }
+                        },
+                        "static-extend": {
+                            "version": "0.1.2",
+                            "bundled": true,
+                            "requires": {
+                                "define-property": "^0.2.5",
+                                "object-copy": "^0.1.0"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "string-width": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^4.0.0"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "3.0.0",
+                                    "bundled": true
+                                },
+                                "strip-ansi": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ansi-regex": "^3.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        },
+                        "strip-bom": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "is-utf8": "^0.2.0"
+                            }
+                        },
+                        "strip-eof": {
+                            "version": "1.0.0",
+                            "bundled": true
+                        },
+                        "supports-color": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "test-exclude": {
+                            "version": "4.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "arrify": "^1.0.1",
+                                "micromatch": "^3.1.8",
+                                "object-assign": "^4.1.0",
+                                "read-pkg-up": "^1.0.1",
+                                "require-main-filename": "^1.0.1"
+                            },
+                            "dependencies": {
+                                "arr-diff": {
+                                    "version": "4.0.0",
+                                    "bundled": true
+                                },
+                                "array-unique": {
+                                    "version": "0.3.2",
+                                    "bundled": true
+                                },
+                                "braces": {
+                                    "version": "2.3.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "arr-flatten": "^1.1.0",
+                                        "array-unique": "^0.3.2",
+                                        "extend-shallow": "^2.0.1",
+                                        "fill-range": "^4.0.0",
+                                        "isobject": "^3.0.1",
+                                        "repeat-element": "^1.1.2",
+                                        "snapdragon": "^0.8.1",
+                                        "snapdragon-node": "^2.0.1",
+                                        "split-string": "^3.0.2",
+                                        "to-regex": "^3.0.1"
+                                    },
+                                    "dependencies": {
+                                        "extend-shallow": {
+                                            "version": "2.0.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-extendable": "^0.1.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "expand-brackets": {
+                                    "version": "2.1.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "debug": "^2.3.3",
+                                        "define-property": "^0.2.5",
+                                        "extend-shallow": "^2.0.1",
+                                        "posix-character-classes": "^0.1.0",
+                                        "regex-not": "^1.0.0",
+                                        "snapdragon": "^0.8.1",
+                                        "to-regex": "^3.0.1"
+                                    },
+                                    "dependencies": {
+                                        "define-property": {
+                                            "version": "0.2.5",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-descriptor": "^0.1.0"
+                                            }
+                                        },
+                                        "extend-shallow": {
+                                            "version": "2.0.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-extendable": "^0.1.0"
+                                            }
+                                        },
+                                        "is-accessor-descriptor": {
+                                            "version": "0.1.6",
+                                            "bundled": true,
+                                            "requires": {
+                                                "kind-of": "^3.0.2"
+                                            },
+                                            "dependencies": {
+                                                "kind-of": {
+                                                    "version": "3.2.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "is-buffer": "^1.1.5"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "is-data-descriptor": {
+                                            "version": "0.1.4",
+                                            "bundled": true,
+                                            "requires": {
+                                                "kind-of": "^3.0.2"
+                                            },
+                                            "dependencies": {
+                                                "kind-of": {
+                                                    "version": "3.2.2",
+                                                    "bundled": true,
+                                                    "requires": {
+                                                        "is-buffer": "^1.1.5"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "is-descriptor": {
+                                            "version": "0.1.6",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-accessor-descriptor": "^0.1.6",
+                                                "is-data-descriptor": "^0.1.4",
+                                                "kind-of": "^5.0.0"
+                                            }
+                                        },
+                                        "kind-of": {
+                                            "version": "5.1.0",
+                                            "bundled": true
+                                        }
+                                    }
+                                },
+                                "extglob": {
+                                    "version": "2.0.4",
+                                    "bundled": true,
+                                    "requires": {
+                                        "array-unique": "^0.3.2",
+                                        "define-property": "^1.0.0",
+                                        "expand-brackets": "^2.1.4",
+                                        "extend-shallow": "^2.0.1",
+                                        "fragment-cache": "^0.2.1",
+                                        "regex-not": "^1.0.0",
+                                        "snapdragon": "^0.8.1",
+                                        "to-regex": "^3.0.1"
+                                    },
+                                    "dependencies": {
+                                        "define-property": {
+                                            "version": "1.0.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-descriptor": "^1.0.0"
+                                            }
+                                        },
+                                        "extend-shallow": {
+                                            "version": "2.0.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-extendable": "^0.1.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "fill-range": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "extend-shallow": "^2.0.1",
+                                        "is-number": "^3.0.0",
+                                        "repeat-string": "^1.6.1",
+                                        "to-regex-range": "^2.1.0"
+                                    },
+                                    "dependencies": {
+                                        "extend-shallow": {
+                                            "version": "2.0.1",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-extendable": "^0.1.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "is-accessor-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^6.0.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^1.0.0",
+                                        "is-data-descriptor": "^1.0.0",
+                                        "kind-of": "^6.0.2"
+                                    }
+                                },
+                                "is-number": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^3.0.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "bundled": true,
+                                            "requires": {
+                                                "is-buffer": "^1.1.5"
+                                            }
+                                        }
+                                    }
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                },
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                },
+                                "micromatch": {
+                                    "version": "3.1.10",
+                                    "bundled": true,
+                                    "requires": {
+                                        "arr-diff": "^4.0.0",
+                                        "array-unique": "^0.3.2",
+                                        "braces": "^2.3.1",
+                                        "define-property": "^2.0.2",
+                                        "extend-shallow": "^3.0.2",
+                                        "extglob": "^2.0.4",
+                                        "fragment-cache": "^0.2.1",
+                                        "kind-of": "^6.0.2",
+                                        "nanomatch": "^1.2.9",
+                                        "object.pick": "^1.3.0",
+                                        "regex-not": "^1.0.0",
+                                        "snapdragon": "^0.8.1",
+                                        "to-regex": "^3.0.2"
+                                    }
+                                }
+                            }
+                        },
+                        "to-fast-properties": {
+                            "version": "1.0.3",
+                            "bundled": true
+                        },
+                        "to-object-path": {
+                            "version": "0.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            }
+                        },
+                        "to-regex": {
+                            "version": "3.0.2",
+                            "bundled": true,
+                            "requires": {
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "regex-not": "^1.0.2",
+                                "safe-regex": "^1.1.0"
+                            }
+                        },
+                        "to-regex-range": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "is-number": "^3.0.0",
+                                "repeat-string": "^1.6.1"
+                            },
+                            "dependencies": {
+                                "is-number": {
+                                    "version": "3.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "kind-of": "^3.0.2"
+                                    }
+                                }
+                            }
+                        },
+                        "trim-right": {
+                            "version": "1.0.1",
+                            "bundled": true
+                        },
+                        "uglify-js": {
+                            "version": "2.8.29",
+                            "bundled": true,
+                            "optional": true,
+                            "requires": {
+                                "source-map": "~0.5.1",
+                                "uglify-to-browserify": "~1.0.0",
+                                "yargs": "~3.10.0"
+                            },
+                            "dependencies": {
+                                "yargs": {
+                                    "version": "3.10.0",
+                                    "bundled": true,
+                                    "optional": true,
+                                    "requires": {
+                                        "camelcase": "^1.0.2",
+                                        "cliui": "^2.1.0",
+                                        "decamelize": "^1.0.0",
+                                        "window-size": "0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "uglify-to-browserify": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "union-value": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "arr-union": "^3.1.0",
+                                "get-value": "^2.0.6",
+                                "is-extendable": "^0.1.1",
+                                "set-value": "^0.4.3"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                },
+                                "set-value": {
+                                    "version": "0.4.3",
+                                    "bundled": true,
+                                    "requires": {
+                                        "extend-shallow": "^2.0.1",
+                                        "is-extendable": "^0.1.1",
+                                        "is-plain-object": "^2.0.1",
+                                        "to-object-path": "^0.3.0"
+                                    }
+                                }
+                            }
+                        },
+                        "unset-value": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "has-value": "^0.3.1",
+                                "isobject": "^3.0.0"
+                            },
+                            "dependencies": {
+                                "has-value": {
+                                    "version": "0.3.1",
+                                    "bundled": true,
+                                    "requires": {
+                                        "get-value": "^2.0.3",
+                                        "has-values": "^0.1.4",
+                                        "isobject": "^2.0.0"
+                                    },
+                                    "dependencies": {
+                                        "isobject": {
+                                            "version": "2.1.0",
+                                            "bundled": true,
+                                            "requires": {
+                                                "isarray": "1.0.0"
+                                            }
+                                        }
+                                    }
+                                },
+                                "has-values": {
+                                    "version": "0.1.4",
+                                    "bundled": true
+                                },
+                                "isobject": {
+                                    "version": "3.0.1",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "urix": {
+                            "version": "0.1.0",
+                            "bundled": true
+                        },
+                        "use": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "kind-of": "^6.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "6.0.2",
+                                    "bundled": true
+                                }
+                            }
+                        },
+                        "validate-npm-package-license": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "requires": {
+                                "spdx-correct": "^3.0.0",
+                                "spdx-expression-parse": "^3.0.0"
+                            }
+                        },
+                        "which": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "isexe": "^2.0.0"
+                            }
+                        },
+                        "which-module": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "window-size": {
+                            "version": "0.1.0",
+                            "bundled": true,
+                            "optional": true
+                        },
+                        "wordwrap": {
+                            "version": "0.0.3",
+                            "bundled": true
+                        },
+                        "wrap-ansi": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "is-fullwidth-code-point": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "number-is-nan": "^1.0.0"
+                                    }
+                                },
+                                "string-width": {
+                                    "version": "1.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "wrappy": {
+                            "version": "1.0.2",
+                            "bundled": true
+                        },
+                        "write-file-atomic": {
+                            "version": "1.3.4",
+                            "bundled": true,
+                            "requires": {
+                                "graceful-fs": "^4.1.11",
+                                "imurmurhash": "^0.1.4",
+                                "slide": "^1.1.5"
+                            }
+                        },
+                        "y18n": {
+                            "version": "3.2.1",
+                            "bundled": true
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        },
+                        "yargs": {
+                            "version": "11.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "cliui": "^4.0.0",
+                                "decamelize": "^1.1.1",
+                                "find-up": "^2.1.0",
+                                "get-caller-file": "^1.0.1",
+                                "os-locale": "^2.0.0",
+                                "require-directory": "^2.1.1",
+                                "require-main-filename": "^1.0.1",
+                                "set-blocking": "^2.0.0",
+                                "string-width": "^2.0.0",
+                                "which-module": "^2.0.0",
+                                "y18n": "^3.2.1",
+                                "yargs-parser": "^9.0.2"
+                            },
+                            "dependencies": {
+                                "ansi-regex": {
+                                    "version": "3.0.0",
+                                    "bundled": true
+                                },
+                                "camelcase": {
+                                    "version": "4.1.0",
+                                    "bundled": true
+                                },
+                                "cliui": {
+                                    "version": "4.1.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "string-width": "^2.1.1",
+                                        "strip-ansi": "^4.0.0",
+                                        "wrap-ansi": "^2.0.0"
+                                    }
+                                },
+                                "strip-ansi": {
+                                    "version": "4.0.0",
+                                    "bundled": true,
+                                    "requires": {
+                                        "ansi-regex": "^3.0.0"
+                                    }
+                                },
+                                "yargs-parser": {
+                                    "version": "9.0.2",
+                                    "bundled": true,
+                                    "requires": {
+                                        "camelcase": "^4.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "8.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "camelcase": "^4.1.0"
+                            },
+                            "dependencies": {
+                                "camelcase": {
+                                    "version": "4.1.0",
+                                    "bundled": true
+                                }
+                            }
+                        }
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                    "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "os-locale": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                    "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+                    "requires": {
+                        "lcid": "^1.0.0"
+                    }
+                },
+                "parse-cache-control": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+                    "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                    "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+                    "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+                },
+                "path-to-regexp": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+                    "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                },
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "promise": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+                    "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+                    "requires": {
+                        "asap": "~2.0.6"
+                    }
+                },
+                "propagate": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+                    "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE="
+                },
+                "q": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+                    "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+                        },
+                        "isarray": {
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+                        }
+                    }
+                },
+                "rechoir": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+                    "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+                    "requires": {
+                        "resolve": "^1.1.6"
+                    }
+                },
+                "resolve": {
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+                    "requires": {
+                        "is-core-module": "^2.2.0",
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "samsam": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+                    "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+                    "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+                },
+                "secure-keys": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+                    "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+                    "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+                },
+                "shelljs": {
+                    "version": "0.8.4",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+                    "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+                    "requires": {
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
+                    },
+                    "dependencies": {
+                        "glob": {
+                            "version": "7.1.6",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "requires": {
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.4",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
+                            }
+                        },
+                        "minimatch": {
+                            "version": "3.0.4",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
+                    }
+                },
+                "sigmund": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                    "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                },
+                "sinon": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
+                    "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+                    "requires": {
+                        "diff": "^3.1.0",
+                        "formatio": "1.2.0",
+                        "lodash.get": "^4.4.2",
+                        "lolex": "^2.1.3",
+                        "native-promise-only": "^0.8.1",
+                        "nise": "^1.1.1",
+                        "path-to-regexp": "^1.7.0",
+                        "samsam": "^1.1.3",
+                        "text-encoding": "0.6.4",
+                        "type-detect": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "diff": {
+                            "version": "3.5.0",
+                            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+                        },
+                        "type-detect": {
+                            "version": "4.0.8",
+                            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+                            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+                        }
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+                    "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+                },
+                "sync-request": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+                    "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+                    "requires": {
+                        "http-response-object": "^3.0.1",
+                        "sync-rpc": "^1.2.1",
+                        "then-request": "^6.0.0"
+                    }
+                },
+                "sync-rpc": {
+                    "version": "1.3.6",
+                    "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+                    "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+                    "requires": {
+                        "get-port": "^3.1.0"
+                    }
+                },
+                "text-encoding": {
+                    "version": "0.6.4",
+                    "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+                    "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+                },
+                "then-request": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+                    "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+                    "requires": {
+                        "@types/concat-stream": "^1.6.0",
+                        "@types/form-data": "0.0.33",
+                        "@types/node": "^8.0.0",
+                        "@types/qs": "^6.2.31",
+                        "caseless": "~0.12.0",
+                        "concat-stream": "^1.6.0",
+                        "form-data": "^2.2.0",
+                        "http-basic": "^8.1.1",
+                        "http-response-object": "^3.0.1",
+                        "promise": "^8.0.0",
+                        "qs": "^6.4.0"
+                    },
+                    "dependencies": {
+                        "@types/node": {
+                            "version": "8.10.66",
+                            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+                            "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+                        }
+                    }
+                },
+                "tunnel": {
+                    "version": "0.0.4",
+                    "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+                    "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+                },
+                "type-detect": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+                    "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+                },
+                "typedarray": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                    "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+                },
+                "typescript": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+                    "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ=="
+                },
+                "uglify-js": {
+                    "version": "3.13.3",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
+                    "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
+                    "optional": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+                },
+                "wordwrap": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                    "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+                },
+                "xml2js": {
+                    "version": "0.4.19",
+                    "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+                    "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+                    "requires": {
+                        "sax": ">=0.6.0",
+                        "xmlbuilder": "~9.0.1"
+                    }
+                },
+                "xmlbuilder": {
+                    "version": "9.0.7",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+                    "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+                    "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
                 }
             }
         },
@@ -118,17 +3408,9 @@
             }
         },
         "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-        },
-        "async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "requires": {
-                "lodash": "^4.17.14"
-            }
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "asynckit": {
             "version": "0.4.0",
@@ -136,9 +3418,9 @@
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
             "version": "1.11.0",
@@ -146,55 +3428,14 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
         },
         "azp-tasks-az-blobstorage-provider-v2": {
-            "version": "2.0.0-preview.0",
-            "resolved": "https://registry.npmjs.org/azp-tasks-az-blobstorage-provider-v2/-/azp-tasks-az-blobstorage-provider-v2-2.0.0-preview.0.tgz",
-            "integrity": "sha512-t/Ua6fBoNfy3DkAIpgPeiqN8ReYomsyj8tRGgn60YLvzOQoa4FRpjZR62WpE+wLT+eQOmrvSXB3IA49CJaooOw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/azp-tasks-az-blobstorage-provider-v2/-/azp-tasks-az-blobstorage-provider-v2-2.0.3.tgz",
+            "integrity": "sha512-S7Haj3JhFdDPIf8dggFc8qjsueH9il8yTdvQufa57V4GWLF0rrw6Bcerskr80H9rvAsHjjMhsVg8sCNge3XzKw==",
             "requires": {
-                "artifact-engine": "0.1.29",
-                "azure-pipelines-task-lib": "3.0.6-preview.0",
-                "azure-storage": "2.2.1",
+                "artifact-engine": "1.0.0",
+                "azure-pipelines-task-lib": "^3.1.0",
+                "azure-storage": "^2.10.3",
                 "q": "1.4.1"
-            },
-            "dependencies": {
-                "azure-pipelines-task-lib": {
-                    "version": "3.0.6-preview.0",
-                    "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.0.tgz",
-                    "integrity": "sha512-Fx+7p5GzvYqVXOQI+LhPk56Pio9yBeEyypKZoPI9cQyti8WTVkmJ7YZwn9HRXurftcLumi2Xq+TC3PwnDq5U5Q==",
-                    "requires": {
-                        "minimatch": "3.0.4",
-                        "mockery": "^1.7.0",
-                        "q": "^1.5.1",
-                        "semver": "^5.1.0",
-                        "shelljs": "^0.8.4",
-                        "sync-request": "6.1.0",
-                        "uuid": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "q": {
-                            "version": "1.5.1",
-                            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-                            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-                        }
-                    }
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "shelljs": {
-                    "version": "0.8.4",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-                    "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-                    "requires": {
-                        "glob": "^7.0.0",
-                        "interpret": "^1.0.0",
-                        "rechoir": "^0.6.2"
-                    }
-                }
             }
         },
         "azure-pipelines-task-lib": {
@@ -316,21 +3557,21 @@
             }
         },
         "azure-storage": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.2.1.tgz",
-            "integrity": "sha1-26BUs1dco9+vw9Q3qr/I6ELmmDE=",
+            "version": "2.10.4",
+            "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.4.tgz",
+            "integrity": "sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==",
             "requires": {
                 "browserify-mime": "~1.2.9",
-                "extend": "~1.2.1",
+                "extend": "^3.0.2",
                 "json-edm-parser": "0.1.2",
                 "md5.js": "1.3.4",
                 "readable-stream": "~2.0.0",
-                "request": "~2.74.0",
-                "underscore": "~1.8.3",
+                "request": "^2.86.0",
+                "underscore": "^1.12.1",
                 "uuid": "^3.0.0",
-                "validator": "~3.35.0",
-                "xml2js": "0.2.7",
-                "xmlbuilder": "0.4.3"
+                "validator": "~9.4.1",
+                "xml2js": "0.2.8",
+                "xmlbuilder": "^9.0.7"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -355,6 +3596,11 @@
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                },
+                "underscore": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+                    "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
                 }
             }
         },
@@ -369,47 +3615,6 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "requires": {
                 "tweetnacl": "^0.14.3"
-            }
-        },
-        "bl": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-            "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
-            "requires": {
-                "readable-stream": "~2.0.5"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                }
-            }
-        },
-        "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "requires": {
-                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -441,18 +3646,6 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
-        "chalk": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-            "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-            }
-        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -460,11 +3653,6 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
-        },
-        "commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -487,27 +3675,12 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
-        "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "requires": {
-                "boom": "2.x.x"
-            }
-        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
                 "assert-plus": "^1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "delayed-stream": {
@@ -532,25 +3705,30 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         },
         "extend": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-            "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -577,22 +3755,6 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
-        "generate-function": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-            "requires": {
-                "is-property": "^1.0.2"
-            }
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "requires": {
-                "is-property": "^1.0.0"
-            }
-        },
         "get-port": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -604,13 +3766,6 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
                 "assert-plus": "^1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "glob": {
@@ -636,26 +3791,18 @@
                 }
             }
         },
-        "handlebars": {
-            "version": "4.0.14",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
-            "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
-            "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            }
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "requires": {
-                "chalk": "^1.1.1",
-                "commander": "^2.9.0",
-                "is-my-json-valid": "^2.12.4",
-                "pinkie-promise": "^2.0.0"
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
             }
         },
         "has": {
@@ -664,14 +3811,6 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
                 "function-bind": "^1.1.1"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "requires": {
-                "ansi-regex": "^2.0.0"
             }
         },
         "hash-base": {
@@ -701,17 +3840,6 @@
                 }
             }
         },
-        "hawk": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
-            }
-        },
         "hoek": {
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -737,11 +3865,11 @@
             }
         },
         "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "requires": {
-                "assert-plus": "^0.2.0",
+                "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
             }
@@ -772,28 +3900,6 @@
             "requires": {
                 "has": "^1.0.3"
             }
-        },
-        "is-my-ip-valid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-        },
-        "is-my-json-valid": {
-            "version": "2.20.5",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
-            "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
-            "requires": {
-                "generate-function": "^2.0.0",
-                "generate-object-property": "^1.1.0",
-                "is-my-ip-valid": "^1.0.0",
-                "jsonpointer": "^4.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
         },
         "is-typedarray": {
             "version": "1.0.0",
@@ -853,6 +3959,11 @@
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -862,11 +3973,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
             "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
-        },
-        "jsonpointer": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-            "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg=="
         },
         "jsonwebtoken": {
             "version": "7.3.0",
@@ -889,13 +3995,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "jwa": {
@@ -916,11 +4015,6 @@
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
             }
-        },
-        "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "lodash.once": {
             "version": "4.1.1",
@@ -949,19 +4043,6 @@
                 "mime-db": "1.44.0"
             }
         },
-        "minimatch": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-            "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-            "requires": {
-                "brace-expansion": "^1.0.0"
-            }
-        },
-        "minimist": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
         "mockery": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
@@ -978,9 +4059,9 @@
             "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "once": {
             "version": "1.4.0",
@@ -988,15 +4069,6 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1"
-            }
-        },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
             }
         },
         "parse-cache-control": {
@@ -1014,18 +4086,10 @@
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "requires": {
-                "pinkie": "^2.0.0"
-            }
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "process-nextick-args": {
             "version": "2.0.1",
@@ -1040,10 +4104,15 @@
                 "asap": "~2.0.6"
             }
         },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+        },
         "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q": {
             "version": "1.4.1",
@@ -1078,62 +4147,46 @@
             }
         },
         "request": {
-            "version": "2.74.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-            "integrity": "sha1-dpPKdou7DqXIzgjAhKRe+gW4kqs=",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "bl": "~1.1.2",
-                "caseless": "~0.11.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~1.0.0-rc4",
-                "har-validator": "~2.0.6",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "node-uuid": "~1.4.7",
-                "oauth-sign": "~0.8.1",
-                "qs": "~6.2.0",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "~0.4.1"
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
-                "caseless": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-                },
-                "extend": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-                    "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-                },
                 "form-data": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
-                    "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
                     "requires": {
-                        "async": "^2.0.1",
-                        "combined-stream": "^1.0.5",
-                        "mime-types": "^2.1.11"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
-                "node-uuid": {
-                    "version": "1.4.8",
-                    "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-                    "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-                },
                 "qs": {
-                    "version": "6.2.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-                    "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
                 }
             }
         },
@@ -1157,9 +4210,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.2.tgz",
-            "integrity": "sha1-c1/6o5oc/4/7lZjwIjq9sDqfsuo="
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+            "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
         },
         "semver": {
             "version": "5.7.1",
@@ -1170,24 +4223,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
             "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
-        },
-        "shelljs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-        },
-        "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "requires": {
-                "hoek": "2.x.x"
-            }
-        },
-        "source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -1208,13 +4243,6 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
         },
         "string_decoder": {
@@ -1224,24 +4252,6 @@
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
-        },
-        "stringstream": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
-        },
-        "strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "requires": {
-                "ansi-regex": "^2.0.0"
-            }
-        },
-        "supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "sync-request": {
             "version": "6.1.0",
@@ -1295,11 +4305,12 @@
             }
         },
         "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "punycode": "^1.4.1"
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tunnel": {
@@ -1308,9 +4319,12 @@
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
         },
         "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -1337,16 +4351,18 @@
             "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
             "dev": true
         },
-        "uglify-js": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.0.tgz",
-            "integrity": "sha512-8lBMSkFZuAK7gGF8LswsXmir8eX8d2AAMOnxSDWjKBx/fBR6MypQjs78m6ML9zQVp1/hD4TBdfeMZMC7nW1TAA==",
-            "optional": true
-        },
         "underscore": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
             "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -1359,9 +4375,9 @@
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         },
         "validator": {
-            "version": "3.35.0",
-            "resolved": "https://registry.npmjs.org/validator/-/validator-3.35.0.tgz",
-            "integrity": "sha1-PwcklALB/I/Ak8MsbkPXKnnModw="
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+            "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
         },
         "verror": {
             "version": "1.10.0",
@@ -1371,19 +4387,7 @@
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-                }
             }
-        },
-        "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrappy": {
             "version": "1.0.2",
@@ -1391,17 +4395,17 @@
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "xml2js": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.7.tgz",
-            "integrity": "sha1-GDhRi7AXQcrgh4urSRXklMMjBq8=",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
+            "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
             "requires": {
-                "sax": "0.5.2"
+                "sax": "0.5.x"
             }
         },
         "xmlbuilder": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
-            "integrity": "sha1-xGFLp04K0ZbmCcknLNnh3bKKilg="
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xtend": {
             "version": "4.0.2",

--- a/Tasks/JavaToolInstallerV0/package.json
+++ b/Tasks/JavaToolInstallerV0/package.json
@@ -26,7 +26,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "@types/q": "^1.0.7",
-        "azp-tasks-az-blobstorage-provider-v2": "2.0.0-preview.0",
+        "azp-tasks-az-blobstorage-provider-v2": "2.0.3",
         "azure-pipelines-task-lib": "^3.1.0",
         "azure-pipelines-tasks-azure-arm-rest-v2": "2.0.0-preview.0",
         "azure-pipelines-tool-lib": "^1.0.1",

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 188,
-        "Patch": 0
+        "Patch": 1
     },
     "satisfies": [
         "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 188,
-    "Patch": 0
+    "Patch": 1
   },
   "satisfies": [
     "Java",

--- a/common-npm-packages/az-blobstorage-provider-v2/package-lock.json
+++ b/common-npm-packages/az-blobstorage-provider-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azp-tasks-az-blobstorage-provider-v2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -42,26 +42,117 @@
       }
     },
     "artifact-engine": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-0.1.29.tgz",
-      "integrity": "sha512-Pg7Gyqfy2cu/Ctam4mdA9GczVQOBTFCqCqdUKoaq9XyA2c1zWmkKYTfa4LxbudGryjmePYern1O6OnnZHZkpew==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/artifact-engine/-/artifact-engine-1.0.0.tgz",
+      "integrity": "sha512-MerSYnKYOn7dzT4cEShfDmDPQYAHqrNNEcPlaodg0QKUGElH9d/DLXwYqKZqoB6fqXkOpXpGRGxmQ77DtvkKHA==",
       "requires": {
-        "azure-pipelines-task-lib": "2.8.0",
-        "handlebars": "4.0.14",
+        "azure-pipelines-task-lib": "^3.1.0",
+        "handlebars": "4.7.7",
         "minimatch": "3.0.2",
         "tunnel": "0.0.4"
       },
       "dependencies": {
+        "@sinonjs/formatio": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+          "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+          "requires": {
+            "samsam": "1.3.0"
+          }
+        },
+        "@types/concat-stream": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+          "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/form-data": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+          "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "@types/minimatch": {
+          "version": "2.0.29",
+          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz",
+          "integrity": "sha1-UALhT3Xi1x5WQoHfBDHIwbSio2o="
+        },
+        "@types/mocha": {
+          "version": "5.2.7",
+          "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+          "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
+        },
+        "@types/mockery": {
+          "version": "1.4.29",
+          "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
+          "integrity": "sha1-m6It838H43gP/4Ux0aOOYz+UV6U="
+        },
+        "@types/node": {
+          "version": "10.17.51",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
+          "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
+        },
+        "@types/qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA=="
+        },
+        "@types/xml2js": {
+          "version": "0.4.8",
+          "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+          "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "asap": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "assert": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+          "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "assertion-error": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+          "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+        },
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
         "azure-pipelines-task-lib": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.8.0.tgz",
-          "integrity": "sha512-PR8oap9z2j+o455W3PwAfB4SX1p4GdJc9OHQaQV0V+iQS1IBY6dVgcNSQMkHAXb0V1bbuLOFBLanXPe5eSgGTQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.0.tgz",
+          "integrity": "sha512-9L+uG3dxwr/orjFy8tWa2fti+2weiRAdsKVtXINfIpLKFSAHS9tKOpupS53CgBJzQxFf5HfZwNeiUTv+/dBPpA==",
           "requires": {
             "minimatch": "3.0.4",
             "mockery": "^1.7.0",
-            "q": "^1.1.2",
+            "q": "^1.5.1",
             "semver": "^5.1.0",
-            "shelljs": "^0.3.0",
+            "shelljs": "^0.8.4",
+            "sync-request": "6.1.0",
             "uuid": "^3.0.1"
           },
           "dependencies": {
@@ -72,8 +163,3206 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
+            },
+            "mockery": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+              "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
             }
           }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "combined-stream": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+          "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            }
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "debug": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "integrity": "sha1-ib2d9nMrUSVrxnBTQrugLtEhMe8=",
+          "requires": {
+            "ms": "0.6.2"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE="
+        },
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "formatio": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+          "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+          "requires": {
+            "samsam": "1.x"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-port": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+          "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+          "requires": {
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+              "requires": {
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+          "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
+        },
+        "growl": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg="
+        },
+        "handlebars": {
+          "version": "4.7.7",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+          "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+          "requires": {
+            "minimist": "^1.2.5",
+            "neo-async": "^2.6.0",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4",
+            "wordwrap": "^1.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "http-basic": {
+          "version": "8.1.3",
+          "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+          "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+          "requires": {
+            "caseless": "^0.12.0",
+            "concat-stream": "^1.6.2",
+            "http-response-object": "^3.0.1",
+            "parse-cache-control": "^1.0.1"
+          }
+        },
+        "http-response-object": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+          "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+          "requires": {
+            "@types/node": "^10.0.3"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+        },
+        "is-core-module": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+          "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "jade": {
+          "version": "0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+          "requires": {
+            "commander": "0.6.1",
+            "mkdirp": "0.3.0"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4="
+            }
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "just-extend": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "lolex": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
+          "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg=="
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        },
+        "mime-db": {
+          "version": "1.46.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+          "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+        },
+        "mime-types": {
+          "version": "2.1.29",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+          "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
+          "requires": {
+            "mime-db": "1.46.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+          "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "mocha": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.3.3.tgz",
+          "integrity": "sha1-lkiMSb/XHYalGMuUHikag/SNiFY=",
+          "requires": {
+            "commander": "2.3.0",
+            "debug": "2.0.0",
+            "diff": "1.4.0",
+            "escape-string-regexp": "1.0.2",
+            "glob": "3.2.3",
+            "growl": "1.8.1",
+            "jade": "0.26.3",
+            "mkdirp": "0.5.0",
+            "supports-color": "1.2.0"
+          }
+        },
+        "mocha-tap-reporter": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/mocha-tap-reporter/-/mocha-tap-reporter-0.1.3.tgz",
+          "integrity": "sha1-Emy70vggZJXnKxWZFNOXuOoXoig=",
+          "requires": {
+            "mocha": "*"
+          }
+        },
+        "mockery": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+          "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+        },
+        "ms": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+          "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw="
+        },
+        "native-promise-only": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+          "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
+        },
+        "nconf": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
+          "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+          "requires": {
+            "async": "^1.4.0",
+            "ini": "^1.3.0",
+            "secure-keys": "^1.0.0",
+            "yargs": "^3.19.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+              "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "window-size": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+              "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+            },
+            "yargs": {
+              "version": "3.32.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+              "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+              "requires": {
+                "camelcase": "^2.0.1",
+                "cliui": "^3.0.3",
+                "decamelize": "^1.1.1",
+                "os-locale": "^1.4.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.1.4",
+                "y18n": "^3.2.0"
+              }
+            }
+          }
+        },
+        "neo-async": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+          "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+        },
+        "nise": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.1.tgz",
+          "integrity": "sha512-9JX3YwoIt3kS237scmSSOpEv7vCukVzLfwK0I0XhocDSHUANid8ZHnLEULbbSkfeMn98B2y5kphIWzZUylESRQ==",
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "just-extend": "^1.1.27",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          }
+        },
+        "nock": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.0.tgz",
+          "integrity": "sha512-u9QOLOZP0DlcKzmAzCuX5PRsIhbiRJupR7hJn1cCCT7VW3ZKUrEH/oxGEtVA8Xbu4EmzH9d/VK0x/3FxCGRrRg==",
+          "requires": {
+            "chai": ">=1.9.2 <4.0.0",
+            "debug": "^2.2.0",
+            "deep-equal": "^1.0.0",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "~4.17.2",
+            "mkdirp": "^0.5.0",
+            "propagate": "0.4.0",
+            "qs": "^6.0.2",
+            "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nyc": {
+          "version": "11.9.0",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.9.0.tgz",
+          "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
+          "requires": {
+            "archy": "^1.0.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.5.1",
+            "debug-log": "^1.0.1",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^2.1.0",
+            "foreground-child": "^1.5.3",
+            "glob": "^7.0.6",
+            "istanbul-lib-coverage": "^1.1.2",
+            "istanbul-lib-hook": "^1.1.0",
+            "istanbul-lib-instrument": "^1.10.0",
+            "istanbul-lib-report": "^1.1.3",
+            "istanbul-lib-source-maps": "^1.2.3",
+            "istanbul-reports": "^1.4.0",
+            "md5-hex": "^1.2.0",
+            "merge-source-map": "^1.1.0",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.1",
+            "spawn-wrap": "^1.4.2",
+            "test-exclude": "^4.2.0",
+            "yargs": "11.1.0",
+            "yargs-parser": "^8.0.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "^1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "atob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.1",
+              "bundled": true,
+              "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+              }
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "2.5.6",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "repeating": "^2.0.0"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "^4.0.1",
+                    "shebang-command": "^1.2.0",
+                    "which": "^1.2.9"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+              }
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "map-cache": "^0.2.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": ">=0.0.4"
+                  }
+                }
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.6.0",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "^1.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-odd": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "^0.4.0"
+              }
+            },
+            "istanbul-lib-instrument": {
+              "version": "1.10.1",
+              "bundled": true,
+              "requires": {
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "semver": "^5.3.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.3",
+              "bundled": true,
+              "requires": {
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "handlebars": "^4.0.3"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "^1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "bundled": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.3",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "object-visit": "^1.0.0"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "source-map": "^0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "bundled": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "nanomatch": {
+              "version": "1.2.9",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "bundled": true
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-finite": "^1.0.0"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ret": "~0.1.10"
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.0"
+              }
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "test-exclude": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "^1.0.1",
+                "micromatch": "^3.1.8",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true
+                },
+                "braces": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "arr-flatten": "^1.1.0",
+                    "array-unique": "^0.3.2",
+                    "extend-shallow": "^2.0.1",
+                    "fill-range": "^4.0.0",
+                    "isobject": "^3.0.1",
+                    "repeat-element": "^1.1.2",
+                    "snapdragon": "^0.8.1",
+                    "snapdragon-node": "^2.0.1",
+                    "split-string": "^3.0.2",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "^2.3.3",
+                    "define-property": "^0.2.5",
+                    "extend-shallow": "^2.0.1",
+                    "posix-character-classes": "^0.1.0",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "0.2.5",
+                      "bundled": true,
+                      "requires": {
+                        "is-descriptor": "^0.1.0"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    },
+                    "is-accessor-descriptor": {
+                      "version": "0.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "^3.0.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "^1.1.5"
+                          }
+                        }
+                      }
+                    },
+                    "is-data-descriptor": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "^3.0.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "^1.1.5"
+                          }
+                        }
+                      }
+                    },
+                    "is-descriptor": {
+                      "version": "0.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
+                      }
+                    },
+                    "kind-of": {
+                      "version": "5.1.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "2.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "array-unique": "^0.3.2",
+                    "define-property": "^1.0.0",
+                    "expand-brackets": "^2.1.4",
+                    "extend-shallow": "^2.0.1",
+                    "fragment-cache": "^0.2.1",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-descriptor": "^1.0.0"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "fill-range": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-number": "^3.0.0",
+                    "repeat-string": "^1.6.1",
+                    "to-regex-range": "^2.1.0"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                },
+                "micromatch": {
+                  "version": "3.1.10",
+                  "bundled": true,
+                  "requires": {
+                    "arr-diff": "^4.0.0",
+                    "array-unique": "^0.3.2",
+                    "braces": "^2.3.1",
+                    "define-property": "^2.0.2",
+                    "extend-shallow": "^3.0.2",
+                    "extglob": "^2.0.4",
+                    "fragment-cache": "^0.2.1",
+                    "kind-of": "^6.0.2",
+                    "nanomatch": "^1.2.9",
+                    "object.pick": "^1.3.0",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.2"
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  }
+                }
+              }
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "set-value": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-extendable": "^0.1.1",
+                    "is-plain-object": "^2.0.1",
+                    "to-object-path": "^0.3.0"
+                  }
+                }
+              }
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "has-value": {
+                  "version": "0.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "get-value": "^2.0.3",
+                    "has-values": "^0.1.4",
+                    "isobject": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "isobject": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "has-values": {
+                  "version": "0.1.4",
+                  "bundled": true
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "use": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.1.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  }
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "parse-cache-control": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+          "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "promise": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+          "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        },
+        "propagate": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-0.4.0.tgz",
+          "integrity": "sha1-8/zKCm/gZzanulcpZgaWF8EwtIE="
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+              "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+            }
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+          "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+          "requires": {
+            "resolve": "^1.1.6"
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "samsam": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+          "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+        },
+        "sax": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+        },
+        "secure-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
+          "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        },
+        "shelljs": {
+          "version": "0.8.4",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+          "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.6",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+              "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "sigmund": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+          "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+        },
+        "sinon": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
+          "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+          "requires": {
+            "diff": "^3.1.0",
+            "formatio": "1.2.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.1.3",
+            "native-promise-only": "^0.8.1",
+            "nise": "^1.1.1",
+            "path-to-regexp": "^1.7.0",
+            "samsam": "^1.1.3",
+            "text-encoding": "0.6.4",
+            "type-detect": "^4.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            },
+            "type-detect": {
+              "version": "4.0.8",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+              "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4="
+        },
+        "sync-request": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+          "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+          "requires": {
+            "http-response-object": "^3.0.1",
+            "sync-rpc": "^1.2.1",
+            "then-request": "^6.0.0"
+          }
+        },
+        "sync-rpc": {
+          "version": "1.3.6",
+          "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+          "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
+          "requires": {
+            "get-port": "^3.1.0"
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+          "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+        },
+        "then-request": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+          "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+          "requires": {
+            "@types/concat-stream": "^1.6.0",
+            "@types/form-data": "0.0.33",
+            "@types/node": "^8.0.0",
+            "@types/qs": "^6.2.31",
+            "caseless": "~0.12.0",
+            "concat-stream": "^1.6.0",
+            "form-data": "^2.2.0",
+            "http-basic": "^8.1.1",
+            "http-response-object": "^3.0.1",
+            "promise": "^8.0.0",
+            "qs": "^6.4.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.10.66",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+              "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+            }
+          }
+        },
+        "tunnel": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+          "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "typescript": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+          "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ=="
+        },
+        "uglify-js": {
+          "version": "3.13.3",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
+          "integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
+          "optional": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         }
       }
     },
@@ -94,14 +3383,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -219,12 +3500,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -382,17 +3657,6 @@
             "brace-expansion": "^1.1.7"
           }
         }
-      }
-    },
-    "handlebars": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
-      "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
-      "requires": {
-        "async": "^2.5.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
       }
     },
     "har-schema": {
@@ -561,11 +3825,6 @@
         "verror": "1.10.0"
       }
     },
-    "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -588,19 +3847,6 @@
         "mime-db": "1.40.0"
       }
     },
-    "minimatch": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-      "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
-      "requires": {
-        "brace-expansion": "^1.0.0"
-      }
-    },
-    "minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-    },
     "mockery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
@@ -617,15 +3863,6 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
       }
     },
     "parse-cache-control": {
@@ -765,16 +4002,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
-    "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
-    },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -871,11 +4098,6 @@
         "punycode": "^2.1.1"
       }
     },
-    "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
-    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -899,16 +4121,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
       "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.0",
-        "source-map": "~0.6.1"
-      }
     },
     "underscore": {
       "version": "1.8.3",
@@ -947,11 +4159,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/common-npm-packages/az-blobstorage-provider-v2/package.json
+++ b/common-npm-packages/az-blobstorage-provider-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azp-tasks-az-blobstorage-provider-v2",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Common Library to download blobs from azure storage",
   "repository": {
     "type": "git",
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "q": "1.4.1",
-    "artifact-engine": "0.1.29",
+    "artifact-engine": "1.0.0",
     "azure-storage": "^2.10.3",
     "azure-pipelines-task-lib": "^3.1.0"
   },


### PR DESCRIPTION
**Task name**: AzureIoTEdgeV2

**Description**: 
- Update pinned version of Azure IoT CLI extension to 0.10.11 since 0.10.10 is broken from newest Azure CLI update 2.24.0
- Removed temporary setuptools solution for Azure CLI, fix no longer needed

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 
- https://github.com/Azure/azure-iot-cli-extension/issues/357

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
