### PR TITLE
Add retry for individual files in CopyFilesV2 task backport (#15035)

### DIFF
--- a/Tasks/CopyFilesV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CopyFilesV2/Strings/resources.resjson/en-US/resources.resjson
@@ -21,6 +21,8 @@
   "loc.input.help.preserveTimestamp": "Using the original source file, preserve the target file timestamp.",
   "loc.input.label.retryCount": "Retry count to copy the file",
   "loc.input.help.retryCount": "Specify the retry count to copy the file. It might help to resolve intermittent issues e.g. with UNC target paths on a remote host.",
+  "loc.input.label.delayBetweenRetries": "Delay between two retries.",
+  "loc.input.help.delayBetweenRetries": "Specify the delay between two retries. It might help to be more resilient to intermittent issues e.g. with UNC target paths on a remote host.",
   "loc.input.label.ignoreMakeDirErrors": "Ignore errors during creation of target folder.",
   "loc.input.help.ignoreMakeDirErrors": "Ignore errors which happen during creation of target folder. This could be useful to avoid issues with parallel execution of task by several agents with one target folder.",
   "loc.messages.FoundNFiles": "found %d files",

--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -11,7 +11,6 @@ describe('CopyFiles L0 Suite', function () {
     after(() => { });
 
     it('copy files from srcdir to destdir', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0copyAllFiles.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -51,7 +50,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('copy files from srcdir to destdir with brackets in src path', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0copyAllFilesWithBracketsInSrcPath.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -91,7 +89,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('copy files and subtract based on exclude pattern', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0copySubtractExclude.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -122,55 +119,50 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('fails if Contents not set', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0failsIfContentsNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue('Unhandled: Input required: Contents'), 'should have created error issue');
+        assert(runner.createdErrorIssue('Error: Input required: Contents'), 'should have created error issue');
         done();
     });
 
     it('fails if SourceFolder not set', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue('Unhandled: Input required: SourceFolder'), 'should have created error issue');
+        assert(runner.createdErrorIssue('Error: Input required: SourceFolder'), 'should have created error issue');
         done();
     });
 
     it('fails if TargetFolder not set', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0failsIfTargetFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue('Unhandled: Input required: TargetFolder'), 'should have created error issue');
+        assert(runner.createdErrorIssue('Error: Input required: TargetFolder'), 'should have created error issue');
         done();
     });
 
     it('fails if SourceFolder not found', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotFound.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
 
         assert(runner.failed, 'should have failed');
-        assert(runner.createdErrorIssue(`Unhandled: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
+        assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
         done();
     });
 
     it('fails if target file is a directory', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0failsIfTargetFileIsDir.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -182,7 +174,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('skips if exists', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0skipsIfExists.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -207,7 +198,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('overwrites if specified', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0overwritesIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -232,7 +222,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('preserves timestamp if specified', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0preservesTimestampIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -260,7 +249,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('cleans if specified', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0cleansIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -291,7 +279,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('cleans if specified and target is file', (done: Mocha.Done) => {
-        this.timeout(1000);
 
         let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndTargetIsFile.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
@@ -319,8 +306,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('roots patterns', (done: Mocha.Done) => {
-        this.timeout(1000);
-
         let testPath = path.join(__dirname, 'L0rootsPatterns.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
@@ -341,8 +326,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('ignores errors during target folder creation if ignoreMakeDirErrors is true', (done: Mocha.Done) => {
-        this.timeout(1000);
-
         let testPath = path.join(__dirname, 'L0IgnoresMakeDirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
@@ -361,8 +344,6 @@ describe('CopyFiles L0 Suite', function () {
     });
 
     it('fails if there are errors during target folder creation if ignoreMakeDirErrors is false', (done: Mocha.Done) => {
-        this.timeout(1000);
-
         let testPath = path.join(__dirname, 'L0FailsIfThereIsMkdirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
@@ -375,8 +356,6 @@ describe('CopyFiles L0 Suite', function () {
 
     if (process.platform == 'win32') {
         it('overwrites readonly', (done: Mocha.Done) => {
-            this.timeout(1000);
-
             let testPath = path.join(__dirname, 'L0overwritesReadonly.js');
             let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
             runner.run();

--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -1,6 +1,7 @@
 import fs = require('fs');
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
+import { RetryOptions, RetryHelper } from './retryHelper'; 
 
 /**
  * Shows timestamp change operation results
@@ -36,175 +37,207 @@ function makeDirP(targetFolder: string, ignoreErrors: boolean): void {
     }
 }
 
-// we allow broken symlinks - since there could be broken symlinks found in source folder, but filtered by contents pattern
-const findOptions: tl.FindOptions = {
-    allowBrokenSymbolicLinks: true,
-    followSpecifiedSymbolicLink: true,
-    followSymbolicLinks: true
-};
+async function main(): Promise<void> {
+    // we allow broken symlinks - since there could be broken symlinks found in source folder, but filtered by contents pattern
+    const findOptions: tl.FindOptions = {
+        allowBrokenSymbolicLinks: true,
+        followSpecifiedSymbolicLink: true,
+        followSymbolicLinks: true
+    };
 
-tl.setResourcePath(path.join(__dirname, 'task.json'));
+    tl.setResourcePath(path.join(__dirname, 'task.json'));
 
-// contents is a multiline input containing glob patterns
-let contents: string[] = tl.getDelimitedInput('Contents', '\n', true);
-let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
-let targetFolder: string = tl.getPathInput('TargetFolder', true);
-let cleanTargetFolder: boolean = tl.getBoolInput('CleanTargetFolder', false);
-let overWrite: boolean = tl.getBoolInput('OverWrite', false);
-let flattenFolders: boolean = tl.getBoolInput('flattenFolders', false);
-let retryCount: number = parseInt(tl.getInput('retryCount'));
-if (isNaN(retryCount) || retryCount < 0) {
-    retryCount = 0;
-}
-const preserveTimestamp: boolean = tl.getBoolInput('preserveTimestamp', false);
-const ignoreMakeDirErrors: boolean = tl.getBoolInput('ignoreMakeDirErrors', false);
+    // contents is a multiline input containing glob patterns
+    let contents: string[] = tl.getDelimitedInput('Contents', '\n', true);
+    let sourceFolder: string = tl.getPathInput('SourceFolder', true, true);
+    let targetFolder: string = tl.getPathInput('TargetFolder', true);
+    let cleanTargetFolder: boolean = tl.getBoolInput('CleanTargetFolder', false);
+    let overWrite: boolean = tl.getBoolInput('OverWrite', false);
+    let flattenFolders: boolean = tl.getBoolInput('flattenFolders', false);
+    let retryCount: number = parseInt(tl.getInput('retryCount'));
+    let delayBetweenRetries: number = parseInt(tl.getInput('delayBetweenRetries'));
 
-// normalize the source folder path. this is important for later in order to accurately
-// determine the relative path of each found file (substring using sourceFolder.length).
-sourceFolder = path.normalize(sourceFolder);
-let allPaths: string[] = tl.find(sourceFolder, findOptions);
-let sourceFolderPattern = sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
-let matchedPaths: string[] = tl.match(allPaths, contents, sourceFolderPattern); // default match options
-let matchedFiles: string[] = matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
-
-// copy the files to the target folder
-console.log(tl.loc('FoundNFiles', matchedFiles.length));
-
-if (matchedFiles.length > 0) {
-    // clean target folder if required
-    if (cleanTargetFolder) {
-        console.log(tl.loc('CleaningTargetFolder', targetFolder));
-
-        // stat the targetFolder path
-        let targetFolderStats: tl.FsStats;
-        try {
-            targetFolderStats = tl.stats(targetFolder);
-        }
-        catch (err) {
-            if (err.code != 'ENOENT') {
-                throw err;
-            }
-        }
-
-        if (targetFolderStats) {
-            if (targetFolderStats.isDirectory()) {
-                // delete the child items
-                fs.readdirSync(targetFolder)
-                    .forEach((item: string) => {
-                        let itemPath = path.join(targetFolder, item);
-                        tl.rmRF(itemPath);
-                    });
-            }
-            else {
-                // targetFolder is not a directory. delete it.
-                tl.rmRF(targetFolder);
-            }
-        }
+    if (isNaN(retryCount) || retryCount < 0) {
+        retryCount = 0;
     }
 
-    // make sure the target folder exists
-    makeDirP(targetFolder, ignoreMakeDirErrors);
+    if (isNaN(delayBetweenRetries) || delayBetweenRetries < 0) {
+        delayBetweenRetries = 0;
+    }
 
-    try {
-        let createdFolders: { [folder: string]: boolean } = {};
-        matchedFiles.forEach((file: string) => {
-            let relativePath;
-            if (flattenFolders) {
-                relativePath = path.basename(file);
-            } else {
-                relativePath = file.substring(sourceFolder.length);
+    const retryOptions: RetryOptions = {
+        timeoutBetweenRetries: delayBetweenRetries,
+        numberOfReties: retryCount
+    };
+    const retryHelper = new RetryHelper(retryOptions);
 
-                // trim leading path separator
-                // note, assumes normalized above
-                if (relativePath.startsWith(path.sep)) {
-                    relativePath = relativePath.substr(1);
+    const preserveTimestamp: boolean = tl.getBoolInput('preserveTimestamp', false);
+    const ignoreMakeDirErrors: boolean = tl.getBoolInput('ignoreMakeDirErrors', false);
+
+    // normalize the source folder path. this is important for later in order to accurately
+    // determine the relative path of each found file (substring using sourceFolder.length).
+    sourceFolder = path.normalize(sourceFolder);
+    let allPaths: string[] = tl.find(sourceFolder, findOptions);
+    let sourceFolderPattern = sourceFolder.replace('[', '[[]'); // directories can have [] in them, and they have special meanings as a pattern, so escape them
+    let matchedPaths: string[] = tl.match(allPaths, contents, sourceFolderPattern); // default match options
+    let matchedFiles: string[] = matchedPaths.filter((itemPath: string) => !tl.stats(itemPath).isDirectory()); // filter-out directories
+
+    // copy the files to the target folder
+    console.log(tl.loc('FoundNFiles', matchedFiles.length));
+
+    if (matchedFiles.length > 0) {
+        // clean target folder if required
+        if (cleanTargetFolder) {
+            console.log(tl.loc('CleaningTargetFolder', targetFolder));
+
+            // stat the targetFolder path
+            let targetFolderStats: tl.FsStats;
+            try {
+                targetFolderStats = await retryHelper.RunWithRetrySingleArg<tl.FsStats, string>(
+                    () => tl.stats(targetFolder),
+                    targetFolder);
+            } catch (err) {
+                if (err.code != 'ENOENT') {
+                    throw err;
                 }
             }
 
-            let targetPath = path.join(targetFolder, relativePath);
-            let targetDir = path.dirname(targetPath);
-
-            if (!createdFolders[targetDir]) {
-                makeDirP(targetDir, ignoreMakeDirErrors);
-                createdFolders[targetDir] = true;
-            }
-
-            // stat the target
-            let targetStats: tl.FsStats;
-            if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
-                try {
-                    targetStats = tl.stats(targetPath);
+            if (targetFolderStats) {
+                if (targetFolderStats.isDirectory()) {
+                    // delete the child items
+                    const folderItems: string[] = await retryHelper.RunWithRetrySingleArg<string[], string>(
+                        () => fs.readdirSync(targetFolder),
+                        targetFolder);
+                    
+                    for (let item of folderItems) {
+                        let itemPath = path.join(targetFolder, item);
+                        await retryHelper.RunWithRetrySingleArg<void, string>(() => 
+                            tl.rmRF(itemPath),
+                            targetFolder
+                        );
+                    }
+                } else {
+                    await retryHelper.RunWithRetrySingleArg<void, string>(() => 
+                            tl.rmRF(targetFolder),
+                            targetFolder);
                 }
-                catch (err) {
-                    if (err.code != 'ENOENT') {
-                        throw err;
+            }
+        }
+
+        // make sure the target folder exists
+        await retryHelper.RunWithRetryMultiArgs<void, string, boolean>(() => 
+            makeDirP(targetFolder, ignoreMakeDirErrors),
+            targetFolder,
+            ignoreMakeDirErrors);
+        try {
+            let createdFolders: { [folder: string]: boolean } = {};
+            for (let file of matchedFiles) {
+                let relativePath;
+                if (flattenFolders) {
+                    relativePath = path.basename(file);
+                } else {
+                    relativePath = file.substring(sourceFolder.length);
+
+                    // trim leading path separator
+                    // note, assumes normalized above
+                    if (relativePath.startsWith(path.sep)) {
+                        relativePath = relativePath.substr(1);
                     }
                 }
-            }
 
-            // validate the target is not a directory
-            if (targetStats && targetStats.isDirectory()) {
-                throw new Error(tl.loc('TargetIsDir', file, targetPath));
-            }
+                let targetPath = path.join(targetFolder, relativePath);
+                let targetDir = path.dirname(targetPath);
 
-            if (!overWrite) {
-                if (targetStats) { // exists, skip
-                    console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                if (!createdFolders[targetDir]) {
+                    await retryHelper.RunWithRetry(
+                        () => makeDirP(targetDir, ignoreMakeDirErrors));
+
+                    createdFolders[targetDir] = true;
                 }
-                else { // copy
+
+                // stat the target
+                let targetStats: tl.FsStats;
+                if (!cleanTargetFolder) { // optimization - no need to check if relative target exists when CleanTargetFolder=true
+                    try {
+                        targetStats = await retryHelper.RunWithRetrySingleArg<tl.FsStats, string>(
+                            () => tl.stats(targetPath),
+                            targetPath);
+                    } catch (err) {
+                        if (err.code != 'ENOENT') {
+                            throw err;
+                        }
+                    }
+                }
+
+                // validate the target is not a directory
+                if (targetStats && targetStats.isDirectory()) {
+                    throw new Error(tl.loc('TargetIsDir', file, targetPath));
+                }
+
+                if (!overWrite) {
+                    if (targetStats) { // exists, skip
+                        console.log(tl.loc('FileAlreadyExistAt', file, targetPath));
+                    } else { // copy
+                        console.log(tl.loc('CopyingTo', file, targetPath));
+                        tl.cp(file, targetPath, undefined, undefined, retryCount);
+                        if (preserveTimestamp) {
+                            try {
+                                let fileStats;
+                                fileStats = await retryHelper.RunWithRetrySingleArg<tl.FsStats, string>(
+                                    (file) => tl.stats(file),
+                                    file);
+                                fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
+                                    displayTimestampChangeResults(fileStats, err);
+                                });
+                            } catch (err) {
+                                console.warn(`Problem preserving the timestamp: ${err}`)
+                            }
+                        }
+                    }
+                } else { // copy
                     console.log(tl.loc('CopyingTo', file, targetPath));
-                    tl.cp(file, targetPath, undefined, undefined, retryCount);
+                    if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
+                        // The readonly attribute can be interpreted by performing a bitwise-AND operation on
+                        // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
+                        // see following chart:
+                        //     R   W  X  R  W X R W X
+                        //   256 128 64 32 16 8 4 2 1
+                        //
+                        // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
+                        // If the readonly attribute is set, then the mode is set to "r--r--r--".
+                        // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
+                        //
+                        // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
+                        // comparison is appropriate.
+                        //
+                        // For additional information, refer to the fs source code and ctrl+f "st_mode":
+                        //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
+                        tl.debug(`removing readonly attribute on '${targetPath}'`);
+
+                        await retryHelper.RunWithRetrySingleArg<void, string>(
+                            () => fs.chmodSync(targetPath, targetStats.mode | 146),
+                            targetPath);
+                    }
+
+                    tl.cp(file, targetPath, "-f", undefined, retryCount);
                     if (preserveTimestamp) {
                         try {
                             const fileStats = tl.stats(file);
                             fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
                                 displayTimestampChangeResults(fileStats, err);
                             });
-                        }
-                        catch (err) {
+                        } catch (err) {
                             console.warn(`Problem preserving the timestamp: ${err}`)
                         }
                     }
                 }
             }
-            else {
-                console.log(tl.loc('CopyingTo', file, targetPath));
-                if (process.platform == 'win32' && targetStats && (targetStats.mode & 146) != 146) {
-                    // The readonly attribute can be interpreted by performing a bitwise-AND operation on
-                    // "fs.Stats.mode" and the integer 146. The integer 146 represents "-w--w--w-" or (128 + 16 + 2),
-                    // see following chart:
-                    //     R   W  X  R  W X R W X
-                    //   256 128 64 32 16 8 4 2 1
-                    //
-                    // "fs.Stats.mode" on Windows is based on whether the readonly attribute is set.
-                    // If the readonly attribute is set, then the mode is set to "r--r--r--".
-                    // If the readonly attribute is not set, then the mode is set to "rw-rw-rw-".
-                    //
-                    // Note, additional bits may also be set (e.g. if directory). Therefore, a bitwise
-                    // comparison is appropriate.
-                    //
-                    // For additional information, refer to the fs source code and ctrl+f "st_mode":
-                    //   https://github.com/nodejs/node/blob/v5.x/deps/uv/src/win/fs.c#L1064
-                    tl.debug(`removing readonly attribute on '${targetPath}'`);
-                    fs.chmodSync(targetPath, targetStats.mode | 146);
-                }
-
-                tl.cp(file, targetPath, "-f", undefined, retryCount);
-                if (preserveTimestamp) {
-                    try {
-                        const fileStats: tl.FsStats = tl.stats(file);
-                        fs.utimes(targetPath, fileStats.atime, fileStats.mtime, (err) => {
-                            displayTimestampChangeResults(fileStats, err);
-                        });
-                    }
-                    catch (err) {
-                        console.warn(`Problem preserving the timestamp: ${err}`)
-                    }
-                }
-            }
-        });
-    }
-    catch (err) {
-        tl.setResult(tl.TaskResult.Failed, err);
+        } catch (err) {
+            tl.setResult(tl.TaskResult.Failed, err);
+        }
     }
 }
+
+main().catch((err) => {
+    tl.setResult(tl.TaskResult.Failed, err);
+});

--- a/Tasks/CopyFilesV2/retryHelper.ts
+++ b/Tasks/CopyFilesV2/retryHelper.ts
@@ -1,0 +1,80 @@
+/**
+ * Interface for FindOptions
+ * Contains properties to control whether to follow symlinks
+ */
+ export interface RetryOptions {
+
+    /**
+     * Number of retries
+     */
+    numberOfReties: number,
+
+    /**
+     * Timeout between retries in milliseconds
+     */
+    timeoutBetweenRetries: number
+}
+
+export class RetryHelper {
+    private retryOptions: RetryOptions;
+
+    constructor (retryOptions: RetryOptions) {
+        this.retryOptions = retryOptions;
+    }
+
+    public async RunWithRetry(action: () => void): Promise<void> {
+        let attempts: number = this.retryOptions.numberOfReties;
+        while (true) {
+            try {
+                await action();
+                break;
+            } catch (err) {
+                --attempts;
+                console.log(`Error while ${action.name}: ${err}. Remaining attempts: ${attempts}`);
+                if (attempts <= 0) {
+                    throw err;
+                }
+                await this.sleep(); 
+            }
+        }
+    }
+
+    public async RunWithRetrySingleArg<T, A>(action: (stringValue: A) => T, firstArg: A): Promise<T>  {
+        let attempts = this.retryOptions.numberOfReties;
+        while (true) {
+            try {
+                const result: T = await action(firstArg);
+                return result;
+            } catch (err) {
+                --attempts;
+                console.log(`Error while ${action.name}: ${err}. Remaining attempts: ${attempts}`);
+                if (attempts <= 0) {
+                    throw err;
+                }
+                await this.sleep(); 
+            }
+        }
+    }
+
+    public async RunWithRetryMultiArgs<T, A, K>(action: (firstArg: A, secondArg: K) => T, firstArg: A, secondArg: K): Promise<T>  {
+        let attempts = this.retryOptions.numberOfReties;
+        while (true) {
+            try {
+                const result: T = await action(firstArg, secondArg);
+                return result;
+            } catch (err) {
+                --attempts;
+                console.log(`Error while ${action.name}: ${err}. Remaining attempts: ${attempts}`);
+                if (attempts <= 0) {
+                    throw err;
+                }
+                await this.sleep(); 
+            }
+        }
+    }
+
+    private async sleep() {
+        return new Promise(resolve => setTimeout(resolve,
+            this.retryOptions.timeoutBetweenRetries));
+    }
+}

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 189,
+        "Minor": 190,
         "Patch": 0
     },
     "releaseNotes": "Match pattern consistency.",
@@ -97,6 +97,15 @@
             "defaultValue": "0",
             "required": false,
             "helpMarkDown": "Specify the retry count to copy the file. It might help to resolve intermittent issues e.g. with UNC target paths on a remote host.",
+            "groupName": "advanced"
+        },
+        {
+            "name": "delayBetweenRetries",
+            "type": "string",
+            "label": "Delay between two retries.",
+            "defaultValue": "1000",
+            "required": false,
+            "helpMarkDown": "Specify the delay between two retries. It might help to be more resilient to intermittent issues e.g. with UNC target paths on a remote host.",
             "groupName": "advanced"
         },
         {

--- a/Tasks/CopyFilesV2/task.loc.json
+++ b/Tasks/CopyFilesV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 189,
+    "Minor": 190,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -97,6 +97,15 @@
       "defaultValue": "0",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.retryCount",
+      "groupName": "advanced"
+    },
+    {
+      "name": "delayBetweenRetries",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.delayBetweenRetries",
+      "defaultValue": "1000",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.delayBetweenRetries",
       "groupName": "advanced"
     },
     {


### PR DESCRIPTION
Task name: CopyFilesV2
Description: Added retry logic to all the methods that are used for working with files. Those methods are receptive to file access issues and retry helps in most cases to address problems with file copying and deleting especially for files that are accessing through UNC paths.

Documentation changes required: (Y/N) Y

Added unit tests: (Y/N) N

Attached related issue: (Y/N) N

Checklist:
- [x] Task version was bumped - please check instruction how to do it
- [x] Checked that applied changes work as expected
