### PR TITLE
ordered test fix for vs test task

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/16377395/TestAgent.zip",
+                "url": "https://publishtestresults.blob.core.windows.net/testexecution/16377395/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://publishtestresults.blob.core.windows.net/testexecution/16377395/TestAgent.zip",
+                "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/16377395/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/16377395/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/16377395/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/12117206/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/16377395/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 170,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "vstest"

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 170,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
**Task name**:  VsTestV2

**Description**:  Changes for order test support in 2020 server

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://portal.microsofticm.com/imp/v3/incidents/details/271425913/home

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
