### PR TITLE
Add support for VS 2022 to the VSBuild, MSBuild, XamarinAndroid tasks

### DIFF
--- a/Tasks/Common/MSBuildHelpers/PathFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/PathFunctions.ps1
@@ -12,23 +12,27 @@ function Get-MSBuildPath {
         [string]$Version,
         [string]$Architecture)
 
+        $VersionNumber = [int]($Version.Remove(2))
+
     Trace-VstsEnteringInvocation $MyInvocation
     try {
         # Only attempt to find Microsoft.Build.Utilities.Core.dll from a VS 15 Willow install
         # when "15.0" or latest is specified. In 15.0, the method GetPathToBuildToolsFile(...)
         # has regressed. When it is called for a version that is not found, the latest version
-        # found is returned instead. Same for "16.0"
+        # found is returned instead. Same for "16.0" and "17.0"
         [System.Reflection.Assembly]$msUtilities = $null
-        if (($Version -eq "16.0" -or !$Version) -and # !$Version indicates "latest"
-            ($visualStudio16 = Get-VisualStudio 16) -and
-            $visualStudio16.installationPath) {
 
-            $msbuildUtilitiesPath = [System.IO.Path]::Combine($visualStudio16.installationPath, "MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll")
+        if (($VersionNumber -ge 16 -or !$Version) -and # !$Version indicates "latest"
+            ($specifiedStudio = Get-VisualStudio $VersionNumber) -and
+            $specifiedStudio.installationPath) {
+
+            $msbuildUtilitiesPath = [System.IO.Path]::Combine($specifiedStudio.installationPath, "MSBuild\Current\Bin\Microsoft.Build.Utilities.Core.dll")
             if (Test-Path -LiteralPath $msbuildUtilitiesPath -PathType Leaf) {
                 Write-Verbose "Loading $msbuildUtilitiesPath"
                 $msUtilities = [System.Reflection.Assembly]::LoadFrom($msbuildUtilitiesPath)
             }
         }
+
         elseif (($Version -eq "15.0" -or !$Version) -and # !$Version indicates "latest"
             ($visualStudio15 = Get-VisualStudio 15) -and
             $visualStudio15.installationPath) {
@@ -183,7 +187,7 @@ function Get-VisualStudio {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet(15, 16)]
+        [ValidateSet(15, 16, 17)]
         [int]$MajorVersion)
 
     Trace-VstsEnteringInvocation $MyInvocation
@@ -273,7 +277,7 @@ function Select-MSBuildPath {
         }
 
         $specificVersion = $PreferredVersion -and $PreferredVersion -ne 'latest'
-        $versions = "16.0", '15.0', '14.0', '12.0', '4.0' | Where-Object { $_ -ne $PreferredVersion }
+        $versions = '17.0', '16.0', '15.0', '14.0', '12.0', '4.0' | Where-Object { $_ -ne $PreferredVersion }
 
         # Look for a specific version of MSBuild.
         if ($specificVersion) {

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.ErrorsIfVersionNotFound.ps1
@@ -13,4 +13,4 @@ Assert-WasCalled Get-MSBuildPath -- -Version '15.0' -Architecture 'Some architec
 Assert-WasCalled Get-MSBuildPath -- -Version '14.0' -Architecture 'Some architecture'
 Assert-WasCalled Get-MSBuildPath -- -Version '12.0' -Architecture 'Some architecture'
 Assert-WasCalled Get-MSBuildPath -- -Version '4.0' -Architecture 'Some architecture'
-Assert-WasCalled Get-MSBuildPath -Times 5
+Assert-WasCalled Get-MSBuildPath -Times 6

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom14.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-WasCalled Get-MSBuildPath -Times 5
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom15.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 3
+Assert-WasCalled Get-MSBuildPath -Times 4
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom16.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsBackFrom16.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 2
+Assert-WasCalled Get-MSBuildPath -Times 3
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom12.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 4
+Assert-WasCalled Get-MSBuildPath -Times 5
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom14.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 3
+Assert-WasCalled Get-MSBuildPath -Times 4
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom15.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.FallsForwardFrom15.ps1
@@ -12,5 +12,5 @@ $actual = Select-MSBuildPath -Method 'Version' -Location '' -PreferredVersion '1
 
 # Assert.
 Assert-WasCalled Write-Warning
-Assert-WasCalled Get-MSBuildPath -Times 2
+Assert-WasCalled Get-MSBuildPath -Times 3
 Assert-AreEqual -Expected 'Some resolved location' -Actual $actual

--- a/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsLatestVersion.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Select-MSBuildPath.ReturnsLatestVersion.ps1
@@ -13,5 +13,5 @@ foreach ($version in @('', 'latest')) {
 
     # Assert.
     Assert-AreEqual -Expected 'Some resolved location' -Actual $actual
-    Assert-WasCalled Get-MSBuildPath -Times 1
+    Assert-WasCalled Get-MSBuildPath -Times 2
 }

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.191.1",
+  "version": "1.191.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.183.0",
+  "version": "1.192.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.192.1",
+  "version": "1.191.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.192.1",
+  "version": "1.191.1",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.191.1",
+  "version": "1.191.0",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.183.0",
+  "version": "1.192.1",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -339,7 +339,7 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "msbuildhelpers": {
-      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.183.0.tgz",
+      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz",
       "requires": {
         "azure-pipelines-task-lib": "^2.9.3"
       },

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -339,7 +339,7 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "msbuildhelpers": {
-      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.1.tgz",
+      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.0.tgz",
       "requires": {
         "azure-pipelines-task-lib": "^2.9.3"
       },

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -339,7 +339,7 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "msbuildhelpers": {
-      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz",
+      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.1.tgz",
       "requires": {
         "azure-pipelines-task-lib": "^2.9.3"
       },

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz"
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.1.tgz"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.183.0.tgz"
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.1.tgz"
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.191.0.tgz"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 188,
-        "Patch": 0
+        "Minor": 192,
+        "Patch": 1
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 191,
-        "Patch": 1
+        "Patch": 0
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
+        "Minor": 191,
         "Patch": 1
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 188,
-    "Patch": 0
+    "Minor": 192,
+    "Patch": 1
   },
   "demands": [
     "msbuild"

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
+    "Minor": 191,
     "Patch": 1
   },
   "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 191,
-    "Patch": 1
+    "Patch": 0
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -2,28 +2,27 @@ function Get-VSPath {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$Version)
-
+        [string]$Version)        
+        
+    $Versions = @('15.0', '16.0', '17.0')
     Trace-VstsEnteringInvocation $MyInvocation
+
     try {
-        if ($Version -eq "16.0" -and
-            ($instance = Get-VisualStudio 16) -and
-            $instance.installationPath) {
-            
-            return $instance.installationPath
-        }
-        # Search for a 15.0 Willow instance.
-        if ($Version -eq "15.0" -and
-            ($instance = Get-VisualStudio 15) -and
-            $instance.installationPath) {
-
-            return $instance.installationPath
-        }
-
-        # Fallback to searching for an older install.
-        if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
-            return $path
-        }
+        if ( !($Version -in $Versions )) {
+          Write-Warning "Please enter one of the versions 15.0, 16.0, 17.0" 
+          } else { 
+            $VersionNumber = [int]$Version.Remove(2)
+            # Search for more than 15.0 Willow instance.
+                if (($instance = Get-VisualStudio $VersionNumber) -and
+                    $instance.installationPath) {
+                    
+                    return $instance.installationPath
+                }
+         
+            if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
+                    return $path
+            }
+          }
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation
     }

--- a/Tasks/VSBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VSBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -30,6 +30,8 @@
   "loc.input.help.logFileVerbosity": "Optional log file verbosity.",
   "loc.input.label.enableDefaultLogger": "Enable Default Logger",
   "loc.input.help.enableDefaultLogger": "If true - enables default logger for msbuild",
+  "loc.input.label.customVersion": "Custom Version",
+  "loc.input.help.customVersion": "Allows setting custom version of Visual Studio. Examples: 15.0, 16.0, 17.0.Make sure that the required version of Visual Studio is installed in the system.",
   "loc.messages.MSBuildLocationDeprecated0": "The MSBuild location parameter has been deprecated. Ignoring value '{0}'",
   "loc.messages.MSBuildVersionDeprecated0": "The MSBuild version parameter has been deprecated. Ignoring value '{0}'.",
   "loc.messages.UnexpectedVSVersion0": "Unexpected Visual Studio version '{0}'.",

--- a/Tasks/VSBuildV1/Tests/MapsVSVersions.ps1
+++ b/Tasks/VSBuildV1/Tests/MapsVSVersions.ps1
@@ -9,6 +9,7 @@ Register-Mock Format-MSBuildArguments
 Register-Mock Invoke-BuildTools
 $mappings = @(
     @{ VSVersion = '' ; MSBuildVersion = '14.0' }
+    @{ VSVersion = '17.0' ; MSBuildVersion = '17.0' }
     @{ VSVersion = '16.0' ; MSBuildVersion = '16.0' }
     @{ VSVersion = '15.0' ; MSBuildVersion = '15.0' }
     @{ VSVersion = '14.0' ; MSBuildVersion = '14.0' }
@@ -32,6 +33,7 @@ foreach ($mapping in $mappings) {
     Register-Mock Get-VstsInput { $false } -- -Name LogProjectEvents -AsBool
     Register-Mock Get-VstsInput { $false } -- -Name CreateLogFile -AsBool
     Register-Mock Get-VstsInput { $false } -- -Name EnableDefaultLogger -AsBool
+    Register-Mock Get-VstsInput { $false } -- -Name isCustomVersion -AsBool
     Register-Mock Select-VSVersion { $mapping.VSVersion } -- -PreferredVersion $mapping.VSVersion
     Register-Mock Select-MSBuildPath
 

--- a/Tasks/VSBuildV1/Tests/PassesArguments.ps1
+++ b/Tasks/VSBuildV1/Tests/PassesArguments.ps1
@@ -36,6 +36,7 @@ foreach ($variableSet in $variableSets) {
     Register-Mock Get-VstsInput { $variableSet.CreateLogFile } -- -Name CreateLogFile -AsBool
     Register-Mock Get-VstsInput { $variableSet.LogFileVerbosity } -- -Name LogFileVerbosity
     Register-Mock Get-VstsInput { $variableSet.EnableDefaultLogger } -- -Name EnableDefaultLogger -AsBool
+    Register-Mock Get-VstsInput { $false } -- -Name isCustomVersion -AsBool
     Register-Mock Get-VstsTaskVariable { $variableSet.Debug } -- -Name System.Debug -AsBool
     Register-Mock Get-SolutionFiles { 'Some solution 1', 'Some solution 2' } -- -Solution 'Some input solution'
     Register-Mock Select-VSVersion { $variableSet.VSVersion } -- -PreferredVersion $variableSet.VSVersion

--- a/Tasks/VSBuildV1/Tests/ThrowsIfUnknownVSVersion.ps1
+++ b/Tasks/VSBuildV1/Tests/ThrowsIfUnknownVSVersion.ps1
@@ -16,6 +16,7 @@ Register-Mock Get-VstsInput { $false } -- -Name RestoreNuGetPackages -AsBool
 Register-Mock Get-VstsInput { $false } -- -Name LogProjectEvents -AsBool
 Register-Mock Get-VstsInput { $false } -- -Name CreateLogFile -AsBool
 Register-Mock Get-VstsInput { $true } -- -Name EnableDefaultLogger -AsBool
+Register-Mock Get-VstsInput { $false } -- -Name isCustomVersion -AsBool
 Register-Mock Get-VstsTaskVariable { $false } -- -Name System.Debug -AsBool
 Register-Mock Select-VSVersion { 'nosuchversion' } -- -PreferredVersion '14.0'
 Register-Mock Select-MSBuildPath

--- a/Tasks/VSBuildV1/VSBuild.ps1
+++ b/Tasks/VSBuildV1/VSBuild.ps1
@@ -22,6 +22,7 @@ try {
     [bool]$createLogFile = Get-VstsInput -Name CreateLogFile -AsBool
     [string]$logFileVerbosity = if ($debug) { "diagnostic" } else { Get-VstsInput -Name LogFileVerbosity }
     [bool]$enableDefaultLogger = Get-VstsInput -Name EnableDefaultLogger -AsBool
+    [string]$customVersion = Get-VstsInput -Name customVersion
 
     # Warn if deprecated inputs were specified.
     if ([string]$vsLocation = Get-VstsInput -Name VSLocation) {
@@ -48,12 +49,17 @@ try {
     $solutionFiles = Get-SolutionFiles -Solution $Solution
 
     # Resolve a VS version.
-    $vsVersion = Select-VSVersion -PreferredVersion $vsVersion
+    if ($customVersion) {
+        $vsVersion = Select-VSVersion -PreferredVersion $customVersion
+    } else {
+        $vsVersion = Select-VSVersion -PreferredVersion $vsVersion
+    }    
 
     # Translate to MSBuild version.
     $msBuildVersion = $null;
     switch ("$vsVersion") {
         '' { $msBuildVersion = '14.0' ; break } # VS wasn't found. Attempt to find MSBuild 14.0 or lower.
+        '17.0' { $msBuildVersion = '17.0' ; break }
         '16.0' { $msBuildVersion = '16.0' ; break }
         '15.0' { $msBuildVersion = '15.0' ; break }
         '14.0' { $msBuildVersion = '14.0' ; break }

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 187,
-        "Patch": 0
+        "Minor": 192,
+        "Patch": 1
     },
     "demands": [
         "msbuild",
@@ -157,6 +157,15 @@
             "defaultValue": "true",
             "required": false,
             "helpMarkDown": "If true - enables default logger for msbuild",
+            "groupName": "advanced"
+        },
+        {
+            "name": "customVersion",
+            "type": "string",
+            "label": "Custom Version",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Allows setting custom version of Visual Studio. Examples: 15.0, 16.0, 17.0. Make sure that the required version of Visual Studio is installed in the system.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
+        "Minor": 191,
         "Patch": 1
     },
     "demands": [

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 191,
-        "Patch": 1
+        "Patch": 0
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 191,
-    "Patch": 1
+    "Patch": 0
   },
   "demands": [
     "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 187,
-    "Patch": 0
+    "Minor": 192,
+    "Patch": 1
   },
   "demands": [
     "msbuild",
@@ -157,6 +157,15 @@
       "defaultValue": "true",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.enableDefaultLogger",
+      "groupName": "advanced"
+    },
+    {
+      "name": "customVersion",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.customVersion",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.customVersion",
       "groupName": "advanced"
     }
   ],

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
+    "Minor": 191,
     "Patch": 1
   },
   "demands": [

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 189,
-        "Patch": 0
+        "Minor": 192,
+        "Patch": 1
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
+        "Minor": 191,
         "Patch": 1
     },
     "demands": [

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 191,
-        "Patch": 1
+        "Patch": 0
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 189,
-    "Patch": 0
+    "Minor": 192,
+    "Patch": 1
   },
   "demands": [
     "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
+    "Minor": 191,
     "Patch": 1
   },
   "demands": [

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 191,
-    "Patch": 1
+    "Patch": 0
   },
   "demands": [
     "MSBuild",


### PR DESCRIPTION
**Task name**: MsBuild, VSBuild, 

**Description**: Add support for VS 2022 to the VSBuild, MSBuild, XamarinAndroid tasks, Add support for VS 2022 to MSBuildHelper in common package, update dependencies in XamarinAndroid task

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) #15051

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
