### PR TITLE
Fixed the path to folder destination of download with JDK file

### DIFF
--- a/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
+++ b/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
@@ -62,7 +62,7 @@ async function getJava(versionSpec: string, jdkArchitectureOption: string): Prom
                 taskLib.getInput('azureStorageAccountName', true), taskLib.getInput('azureContainerName', true), "");
             await azureDownloader.downloadArtifacts(extractLocation, '*' + fileNameAndPath);
             await taskutils.sleepFor(250); //Wait for the file to be released before extracting it.
-            let jdkArchiveName = fileNameAndPath.slice(fileNameAndPath.lastIndexOf('/')+1);
+            let jdkArchiveName = fileNameAndPath.slice(fileNameAndPath.lastIndexOf('/') + 1);
             jdkFileName = path.join(extractLocation, jdkArchiveName);
         } else {
             // get from local directory

--- a/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
+++ b/Tasks/JavaToolInstallerV0/javatoolinstaller.ts
@@ -62,7 +62,8 @@ async function getJava(versionSpec: string, jdkArchitectureOption: string): Prom
                 taskLib.getInput('azureStorageAccountName', true), taskLib.getInput('azureContainerName', true), "");
             await azureDownloader.downloadArtifacts(extractLocation, '*' + fileNameAndPath);
             await taskutils.sleepFor(250); //Wait for the file to be released before extracting it.
-            jdkFileName = path.join(extractLocation, fileNameAndPath);
+            let jdkArchiveName = fileNameAndPath.slice(fileNameAndPath.lastIndexOf('/')+1);
+            jdkFileName = path.join(extractLocation, jdkArchiveName);
         } else {
             // get from local directory
             console.log(taskLib.loc('RetrievingJdkFromLocalPath'));

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 193,
+        "Minor": 194,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 193,
+    "Minor": 194,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: JavaToolInstallerV0

**Description**: fix the path to folder destination of download with JDK file

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N
**Attached related issue:** (Y/N) #14214

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
