### PR TITLE
Allow Tasks users to pass environment variables into their static app

### DIFF
--- a/Tasks/AzureStaticWebAppV0/launch-docker.sh
+++ b/Tasks/AzureStaticWebAppV0/launch-docker.sh
@@ -2,14 +2,14 @@ workspace="/working_dir"
 
 params=()
 
-[[ ! -z "$SWA_APP_LOCATION" ]] && params+=(-e "INPUT_APP_LOCATION=$SWA_APP_LOCATION")
-[[ ! -z "$SWA_APP_BUILD_COMMAND" ]] && params+=(-e "INPUT_APP_BUILD_COMMAND=$SWA_APP_BUILD_COMMAND")
-[[ ! -z "$SWA_OUTPUT_LOCATION" ]] && params+=(-e "INPUT_OUTPUT_LOCATION=$SWA_OUTPUT_LOCATION")
-[[ ! -z "$SWA_API_LOCATION" ]] && params+=(-e "INPUT_API_LOCATION=$SWA_API_LOCATION")
-[[ ! -z "$SWA_API_BUILD_COMMAND" ]] && params+=(-e "INPUT_API_BUILD_COMMAND=$SWA_API_BUILD_COMMAND")
-[[ ! -z "$SWA_ROUTES_LOCATION" ]] && params+=(-e "INPUT_ROUTES_LOCATION=$SWA_ROUTES_LOCATION")
+envvars=$(( set -o posix ; set ) | grep -E -v '^(PATH|USER|LOGNAME|HOME|SHELL|VSCODE|SSH|BASH|NVM|HOSTNAME|GIT|NODE|PWD|TMPDIR)')
 
-params+=(-e "INPUT_SKIP_APP_BUILD=$SWA_SKIP_APP_BUILD")
+for ev in $envvars
+do
+    if [[ "$ev" == *"="* ]]; then
+        params+=(-e $ev)
+    fi
+done
 
 docker run \
     -e INPUT_AZURE_STATIC_WEB_APPS_API_TOKEN="$SWA_API_TOKEN" \

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -14,8 +14,8 @@
   "demands": [],
   "version": {
     "Major": "0",
-    "Minor": "187",
-    "Patch": "1"
+    "Minor": "189",
+    "Patch": "0"
   },
   "preview": true,
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION


**Task name**: AzureStaticWebAppV0

**Description**: This fix allows allows Tasks users to pass environment variables into their static app, for example, REACT_APP_FOO=bar, so that the frontend can use the variable with `process.env`. There is an exclusion list which prevents sensitive env variables from being passed into the docker container (e.g., PATH). 

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/Azure/static-web-apps/issues/392

**Checklist**:
- [X] Task version was bumped
- [X] Checked that applied changes work as expected
