### PR TITLE
Fixes typed-rest-client/HttpClient missing from ContainerStuctureTest task and uses new syntax for container-structure-test tool output formatting

### DIFF
--- a/Tasks/ContainerStructureTestV0/package-lock.json
+++ b/Tasks/ContainerStructureTestV0/package-lock.json
@@ -20,9 +20,9 @@
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
     },
     "@types/uuid": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
-      "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ=="
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -331,9 +331,9 @@
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "typed-rest-client": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.12.0.tgz",
-      "integrity": "sha1-Y3b1Un9CfaEh3K/f1+QeEyHgcgw=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.5.0.tgz",
+      "integrity": "sha512-DVZRlmsfnTjp6ZJaatcdyvvwYwbWvR4YDNFDqb+qdTxpvaVP99YCpBkA8rxsLtAPjBVoDe4fNsnMIdZTiPuKWg==",
       "requires": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
@@ -356,26 +356,8 @@
       "requires": {
         "js-yaml": "3.6.1",
         "semver": "^5.4.1",
-        "vso-node-api": "6.5.0",
         "vsts-task-lib": "2.6.0",
         "vsts-task-tool-lib": "0.4.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "vso-node-api": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-          "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-          "requires": {
-            "tunnel": "0.0.4",
-            "typed-rest-client": "^0.12.0",
-            "underscore": "1.8.3"
-          }
-        }
       }
     },
     "utility-common-v2": {
@@ -384,25 +366,7 @@
         "azure-pipelines-task-lib": "2.8.0",
         "azure-pipelines-tool-lib": "0.12.0",
         "js-yaml": "3.6.1",
-        "semver": "^5.4.1",
-        "vso-node-api": "6.5.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "vso-node-api": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/vso-node-api/-/vso-node-api-6.5.0.tgz",
-          "integrity": "sha512-hFjPLMJkq02zF8U+LhZ4airH0ivaiKzGdlNAQlYFB3lWuGH/UANUrl63DVPUQOyGw+7ZNQ+ufM44T6mWN92xyg==",
-          "requires": {
-            "tunnel": "0.0.4",
-            "typed-rest-client": "^0.12.0",
-            "underscore": "1.8.3"
-          }
-        }
+        "semver": "^5.4.1"
       }
     },
     "uuid": {

--- a/Tasks/ContainerStructureTestV0/package.json
+++ b/Tasks/ContainerStructureTestV0/package.json
@@ -21,6 +21,7 @@
     "@types/q": "^1.0.7",
     "azure-pipelines-task-lib": "2.8.0",
     "azure-pipelines-tasks-docker-common-v2": "1.0.0",
+    "typed-rest-client": "1.5.0",
     "utility-common": "file:../../_build/Tasks/Common/utility-common-1.0.2.tgz",
     "utility-common-v2": "file:../../_build/Tasks/Common/utility-common-v2-2.0.0.tgz",
     "uuid": "^3.0.1"

--- a/Tasks/ContainerStructureTestV0/testrunner.ts
+++ b/Tasks/ContainerStructureTestV0/testrunner.ts
@@ -69,7 +69,7 @@ export class TestRunner {
     }
 
     private runContainerStructureTest(runnerPath: string, testFilePath: string, image: string): string {
-        var tool:tr.ToolRunner = tl.tool(runnerPath).arg(["test", "--image", image, "--config", testFilePath, "--json"]);
+        var tool:tr.ToolRunner = tl.tool(runnerPath).arg(["test", "--image", image, "--config", testFilePath, "--output", "json"]);
         let output = undefined;
 
         try {


### PR DESCRIPTION
Fixes typed-rest-client/HttpClient missing from ContainerStuctureTest task and uses new syntax for formatting container-structure-test tool output

**Task name**: ContainerStructureTestV0

**Description**: Fixes #14247 and updates the old syntax for formatting container-structure-test tool output

**Documentation changes required:** (Y/N) No since this is mostly a bug fix

**Added unit tests:** (Y/N) No

**Attached related issue:** (Y/N) #14247

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
