### PR TITLE
Increase timeout for build all tasks job on windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   condition: and(succeeded(), not(variables.task), eq(variables.os, 'Windows_NT'))
   pool:
     vmImage: vs2017-win2016
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   steps:
   - template: ci/build-all-steps.yml
     parameters:


### PR DESCRIPTION
**Task name**: N/A

**Description**: We need to increase job timeout for build all tasks job on windows since there are slower agents that are not able to build and test all tasks in 90 minutes.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N
