### PR TITLE
Remove MSBuildArguments property from telemetry for MSBuildV1 and VSBuildV1

### DIFF
--- a/Tasks/MSBuildV1/MSBuild.ps1
+++ b/Tasks/MSBuildV1/MSBuild.ps1
@@ -4,7 +4,6 @@ param()
 Trace-VstsEnteringInvocation $MyInvocation
 $msbuildTelemetry = [PSCustomObject]@{
     MSBuildVersion = ""
-    MSBuildArguments = ""
     MSBuildLocationMethod = ""
     Platform = ""
     Configuration = ""
@@ -37,7 +36,6 @@ try {
     [string]$msBuildArchitecture = Get-VstsInput -Name MSBuildArchitecture
 
     $msbuildTelemetry.MSBuildVersion = "$msBuildVersion"
-    $msbuildTelemetry.MSBuildArguments = "$msBuildArguments"
     $msbuildTelemetry.MSBuildLocationMethod = "$msBuildLocationMethod"
     $msbuildTelemetry.Platform = "$platform"
     $msbuildTelemetry.Configuration = "$configuration"

--- a/Tasks/MSBuildV1/msbuild.ts
+++ b/Tasks/MSBuildV1/msbuild.ts
@@ -19,7 +19,6 @@ async function run() {
         // pass inputs to telemetry object
         telemetry.configuration = configuration;
         telemetry.platform = platform;
-        telemetry.msBuildArguments = msbuildArguments;
 
         let logsolutionEvents: boolean = tl.getBoolInput('logsolutionEvents');
         if (logsolutionEvents) {

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 199,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 199,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/MSBuildV1/telemetryHelper.ts
+++ b/Tasks/MSBuildV1/telemetryHelper.ts
@@ -3,7 +3,6 @@ import * as semver from 'semver';
 
 export interface TelemetryPayload {
     msBuildVersion: string;
-    msBuildArguments: string;
     msBuildLocationMethod: string;
     platform: string;
     configuration: string;

--- a/Tasks/VSBuildV1/VSBuild.ps1
+++ b/Tasks/VSBuildV1/VSBuild.ps1
@@ -4,7 +4,6 @@ param()
 Trace-VstsEnteringInvocation $MyInvocation
 $vsBuildTelemetry = [PSCustomObject]@{
     VsVersion = ""
-    MSBuildArguments = ""
     CustomVersion = ""
     Platform = ""
     Configuration = ""
@@ -55,7 +54,6 @@ try {
     }
 
     $vsBuildTelemetry.VsVersion = "$vsVersion"
-    $vsBuildTelemetry.MSBuildArguments = "$msBuildArgs"
     $vsBuildTelemetry.CustomVersion = "$customVersion"
     $vsBuildTelemetry.Platform = "$platform"
     $vsBuildTelemetry.Configuration = "$configuration"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 199,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 199,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
**Task name**: MSBuildV1, VSBuildV1

**Description**: Was removed MSBuildArguments from telemetry, since it could contain pii data.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
