### PR TITLE
Update packaging-common package dependencies to fix high vulnerability https://www.npmjs.com/advisories/1674

### DIFF
--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -64,9 +64,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
     },
     "adm-zip": {
       "version": "0.4.16",
@@ -84,13 +84,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-devops-node-api": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.0.0.tgz",
-      "integrity": "sha512-QkIzphuE3y/hZVMB6ONN0Dev5r9+CIAiopWulwoYx1Er0kYcsbXsKXKynuLSxsVPocMppbr4YPhTsX2eHY/Mjw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+      "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
       "requires": {
-        "tunnel": "0.0.4",
-        "typed-rest-client": "1.2.0",
-        "underscore": "1.8.3"
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
       }
     },
     "azure-pipelines-task-lib": {
@@ -108,34 +107,17 @@
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.1.tgz",
-      "integrity": "sha512-LonIQs/y0fDmrged2PDHMox8UHQuRrTs388gwBP1axgx4aU/vV/73e7v8tY/++kBF4sDCFea8ZrNxoYSSzRCtQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.2.tgz",
+      "integrity": "sha512-0wWAqIY1n9UvcHP3AKLWIVd5fTPKaUOZJ50bNwW3NMpFlfpxZDAi8Ck9wvVm9oBdwHVYZsQy3WfK71DiBWQiHg==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
         "azure-pipelines-task-lib": "^3.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.7.3",
+        "typed-rest-client": "^1.8.4",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "tunnel": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-        },
-        "typed-rest-client": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.1.tgz",
-          "integrity": "sha512-7JbJFBZZuu3G64u6ksklN1xtVGfqBKiR5MQoTe5oLTi68OyB6pRuuIQCllfK/BdGjQtZYp62rgUOnEYDz4e9Xg==",
-          "requires": {
-            "qs": "^6.9.1",
-            "tunnel": "0.0.6",
-            "underscore": "1.8.3"
-          }
-        }
       }
     },
     "balanced-match": {
@@ -511,17 +493,18 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -536,9 +519,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/common-npm-packages/packaging-common/package-lock.json
+++ b/common-npm-packages/packaging-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -20,15 +20,15 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.5.2",
     "adm-zip": "^0.4.11",
-    "azure-devops-node-api": "8.0.0",
+    "azure-devops-node-api": "10.2.2",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tool-lib": "^1.0.1",
+    "azure-pipelines-tool-lib": "^1.0.2",
     "ini": "^1.3.4",
     "ip-address": "^5.8.9",
     "ltx": "^2.6.2",
     "q": "^1.5.0",
     "semver": "^5.5.0",
-    "typed-rest-client": "1.2.0"
+    "typed-rest-client": "1.8.4"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Azure Pipelines Packaging Tasks Common",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/common-npm-packages/packaging-common/package.json
+++ b/common-npm-packages/packaging-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-packaging-common",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Azure Pipelines Packaging Tasks Common",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
**Task name**: packaging-common package

**Description**: Update versions of "azure-pipelines-tool-lib" and "azure-devops-node-api" to fix high vulnerability related to "underscore" package.
![image](https://user-images.githubusercontent.com/86476103/129326511-236f4bc9-93d3-4397-ba74-e8826eb868a5.png)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
