### PR TITLE
add in ability to lock simulator version

### DIFF
--- a/Tasks/AzureIoTEdgeV2/constant.ts
+++ b/Tasks/AzureIoTEdgeV2/constant.ts
@@ -8,7 +8,9 @@ export default class Constants {
   public static folderNameModules = "modules";
   public static folderNameConfig = "config";
   public static iotedgedev = "iotedgedev";
+  public static iotedgehubdev = "iotedgehubdev";
   public static iotedgedevLockVersionKey = "IOTEDGEDEV_VERSION";
+  public static iotedgehubdevLockVersionKey = "IOTEDGEHUBDEV_VERSION";
   public static iotedgedevDefaultVersion = "3.0.0";
   public static iotedgedevEnv = {
     registryServer: "CONTAINER_REGISTRY_SERVER",

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 4,
-        "Patch": 8
+        "Patch": 9
     },
     "preview": false,
     "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 4,
-    "Patch": 8
+    "Patch": 9
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/util.ts
+++ b/Tasks/AzureIoTEdgeV2/util.ts
@@ -81,7 +81,9 @@ export default class Util {
 
     let cmds: Cmd[] = [];
     let edgeDevVersion = Constants.iotedgedevDefaultVersion;
-    let simulatorVersion : string = null;
+    let lockSimVersion = tl.getVariable(Constants.iotedgehubdevLockVersionKey); 
+    // if no version is specified, iotedgedev installs default simulator version
+
     // install pre reqs
     if (tl.osType() === Constants.osTypeLinux) {
       cmds = [
@@ -91,15 +93,15 @@ export default class Util {
         { path: `sudo`, arg: `apt-get install -y python3-setuptools`, execOption: Constants.execSyncSilentOption },
       ]
 
-      if (tl.getVariable(Constants.iotedgedevLockVersionKey)) {
-        edgeDevVersion = tl.getVariable(Constants.iotedgedevLockVersionKey);
+      let lockVersion = tl.getVariable(Constants.iotedgedevLockVersionKey);
+      if (lockVersion) {
+        edgeDevVersion = lockVersion;
       }  
       cmds.push({ path: `sudo`, arg: `pip3 install ${Constants.iotedgedev}==${edgeDevVersion}`, execOption: Constants.execSyncSilentOption });
 
-      if (tl.getVariable(Constants.iotedgehubdevLockVersionKey)) {
-        simulatorVersion = tl.getVariable(Constants.iotedgehubdevLockVersionKey);
+      if (lockSimVersion) {
         cmds.push({ path: `sudo`, arg: `pip3 uninstall ${Constants.iotedgehubdev} -y`, execOption: Constants.execSyncSilentOption });
-        cmds.push({ path: `sudo`, arg: `pip3 install ${Constants.iotedgehubdev}==${simulatorVersion}`, execOption: Constants.execSyncSilentOption });
+        cmds.push({ path: `sudo`, arg: `pip3 install ${Constants.iotedgehubdev}==${lockSimVersion}`, execOption: Constants.execSyncSilentOption });
       }
     } else if (tl.osType() === Constants.osTypeWindows) {
       if (tl.getVariable(Constants.iotedgedevLockVersionKey)) {
@@ -107,15 +109,14 @@ export default class Util {
       }
       cmds.push({path: `pip`, arg: `install ${Constants.iotedgedev}==${edgeDevVersion}`, execOption: Constants.execSyncSilentOption },)
       
-      if (tl.getVariable(Constants.iotedgehubdevLockVersionKey)) {
-        simulatorVersion = tl.getVariable(Constants.iotedgehubdevLockVersionKey);
+      if (lockSimVersion) {
         cmds.push({ path: `pip`, arg: `uninstall ${Constants.iotedgehubdev} -y`, execOption: Constants.execSyncSilentOption },);
-        cmds.push({ path: `pip`, arg: `install ${Constants.iotedgehubdev}==${simulatorVersion}`, execOption: Constants.execSyncSilentOption },);
+        cmds.push({ path: `pip`, arg: `install ${Constants.iotedgehubdev}==${lockSimVersion}`, execOption: Constants.execSyncSilentOption },);
       }
     }
 
     tl.debug(`The specified iotedgedev version is: ${edgeDevVersion}`);
-    tl.debug(`The specified iotedgehubdev version is: ${simulatorVersion}`);
+    tl.debug(`The specified iotedgehubdev version is: ${lockSimVersion}`);
 
     try {
       for (let cmd of cmds) {


### PR DESCRIPTION
**Task name**: AzureIoTEdgeV2

**Description**: 
- add in logic to set iotedgehubdev version via environment variable

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
