### PR TITLE
Add doc about migrate tasks to node10

### DIFF
--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -38,7 +38,6 @@ to
       "argumentFormat": ""
     }
 ```
-**Use Node10 instead of Node14 for Node 10**
 
 5. Upgrade any additional dependencies that may be incompatible with Node 10.
 An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1
@@ -54,13 +53,7 @@ See some additional dependency issues below.
 
 ## Common packages dependent on azure-pipeline-task-lib
 
-- use the latest major `x.x.x-preview` version of a "common package" (preview versions of common packages are stored at [common-packages-preview branch](https://github.com/microsoft/azure-pipelines-tasks/tree/common-packages-preview) at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
-
-If there's no `x.x.x-preview.0` version prepared for Node 10 migration:
-
-- make sure that common package's dependencies are compatible with Node 10;
-- Update `azure-pipelines-task-lib` dependency to the latest `^3.1.0` version.
-- bump the package's major version and create a new `x.x.x-preview` package release.
+- use the latest major version of a "common package" at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
 
 The task-lib package uses some shared (e.g. global object) resources to operate so it may cause unexpected errors in cases when more than one version of the package is installed for a task. It happens in the case of a child package's task-lib dependency has a different version than a task's `task-lib` has.
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -53,7 +53,7 @@ See some additional dependency issues below.
 
 ## Common packages dependent on azure-pipeline-task-lib
 
-- use the latest major version of a "common package" at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
+Use the latest major version of a "common package" at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
 
 The task-lib package uses some shared (e.g. global object) resources to operate so it may cause unexpected errors in cases when more than one version of the package is installed for a task. It happens in the case of a child package's task-lib dependency has a different version than a task's `task-lib` has.
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -77,7 +77,7 @@ If you are planning to move some common package to common-npm-packages directory
 
 # List of known dependency issues
 
-### fs module
+## `fs` module
 
 The following `fs` functions all have incompatibilities. In addition, any other `fs` usage should probably face extra strict scrutiny.
 - fs.appendFile

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -67,7 +67,7 @@ See some additional [dependency issues](#list-of-known-dependency-issues) below.
 
 7. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
 
-## Common packages dependent on azure-pipeline-task-lib
+## Common packages dependent on `azure-pipeline-task-lib`
 
 Use the latest major version of a "common package" at `common-npm-packages` folder, which depends on the `azure-pipelines-task-lib` package with `^3.1.7` version.
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -6,18 +6,17 @@
 
 # Upgrading Tasks to Node 10
 
-1. Upgrade to typescript 4.0.2 and fix type errors
-Add the following to the package.json
+1. Upgrade `typescript` to `4.0.2` version and fix type errors. Add the following snippet to the `package.json`:
 ```
   "devDependencies": {
     "typescript": "^4.0.0"
   }
 ``` 
 2. Replace typings with @types
-Delete `typings` folders and `typings.json` files
-Add @types packages to package.json dependencies.
+   * Delete `typings` folders and `typings.json` files
+   * Add @types packages to `package.json` dependencies.
 
-```
+```json
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
@@ -27,11 +26,11 @@ Add @types packages to package.json dependencies.
 ```
 3. Upgrade `azure-pipelines-task-lib` to `^3.1.7` in package.json dependencies.
 
-4. Change execution handlers in task.json from "Node" to "Node10"
-_Note: the "target" property should be the main file targetted for the task to execute._
+4. Change execution handlers in `task.json` from `Node` to `Node10`
+   * **Note**: _the `target` property should be the main file targetted for the task to execute._
 
 from:
-```
+```json
   "execution": {
     "Node": {
       "target": "bash.js",
@@ -39,7 +38,8 @@ from:
     }
 ```
 to:
-```
+
+```json
   "execution": {
     "Node10": {
       "target": "bash.js",

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -1,10 +1,16 @@
+# Table of content
+- [Upgrading Tasks to Node 10](#upgrading-tasks-to-node-10)
+  - [Common packages dependent on `azure-pipeline-task-lib`](#common-packages-dependent-on-azure-pipeline-task-lib)
+- [List of known dependency issues](#list-of-known-dependency-issues)
+  - [`fs` module](#fs-module)
+
 # Upgrading Tasks to Node 10
 
 1. Upgrade to typescript 4.0.2 and fix type errors
 Add the following to the package.json
 ```
   "devDependencies": {
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.0"
   }
 ``` 
 2. Replace typings with @types
@@ -41,9 +47,11 @@ to
 
 5. Upgrade any additional dependencies that may be incompatible with Node 10.
 An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1
-See some additional dependency issues below.
+See some additional [dependency issues](#list-of-known-dependency-issues) below.
 
-6. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
+6. Thoroughly test tasks with unit tests and on an actual agent. The build agent now supports Node 10, so testing can be done on live versions of Azure DevOps.
+
+7. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
 
 ## Common packages dependent on azure-pipeline-task-lib
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -4,7 +4,7 @@
 Add the following to the package.json
 ```
   "devDependencies": {
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.2"
   }
 ``` 
 2. Replace typings with @types
@@ -19,7 +19,7 @@ Add @types packages to package.json dependencies.
     ...
   }
 ```
-3. Upgrade `azure-pipelines-task-lib` to `^3.1.0` in package.json dependencies.
+3. Upgrade `azure-pipelines-task-lib` to `^3.1.7` in package.json dependencies.
 
 4. Change execution handlers in task.json from "Node" to "Node10"
 _Note: the "target" property should be the main file targetted for the task to execute._
@@ -43,15 +43,11 @@ to
 An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1
 See some additional dependency issues below.
 
-6. Thoroughly test tasks with unit tests and on an actual agent. The build agent now supports Node 10, so testing can be done on live versions of Azure DevOps.
-- Ensure tests have good L0 coverage
-- Add build canary tests if they are missing
-
-7. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
+6. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
 
 ## Common packages dependent on azure-pipeline-task-lib
 
-Use the latest major version of a "common package" at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
+Use the latest major version of a "common package" at `common-npm-packages` folder, which depends on the `azure-pipelines-task-lib` package with `^3.1.7` version.
 
 The task-lib package uses some shared (e.g. global object) resources to operate so it may cause unexpected errors in cases when more than one version of the package is installed for a task. It happens in the case of a child package's task-lib dependency has a different version than a task's `task-lib` has.
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -7,10 +7,13 @@
 # Upgrading Tasks to Node 10
 
 1. Upgrade `typescript` to `4.0.2` version and fix type errors. Add the following snippet to the `package.json`:
+
 ```json
   "devDependencies": {
     "typescript": "^4.0.0"
   }
+```
+  
 2. Replace typings with @types
    * Delete `typings` folders and `typings.json` files
    * Add @types packages to `package.json` dependencies.

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -29,6 +29,8 @@ Add @types packages to package.json dependencies.
 
 4. Change execution handlers in task.json from "Node" to "Node10"
 _Note: the "target" property should be the main file targetted for the task to execute._
+
+from:
 ```
   "execution": {
     "Node": {
@@ -36,7 +38,7 @@ _Note: the "target" property should be the main file targetted for the task to e
       "argumentFormat": ""
     }
 ```
-to
+to:
 ```
   "execution": {
     "Node10": {

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -43,13 +43,11 @@ to
 An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1
 See some additional dependency issues below.
 
-6. Delete or migrate any tests in the Tests-Legacy folder for the task. These tests are no longer supported on Node 10. Add unit tests if they don't already exist :)
-
-7. Thoroughly test tasks with unit tests and on an actual agent. The build agent now supports Node 10, so testing can be done on live versions of Azure DevOps.
+6. Thoroughly test tasks with unit tests and on an actual agent. The build agent now supports Node 10, so testing can be done on live versions of Azure DevOps.
 - Ensure tests have good L0 coverage
 - Add build canary tests if they are missing
 
-8. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
+7. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
 
 ## Common packages dependent on azure-pipeline-task-lib
 

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -1,0 +1,102 @@
+# Upgrading Tasks to Node 10
+
+1. Upgrade to typescript 4.0.2 and fix type errors
+Add the following to the package.json
+```
+  "devDependencies": {
+    "typescript": "^4.0.0"
+  }
+``` 
+2. Replace typings with @types
+Delete `typings` folders and `typings.json` files
+Add @types packages to package.json dependencies.
+
+```
+  "dependencies": {
+    "@types/node": "^10.17.0",
+    "@types/mocha": "^5.2.7",
+    "@types/uuid": "^8.3.0"
+    ...
+  }
+```
+3. Upgrade `azure-pipelines-task-lib` to `^3.1.0` in package.json dependencies.
+
+4. Change execution handlers in task.json from "Node" to "Node10"
+_Note: the "target" property should be the main file targetted for the task to execute._
+```
+  "execution": {
+    "Node": {
+      "target": "bash.js",
+      "argumentFormat": ""
+    }
+```
+to
+```
+  "execution": {
+    "Node10": {
+      "target": "bash.js",
+      "argumentFormat": ""
+    }
+```
+**Use Node10 instead of Node14 for Node 10**
+
+5. Upgrade any additional dependencies that may be incompatible with Node 10.
+An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1
+See some additional dependency issues below.
+
+6. Delete or migrate any tests in the Tests-Legacy folder for the task. These tests are no longer supported on Node 10. Add unit tests if they don't already exist :)
+
+7. Thoroughly test tasks with unit tests and on an actual agent. The build agent now supports Node 10, so testing can be done on live versions of Azure DevOps.
+- Ensure tests have good L0 coverage
+- Add build canary tests if they are missing
+
+8. Bumping the minimum agent version is not required, as the server will enforce a minimum version for pipelines containing Node 10 tasks.
+
+## Common packages dependent on azure-pipeline-task-lib
+
+- use the latest major `x.x.x-preview` version of a "common package" (preview versions of common packages are stored at [common-packages-preview branch](https://github.com/microsoft/azure-pipelines-tasks/tree/common-packages-preview) at `common-npm-packages` folder) which depends on the `azure-pipelines-task-lib` package with `^3.1.0` version.
+
+If there's no `x.x.x-preview.0` version prepared for Node 10 migration:
+
+- make sure that common package's dependencies are compatible with Node 10;
+- Update `azure-pipelines-task-lib` dependency to the latest `^3.1.0` version.
+- bump the package's major version and create a new `x.x.x-preview` package release.
+
+The task-lib package uses some shared (e.g. global object) resources to operate so it may cause unexpected errors in cases when more than one version of the package is installed for a task. It happens in the case of a child package's task-lib dependency has a different version than a task's `task-lib` has.
+
+If you are planning to move some common package to common-npm-packages directory - please note that you need to update all necessary paths in this package ([example of such path](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/packaging-common/Tests/MockHelper.ts#L44))
+
+# List of known dependency issues
+
+### fs module
+
+The following `fs` functions all have incompatibilities. In addition, any other `fs` usage should probably face extra strict scrutiny.
+- fs.appendFile
+- fs.chmod
+- fs.chown
+- fs.close
+- fs.fchmod
+- fs.fchown
+- fs.fdatasync
+- fs.fstat
+- fs.fsync
+- fs.ftruncate
+- fs.futimes
+- fs.lchmod
+- fs.lchown
+- fs.link
+- fs.lstat
+- fs.mkdir
+- fs.mkdtemp
+- fs.readdir
+- fs.readFile
+- fs.readlink
+- fs.realpath
+- fs.rename
+- fs.rmdir
+- fs.stat
+- fs.truncate
+- fs.unlink
+- fs.utimes
+- fs.write
+- fs.writeFile

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -7,11 +7,10 @@
 # Upgrading Tasks to Node 10
 
 1. Upgrade `typescript` to `4.0.2` version and fix type errors. Add the following snippet to the `package.json`:
-```
+```json
   "devDependencies": {
     "typescript": "^4.0.0"
   }
-``` 
 2. Replace typings with @types
    * Delete `typings` folders and `typings.json` files
    * Add @types packages to `package.json` dependencies.

--- a/docs/migrateNode10.md
+++ b/docs/migrateNode10.md
@@ -29,7 +29,14 @@
 4. Change execution handlers in `task.json` from `Node` to `Node10`
    * **Note**: _the `target` property should be the main file targetted for the task to execute._
 
-from:
+<table>
+<tr>
+<th>From</th>
+<th>To</th>
+</tr>
+<tr>
+<td>
+
 ```json
   "execution": {
     "Node": {
@@ -37,7 +44,9 @@ from:
       "argumentFormat": ""
     }
 ```
-to:
+
+</td>
+<td>
 
 ```json
   "execution": {
@@ -46,6 +55,10 @@ to:
       "argumentFormat": ""
     }
 ```
+
+</td>
+</tr>
+</table>
 
 5. Upgrade any additional dependencies that may be incompatible with Node 10.
 An example is the `sync-request` package, which needs to be upgraded to the latest version from v3.0.1


### PR DESCRIPTION
Add a guideline for migrating tasks to Node 10.

[link to new doc](https://github.com/microsoft/azure-pipelines-tasks/blob/users/v-aopareva/add_doc_about_migrate_tasks_node10/docs/migrateNode10.md)


