### PR TITLE
Add OneLocBuild removal to the localization pipeline

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -85,10 +85,16 @@ stages:
 
         git checkout -b $updateBranch
 
-        Remove-Item -Recurse -Force Localize
+        if (Test-Path -Path Localize) { 
+          Remove-Item -Recurse -Force Localize 
+        }
+        
+        if (Test-Path -Path OneLocBuild) { 
+          Remove-Item -Recurse -Force OneLocBuild 
+        }
 
         git add -A
-        git commit -m "Removing Localize folder"
+        git commit -m "Removing Localize and OneLocBuild folder"
         git push origin $updateBranch
       displayName: Create and push localization update branch
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))


### PR DESCRIPTION
**Description**: Added removal of OneLocBuild and conditional check for Localization folder deletion. Related [issue](https://github.com/microsoft/build-task-team/issues/1844)

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** No

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
