### PR TITLE
[PowershellV2] Fix powershell execution script to fail on wrong targettype

### DIFF
--- a/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/en-US/resources.resjson
@@ -32,9 +32,11 @@
   "loc.messages.JS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '%s'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
   "loc.messages.JS_InvalidFilePath": "Invalid file path '%s'. A path to a .ps1 file is required.",
   "loc.messages.JS_Stderr": "PowerShell wrote one or more lines to the standard error stream.",
+  "loc.messages.JS_InvalidTargetType": "Invalid target type '%s'. The value must be one of: 'filepath' or 'inline'",
   "loc.messages.PS_ExitCode": "PowerShell exited with code '{0}'.",
   "loc.messages.PS_FormattedCommand": "Formatted command: {0}",
   "loc.messages.PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
   "loc.messages.PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
-  "loc.messages.PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
+  "loc.messages.PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell.",
+  "loc.messages.PS_InvalidTargetType": "Invalid target type '{0}'. The value must be one of: 'filepath' or 'inline'"
 }

--- a/Tasks/PowerShellV2/powershell.ps1
+++ b/Tasks/PowerShellV2/powershell.ps1
@@ -37,7 +37,7 @@ try {
 
         $input_arguments = Get-VstsInput -Name 'arguments'
     }
-    else if("$input_targetType".ToUpperInvariant() -eq "INLINE") {
+    elseif("$input_targetType".ToUpperInvariant() -eq "INLINE") {
         $input_script = Get-VstsInput -Name 'script'
     }
     else {

--- a/Tasks/PowerShellV2/powershell.ps1
+++ b/Tasks/PowerShellV2/powershell.ps1
@@ -37,8 +37,11 @@ try {
 
         $input_arguments = Get-VstsInput -Name 'arguments'
     }
-    else {
+    else if("$input_targetType".ToUpperInvariant() -eq "INLINE") {
         $input_script = Get-VstsInput -Name 'script'
+    }
+    else {
+        Write-Error (Get-VstsLocString -Key 'PS_InvalidTargetType' -ArgumentList $input_targetType)
     }
     $input_runScriptInSeparateScope = Get-VstsInput -Name 'runScriptInSeparateScope' -AsBool
 

--- a/Tasks/PowerShellV2/powershell.ts
+++ b/Tasks/PowerShellV2/powershell.ts
@@ -39,7 +39,7 @@ async function run() {
             input_script = tl.getInput('script', false) || '';
         }
         else {
-            throw new Error(tl.loc('PS_InvalidTargetType', input_targetType));
+            throw new Error(tl.loc('JS_InvalidTargetType', input_targetType));
         }
         const input_runScriptInSeparateScope = tl.getBoolInput('runScriptInSeparateScope');
 

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 189,
+        "Minor": 190,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",
@@ -163,10 +163,12 @@
         "JS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '%s'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
         "JS_InvalidFilePath": "Invalid file path '%s'. A path to a .ps1 file is required.",
         "JS_Stderr": "PowerShell wrote one or more lines to the standard error stream.",
+        "JS_InvalidTargetType": "Invalid target type '%s'. The value must be one of: 'filepath' or 'inline'",
         "PS_ExitCode": "PowerShell exited with code '{0}'.",
         "PS_FormattedCommand": "Formatted command: {0}",
         "PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
         "PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
-        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
+        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell.",
+        "PS_InvalidTargetType": "Invalid target type '{0}'. The value must be one of: 'filepath' or 'inline'"
     }
 }

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -167,6 +167,7 @@
         "PS_FormattedCommand": "Formatted command: {0}",
         "PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
         "PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
-        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
+        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell.",
+        "PS_InvalidTargetType": "Invalid target type '%s'. Target type should be 'File path', 'Inline' or empty string"
     }
 }

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -167,7 +167,6 @@
         "PS_FormattedCommand": "Formatted command: {0}",
         "PS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '{0}'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
         "PS_InvalidFilePath": "Invalid file path '{0}'. A path to a .ps1 file is required.",
-        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell.",
-        "PS_InvalidTargetType": "Invalid target type '%s'. Target type should be 'File path', 'Inline' or empty string"
+        "PS_UnableToDetermineExitCode": "Unexpected exception. Unable to determine the exit code from powershell."
     }
 }

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 189,
+    "Minor": 190,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -163,10 +163,12 @@
     "JS_InvalidErrorActionPreference": "ms-resource:loc.messages.JS_InvalidErrorActionPreference",
     "JS_InvalidFilePath": "ms-resource:loc.messages.JS_InvalidFilePath",
     "JS_Stderr": "ms-resource:loc.messages.JS_Stderr",
+    "JS_InvalidTargetType": "ms-resource:loc.messages.JS_InvalidTargetType",
     "PS_ExitCode": "ms-resource:loc.messages.PS_ExitCode",
     "PS_FormattedCommand": "ms-resource:loc.messages.PS_FormattedCommand",
     "PS_InvalidErrorActionPreference": "ms-resource:loc.messages.PS_InvalidErrorActionPreference",
     "PS_InvalidFilePath": "ms-resource:loc.messages.PS_InvalidFilePath",
-    "PS_UnableToDetermineExitCode": "ms-resource:loc.messages.PS_UnableToDetermineExitCode"
+    "PS_UnableToDetermineExitCode": "ms-resource:loc.messages.PS_UnableToDetermineExitCode",
+    "PS_InvalidTargetType": "ms-resource:loc.messages.PS_InvalidTargetType"
   }
 }


### PR DESCRIPTION
**Task name**: PowershellV2

**Description**: 
- Add additional condition to validate if target path is 'filepath' or 'inline', otherwise write error
- Add localization string for error message 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/build-task-team/issues/1355

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
