### PR TITLE
[XcodeV5] Add Xcode ver. 13 support

### DIFF
--- a/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/XcodeV5/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=613730) or [see the Xcode documentation](https://developer.apple.com/xcode/)",
   "loc.description": "Build, test, or archive an Xcode workspace on macOS. Optionally package an app.",
   "loc.instanceNameFormat": "Xcode $(actions)",
-  "loc.releaseNotes": "This version of the task is compatible with Xcode 8 - 11. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
+  "loc.releaseNotes": "This version of the task is compatible with Xcode 8 - 13. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
   "loc.group.displayName.sign": "Signing & provisioning",
   "loc.group.displayName.package": "Package options",
   "loc.group.displayName.devices": "Devices & simulators",

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -15,7 +15,7 @@
         "Minor": 198,
         "Patch": 0
     },
-    "releaseNotes": "This version of the task is compatible with Xcode 8 - 11. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
+    "releaseNotes": "This version of the task is compatible with Xcode 8 - 13. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
     "demands": [
         "xcode"
     ],

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 5,
-        "Minor": 193,
+        "Minor": 198,
         "Patch": 0
     },
     "releaseNotes": "This version of the task is compatible with Xcode 8 - 11. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
@@ -96,6 +96,7 @@
                 "10": "Xcode 10",
                 "11": "Xcode 11",
                 "12": "Xcode 12",
+                "13": "Xcode 13",
                 "default": "Default",
                 "specifyPath": "Specify path"
             }

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 193,
+    "Minor": 198,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -96,6 +96,7 @@
         "10": "Xcode 10",
         "11": "Xcode 11",
         "12": "Xcode 12",
+        "13": "Xcode 13",
         "default": "Default",
         "specifyPath": "Specify path"
       }


### PR DESCRIPTION
**Task name**: XcodeV5

**Description**: 
- Add Xcode 13 to list of supported versions
- Update task version
- Update release notes description

**Documentation changes required:** (Y/N) Yes

**Added unit tests:** (Y/N) No

**Attached related issue:**  #15535 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
