### PR TITLE
Add fallback url in case download fails

### DIFF
--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 184,
-        "Patch": 0
+        "Patch": 4
     },
     "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 184,
-        "Patch": 4
+        "Minor": 191,
+        "Patch": 0
     },
     "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 184,
-    "Patch": 0
+    "Patch": 4
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 184,
-    "Patch": 4
+    "Minor": 191,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/versioninstaller.ts
+++ b/Tasks/UseDotNetV2/versioninstaller.ts
@@ -38,14 +38,17 @@ export class VersionInstaller {
                 var downloadPath = await toolLib.downloadTool(downloadUrl)
             }
             catch (ex) {
-                throw tl.loc("CouldNotDownload", downloadUrl, ex);
+                tl.warning(tl.loc("CouldNotDownload", downloadUrl, ex));
+                let fallBackUrl = `https://dotnetcli.azureedge.net/dotnet/${this.packageType === "runtime" ? "Runtime" : "Sdk"}/${version}/${downloadUrl.substring(downloadUrl.lastIndexOf('/') + 1)}`;
+                console.log("Using fallback url for download: " + fallBackUrl);
+                var downloadPath = await toolLib.downloadTool(fallBackUrl)
             }
 
             // Extract
             console.log(tl.loc("ExtractingPackage", downloadPath));
             try {
                 let tempDirectory = tl.getVariable('Agent.TempDirectory');
-                let extDirectory = path.join( tempDirectory, tinyGuid());
+                let extDirectory = path.join(tempDirectory, tinyGuid());
                 var extPath = tl.osType().match(/^Win/) ? await toolLib.extractZip(downloadPath, extDirectory) : await toolLib.extractTar(downloadPath);
             }
             catch (ex) {


### PR DESCRIPTION
**Task name**: UseDotNetV2

**Description**: Fixes #15086 There is some problem with .NET download CDN servers and that is causing the download to fail intermittently. This fix tries to use a fallback url based on https://dotnetcli.azureedge.net domain which is also used by [dotnet install](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script) scripts.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #15086 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
