### PR TITLE
Move notifications about Tasks Localization PR from Slack to MS Teams - Part 1

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -123,7 +123,7 @@ stages:
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $titleText = "Azure Pipelines Tasks Localization build failed - ID$($(Build.BuildId))"
+        $titleText = "Azure Pipelines Tasks Localization build failed - ID $($(Build.BuildId))"
         $messageText = "Failed to create tasks Localization update PR. Please review the results of failed build [ID $($(Build.BuildId))]($($buildUrl)). Related article in [Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)."
         $body = [PSCustomObject]@{
           title = $titleText

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -109,27 +109,18 @@ stages:
       displayName: Open a PR
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
-    - powershell: |
-        $titleText = "Azure Pipelines Tasks Localization update PR created - ID $($env:PR_NUMBER)"
-        $messageText = "Created tasks Localization update PR. Please review and approve/merge [PR $($env:PR_NUMBER)]($($env:PR_LINK)). Related article in [Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)."
-        $body = [PSCustomObject]@{
-          title = $titleText
-          text = $messageText
-          themeColor = "#FFFF00"
-        } | ConvertTo-Json
-        Invoke-RestMethod -Uri $(MSTeamsUri) -Method Post -Body $body -ContentType 'application/json'
+    # Two next tasks are used to notify about Localization update PRs
+    # Notifications are set by POST method to MS Teams webhook
+    # Body of message is compiled as Office 365 connector card
+    # More details about cards - https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#office-365-connector-card
+    - powershell: .\ci\localization-updates\send-notifications.ps1 -IsPRCreated $true -RepoName "Tasks"
       displayName: 'Send MS Teams notification about PR opened'
+      env:
+        TEAMS_WEBHOOK: $(MSTeamsUri)
       condition: and(succeeded(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))
 
-    - powershell: |
-        $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $titleText = "Azure Pipelines Tasks Localization build failed - ID $($(Build.BuildId))"
-        $messageText = "Failed to create tasks Localization update PR. Please review the results of failed build [ID $($(Build.BuildId))]($($buildUrl)). Related article in [Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)."
-        $body = [PSCustomObject]@{
-          title = $titleText
-          text = $messageText
-          themeColor = "#FF0000"
-        } | ConvertTo-Json
-        Invoke-RestMethod -Uri $(MSTeamsUri) -Method Post -Body $body -ContentType 'application/json'
+    - powershell: .\ci\localization-updates\send-notifications.ps1 -IsPRCreated $false -RepoName "Tasks"
       displayName: 'Send MS Teams notification about error'
+      env:
+        TEAMS_WEBHOOK: $(MSTeamsUri)
       condition: and(failed(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -110,20 +110,26 @@ stages:
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
-        $message="Created tasks localization update PR. Someone please approve/merge it. :please-puss-in-boots: $env:PR_LINK"
+        $titleText = "Azure Pipelines Tasks localization update PR $($env:BUILD_BUILDID) created"
+        $messageText = "Created tasks localization update PR. Please approve/merge PR [$($env:PR_NUMBER)]($($env:PR_LINK))"
         $body = [PSCustomObject]@{
-          text = $message
+          title = $titleText
+          text = $messageText
+          themeColor = "#FFFF00"
         } | ConvertTo-Json
-        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification about PR opened'
+        Invoke-RestMethod -Uri $(MSTeamsUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send MS Teams notification about PR opened'
       condition: and(succeeded(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $message="Something went wrong while creating tasks localization update PR. Build: $buildUrl"
+        $titleText = "Azure Pipelines Tasks localization build $($(Build.BuildId)) failed"
+        $messageText = "Failed to create Azure Pipelines Tasks localization update PR. Please review the results of failed build [$($(Build.BuildId))]($($buildUrl))"
         $body = [PSCustomObject]@{
-          text = $message
+          title = $titleText
+          text = $messageText
+          themeColor = "#FF0000"
         } | ConvertTo-Json
-        Invoke-RestMethod -Uri $(slackUri) -Method Post -Body $body -ContentType 'application/json'
-      displayName: 'Send Slack notification about error'
+        Invoke-RestMethod -Uri $(MSTeamsUri) -Method Post -Body $body -ContentType 'application/json'
+      displayName: 'Send MS Teams notification about error'
       condition: and(failed(), eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule'))

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -110,7 +110,7 @@ stages:
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
-        $titleText = "Azure Pipelines Tasks localization update PR $($env:BUILD_BUILDID) created"
+        $titleText = "Azure Pipelines Tasks localization update PR $($env:PR_NUMBER) created"
         $messageText = "Created tasks localization update PR. Please approve/merge PR [$($env:PR_NUMBER)]($($env:PR_LINK))"
         $body = [PSCustomObject]@{
           title = $titleText

--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -110,8 +110,8 @@ stages:
       condition: and(succeeded(), or(and(eq(variables['SHOULDCREATEPR'], 'True'), eq(variables['build.reason'], 'Schedule')), eq(variables['build.reason'], 'Manual')))
 
     - powershell: |
-        $titleText = "Azure Pipelines Tasks localization update PR $($env:PR_NUMBER) created"
-        $messageText = "Created tasks localization update PR. Please approve/merge PR [$($env:PR_NUMBER)]($($env:PR_LINK))"
+        $titleText = "Azure Pipelines Tasks Localization update PR created - ID $($env:PR_NUMBER)"
+        $messageText = "Created tasks Localization update PR. Please review and approve/merge [PR $($env:PR_NUMBER)]($($env:PR_LINK)). Related article in [Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)."
         $body = [PSCustomObject]@{
           title = $titleText
           text = $messageText
@@ -123,8 +123,8 @@ stages:
 
     - powershell: |
         $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-        $titleText = "Azure Pipelines Tasks localization build $($(Build.BuildId)) failed"
-        $messageText = "Failed to create Azure Pipelines Tasks localization update PR. Please review the results of failed build [$($(Build.BuildId))]($($buildUrl))"
+        $titleText = "Azure Pipelines Tasks Localization build failed - ID$($(Build.BuildId))"
+        $messageText = "Failed to create tasks Localization update PR. Please review the results of failed build [ID $($(Build.BuildId))]($($buildUrl)). Related article in [Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)."
         $body = [PSCustomObject]@{
           title = $titleText
           text = $messageText

--- a/ci/localization-updates/send-notifications.ps1
+++ b/ci/localization-updates/send-notifications.ps1
@@ -1,0 +1,45 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [bool]$IsPRCreated,
+    [Parameter(Mandatory = $true)]
+    [bool]$RepoName
+)
+
+# Function sends Office 365 connector card to webhook.
+# It requires title and message text displyed in card and theme color used to hignlight card.
+function Send-Notification {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$titleText,
+        [Parameter(Mandatory = $true)]
+        [string]$messageText,
+        [Parameter(Mandatory = $true)]
+        [string]$themeColor
+    )
+
+    $body = [PSCustomObject]@{
+        title = $titleText
+        text = $messageText
+        themeColor = $themeColor
+    } | ConvertTo-Json
+
+    Invoke-RestMethod -Uri $($env:TEAMS_WEBHOOK) -Method Post -Body $body -ContentType 'application/json' 
+}
+
+$wikiLink = "[Wiki](https://mseng.visualstudio.com/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/16150/Localization-update)"
+
+if ($IsPRCreated) {
+    $pullRequestLink = "[PR $($env:PR_NUMBER)]($($env:PR_LINK))"
+    $titleText = "Azure Pipelines $RepoName Localization update PR created - ID $($env:PR_NUMBER)"
+    $messageText = "Created $RepoName Localization update PR. Please review and approve/merge $pullRequestLink. Related article in $wikiLink."
+    $themeColor = "#FFFF00"
+}
+else {
+    $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
+    $buildLink = "[ID $($(Build.BuildId))]($($buildUrl))"
+    $titleText = "Azure Pipelines $RepoName Localization build failed - ID $($(Build.BuildId))"
+    $messageText = "Failed to create $RepoName Localization update PR. Please review the results of failed build $buildLink. Related article in $wikiLink."
+    $themeColor = "#FF0000"
+}
+
+Send-Notification -titleText $titleText -messageText $messageText -themeColor $themeColor

--- a/ci/localization-updates/send-notifications.ps1
+++ b/ci/localization-updates/send-notifications.ps1
@@ -35,9 +35,9 @@ if ($IsPRCreated) {
     $themeColor = "#FFFF00"
 }
 else {
-    $buildUrl = "$(System.TeamFoundationCollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)&_a=summary"
-    $buildLink = "[ID $($(Build.BuildId))]($($buildUrl))"
-    $titleText = "Azure Pipelines $RepoName Localization build failed - ID $($(Build.BuildId))"
+    $buildUrl = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$env:SYSTEM_TEAMPROJECT/_build/results?buildId=$($env:BUILD_BUILDID)&_a=summary"
+    $buildLink = "[ID $($env:BUILD_BUILDID)]($($buildUrl))"
+    $titleText = "Azure Pipelines $RepoName Localization build failed - ID $($env:BUILD_BUILDID)"
     $messageText = "Failed to create $RepoName Localization update PR. Please review the results of failed build $buildLink. Related article in $wikiLink."
     $themeColor = "#FF0000"
 }

--- a/ci/localization-updates/send-notifications.ps1
+++ b/ci/localization-updates/send-notifications.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(Mandatory = $true)]
     [bool]$IsPRCreated,
     [Parameter(Mandatory = $true)]
-    [bool]$RepoName
+    [string]$RepoName
 )
 
 # Function sends Office 365 connector card to webhook.

--- a/ci/open-pullrequest.ps1
+++ b/ci/open-pullrequest.ps1
@@ -4,6 +4,7 @@ param(
     $SourceBranch
 )
 
+# Getting a created PR. Result object has interface in accordance with article https://docs.github.com/en/rest/reference/pulls#get-a-pull-request
 function Get-PullRequest() {
     return (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
 }

--- a/ci/open-pullrequest.ps1
+++ b/ci/open-pullrequest.ps1
@@ -5,13 +5,12 @@ param(
 )
 
 function Get-PullRequest() {
-    $prInfo = (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
-    return $prInfo.html_url
+    return (gh api -X GET repos/:owner/:repo/pulls -F head=":owner:$SourceBranch" -f state=open -f base=master | ConvertFrom-Json)
 }
 
 $openedPR=Get-PullRequest
 
-if ($openedPR.length -ne 0) {
+if ($openedPR.html_url.length -ne 0) {
     throw "A PR from $SourceBranch to master already exists."
 }
 
@@ -20,6 +19,10 @@ $body = "This PR was auto-generated with [the localization pipeline build]($buil
 
 gh pr create --head $SourceBranch --title 'Localization update' --body $body
 
+# Getting a number to the opened PR
+$PR_NUMBER = (Get-PullRequest).number
+Write-Host "##vso[task.setvariable variable=PR_NUMBER]$PR_NUMBER"
+
 # Getting a link to the opened PR
-$PR_LINK = Get-PullRequest
+$PR_LINK = (Get-PullRequest).html_url
 Write-Host "##vso[task.setvariable variable=PR_LINK]$PR_LINK"


### PR DESCRIPTION
**IMPORTANT - The PR must be completed with PR https://github.com/microsoft/azure-pipelines-tasks/pull/15918 at the same time.**

---

**Task name**: -

**Description**: Move notifications about Tasks Localization PR from Slack to MS Teams. Content of notifications was updated.

**Documentation changes required:** (Y/N) No

**Added unit tests:** (Y/N) No

**Attached related issue:** (Y/N) microsoft/build-task-team/issues/2123

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it - Not applicable for the changes
- [x] Checked that applied changes work as expected