### PR TITLE
Update PublishPipelineArtifact tasks to support passing custom properties

### DIFF
--- a/Tasks/PublishPipelineArtifactV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishPipelineArtifactV0/Strings/resources.resjson/en-US/resources.resjson
@@ -5,6 +5,8 @@
   "loc.instanceNameFormat": "Publish Pipeline Artifact",
   "loc.input.label.artifactName": "The name of this artifact",
   "loc.input.help.artifactName": "The name of this artifact.",
+  "loc.input.label.customProperties": "Custom properties",
+  "loc.input.help.customProperties": "Enter custom properties to associate with the artifact. Valid JSON string expected with all keys having the prefix 'user-'",
   "loc.input.label.targetPath": "Path to publish",
   "loc.input.help.targetPath": "The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported."
 }

--- a/Tasks/PublishPipelineArtifactV0/task.json
+++ b/Tasks/PublishPipelineArtifactV0/task.json
@@ -9,12 +9,12 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 140,
-        "Patch": 1
+        "Minor": 141,
+        "Patch": 0
     },
     "groups": [],
     "demands": [],
-    "minimumAgentVersion": "2.155.1",
+    "minimumAgentVersion": "2.199",
     "preview": false,
     "deprecated": true,
     "inputs": [
@@ -33,6 +33,14 @@
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "The folder or file path to publish. This can be a fully-qualified path or a path relative to the root of the repository. Wildcards are not supported. [Variables](https://go.microsoft.com/fwlink/?LinkID=550988) are supported."
+        },
+        {
+            "name": "properties",
+            "type": "string",
+            "label": "Custom properties",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Enter custom properties to associate with the artifact. Valid JSON string expected with all keys having the prefix 'user-'"
         }
     ],
     "instanceNameFormat": "Publish Pipeline Artifact",

--- a/Tasks/PublishPipelineArtifactV0/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV0/task.loc.json
@@ -9,12 +9,12 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 140,
-    "Patch": 1
+    "Minor": 141,
+    "Patch": 0
   },
   "groups": [],
   "demands": [],
-  "minimumAgentVersion": "2.155.1",
+  "minimumAgentVersion": "2.199",
   "preview": false,
   "deprecated": true,
   "inputs": [
@@ -33,6 +33,14 @@
       "defaultValue": "",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.targetPath"
+    },
+    {
+        "name": "properties",
+        "type": "string",
+        "label": "ms-resource:loc.input.label.customProperties",
+        "defaultValue": "",
+        "required": false,
+        "helpMarkDown": "ms-resource:loc.input.help.customProperties"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/PublishPipelineArtifactV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishPipelineArtifactV1/Strings/resources.resjson/en-US/resources.resjson
@@ -9,6 +9,8 @@
   "loc.input.help.artifactName": "Name of the artifact to publish. If not set, defaults to a unique ID scoped to the job.",
   "loc.input.label.artifactType": "Artifact publish location",
   "loc.input.help.artifactType": "Choose whether to store the artifact in Azure Pipelines, or to copy it to a file share that must be accessible from the pipeline agent.",
+  "loc.input.label.customProperties": "Custom properties",
+  "loc.input.help.customProperties": "Enter custom properties to associate with the artifact. Valid JSON string expected with all keys having the prefix 'user-'",
   "loc.input.label.fileSharePath": "File share path",
   "loc.input.help.fileSharePath": "The file share to which the artifact files will be copied. This can include variables. Example: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). Publishing artifacts from a Linux or macOS agent to a file share is not supported.",
   "loc.input.label.parallel": "Parallel copy",

--- a/Tasks/PublishPipelineArtifactV1/task.json
+++ b/Tasks/PublishPipelineArtifactV1/task.json
@@ -9,13 +9,13 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 199,
         "Patch": 0
     },
     "groups": [],
     "demands": [],
     "preview": false,
-    "minimumAgentVersion": "2.159.2",
+    "minimumAgentVersion": "2.199",
     "inputs": [
         {
             "name": "path",
@@ -80,6 +80,14 @@
             "required": false,
             "helpMarkDown": "Enter the degree of parallelism, or number of threads used, to perform the copy. The value must be at least 1 and not greater than 128.",
             "visibleRule": "artifactType = filepath && parallel = true"
+        },
+        {
+            "name": "properties",
+            "type": "string",
+            "label": "Custom properties",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Enter custom properties to associate with the artifact. Valid JSON string expected with all keys having the prefix 'user-'"
         }
     ],
     "instanceNameFormat": "Publish Pipeline Artifact",

--- a/Tasks/PublishPipelineArtifactV1/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV1/task.loc.json
@@ -9,13 +9,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 199,
     "Patch": 0
   },
   "groups": [],
   "demands": [],
   "preview": false,
-  "minimumAgentVersion": "2.159.2",
+  "minimumAgentVersion": "2.199",
   "inputs": [
     {
       "name": "path",
@@ -80,6 +80,14 @@
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.parallelCount",
       "visibleRule": "artifactType = filepath && parallel = true"
+    },
+    {
+        "name": "properties",
+        "type": "string",
+        "label": "ms-resource:loc.input.label.customProperties",
+        "defaultValue": "",
+        "required": false,
+        "helpMarkDown": "ms-resource:loc.input.help.customProperties"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: PublishPipelineArtifactV0, PublishPipelineArtifactV1

**Description**: Updating PublishPipelineArtifact tasks to allow specifying custom properties that can be associated with the artifact. This change is dependent on a change to the pipelines agent - https://github.com/microsoft/azure-pipelines-agent/commit/8ea28ebb7e1be0bf3da354a042201a71b9902ee7

**Documentation changes required:** N

**Added unit tests:** N/a

**Attached related issue:** N/a

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
