### PR TITLE
[CI] Filter out fully removed tasks

### DIFF
--- a/ci/filter-tasks.js
+++ b/ci/filter-tasks.js
@@ -180,6 +180,9 @@ var getTasksToBuildForPR = function() {
         }
     });
 
+    // Filter out fully removed tasks
+    toBeBuilt = toBeBuilt.filter((taskName) => fs.existsSync(path.join(__dirname, '..', 'Tasks' , taskName)));
+
     return toBeBuilt;
 }
 


### PR DESCRIPTION
**Task name**: CI

**Description**: Currently the CI is failing when a task is being removed. CI is looking for tasks that have changes in files and then tries to run checks for these tasks. If a task has changed and its files have been removed, the CI fails.

**Documentation changes required:** No

**Added unit tests:** No

**Checklist**:
- [ ] Task version was bumped - not needed
- [x] Checked that applied changes work as expected - [successful PR example](https://github.com/microsoft/azure-pipelines-tasks/pull/15790); also checked locally
