### PR TITLE
update artifacts cred provider version in NuGetCommandV2 and NugetAuthenticateV0

### DIFF
--- a/Tasks/NuGetAuthenticateV0/make.json
+++ b/Tasks/NuGetAuthenticateV0/make.json
@@ -10,7 +10,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.24/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.28/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetAuthenticateV0/task.json
+++ b/Tasks/NuGetAuthenticateV0/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 194,
+        "Minor": 193,
         "Patch": 0
     },
     "minimumAgentVersion": "2.120.0",

--- a/Tasks/NuGetAuthenticateV0/task.json
+++ b/Tasks/NuGetAuthenticateV0/task.json
@@ -13,7 +13,7 @@
     ],
     "version": {
         "Major": 0,
-        "Minor": 181,
+        "Minor": 194,
         "Patch": 0
     },
     "minimumAgentVersion": "2.120.0",

--- a/Tasks/NuGetCommandV2/make.json
+++ b/Tasks/NuGetCommandV2/make.json
@@ -56,7 +56,7 @@
                 "dest": "./CredentialProvider/"
             },
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.24/c.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGetCredProvider/0.1.28/c.zip",
                 "dest": "./CredentialProviderV2/"
             }
         ]

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 194,
+        "Minor": 193,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 179,
+        "Minor": 194,
         "Patch": 0
     },
     "runsOn": [


### PR DESCRIPTION
**Task name**: NuGetCommandV2 and NuGetAuthenticateV0

**Description**: update cred provider version to 0.1.28

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N)  N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
