### PR TITLE
[azp-tasks-az-blobstorage-provider-v2] Fixed npm audit 

### DIFF
--- a/common-npm-packages/az-blobstorage-provider-v2/package-lock.json
+++ b/common-npm-packages/az-blobstorage-provider-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azp-tasks-az-blobstorage-provider-v2",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -728,7 +728,6 @@
             "align-text": {
               "version": "0.1.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -1760,8 +1759,7 @@
             },
             "longest": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "loose-envify": {
               "version": "1.3.1",
@@ -3439,9 +3437,9 @@
       }
     },
     "azure-storage": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
-      "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "version": "2.10.4",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.4.tgz",
+      "integrity": "sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==",
       "requires": {
         "browserify-mime": "~1.2.9",
         "extend": "^3.0.2",
@@ -3449,7 +3447,7 @@
         "md5.js": "1.3.4",
         "readable-stream": "~2.0.0",
         "request": "^2.86.0",
-        "underscore": "~1.8.3",
+        "underscore": "^1.12.1",
         "uuid": "^3.0.0",
         "validator": "~9.4.1",
         "xml2js": "0.2.8",
@@ -4123,9 +4121,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/common-npm-packages/az-blobstorage-provider-v2/package.json
+++ b/common-npm-packages/az-blobstorage-provider-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azp-tasks-az-blobstorage-provider-v2",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Common Library to download blobs from azure storage",
   "repository": {
     "type": "git",
@@ -13,10 +13,10 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "q": "1.4.1",
     "artifact-engine": "1.0.0",
-    "azure-storage": "^2.10.3",
-    "azure-pipelines-task-lib": "^3.1.0"
+    "azure-pipelines-task-lib": "^3.1.0",
+    "azure-storage": "^2.10.4",
+    "q": "1.4.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"


### PR DESCRIPTION
**Task name**: N/A - azp-tasks-az-blobstorage-provider-v2 common package

**Description**: fixed vulnerable dependencies via npm audit for azp-tasks-az-blobstorage-provider-v2

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it - bumped package version
- [x] Checked that applied changes work as expected - checked that there is no tasks for which there will be unexpected bump - for separate tasks specific testing is required
