### PR TITLE
Remove ACRTaskV0 from localization

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -112,12 +112,6 @@
           },
           {
             "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
-            "SourceFile": "Tasks\\ACRTaskV0\\Strings\\resources.resjson\\en-US\\resources.resjson",
-            "CopyOption": "LangIDOnPath",
-            "OutputPath": "Tasks\\ACRTaskV0\\Strings\\resources.resjson"
-          },
-          {
-            "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
             "SourceFile": "Tasks\\AndroidSigningV2\\Strings\\resources.resjson\\en-US\\resources.resjson",
             "CopyOption": "LangIDOnPath",
             "OutputPath": "Tasks\\AndroidSigningV2\\Strings\\resources.resjson"


### PR DESCRIPTION
**Task name**: ACRTaskV0

**Description**: Remove task from localization due to being unpublished and unused

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [x] Task version was bumped - not needed
- [ ] Checked that applied changes work as expected
