### PR TITLE
[PublishSymbolsV2] Add support for IndexableFileFormats flag on symbol.exe

### DIFF
--- a/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
+++ b/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
@@ -38,6 +38,9 @@ param(
     [string] $SourcePathListFileName,
 
     [Parameter(Mandatory=$false)]
+    [string] $IndexableFileFormats,
+
+    [Parameter(Mandatory=$false)]
     [string] $ExpirationInDays,
 
     [Parameter(Mandatory=$false)]
@@ -81,6 +84,10 @@ function Publish-Symbols([string]$symbolServiceUri, [string]$requestName, [strin
 
         if ($SourcePathListFileName) {
             $args += " --fileListFileName `"$SourcePathListFileName`""
+        }
+
+        if ($IndexableFileFormats) {
+            $args += " --indexableFileFormats `"$IndexableFileFormats`""
         }
 
         Run-SymbolCommand $assemblyPath $args

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -177,7 +177,7 @@ try {
         [string]$asAccountName = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.AccountName')
         [string]$PersonalAccessToken = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.PAT')
         [bool]$UseAad = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.UseAad' -AsBool)
-        [string]$IndexableFileFormats = (Get-VstsInput -Name 'IndexableFileFormats' -Default 'Default')
+        [string]$IndexableFileFormats = (Get-VstsInput -Name 'IndexableFileFormats')
 
         if ( $asAccountName ) {
             if ( $PersonalAccessToken ) {
@@ -228,7 +228,7 @@ try {
         [string] $requestUrl = "#$SymbolServiceUri/_apis/Symbol/requests?requestName=$encodedRequestName"
         Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
 
-        & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -IndexableFileFormats $IndexableFileFormats -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
+        & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -IndexableFileFormats `"$IndexableFileFormats`" -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
 
         if (Test-Path -Path $tmpFileName) {
             del $tmpFileName

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -177,6 +177,7 @@ try {
         [string]$asAccountName = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.AccountName')
         [string]$PersonalAccessToken = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.PAT')
         [bool]$UseAad = (Get-VstsTaskVariable -Name 'ArtifactServices.Symbol.UseAad' -AsBool)
+        [string]$IndexableFileFormats = (Get-VstsInput -Name 'IndexableFileFormats' -Default 'Default')
 
         if ( $asAccountName ) {
             if ( $PersonalAccessToken ) {
@@ -227,7 +228,7 @@ try {
         [string] $requestUrl = "#$SymbolServiceUri/_apis/Symbol/requests?requestName=$encodedRequestName"
         Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
 
-        & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
+        & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -IndexableFileFormats $IndexableFileFormats -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
 
         if (Test-Path -Path $tmpFileName) {
             del $tmpFileName

--- a/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -18,6 +18,8 @@
   "loc.input.help.SymbolsPath": "The file share that hosts your symbols. This value will be used in the call to `symstore.exe add` as the `/s` parameter.",
   "loc.input.label.CompressSymbols": "Compress symbols",
   "loc.input.help.CompressSymbols": "Compress symbols when publishing to file share.",
+  "loc.input.label.IndexableFileFormats": "Symbol file formats to publish",
+  "loc.input.help.IndexableFileFormats": "Which debug formats to publish to the symbol server",
   "loc.input.label.DetailedLog": "Verbose logging",
   "loc.input.help.DetailedLog": "Use verbose logging.",
   "loc.input.label.TreatNotIndexedAsWarning": "Warn if not indexed",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
     "preview": false,
     "version": {
         "Major": 2,
-        "Minor": 190,
+        "Minor": 191,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
@@ -88,6 +88,21 @@
             "required": true,
             "helpMarkDown": "Compress symbols when publishing to file share.",
             "visibleRule": "SymbolServerType = FileShare"
+        },
+        {
+            "name": "IndexableFileFormats",
+            "type": "pickList",
+            "label": "Symbol file formats to publish",
+            "defaultValue": "Default",
+            "helpMarkDown": "Which debug formats to publish to the symbol server",
+            "options": {
+                "Default": "The Default set of symbols to upload",
+                "Pdb": "Only Pdb based symbols Windows pdb's and managed Portable pdb's.",
+                "SourceMap": "Only JavaScript based SourceMap symbols (*.js.map)",
+                "All": "All supported symbol formats"
+            },
+            "groupName": "advanced",
+            "visibleRule": "PublishSymbols = true && SymbolServerType = TeamServices"
         },
         {
             "name": "DetailedLog",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 190,
+    "Minor": 191,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
@@ -88,6 +88,21 @@
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.CompressSymbols",
       "visibleRule": "SymbolServerType = FileShare"
+    },
+    {
+      "name": "IndexableFileFormats",
+      "type": "pickList",
+      "label": "ms-resource:loc.input.label.IndexableFileFormats",
+      "defaultValue": "Default",
+      "helpMarkDown": "ms-resource:loc.input.help.IndexableFileFormats",
+      "options": {
+        "Default": "The Default set of symbols to upload",
+        "Pdb": "Only Pdb based symbols Windows pdb's and managed Portable pdb's.",
+        "SourceMap": "Only JavaScript based SourceMap symbols (*.js.map)",
+        "All": "All supported symbol formats"
+      },
+      "groupName": "advanced",
+      "visibleRule": "PublishSymbols = true && SymbolServerType = TeamServices"
     },
     {
       "name": "DetailedLog",


### PR DESCRIPTION
**Task name**: Add support for the newly introduced flag IndexableFileFormts on symbol.exe. 

**Description**: To support JavaScript SourceMap symbol uploads symbol.exe now has an extra flag: `--indexableFileFormats` which maps to an enumeration. This fully rolled out as part of m191 of artifacts services. This change add support for defining the flag so customers can upload there .js.map files to the symbols backend to provide all the same benefits of string the .pdb's in Azure Dev Ops and not having to roll out their own backend servers to serve the .js.map files.

**Documentation changes required:** Y. This flag should be documented. 
I am happy to sign up to write the documentation

**Added unit tests:** N
[In Progress, wanted to get the PR out early to start discussion]

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected:
  I deployed it to my test instance and tested the pipeline and was able to control the flag and observe the expected behavior.
