### PR TITLE
Sanityze the base image name and remote the digest if any

### DIFF
--- a/common-npm-packages/docker-common-v2/containerimageutils.ts
+++ b/common-npm-packages/docker-common-v2/containerimageutils.ts
@@ -86,13 +86,26 @@ export function getBaseImageName(dockerFileContent: string): string {
                     : prospectImageName;
             }
         }
+
         return baseImage.includes("$") // In this case the base image has an argument and we don't know what its real value is
             ? null
-            : baseImage;
+            : sanityzeBaseImage(baseImage);
     } catch (error) {
         tl.debug(`An error ocurred getting the base image name. ${error.message}`);
         return null;
     }
+}
+
+function sanityzeBaseImage(baseImage: string): string {
+    if (!baseImage){
+        return null;
+    }
+
+    // If the baseimage name contains the digest we should remove the digest from its name
+    // ubuntu:16.04@sha256:123412343 should be just ubuntu:16.04
+    let baseImageComponents: string[] = baseImage.split("@");
+
+    return baseImageComponents[0];
 }
 
 export function getResourceName(image: string, digest: string) {

--- a/common-npm-packages/docker-common-v2/package-lock.json
+++ b/common-npm-packages/docker-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-docker-common-v2",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/docker-common-v2/package.json
+++ b/common-npm-packages/docker-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-docker-common-v2",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Common Library for Azure Rest Calls",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: docker-common

**Description**: This change is going to remove the digest when is included as part of the base image name.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/15112

