### PR TITLE
Update common packages to resolve https://www.npmjs.com/advisories/1674

### DIFF
--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-artifacts-common",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,13 +54,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+      "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
-        "underscore": "1.8.3"
+        "typed-rest-client": "^1.8.4"
       }
     },
     "azure-pipelines-task-lib": {
@@ -442,13 +441,13 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
-        "underscore": "1.8.3"
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -463,9 +462,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "universalify": {
       "version": "0.1.2",

--- a/common-npm-packages/artifacts-common/package-lock.json
+++ b/common-npm-packages/artifacts-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-artifacts-common",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-artifacts-common",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Azure Artifacts common code (for new authentication tasks)",
   "scripts": {
     "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"
@@ -15,7 +15,7 @@
     "@types/fs-extra": "8.0.0",
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.6",
-    "azure-devops-node-api": "10.1.2",
+    "azure-devops-node-api": "10.2.2",
     "azure-pipelines-task-lib": "^3.1.0",
     "fs-extra": "8.1.0",
     "semver": "6.3.0"

--- a/common-npm-packages/artifacts-common/package.json
+++ b/common-npm-packages/artifacts-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-artifacts-common",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Azure Artifacts common code (for new authentication tasks)",
   "scripts": {
     "build": "cd ../build-scripts && npm install && cd ../artifacts-common && node make.js"

--- a/common-npm-packages/kubernetes-common-v2/package-lock.json
+++ b/common-npm-packages/kubernetes-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-kubernetes-common-v2",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -78,23 +78,23 @@
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.1.tgz",
-      "integrity": "sha512-LonIQs/y0fDmrged2PDHMox8UHQuRrTs388gwBP1axgx4aU/vV/73e7v8tY/++kBF4sDCFea8ZrNxoYSSzRCtQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.2.tgz",
+      "integrity": "sha512-0wWAqIY1n9UvcHP3AKLWIVd5fTPKaUOZJ50bNwW3NMpFlfpxZDAi8Ck9wvVm9oBdwHVYZsQy3WfK71DiBWQiHg==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
         "azure-pipelines-task-lib": "^3.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.7.3",
+        "typed-rest-client": "^1.8.4",
         "uuid": "^3.3.2"
       },
       "dependencies": {
         "@types/uuid": {
-          "version": "3.4.9",
-          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-          "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+          "version": "3.4.10",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+          "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
         }
       }
     },
@@ -457,13 +457,13 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.1.tgz",
-      "integrity": "sha512-7JbJFBZZuu3G64u6ksklN1xtVGfqBKiR5MQoTe5oLTi68OyB6pRuuIQCllfK/BdGjQtZYp62rgUOnEYDz4e9Xg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
-        "underscore": "1.8.3"
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -478,9 +478,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/common-npm-packages/kubernetes-common-v2/package.json
+++ b/common-npm-packages/kubernetes-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-kubernetes-common-v2",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Common Library for Kubernetes",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
     "@types/mocha": "5.2.7",
     "@types/uuid": "8.3.0",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tool-lib": "^1.0.1",
+    "azure-pipelines-tool-lib": "^1.0.2",
     "js-yaml": "3.6.1"
   },
   "devDependencies": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/securefiles-common/package-lock.json
+++ b/common-npm-packages/securefiles-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -46,13 +46,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.1.2.tgz",
-      "integrity": "sha512-0oPwjVcV1IbzSx+rcT6clhmO8bQQazU/p6haErbRwAlPf2Oh+MK277TCqo4bFNL/8HS3LR4nDrNowMSmQDh//Q==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+      "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
-        "underscore": "1.8.3"
+        "typed-rest-client": "^1.8.4"
       }
     },
     "azure-pipelines-task-lib": {
@@ -404,13 +403,13 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-      "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
-        "underscore": "1.8.3"
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -425,9 +424,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/q": "^1.5.4",
-    "azure-devops-node-api": "10.1.2",
+    "azure-devops-node-api": "10.2.2",
     "azure-pipelines-task-lib": "^3.1.0"
   },
   "devDependencies": {

--- a/common-npm-packages/securefiles-common/package.json
+++ b/common-npm-packages/securefiles-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-securefiles-common",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Azure Pipelines tasks SecureFiles Common",
   "main": "securefiles-common.js",
   "scripts": {

--- a/common-npm-packages/utility-common-v2/package-lock.json
+++ b/common-npm-packages/utility-common-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-utility-common",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -36,9 +36,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -73,16 +73,16 @@
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.1.tgz",
-      "integrity": "sha512-LonIQs/y0fDmrged2PDHMox8UHQuRrTs388gwBP1axgx4aU/vV/73e7v8tY/++kBF4sDCFea8ZrNxoYSSzRCtQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.2.tgz",
+      "integrity": "sha512-0wWAqIY1n9UvcHP3AKLWIVd5fTPKaUOZJ50bNwW3NMpFlfpxZDAi8Ck9wvVm9oBdwHVYZsQy3WfK71DiBWQiHg==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
         "azure-pipelines-task-lib": "^3.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.7.3",
+        "typed-rest-client": "^1.8.4",
         "uuid": "^3.3.2"
       }
     },
@@ -445,13 +445,13 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.1.tgz",
-      "integrity": "sha512-7JbJFBZZuu3G64u6ksklN1xtVGfqBKiR5MQoTe5oLTi68OyB6pRuuIQCllfK/BdGjQtZYp62rgUOnEYDz4e9Xg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
-        "underscore": "1.8.3"
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -466,9 +466,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/common-npm-packages/utility-common-v2/package.json
+++ b/common-npm-packages/utility-common-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-utility-common",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Common Library for Azure Rest Calls",
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   "dependencies": {
     "semver": "^5.4.1",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tool-lib": "^1.0.1",
+    "azure-pipelines-tool-lib": "^1.0.2",
     "js-yaml": "3.13.1",
     "@types/node": "^10.17.0"
   },


### PR DESCRIPTION
**Task name**: common npm packages: atrifacts-common, kubernetes-common-v2, securefiles-common, utility-common-v2

**Description**: Update versions of "azure-pipelines-tool-lib" and "azure-devops-node-api" to fix high vulnerability related to "underscore" package.
![image](https://user-images.githubusercontent.com/86476103/129152295-279b9e49-d531-4cfc-8dfb-2c389495e023.png)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
