### PR TITLE
14091 Inline scripts not working in v5 with space in the filename #14091

### DIFF
--- a/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV4/AzurePowerShell.ps1
@@ -93,7 +93,7 @@ try {
             $contents += "`$VerbosePreference = 'continue'"
         }
 
-        $contents += ". $PSScriptRoot\UpdatePSModulePath.ps1 $UpdatePSModulePathArgument"
+        $contents += ". `"$PSScriptRoot\UpdatePSModulePath.ps1`" $UpdatePSModulePathArgument"
         if ($scriptType -eq "InlineScript") {
             $contents += "$scriptInline".Replace("`r`n", "`n").Replace("`n", "`r`n")
         } else {

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 185,
+        "Minor": 193,
         "Patch": 0
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 184,
-    "Patch": 1
+    "Minor": 193,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -70,7 +70,7 @@ try
     } else {
         $CoreAzArgument = "-endpoint '$endpoint'"
     }
-    $contents += ". $PSScriptRoot\CoreAz.ps1 $CoreAzArgument"
+    $contents += ". `"$PSScriptRoot\CoreAz.ps1`" $CoreAzArgument"
 
     if ($scriptType -eq "InlineScript") {
         $contents += "$scriptInline".Replace("`r`n", "`n").Replace("`n", "`r`n")

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 185,
+        "Minor": 193,
         "Patch": 0
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 184,
-    "Patch": 1
+    "Minor": 193,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [


### PR DESCRIPTION
**Task name**: AzurePowerShellV4, AzurePowerShellV5

**Description**:  Inline scripts not working in v5 with space in the filename

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N)  Y

**Checklist**:
- [x ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x ] Checked that applied changes work as expected
