### PR TITLE
Force task "PublishSymbolsV2" to use TLS1.2

### DIFF
--- a/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
+++ b/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
@@ -52,6 +52,8 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 . $PSScriptRoot\SymbolClientFunctions.ps1
 
 function Publish-Symbols([string]$symbolServiceUri, [string]$requestName, [string]$sourcePath, [string]$expirationInDays, [string]$personalAccessToken)

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
     "preview": false,
     "version": {
         "Major": 2,
-        "Minor": 198,
+        "Minor": 200,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 198,
+    "Minor": 200,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",


### PR DESCRIPTION
**Task name**: PublishSymbolsV2

**Description**: Enable Tls12 for secure access to AzureDevOps after change on 31st Jan 2022

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N
**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
