### PR TITLE
Update AzureRmDeploy-common package dependencies to fix high vulnerability https://www.npmjs.com/advisories/1674

### DIFF
--- a/common-npm-packages/AzureRmDeploy-common/package-lock.json
+++ b/common-npm-packages/AzureRmDeploy-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -779,17 +779,18 @@
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+      "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
       "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -804,9 +805,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/common-npm-packages/AzureRmDeploy-common/package-lock.json
+++ b/common-npm-packages/AzureRmDeploy-common/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/AzureRmDeploy-common/package.json
+++ b/common-npm-packages/AzureRmDeploy-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/AzureRmDeploy-common/package.json
+++ b/common-npm-packages/AzureRmDeploy-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azurermdeploycommon",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",
@@ -19,16 +19,16 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "jsonwebtoken": "7.3.0",
-    "q": "1.5.1",
-    "typed-rest-client": "0.12.0",
-    "azure-pipelines-task-lib": "^3.1.0",
     "archiver": "2.1.1",
+    "azure-pipelines-task-lib": "^3.1.0",
     "decompress-zip": "0.3.0",
+    "jsonwebtoken": "7.3.0",
     "ltx": "2.6.2",
+    "node-stream-zip": "1.7.0",
+    "q": "1.5.1",
+    "typed-rest-client": "^1.8.4",
     "winreg": "1.2.2",
-    "xml2js": "0.4.13",
-    "node-stream-zip": "1.7.0"
+    "xml2js": "0.4.13"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/common-npm-packages/AzureRmDeploy-common/package.json
+++ b/common-npm-packages/AzureRmDeploy-common/package.json
@@ -19,16 +19,16 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "archiver": "2.1.1",
-    "azure-pipelines-task-lib": "^3.1.0",
-    "decompress-zip": "0.3.0",
     "jsonwebtoken": "7.3.0",
-    "ltx": "2.6.2",
-    "node-stream-zip": "1.7.0",
     "q": "1.5.1",
     "typed-rest-client": "^1.8.4",
+    "azure-pipelines-task-lib": "^3.1.0",
+    "archiver": "2.1.1",
+    "decompress-zip": "0.3.0",
+    "ltx": "2.6.2",
     "winreg": "1.2.2",
-    "xml2js": "0.4.13"
+    "xml2js": "0.4.13",
+    "node-stream-zip": "1.7.0"
   },
   "devDependencies": {
     "typescript": "4.0.2"


### PR DESCRIPTION
**Task name**: AzureRmDeploy-common package

**Description**: Update version of "typed-rest-client" to fix high vulnerability related to "underscore" package.
![image](https://user-images.githubusercontent.com/86476103/129562612-3fe0576d-8a62-4f74-83e9-6d891f23fbc1.png)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
