### PR TITLE
Fix uri for ADFS token API

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
@@ -220,7 +220,7 @@ export class ApplicationTokenCredentials {
         var deferred = Q.defer<string>();
         let webRequest = new webClient.WebRequest();
         webRequest.method = "POST";
-        webRequest.uri = this.authorityUrl + this.domain + "/oauth2/token/";
+        webRequest.uri = this.authorityUrl + (this.isADFSEnabled ? "" : this.domain) + "/oauth2/token/";
         webRequest.body = querystring.stringify({
             resource: this.activeDirectoryResourceId,
             client_id: this.clientId,


### PR DESCRIPTION
**Task name**: <Name of changed or new pipeline task>

**Description**: The URI was constructed correct when using a certificate, but not a client secret. Was likely overlooked when ADFS support was first added.

**Documentation changes required:** (N) <Please mark if documentation changes are required>

**Added unit tests:** (N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
