### PR TITLE
Conditional validation of path arguments

### DIFF
--- a/Tasks/WindowsMachineFileCopyV2/Tests/L0ValidateDestinationPath.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/Tests/L0ValidateDestinationPath.ps1
@@ -7,9 +7,9 @@ param()
 . $PSScriptRoot\..\Utility.ps1
 
 Assert-Throws {
-   Validate-DestinationPath -value "" -environmentName $validEnvironmentName
+    Validate-Remote-Path -value "" -environmentName $validEnvironmentName
 } -Message "WFC_ParameterCannotBeNullorEmpty targetPath"
 
 Assert-Throws {
-    Validate-DestinationPath -value $invalidTargetPath -environmentName $validEnvironmentName
+    Validate-Remote-Path -value $invalidTargetPath -environmentName $validEnvironmentName
 } -Message "WFC_RemoteDestinationPathCannotContainEnvironmentVariables `$env:abc\123"

--- a/Tasks/WindowsMachineFileCopyV2/Tests/L0ValidateSourcePath.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/Tests/L0ValidateSourcePath.ps1
@@ -9,9 +9,9 @@ Unregister-Mock Test-Path
 Register-Mock Test-Path { return $false } -ParametersEvaluator { $LiteralPath -eq $invalidSourcePath }
 
 Assert-Throws {
-    Validate-SourcePath -value ""
+    Validate-Local-Path -value ""
 } -MessagePattern "WFC_ParameterCannotBeNullorEmpty sourcePath"
 
 Assert-Throws {
-    Validate-SourcePath -value "$invalidSourcePath"
+    Validate-Local-Path -value "$invalidSourcePath"
 } -MessagePattern "WFC_SourcePathDoesNotExist Invalid"

--- a/Tasks/WindowsMachineFileCopyV2/Utility.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/Utility.ps1
@@ -17,7 +17,7 @@ function Validate-Null(
     }
 }
 
-function Validate-SourcePath(
+function Validate-Local-Path(
     [string]$value
     )
 {
@@ -29,7 +29,7 @@ function Validate-SourcePath(
     }
 }
 
-function Validate-DestinationPath(
+function Validate-Remote-Path(
     [string]$value,
     [string]$environmentName
     )

--- a/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
@@ -32,8 +32,21 @@ try
 
     $envOperationStatus = 'Passed'
 
-    Validate-SourcePath $sourcePath
-    Validate-DestinationPath $targetPath $machineNames
+    $uncSourcePath = (New-Object System.Uri -ArgumentList $sourcePath).Host
+    $uncTargetPath = (New-Object System.Uri -ArgumentList $targetPath).Host
+
+    # Compare source and target unc root to determine if they're based on the same host.
+    # If so, assume we're copying on the same host and disable local-path validation at this point.
+    if( $uncSourcePath -and $uncTargetPath -and ($uncSourcePath -eq $uncTargetPath))
+    {
+        Validate-Remote-Path $sourcePath $machineNames
+        Validate-Remote-Path $targetPath $machineNames
+    }
+    else 
+    {
+        Validate-Local-Path $sourcePath
+        Validate-Remote-Path $targetPath $machineNames
+    }
 
     $machines = $machineNames.split(',') | ForEach-Object { if ($_ -and $_.trim()) { $_.trim() } }
 

--- a/Tasks/WindowsMachineFileCopyV2/task.json
+++ b/Tasks/WindowsMachineFileCopyV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 1,
-        "Patch": 13
+        "Minor": 189,
+        "Patch": 0
     },
     "releaseNotes": "What's new in Version 2.0: <br/>&nbsp;&nbsp;Proxy support is being added. <br/>&nbsp;&nbsp; Removed support of legacy DTL machines.",
     "minimumAgentVersion": "1.104.0",


### PR DESCRIPTION
**Task name**: WindowsMachineFileCopy

**Description**: 
Conditionaly switch path validation before running any action to (hopefuly) support copying (from / to) on the same remote machine.

Check if the source and destination paths are on the same host to
disable local path validation for the source-path.

This commit changes the names of validation-functions to reflect what
they're acutally doing now.

**Documentation changes required:** No

**Added unit tests:** Yes (but only refactored function names; no feature test)

**Attached related issue:** #14917 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

## Important
Unfortunately I haven't managed to run any tests!
