### PR TITLE
Fix support VS old versions in VSBuildV1 task

### DIFF
--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -9,8 +9,8 @@ function Get-VSPath {
 
     try {
         if ( !($Version -in $Versions )) {
-          Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
-            } else { 
+            Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
+        } else { 
             $VersionNumber = [int]$Version.Remove(2)
             # Search for more than 15.0 Willow instance.
             if ($VersionNumber -ge 15) {

--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -9,7 +9,7 @@ function Get-VSPath {
 
     try {
         if ( !($Version -in $Versions )) {
-            Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
+          Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
             } else { 
             $VersionNumber = [int]$Version.Remove(2)
             # Search for more than 15.0 Willow instance.

--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -15,8 +15,7 @@ function Get-VSPath {
                 # Search for more than 15.0 Willow instance.
                 if ($VersionNumber -ge 15) {
                     if (($instance = Get-VisualStudio $VersionNumber) -and
-                        $instance.installationPath) {
-                    
+                        $instance.installationPath) {                    
                         return $instance.installationPath
                         }
                 }

--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -9,21 +9,21 @@ function Get-VSPath {
 
     try {
         if ( !($Version -in $Versions )) {
-          Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
-          } else { 
+            Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
+            } else { 
             $VersionNumber = [int]$Version.Remove(2)
-                # Search for more than 15.0 Willow instance.
-                if ($VersionNumber -ge 15) {
-                    if (($instance = Get-VisualStudio $VersionNumber) -and
-                        $instance.installationPath) {                    
-                        return $instance.installationPath
-                        }
-                }
-                # Fallback to searching for an older install.
-                if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
-                    return $path
-                }
-          }
+            # Search for more than 15.0 Willow instance.
+            if ($VersionNumber -ge 15) {
+                if (($instance = Get-VisualStudio $VersionNumber) -and
+                    $instance.installationPath) {                    
+                    return $instance.installationPath
+                    }
+            }
+            # Fallback to searching for an older install.
+            if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
+                return $path
+            }
+        }
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation
     }

--- a/Tasks/VSBuildV1/Get-VSPath.ps1
+++ b/Tasks/VSBuildV1/Get-VSPath.ps1
@@ -4,24 +4,26 @@ function Get-VSPath {
         [Parameter(Mandatory = $true)]
         [string]$Version)        
         
-    $Versions = @('15.0', '16.0', '17.0')
+    $Versions = @('10.0', '11.0', '12.0','14.0','15.0', '16.0', '17.0')
     Trace-VstsEnteringInvocation $MyInvocation
 
     try {
         if ( !($Version -in $Versions )) {
-          Write-Warning "Please enter one of the versions 15.0, 16.0, 17.0" 
+          Write-Warning "Please enter one of the versions 10.0, 11.0, 12.0, 14.0, 15.0, 16.0, 17.0" 
           } else { 
             $VersionNumber = [int]$Version.Remove(2)
-            # Search for more than 15.0 Willow instance.
-                if (($instance = Get-VisualStudio $VersionNumber) -and
-                    $instance.installationPath) {
+                # Search for more than 15.0 Willow instance.
+                if ($VersionNumber -ge 15) {
+                    if (($instance = Get-VisualStudio $VersionNumber) -and
+                        $instance.installationPath) {
                     
-                    return $instance.installationPath
+                        return $instance.installationPath
+                        }
                 }
-         
-            if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
+                # Fallback to searching for an older install.
+                if ($path = (Get-ItemProperty -LiteralPath "HKLM:\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\$Version" -Name 'ShellFolder' -ErrorAction Ignore).ShellFolder) {
                     return $path
-            }
+                }
           }
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 192,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 192,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "msbuild",


### PR DESCRIPTION
**Task name**: VSBuildV1

**Description**: Fix VSBuildV1 task support old versions of VS

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
