### PR TITLE
updated inputparser.ts file for vs2022 preview version

### DIFF
--- a/Tasks/VsTestV2/inputparser.ts
+++ b/Tasks/VsTestV2/inputparser.ts
@@ -528,8 +528,12 @@ function getTestPlatformPath(inputDataContract : idc.InputDataContract) {
 
     if (vsTestVersion.toLowerCase() === 'latest') {
         tl.debug('Searching for latest Visual Studio.');
-
-        let vstestconsolePath = getVSTestConsolePath('16.0', '17.0');
+        let vstestconsolePath = getVSTestConsolePath('17.0', '18.0');
+        if (vstestconsolePath) {
+            
+            return path.join(vstestconsolePath, 'Common7', 'IDE', 'Extensions', 'TestPlatform');
+        }
+         vstestconsolePath = getVSTestConsolePath('16.0', '17.0');
         if (vstestconsolePath) {
             return path.join(vstestconsolePath, 'Common7', 'IDE', 'Extensions', 'TestPlatform');
         }

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 170,
-        "Patch": 1
+        "Minor": 194,
+        "Patch": 0
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 170,
-    "Patch": 1
+    "Minor": 194,
+    "Patch": 0
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
**Task name**: VsTestV2

**Description**: Added versions 17,18 for visual studio 2022 preview

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
