### PR TITLE
Encode only when decode is true

### DIFF
--- a/Tasks/AzureKeyVaultV2/Tests/L0.ts
+++ b/Tasks/AzureKeyVaultV2/Tests/L0.ts
@@ -67,7 +67,7 @@ describe('Azure Key Vault', function () {
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret2;issecret=true;]secret2-value") > 0, "##vso[task.setvariable variable=secret2;issecret=true;]secret2-value");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret3;issecret=true;]secret3/versionIdentifierGuid-value") > 0, "##vso[task.setvariable variable=secret3;issecret=true;]secret3/versionIdentifierGuid-value");
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret3/versionIdentifierGuid;issecret=true;]secret3/versionIdentifierGuid-value") > 0, "##vso[task.setvariable variable=secret3/versionIdentifierGuid;issecret=true;]secret3/versionIdentifierGuid-value");
-            assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret5_%AZP253B;issecret=true;]secret5_%AZP253B-value") > 0, "##vso[task.setvariable variable=secret5_%AZP253B;issecret=true;]secret5_%AZP253B-value");
+            assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret5_%3B;issecret=true;]secret5_%3B-value") > 0, "##vso[task.setvariable variable=secret5_%3B;issecret=true;]secret5_%3B-value");
 
             assert(tr.stdout.indexOf("##vso[task.setvariable variable=secret4;issecret=true;]secret4-value") < 0, "secret4 value should not be set");
 

--- a/Tasks/AzureKeyVaultV2/Tests/downloadSelectedSecrets.ts
+++ b/Tasks/AzureKeyVaultV2/Tests/downloadSelectedSecrets.ts
@@ -24,6 +24,7 @@ process.env["ENDPOINT_DATA_AzureRMSpn_AzureKeyVaultServiceEndpointResourceId"] =
 process.env["ENDPOINT_URL_AzureRMSpn"] = "https://management.azure.com/";
 process.env["SYSTEM_DEFAULTWORKINGDIRECTORY"] =  "C:\\a\\w\\";
 process.env["AGENT_TEMPDIRECTORY"] = process.cwd();
+process.env["DECODE_PERCENTS"] = "false";
 
 tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
 tr.registerMock('./azure-arm-keyvault', require('./mock_node_modules/azure-arm-keyvault'));

--- a/Tasks/AzureKeyVaultV2/operations/KeyVault.ts
+++ b/Tasks/AzureKeyVaultV2/operations/KeyVault.ts
@@ -6,6 +6,8 @@ import tl = require("azure-pipelines-task-lib/task");
 import * as path from 'path';
 import * as fs from 'fs';
 
+const DECODE_PERCENTS = "DECODE_PERCENTS";
+
 export class SecretsToErrorsMapping { 
     public errorsMap: { [key: string]: string; };
 
@@ -193,8 +195,11 @@ export class KeyVault {
         }
 
         // Encode percent explicitely as the task lib does not encode % to %AZP25 as of now.
-        secretName = secretName.replace(/%/g, '%AZP25');
-        secretValue = secretValue.replace(/%/g, '%AZP25');
+        let decodePercents = tl.getVariable(DECODE_PERCENTS);
+        if (decodePercents && decodePercents.toUpperCase() === "TRUE") {
+            secretName = secretName.replace(/%/g, '%AZP25');
+            secretValue = secretValue.replace(/%/g, '%AZP25');
+        }
 
         // Support multiple stages using different key vaults with the same secret name but with different version identifiers
         let secretNameWithoutVersion = secretName.split("/")[0];

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 186,
+        "Minor": 189,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/AzureKeyVaultV2/task.loc.json
+++ b/Tasks/AzureKeyVaultV2/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 186,
+    "Minor": 189,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: AzureKeyVaultV2

**Description**: Task was encoding variables even when decode variable was set as false.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) #14942

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
