### PR TITLE
use ClientCredential for service principal

### DIFF
--- a/Tasks/Common/ServiceFabricHelpers/Connect-ServiceFabricClusterFromServiceEndpoint.ps1
+++ b/Tasks/Common/ServiceFabricHelpers/Connect-ServiceFabricClusterFromServiceEndpoint.ps1
@@ -39,19 +39,19 @@ function Get-AadSecurityToken
     Add-Type -LiteralPath "$PSScriptRoot\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
     $authContext = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext -ArgumentList @($authority)
     $authParams = $ConnectedServiceEndpoint.Auth.Parameters
-    if ($authParams.ServicePrincipal -eq "true")
-    {
-        $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList @($authParams.Username, $authParams.Password)
-    }
-    else
-    {
-        $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential -ArgumentList @($authParams.Username, $authParams.Password)
-    }
-
     try
     {
-        # Acquiring a token using UserCredential implies a non-interactive flow. No credential prompts will occur.
-        $accessToken = $authContext.AcquireToken($clusterApplicationId, $clientApplicationId, $credential).AccessToken
+        if ($authParams.ServicePrincipal -eq "true")
+        {
+            $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList @($authParams.Username, $authParams.Password)
+            $accessToken = $authContext.AcquireToken($clusterApplicationId, $credential).AccessToken
+        }
+        else
+        {
+            $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential -ArgumentList @($authParams.Username, $authParams.Password)
+            # Acquiring a token using UserCredential implies a non-interactive flow. No credential prompts will occur.
+            $accessToken = $authContext.AcquireToken($clusterApplicationId, $clientApplicationId, $credential).AccessToken
+        }
     }
     catch
     {

--- a/Tasks/Common/ServiceFabricHelpers/Connect-ServiceFabricClusterFromServiceEndpoint.ps1
+++ b/Tasks/Common/ServiceFabricHelpers/Connect-ServiceFabricClusterFromServiceEndpoint.ps1
@@ -39,12 +39,19 @@ function Get-AadSecurityToken
     Add-Type -LiteralPath "$PSScriptRoot\Microsoft.IdentityModel.Clients.ActiveDirectory.dll"
     $authContext = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext -ArgumentList @($authority)
     $authParams = $ConnectedServiceEndpoint.Auth.Parameters
-    $userCredential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential -ArgumentList @($authParams.Username, $authParams.Password)
+    if ($authParams.ServicePrincipal -eq "true")
+    {
+        $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.ClientCredential -ArgumentList @($authParams.Username, $authParams.Password)
+    }
+    else
+    {
+        $credential = Create-Object -TypeName Microsoft.IdentityModel.Clients.ActiveDirectory.UserCredential -ArgumentList @($authParams.Username, $authParams.Password)
+    }
 
     try
     {
         # Acquiring a token using UserCredential implies a non-interactive flow. No credential prompts will occur.
-        $accessToken = $authContext.AcquireToken($clusterApplicationId, $clientApplicationId, $userCredential).AccessToken
+        $accessToken = $authContext.AcquireToken($clusterApplicationId, $clientApplicationId, $credential).AccessToken
     }
     catch
     {
@@ -186,11 +193,11 @@ function Connect-ServiceFabricClusterFromServiceEndpoint
         if ($ConnectedServiceEndpoint.Auth.Scheme -ne "None")
         {
             # Add server cert thumbprint(s)/commonname(s) (common to both auth-types)
-            if ($ConnectedServiceEndpoint.Auth.Parameters.ServerCertCommonName) 
+            if ($ConnectedServiceEndpoint.Auth.Parameters.ServerCertCommonName)
             {
                 $clusterConnectionParameters["ServerCommonName"] = $ConnectedServiceEndpoint.Auth.Parameters.ServerCertCommonName -split ',' | ForEach-Object { $_.Trim() }
-            } 
-            elseif ($ConnectedServiceEndpoint.Auth.Parameters.ServerCertThumbprint) 
+            }
+            elseif ($ConnectedServiceEndpoint.Auth.Parameters.ServerCertThumbprint)
             {
                 $clusterConnectionParameters["ServerCertThumbprint"] = $ConnectedServiceEndpoint.Auth.Parameters.ServerCertThumbprint -split ',' | ForEach-Object { $_.Trim() }
             }


### PR DESCRIPTION
**Task name**: ServiceFabric*

**Description**: Use the ClientCredential class for obtaining an access token if a service principal is used.

This would require a new option on the Service Fabric service connection to indicate a service principal is being used, but I can't find where the service connection is defined - it doesn't seem to be in this repository?

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** #15361

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

