### PR TITLE
Update ubuntu image in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
   displayName: Build all tasks (Linux)
   condition: and(succeeded(), not(variables.task), eq(variables.os, 'Linux'))
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps:
   - template: ci/build-all-steps.yml
     parameters:
@@ -121,7 +121,7 @@ jobs:
   displayName: Build shared npm packages (Linux)
   condition: and(succeeded(), not(variables.task), eq(variables.os, 'Linux'))
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   steps:
   - template: ci/build-common-npm.yml
 


### PR DESCRIPTION
We need to update the image in the CI from `ubuntu-16.04` at least to `ubuntu-18.04` since
```
Ubuntu 16.04 LTS environment is deprecated and will be removed on September 20, 2021.
```