### PR TITLE
[MavenV2 / MavenV3] Add `JAVA 17` to the JDK picklist

### DIFF
--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 198,
+        "Minor": 200,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
@@ -227,6 +227,7 @@
             "visibleRule": "javaHomeSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.17": "JDK 17",
                 "1.11": "JDK 11",
                 "1.10": "JDK 10 (out of support)",
                 "1.9": "JDK 9 (out of support)",

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 198,
+    "Minor": 200,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -227,6 +227,7 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.17": "JDK 17",
         "1.11": "JDK 11",
         "1.10": "JDK 10 (out of support)",
         "1.9": "JDK 9 (out of support)",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 198,
+        "Minor": 200,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
@@ -227,6 +227,7 @@
             "visibleRule": "javaHomeSelection = JDKVersion",
             "options": {
                 "default": "default",
+                "1.17": "JDK 17",
                 "1.11": "JDK 11",
                 "1.10": "JDK 10 (out of support)",
                 "1.9": "JDK 9 (out of support)",

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 198,
+    "Minor": 200,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -227,6 +227,7 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.17": "JDK 17",
         "1.11": "JDK 11",
         "1.10": "JDK 10 (out of support)",
         "1.9": "JDK 9 (out of support)",


### PR DESCRIPTION
**Task name**: 
- MavenV2
- MavenV3

**Description**: 
All virtual images have recently been updated to contain `JAVA 17` which means that now we are able to provide an ability to select `JAVA 17` in the `Maven` pipeline task.

**Changelog**:
_MavenV2_:
- The `JDK 17` option added to the `jdkVersion` picklist 
- The minor version of the task was bumped up to `200`

_MavenV3_:
- The `JDK 17` option added to the `jdkVersion` picklist 
- The minor version of the task was bumped up to `200`

**Documentation changes required**: Yes

**Added unit tests**: No

**Attached related issue**: 
- #14915

**Testing**:
The related changes were tested `end-2-end` on all available virtual images. All works as expected.
_Link to pipeline run_: [Pipelines - Run 20220129.4](https://v-alsmo.visualstudio.com/Test%20Playground/_build/results?buildId=1562&view=results)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
