### PR TITLE
[MSBuildHelpers, MSBuildV1, VSBuildV1, XamarinAndroidV1] Enable fix for MSBuild.Logger

### DIFF
--- a/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
+++ b/Tasks/Common/MSBuildHelpers/InvokeFunctions.ps1
@@ -108,7 +108,7 @@ function Invoke-MSBuild {
             # Hook up the custom logger.
             $loggerAssembly = "$PSScriptRoot\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
             Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
-            $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
+            $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$loggerAssembly`""
         }
 
         # Append additional arguments.

--- a/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
@@ -19,7 +19,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile 'Some project file' -NoTimelineL
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
@@ -31,7 +31,7 @@ Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
             $State -eq 'Initialized' -and
             $AsOutput -eq $true
     }
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -- -Result Failed -DoNotThrow
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
@@ -20,7 +20,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimeline
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
@@ -24,7 +24,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimeline
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /fl /flp:`"logfile=$expectedLogFile;verbosity=$expectedLogFileVerbosity`" /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /fl /flp:`"logfile=$expectedLogFile;verbosity=$expectedLogFileVerbosity`" /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-WasCalled Write-Host -Times 0
 Assert-AreEqual -Expected @(

--- a/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
+++ b/Tasks/Common/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
@@ -31,7 +31,7 @@ Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
             $State -eq 'Initialized' -and
             $AsOutput -eq $true
     }
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/Tasks/Common/MSBuildHelpers/Tests/L0.ts
+++ b/Tasks/Common/MSBuildHelpers/Tests/L0.ts
@@ -9,7 +9,7 @@ var psm = require('../../../../Tests/lib/psRunner');
 var psr = null;
 
 describe('Common-MSBuildHelpers Suite', function () {
-    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 30000);
 
     before((done) => {
         if (psm.testSupported()) {

--- a/Tasks/Common/MSBuildHelpers/make.json
+++ b/Tasks/Common/MSBuildHelpers/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/4/msbuildlogger.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/5/msbuildlogger.zip",
                 "dest": "./"
             },
             {

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.192.1",
+  "version": "1.196.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/Common/MSBuildHelpers/package-lock.json
+++ b/Tasks/Common/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.196.0",
+  "version": "1.197.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.196.0",
+  "version": "1.197.0",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {

--- a/Tasks/Common/MSBuildHelpers/package.json
+++ b/Tasks/Common/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msbuildhelpers",
-  "version": "1.192.1",
+  "version": "1.196.0",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -339,7 +339,7 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "msbuildhelpers": {
-      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz",
+      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.196.0.tgz",
       "requires": {
         "azure-pipelines-task-lib": "^2.9.3"
       },

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -339,7 +339,7 @@
       "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "msbuildhelpers": {
-      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.196.0.tgz",
+      "version": "file:../../_build/Tasks/Common/msbuildhelpers-1.197.0.tgz",
       "requires": {
         "azure-pipelines-task-lib": "^2.9.3"
       },

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.196.0.tgz"
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.197.0.tgz"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.192.1.tgz"
+    "msbuildhelpers": "file:../../_build/Tasks/Common/msbuildhelpers-1.196.0.tgz"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
-        "Patch": 2
+        "Minor": 196,
+        "Patch": 0
     },
     "demands": [
         "msbuild"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 196,
+        "Minor": 197,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 196,
+    "Minor": 197,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
-    "Patch": 2
+    "Minor": 196,
+    "Patch": 0
   },
   "demands": [
     "msbuild"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
-        "Patch": 3
+        "Minor": 196,
+        "Patch": 0
     },
     "demands": [
         "msbuild",

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 196,
+        "Minor": 197,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
-    "Patch": 3
+    "Minor": 196,
+    "Patch": 0
   },
   "demands": [
     "msbuild",

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 196,
+    "Minor": 197,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 192,
-        "Patch": 2
+        "Minor": 196,
+        "Patch": 0
     },
     "demands": [
         "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 196,
+        "Minor": 197,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 192,
-    "Patch": 2
+    "Minor": 196,
+    "Patch": 0
   },
   "demands": [
     "MSBuild",

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 196,
+    "Minor": 197,
     "Patch": 0
   },
   "demands": [

--- a/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
+++ b/common-npm-packages/MSBuildHelpers/InvokeFunctions.ps1
@@ -108,7 +108,7 @@ function Invoke-MSBuild {
             # Hook up the custom logger.
             $loggerAssembly = "$PSScriptRoot\msbuildlogger\Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll"
             Assert-VstsPath -LiteralPath $loggerAssembly -PathType Leaf
-            $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)`"*ForwardingLogger,`"$loggerAssembly`""
+            $arguments = "$arguments /dl:CentralLogger,`"$loggerAssembly`";`"RootDetailId=$($detailId)|SolutionDir=$($solutionDirectory)|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$loggerAssembly`""
         }
 
         # Append additional arguments.

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.CombinesMsbuildexe.ps1
@@ -19,7 +19,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile 'Some project file' -NoTimelineL
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"Some project file`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1
@@ -31,7 +31,7 @@ Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
             $State -eq 'Initialized' -and
             $AsOutput -eq $true
     }
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -- -Result Failed -DoNotThrow
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.OmitsTimelineDetail.ps1
@@ -20,7 +20,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimeline
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.SkipsLogUploadIfMissing.ps1
@@ -24,7 +24,7 @@ $actual = & $module Invoke-MSBuild -ProjectFile $expectedProjectFile -NoTimeline
 # Assert.
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedMSBuildPath -PathType Leaf
 Assert-WasCalled Assert-VstsPath -- -LiteralPath $expectedLoggerPath -PathType Leaf
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /fl /flp:`"logfile=$expectedLogFile;verbosity=$expectedLogFileVerbosity`" /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /fl /flp:`"logfile=$expectedLogFile;verbosity=$expectedLogFileVerbosity`" /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-WasCalled Write-Host -Times 0
 Assert-AreEqual -Expected @(

--- a/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
+++ b/common-npm-packages/MSBuildHelpers/Tests/Invoke-MSBuild.WritesRootTimelineDetail.ps1
@@ -31,7 +31,7 @@ Assert-WasCalled Write-VstsLogDetail -ParametersEvaluator {
             $State -eq 'Initialized' -and
             $AsOutput -eq $true
     }
-Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
+Assert-WasCalled Invoke-VstsTool -- -FileName $expectedMSBuildPath -Arguments "`"$expectedProjectFile`" /nologo /nr:false /dl:CentralLogger,`"$expectedLoggerPath`";`"RootDetailId=$script:rootDetailId|SolutionDir=C:\Some solution dir|enableOrphanedProjectsLogs=true`"*ForwardingLogger,`"$expectedLoggerPath`"" -RequireExitCodeZero
 Assert-WasCalled Write-VstsSetResult -Times 0
 Assert-AreEqual -Expected @(
         'Some output 1'

--- a/common-npm-packages/MSBuildHelpers/Tests/L0.ts
+++ b/common-npm-packages/MSBuildHelpers/Tests/L0.ts
@@ -5,7 +5,7 @@ var psm = require('../../../../Tests/lib/psRunner');
 var psr = null;
 
 describe('Common-MSBuildHelpers Suite', function () {
-    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 30000);
 
     before((done) => {
         if (psm.testSupported()) {

--- a/common-npm-packages/MSBuildHelpers/make.json
+++ b/common-npm-packages/MSBuildHelpers/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/3/msbuildlogger.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/5/msbuildlogger.zip",
                 "dest": "./"
             },
             {

--- a/common-npm-packages/MSBuildHelpers/package-lock.json
+++ b/common-npm-packages/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.196.0",
+  "version": "2.197.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/MSBuildHelpers/package-lock.json
+++ b/common-npm-packages/MSBuildHelpers/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.0.1",
+  "version": "2.196.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/MSBuildHelpers/package.json
+++ b/common-npm-packages/MSBuildHelpers/package.json
@@ -1,10 +1,10 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.0.1",
+  "version": "2.196.0",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {
-    "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip ./vswhere && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/3/msbuildlogger.zip ./msbuildlogger &&  node make.js"
+    "build": "node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/vswhere/1_0_62/vswhere.zip ./vswhere && node ../build-scripts/downloadArchive.js https://vstsagenttools.blob.core.windows.net/tools/msbuildlogger/5/msbuildlogger.zip ./msbuildlogger &&  node make.js"
   },
   "repository": {
     "type": "git",

--- a/common-npm-packages/MSBuildHelpers/package.json
+++ b/common-npm-packages/MSBuildHelpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-msbuildhelpers",
-  "version": "2.196.0",
+  "version": "2.197.0",
   "description": "Azure Pipelines tasks MSBuild helpers",
   "main": "msbuildhelpers.js",
   "scripts": {


### PR DESCRIPTION
**Module names:** `MSBuildHelpers` ; `MSBuildV1` ; `VSBuildV1` ; `XamarinAndroidV1`

**Description:** This Pull Request enables the fix for `MSBuild.Logger` used by `msbuild.exe` during the `MSBuild` task execution.

**Documentation changes required:** `N`

**Added unit tests:** `N`

**Modified unit tests:** `Y`

**[Attached related issue](https://github.com/microsoft/build-task-team/issues/1176)**

**Checklist:**
- [x] `MSBuildHelpers` and tasks versions were bumped - [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected — built and deployed (using tfx) MSBuild task to the ADO organization.
    The task works as expected.

**ChangeLog:**

* **common-npm-packages/MSBuildHelpers**
    * `InvokeFunctions.ps1` — new input `|enableOrphanedProjectsLogs=true` added for `MSBuild.Logger`
    * `make.json` — archive url updated
    * `package.json` and `package-lock.json` — MSBuildHelpers version bumped up

* **Tasks**
    * **Common/MSBuildHelpers**
        * `InvokeFunctions.ps1` — new input `|enableOrphanedProjectsLogs=true` added for `MSBuild.Logger`
        * `make.json` — archive url updated
        * `package.json` and `package-lock.json` — MSBuildHelpers version bumped up
    * **MSBuildV1**
        * `task.json` and `task.loc.json` — task version bumped up
        * `package.json` and `package-lock.json` — MSBuildHelpers version bumped up
    * **VSBuildV1**
        * `task.json` and `task.loc.json` — task version bumped up
    * **XamarinAndroidV1**
        * `task.json` and `task.loc.json` — task version bumped up

* **Tasks/Common/MSBuildHelpers/Tests** +
  **common-npm-packages/MSBuildHelpers/Tests** (`L0.ts` and 5 unit tests for each of them)
    * `L0.ts` — timeout changed from 20 to 30 seconds (20 is not always enough)
    * New input `|enableOrphanedProjectsLogs=true` added for `MSBuild.Logger`
        * `Invoke-MSBuild.CombinesMsbuildexe.ps1`
        * `Invoke-MSBuild.FailsRootTimelineDetailOnExitCode.ps1`
        * `Invoke-MSBuild.OmitsTimelineDetail.ps1`
        * `Invoke-MSBuild.SkipsLogUploadIfMissing.ps1`
        * `Invoke-MSBuild.WritesRootTimelineDetail.ps1`
