### PR TITLE
Update `UsePythonVersion` to allow versions other than (pypy2 or pypy3.6)

### DIFF
--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -143,6 +143,6 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
         return await usePyPy(fullSpec.substr(4), parameters, platform);
     }
     else {
-        return await  useCpythonVersion(parameters, platform);
+        return await useCpythonVersion(parameters, platform);
     }
 }


### PR DESCRIPTION
**Task name**: `UsePythonVersion@0`

**Description**: Removes hardcoding of pypy version in favor of a prepended full version.

**Documentation changes required:** Y?

**Added unit tests:** Most likely necessary, I'll listen for feedback here.

**Attached related issue:** Y #15232 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

^ for the above questions, what's the best way to test these updates in a real job?
