### PR TITLE
[CopyFilesV2] Added retries to whole task logic. Refactored task code

### DIFF
--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -141,7 +141,7 @@ describe('CopyFiles L0 Suite', function () {
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue('Unhandled: Input required: SourceFolder'), 'should have created error issue');
+        assert(runner.createdErrorIssue('Error: Input required: SourceFolder'), 'should have created error issue');
         done();
     });
 
@@ -153,7 +153,7 @@ describe('CopyFiles L0 Suite', function () {
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue('Unhandled: Input required: TargetFolder'), 'should have created error issue');
+        assert(runner.createdErrorIssue('Error: Input required: TargetFolder'), 'should have created error issue');
         done();
     });
 
@@ -165,9 +165,25 @@ describe('CopyFiles L0 Suite', function () {
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue(`Unhandled: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
+        assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
         done();
     });
+
+    it('retries and fails if SourceFolder not found, but retryCount is specified', (done: Mocha.Done) => {
+        this.timeout(1000);
+
+        let testPath = path.join(__dirname, 'L0retriesIfSourceFolderNotFoundButRetrySpecified.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        runner.run();
+
+        assert(runner.failed, 'should have failed');
+        assert(runner.stdOutContained(`Error while task execution: Error: Not found ${path.normalize('/srcDir')}. Remaining attempts: 3`));
+        assert(runner.stdOutContained(`Error while task execution: Error: Not found ${path.normalize('/srcDir')}. Remaining attempts: 2`));
+        assert(runner.stdOutContained(`Error while task execution: Error: Not found ${path.normalize('/srcDir')}. Remaining attempts: 1`));
+        assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
+        done();
+    });
+
 
     it('fails if target file is a directory', (done: Mocha.Done) => {
         this.timeout(1000);

--- a/Tasks/CopyFilesV2/Tests/L0retriesIfSourceFolderNotFoundButRetrySpecified.ts
+++ b/Tasks/CopyFilesV2/Tests/L0retriesIfSourceFolderNotFoundButRetrySpecified.ts
@@ -1,0 +1,25 @@
+import fs = require('fs');
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'copyfiles.js');
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+runner.setInput('Contents', '**');
+runner.setInput('SourceFolder', path.normalize('/srcDir'));
+runner.setInput('TargetFolder', path.normalize('/targetDir'));
+runner.setInput('CleanTargetFolder', 'false');
+runner.setInput('Overwrite', 'false');
+runner.setInput('retryCount', '3');
+
+let answers = <mockanswer.TaskLibAnswers> {
+    checkPath: { },
+};
+answers.checkPath[path.normalize('/srcDir')] = false;
+runner.setAnswers(answers);
+
+// as a precaution, disable fs.chmodSync. it should not be called during this scenario.
+fs.chmodSync = null;
+runner.registerMock('fs', fs);
+
+runner.run();

--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -4,18 +4,15 @@ import tl = require('azure-pipelines-task-lib/task');
 
 /**
  * Input task data - including some processed inputs
+ * This data is consistent between retries
  */
 interface ITaskInputData {
     contents: string[];
-    sourceFolder: string;
-    targetFolder: string;
     cleanTargetFolder: boolean;
     overWrite: boolean;
     flattenFolders: boolean;
     preserveTimestamp: boolean;
     ignoreMakeDirErrors: boolean;
-    matchedPaths: string[];
-    matchedFiles: string[];
     retryCount: number;
 }
 
@@ -59,16 +56,24 @@ function makeDirP(targetFolder: string, ignoreErrors: boolean): void {
  */
 function main(inputsData: ITaskInputData) {
     const {
-        sourceFolder,
-        targetFolder,
+        contents,
         cleanTargetFolder,
         overWrite,
         flattenFolders,
         preserveTimestamp,
         ignoreMakeDirErrors,
-        matchedFiles,
         retryCount,
     } = inputsData;
+
+    let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
+
+    sourceFolder = path.normalize(sourceFolder);
+
+    const targetFolder: string = tl.getPathInput('TargetFolder', true);
+    let allPaths: string[] = tl.find(sourceFolder, findOptions);
+    let sourceFolderPattern = sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
+    const matchedPaths: string[] = tl.match(allPaths, contents, sourceFolderPattern); // default match options
+    const matchedFiles: string[] = matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
 
     // copy the files to the target folder
     console.log(tl.loc('FoundNFiles', matchedFiles.length));
@@ -107,95 +112,57 @@ function main(inputsData: ITaskInputData) {
 
         // make sure the target folder exists
         makeDirP(targetFolder, ignoreMakeDirErrors);
+        let createdFolders: { [folder: string]: boolean } = {};
+        matchedFiles.forEach((file: string) => {
+            let relativePath;
+            if (flattenFolders) {
+                relativePath = path.basename(file);
+            } else {
+                relativePath = file.substring(sourceFolder.length);
 
-        try {
-            let createdFolders: { [folder: string]: boolean } = {};
-            matchedFiles.forEach((file: string) => {
-                let relativePath;
-                if (flattenFolders) {
-                    relativePath = path.basename(file);
-                } else {
-                    relativePath = file.substring(sourceFolder.length);
+                // trim leading path separator
+                // note, assumes normalized above
+                if (relativePath.startsWith(path.sep)) {
+                    relativePath = relativePath.substr(1);
+                }
+            }
 
-                    // trim leading path separator
-                    // note, assumes normalized above
-                    if (relativePath.startsWith(path.sep)) {
-                        relativePath = relativePath.substr(1);
+            let targetPath = path.join(targetFolder, relativePath);
+            let targetDir = path.dirname(targetPath);
+
+            if (!createdFolders[targetDir]) {
+                makeDirP(targetDir, ignoreMakeDirErrors);
+                createdFolders[targetDir] = true;
+            }
+
+            // stat the target
+            let targetStats: tl.FsStats;
+            if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
+                try {
+                    targetStats = tl.stats(targetPath);
+                }
+                catch (err) {
+                    if (err.code != 'ENOENT') {
+                        throw err;
                     }
                 }
+            }
 
-                let targetPath = path.join(targetFolder, relativePath);
-                let targetDir = path.dirname(targetPath);
+            // validate the target is not a directory
+            if (targetStats && targetStats.isDirectory()) {
+                throw new Error(tl.loc('TargetIsDir', file, targetPath));
+            }
 
-                if (!createdFolders[targetDir]) {
-                    makeDirP(targetDir, ignoreMakeDirErrors);
-                    createdFolders[targetDir] = true;
+            if (!overWrite) {
+                if (targetStats) { // exists, skip
+                    console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
                 }
-
-                // stat the target
-                let targetStats: tl.FsStats;
-                if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
-                    try {
-                        targetStats = tl.stats(targetPath);
-                    }
-                    catch (err) {
-                        if (err.code != 'ENOENT') {
-                            throw err;
-                        }
-                    }
-                }
-
-                // validate the target is not a directory
-                if (targetStats && targetStats.isDirectory()) {
-                    throw new Error(tl.loc('TargetIsDir', file, targetPath));
-                }
-
-                if (!overWrite) {
-                    if (targetStats) { // exists, skip
-                        console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
-                    }
-                    else { // copy
-                        console.log(tl.loc('CopyingTo', file, targetPath));
-                        tl.cp(file, targetPath, undefined, undefined, retryCount);
-                        if (preserveTimestamp) {
-                            try {
-                                const fileStats = tl.stats(file);
-                                fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
-                                    displayTimestampChangeResults(fileStats, err);
-                                });
-                            }
-                            catch (err) {
-                                console.warn(`Problem preserving the timestamp: ${err}`)
-                            }
-                        }
-                    }
-                }
-                else {
+                else { // copy
                     console.log(tl.loc('CopyingTo', file, targetPath));
-                    if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
-                        // The readonly attribute can be interpreted by performing a bitwise-AND operation on
-                        // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
-                        // see following chart:
-                        //     R   W  X  R  W X R W X
-                        //   256 128 64 32 16 8 4 2 1
-                        //
-                        // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
-                        // If the readonly attribute is set, then the mode is set to "r--r--r--".
-                        // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
-                        //
-                        // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
-                        // comparison is appropriate.
-                        //
-                        // For additional information, refer to the fs source code and ctrl+f "st_mode":
-                        //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
-                        tl.debug(`removing readonly attribute on '${targetPath}'`);
-                        fs.chmodSync(targetPath, targetStats.mode | 146);
-                    }
-
-                    tl.cp(file, targetPath, "-f", undefined, retryCount);
+                    tl.cp(file, targetPath, undefined, undefined, retryCount);
                     if (preserveTimestamp) {
                         try {
-                            const fileStats: tl.FsStats = tl.stats(file);
+                            const fileStats = tl.stats(file);
                             fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
                                 displayTimestampChangeResults(fileStats, err);
                             });
@@ -205,11 +172,43 @@ function main(inputsData: ITaskInputData) {
                         }
                     }
                 }
-            });
-        }
-        catch (err) {
-            tl.setResult(tl.TaskResult.Failed, err);
-        }
+            }
+            else {
+                console.log(tl.loc('CopyingTo', file, targetPath));
+                if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
+                    // The readonly attribute can be interpreted by performing a bitwise-AND operation on
+                    // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
+                    // see following chart:
+                    //     R   W  X  R  W X R W X
+                    //   256 128 64 32 16 8 4 2 1
+                    //
+                    // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
+                    // If the readonly attribute is set, then the mode is set to "r--r--r--".
+                    // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
+                    //
+                    // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
+                    // comparison is appropriate.
+                    //
+                    // For additional information, refer to the fs source code and ctrl+f "st_mode":
+                    //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
+                    tl.debug(`removing readonly attribute on '${targetPath}'`);
+                    fs.chmodSync(targetPath, targetStats.mode | 146);
+                }
+
+                tl.cp(file, targetPath, "-f", undefined, retryCount);
+                if (preserveTimestamp) {
+                    try {
+                        const fileStats: tl.FsStats = tl.stats(file);
+                        fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
+                            displayTimestampChangeResults(fileStats, err);
+                        });
+                    }
+                    catch (err) {
+                        console.warn(`Problem preserving the timestamp: ${err}`)
+                    }
+                }
+            }
+        });
     }
 }
 /**
@@ -225,8 +224,10 @@ function runWithRetries(taskInputData: ITaskInputData) {
             let errorMessage = `Error while task execution: ${e}.`;
             if (taskInputData.retryCount) {
                 errorMessage += `Remaining attempts: ${taskInputData.retryCount}`;
+                console.log(errorMessage);
+            } else {
+                tl.setResult(tl.TaskResult.Failed, e);
             }
-            console.log(errorMessage);
         }
 
         --taskInputData.retryCount;
@@ -236,27 +237,17 @@ function runWithRetries(taskInputData: ITaskInputData) {
 function readInputsData(): ITaskInputData {
     const taskInputsData: ITaskInputData = {
         contents: tl.getDelimitedInput('Contents', '\n', true),
-        sourceFolder: tl.getPathInput('SourceFolder', true, true),
-        targetFolder: tl.getPathInput('TargetFolder', true),
         cleanTargetFolder: tl.getBoolInput('CleanTargetFolder', false),
         overWrite: tl.getBoolInput('OverWrite', false),
         flattenFolders: tl.getBoolInput('flattenFolders', false),
         preserveTimestamp: tl.getBoolInput('preserveTimestamp', false),
         ignoreMakeDirErrors: tl.getBoolInput('ignoreMakeDirErrors', false),
         retryCount: parseInt(tl.getInput('retryCount')),
-        matchedPaths: [],
-        matchedFiles: []
     };
 
     if (isNaN(taskInputsData.retryCount) || taskInputsData.retryCount < 0) {
         taskInputsData.retryCount = 0;
     }
-
-    taskInputsData.sourceFolder = path.normalize(taskInputsData.sourceFolder);
-    let allPaths: string[] = tl.find(taskInputsData.sourceFolder, findOptions);
-    let sourceFolderPattern = taskInputsData.sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
-    taskInputsData.matchedPaths = tl.match(allPaths, taskInputsData.contents, sourceFolderPattern); // default match options
-    taskInputsData.matchedFiles = taskInputsData.matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
 
     return taskInputsData;
 }

--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -66,10 +66,10 @@ function main(inputsData: ITaskInputData) {
     } = inputsData;
 
     let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
+    const targetFolder: string = tl.getPathInput('TargetFolder', true);
 
     sourceFolder = path.normalize(sourceFolder);
 
-    const targetFolder: string = tl.getPathInput('TargetFolder', true);
     let allPaths: string[] = tl.find(sourceFolder, findOptions);
     let sourceFolderPattern = sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
     const matchedPaths: string[] = tl.match(allPaths, contents, sourceFolderPattern); // default match options
@@ -223,7 +223,7 @@ function runWithRetries(taskInputData: ITaskInputData) {
         } catch (e) {
             let errorMessage = `Error while task execution: ${e}.`;
             if (taskInputData.retryCount) {
-                errorMessage += `Remaining attempts: ${taskInputData.retryCount}`;
+                errorMessage += ` Remaining attempts: ${taskInputData.retryCount}`;
                 console.log(errorMessage);
             } else {
                 tl.setResult(tl.TaskResult.Failed, e);

--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -3,6 +3,23 @@ import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 
 /**
+ * Input task data - including some processed inputs
+ */
+interface ITaskInputData {
+    contents: string[];
+    sourceFolder: string;
+    targetFolder: string;
+    cleanTargetFolder: boolean;
+    overWrite: boolean;
+    flattenFolders: boolean;
+    preserveTimestamp: boolean;
+    ignoreMakeDirErrors: boolean;
+    matchedPaths: string[];
+    matchedFiles: string[];
+    retryCount: number;
+}
+
+/**
  * Shows timestamp change operation results
  * @param fileStats file stats
  * @param err error - null if there is no error
@@ -36,127 +53,149 @@ function makeDirP(targetFolder: string, ignoreErrors: boolean): void {
     }
 }
 
-// we allow broken symlinks - since there could be broken symlinks found in source folder, but filtered by contents pattern
-const findOptions: tl.FindOptions = {
-    allowBrokenSymbolicLinks: true,
-    followSpecifiedSymbolicLink: true,
-    followSymbolicLinks: true
-};
+/**
+ * Main Copy files task logic
+ * @param retryCount count of retries for copying operation
+ */
+function main(inputsData: ITaskInputData) {
+    const {
+        sourceFolder,
+        targetFolder,
+        cleanTargetFolder,
+        overWrite,
+        flattenFolders,
+        preserveTimestamp,
+        ignoreMakeDirErrors,
+        matchedFiles,
+        retryCount,
+    } = inputsData;
 
-tl.setResourcePath(path.join(__dirname, 'task.json'));
+    // copy the files to the target folder
+    console.log(tl.loc('FoundNFiles', matchedFiles.length));
 
-// contents is a multiline input containing glob patterns
-let contents: string[] = tl.getDelimitedInput('Contents', '\n', true);
-let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
-let targetFolder: string = tl.getPathInput('TargetFolder', true);
-let cleanTargetFolder: boolean = tl.getBoolInput('CleanTargetFolder', false);
-let overWrite: boolean = tl.getBoolInput('OverWrite', false);
-let flattenFolders: boolean = tl.getBoolInput('flattenFolders', false);
-let retryCount: number = parseInt(tl.getInput('retryCount'));
-if (isNaN(retryCount) || retryCount < 0) {
-    retryCount = 0;
-}
-const preserveTimestamp: boolean = tl.getBoolInput('preserveTimestamp', false);
-const ignoreMakeDirErrors: boolean = tl.getBoolInput('ignoreMakeDirErrors', false);
+    if (matchedFiles.length > 0) {
+        // clean target folder if required
+        if (cleanTargetFolder) {
+            console.log(tl.loc('CleaningTargetFolder', targetFolder));
 
-// normalize the source folder path. this is important for later in order to accurately
-// determine the relative path of each found file (substring using sourceFolder.length).
-sourceFolder = path.normalize(sourceFolder);
-let allPaths: string[] = tl.find(sourceFolder, findOptions);
-let sourceFolderPattern = sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
-let matchedPaths: string[] = tl.match(allPaths, contents, sourceFolderPattern); // default match options
-let matchedFiles: string[] = matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
+            // stat the targetFolder path
+            let targetFolderStats: tl.FsStats;
+            try {
+                targetFolderStats = tl.stats(targetFolder);
+            }
+            catch (err) {
+                if (err.code != 'ENOENT') {
+                    throw err;
+                }
+            }
 
-// copy the files to the target folder
-console.log(tl.loc('FoundNFiles', matchedFiles.length));
+            if (targetFolderStats) {
+                if (targetFolderStats.isDirectory()) {
+                    // delete the child items
+                    fs.readdirSync(targetFolder)
+                        .forEach((item: string) => {
+                            let itemPath = path.join(targetFolder, item);
+                            tl.rmRF(itemPath);
+                        });
+                }
+                else {
+                    // targetFolder is not a directory. delete it.
+                    tl.rmRF(targetFolder);
+                }
+            }
+        }
 
-if (matchedFiles.length > 0) {
-    // clean target folder if required
-    if (cleanTargetFolder) {
-        console.log(tl.loc('CleaningTargetFolder', targetFolder));
+        // make sure the target folder exists
+        makeDirP(targetFolder, ignoreMakeDirErrors);
 
-        // stat the targetFolder path
-        let targetFolderStats: tl.FsStats;
         try {
-            targetFolderStats = tl.stats(targetFolder);
-        }
-        catch (err) {
-            if (err.code != 'ENOENT') {
-                throw err;
-            }
-        }
+            let createdFolders: { [folder: string]: boolean } = {};
+            matchedFiles.forEach((file: string) => {
+                let relativePath;
+                if (flattenFolders) {
+                    relativePath = path.basename(file);
+                } else {
+                    relativePath = file.substring(sourceFolder.length);
 
-        if (targetFolderStats) {
-            if (targetFolderStats.isDirectory()) {
-                // delete the child items
-                fs.readdirSync(targetFolder)
-                    .forEach((item: string) => {
-                        let itemPath = path.join(targetFolder, item);
-                        tl.rmRF(itemPath);
-                    });
-            }
-            else {
-                // targetFolder is not a directory. delete it.
-                tl.rmRF(targetFolder);
-            }
-        }
-    }
-
-    // make sure the target folder exists
-    makeDirP(targetFolder, ignoreMakeDirErrors);
-
-    try {
-        let createdFolders: { [folder: string]: boolean } = {};
-        matchedFiles.forEach((file: string) => {
-            let relativePath;
-            if (flattenFolders) {
-                relativePath = path.basename(file);
-            } else {
-                relativePath = file.substring(sourceFolder.length);
-
-                // trim leading path separator
-                // note, assumes normalized above
-                if (relativePath.startsWith(path.sep)) {
-                    relativePath = relativePath.substr(1);
-                }
-            }
-
-            let targetPath = path.join(targetFolder, relativePath);
-            let targetDir = path.dirname(targetPath);
-
-            if (!createdFolders[targetDir]) {
-                makeDirP(targetDir, ignoreMakeDirErrors);
-                createdFolders[targetDir] = true;
-            }
-
-            // stat the target
-            let targetStats: tl.FsStats;
-            if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
-                try {
-                    targetStats = tl.stats(targetPath);
-                }
-                catch (err) {
-                    if (err.code != 'ENOENT') {
-                        throw err;
+                    // trim leading path separator
+                    // note, assumes normalized above
+                    if (relativePath.startsWith(path.sep)) {
+                        relativePath = relativePath.substr(1);
                     }
                 }
-            }
 
-            // validate the target is not a directory
-            if (targetStats && targetStats.isDirectory()) {
-                throw new Error(tl.loc('TargetIsDir', file, targetPath));
-            }
+                let targetPath = path.join(targetFolder, relativePath);
+                let targetDir = path.dirname(targetPath);
 
-            if (!overWrite) {
-                if (targetStats) { // exists, skip
-                    console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                if (!createdFolders[targetDir]) {
+                    makeDirP(targetDir, ignoreMakeDirErrors);
+                    createdFolders[targetDir] = true;
                 }
-                else { // copy
+
+                // stat the target
+                let targetStats: tl.FsStats;
+                if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
+                    try {
+                        targetStats = tl.stats(targetPath);
+                    }
+                    catch (err) {
+                        if (err.code != 'ENOENT') {
+                            throw err;
+                        }
+                    }
+                }
+
+                // validate the target is not a directory
+                if (targetStats && targetStats.isDirectory()) {
+                    throw new Error(tl.loc('TargetIsDir', file, targetPath));
+                }
+
+                if (!overWrite) {
+                    if (targetStats) { // exists, skip
+                        console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                    }
+                    else { // copy
+                        console.log(tl.loc('CopyingTo', file, targetPath));
+                        tl.cp(file, targetPath, undefined, undefined, retryCount);
+                        if (preserveTimestamp) {
+                            try {
+                                const fileStats = tl.stats(file);
+                                fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
+                                    displayTimestampChangeResults(fileStats, err);
+                                });
+                            }
+                            catch (err) {
+                                console.warn(`Problem preserving the timestamp: ${err}`)
+                            }
+                        }
+                    }
+                }
+                else {
                     console.log(tl.loc('CopyingTo', file, targetPath));
-                    tl.cp(file, targetPath, undefined, undefined, retryCount);
+                    if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
+                        // The readonly attribute can be interpreted by performing a bitwise-AND operation on
+                        // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
+                        // see following chart:
+                        //     R   W  X  R  W X R W X
+                        //   256 128 64 32 16 8 4 2 1
+                        //
+                        // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
+                        // If the readonly attribute is set, then the mode is set to "r--r--r--".
+                        // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
+                        //
+                        // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
+                        // comparison is appropriate.
+                        //
+                        // For additional information, refer to the fs source code and ctrl+f "st_mode":
+                        //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
+                        tl.debug(`removing readonly attribute on '${targetPath}'`);
+                        fs.chmodSync(targetPath, targetStats.mode | 146);
+                    }
+
+                    tl.cp(file, targetPath, "-f", undefined, retryCount);
                     if (preserveTimestamp) {
                         try {
-                            const fileStats = tl.stats(file);
+                            const fileStats: tl.FsStats = tl.stats(file);
                             fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
                                 displayTimestampChangeResults(fileStats, err);
                             });
@@ -166,45 +205,71 @@ if (matchedFiles.length > 0) {
                         }
                     }
                 }
-            }
-            else {
-                console.log(tl.loc('CopyingTo', file, targetPath));
-                if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
-                    // The readonly attribute can be interpreted by performing a bitwise-AND operation on
-                    // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
-                    // see following chart:
-                    //     R   W  X  R  W X R W X
-                    //   256 128 64 32 16 8 4 2 1
-                    //
-                    // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
-                    // If the readonly attribute is set, then the mode is set to "r--r--r--".
-                    // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
-                    //
-                    // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
-                    // comparison is appropriate.
-                    //
-                    // For additional information, refer to the fs source code and ctrl+f "st_mode":
-                    //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
-                    tl.debug(`removing readonly attribute on '${targetPath}'`);
-                    fs.chmodSync(targetPath, targetStats.mode | 146);
-                }
-
-                tl.cp(file, targetPath, "-f", undefined, retryCount);
-                if (preserveTimestamp) {
-                    try {
-                        const fileStats: tl.FsStats = tl.stats(file);
-                        fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
-                            displayTimestampChangeResults(fileStats, err);
-                        });
-                    }
-                    catch (err) {
-                        console.warn(`Problem preserving the timestamp: ${err}`)
-                    }
-                }
-            }
-        });
-    }
-    catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err);
+            });
+        }
+        catch (err) {
+            tl.setResult(tl.TaskResult.Failed, err);
+        }
     }
 }
+/**
+ * Executes task logic with specifies amount of retries
+ * @param retryCount count of retries for copying operation
+ */
+function runWithRetries(taskInputData: ITaskInputData) {
+    while (taskInputData.retryCount >= 0) {
+        try {
+            main(taskInputData);
+            break;
+        } catch (e) {
+            let errorMessage = `Error while task execution: ${e}.`;
+            if (taskInputData.retryCount) {
+                errorMessage += `Remaining attempts: ${taskInputData.retryCount}`;
+            }
+            console.log(errorMessage);
+        }
+
+        --taskInputData.retryCount;
+    }
+}
+
+function readInputsData(): ITaskInputData {
+    const taskInputsData: ITaskInputData = {
+        contents: tl.getDelimitedInput('Contents', '\n', true),
+        sourceFolder: tl.getPathInput('SourceFolder', true, true),
+        targetFolder: tl.getPathInput('TargetFolder', true),
+        cleanTargetFolder: tl.getBoolInput('CleanTargetFolder', false),
+        overWrite: tl.getBoolInput('OverWrite', false),
+        flattenFolders: tl.getBoolInput('flattenFolders', false),
+        preserveTimestamp: tl.getBoolInput('preserveTimestamp', false),
+        ignoreMakeDirErrors: tl.getBoolInput('ignoreMakeDirErrors', false),
+        retryCount: parseInt(tl.getInput('retryCount')),
+        matchedPaths: [],
+        matchedFiles: []
+    };
+
+    if (isNaN(taskInputsData.retryCount) || taskInputsData.retryCount < 0) {
+        taskInputsData.retryCount = 0;
+    }
+
+    taskInputsData.sourceFolder = path.normalize(taskInputsData.sourceFolder);
+    let allPaths: string[] = tl.find(taskInputsData.sourceFolder, findOptions);
+    let sourceFolderPattern = taskInputsData.sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
+    taskInputsData.matchedPaths = tl.match(allPaths, taskInputsData.contents, sourceFolderPattern); // default match options
+    taskInputsData.matchedFiles = taskInputsData.matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
+
+    return taskInputsData;
+}
+
+// we allow broken symlinks - since there could be broken symlinks found in source folder, but filtered by contents pattern
+const findOptions: tl.FindOptions = {
+    allowBrokenSymbolicLinks: true,
+    followSpecifiedSymbolicLink: true,
+    followSymbolicLinks: true
+};
+
+tl.setResourcePath(path.join(__dirname, 'task.json'));
+
+const taskInputData: ITaskInputData = readInputsData();
+
+runWithRetries(taskInputData);

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 189,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Match pattern consistency.",
     "demands": [],

--- a/Tasks/CopyFilesV2/task.loc.json
+++ b/Tasks/CopyFilesV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 189,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [],


### PR DESCRIPTION
**Task name**: CopyFilesV2

**Description**: there are intermittent errors sometimes for UNC paths even during cleaning up of target folder and other task steps.
This PR contains next changes:
- Retry logic update - now it retries for any error happening during copying - to make whole task execution more robust agains intermittent issues
- Refactored task code

**Documentation changes required:** N

**Added unit tests:** reworked existing tests to consider this changes, added test for retry logic - case when source folder path is not available.

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
