### PR TITLE
[Maven tasks] Bump the codecoverage-tools package at the dependencies

### DIFF
--- a/Tasks/MavenV2/package-lock.json
+++ b/Tasks/MavenV2/package-lock.json
@@ -177,9 +177,9 @@
       }
     },
     "azure-pipelines-tasks-codecoverage-tools": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-codecoverage-tools/-/azure-pipelines-tasks-codecoverage-tools-2.0.3.tgz",
-      "integrity": "sha512-GphQf+OnwmFb7f3F5GKhRG7jymDBUjSDO0EtjhK8GA8/ODI3b7+SAIXdOvrEELPFYaoVFbQf6/XVHMXn6FMdSA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-codecoverage-tools/-/azure-pipelines-tasks-codecoverage-tools-2.0.4.tgz",
+      "integrity": "sha512-yOidYZu9x5gX7wlSRsYiJQHuYSkWC09Cgir9cX/OcFXa9xy7uNzzSzbD0zpteIX2ydI902Qxjp3uD5RI9p4cwA==",
       "requires": {
         "@types/cheerio": "0.22.0",
         "@types/node": "^10.17.0",

--- a/Tasks/MavenV2/package.json
+++ b/Tasks/MavenV2/package.json
@@ -13,7 +13,7 @@
     "@types/q": "^1.5.4",
     "azure-pipelines-task-lib": "^3.1.2",
     "azure-pipelines-tasks-codeanalysis-common": "^2.0.0-preview.0",
-    "azure-pipelines-tasks-codecoverage-tools": "2.0.3",
+    "azure-pipelines-tasks-codecoverage-tools": "2.0.4",
     "azure-pipelines-tasks-java-common": "^2.0.0-preview.0",
     "azure-pipelines-tasks-packaging-common-v3": "^3.200.0",
     "base-64": "^0.1.0",

--- a/Tasks/MavenV2/task.json
+++ b/Tasks/MavenV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 200,
-        "Patch": 1
+        "Minor": 201,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV2/task.loc.json
+++ b/Tasks/MavenV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 200,
-    "Patch": 1
+    "Minor": 201,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/MavenV3/package-lock.json
+++ b/Tasks/MavenV3/package-lock.json
@@ -162,9 +162,9 @@
       }
     },
     "azure-pipelines-tasks-codecoverage-tools": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-codecoverage-tools/-/azure-pipelines-tasks-codecoverage-tools-2.0.3.tgz",
-      "integrity": "sha512-GphQf+OnwmFb7f3F5GKhRG7jymDBUjSDO0EtjhK8GA8/ODI3b7+SAIXdOvrEELPFYaoVFbQf6/XVHMXn6FMdSA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-codecoverage-tools/-/azure-pipelines-tasks-codecoverage-tools-2.0.4.tgz",
+      "integrity": "sha512-yOidYZu9x5gX7wlSRsYiJQHuYSkWC09Cgir9cX/OcFXa9xy7uNzzSzbD0zpteIX2ydI902Qxjp3uD5RI9p4cwA==",
       "requires": {
         "@types/cheerio": "0.22.0",
         "@types/node": "^10.17.0",

--- a/Tasks/MavenV3/package.json
+++ b/Tasks/MavenV3/package.json
@@ -12,7 +12,7 @@
     "@types/mocha": "^5.2.7",
     "azure-pipelines-task-lib": "^3.1.2",
     "azure-pipelines-tasks-codeanalysis-common": "2.0.0-preview.0",
-    "azure-pipelines-tasks-codecoverage-tools": "2.0.3",
+    "azure-pipelines-tasks-codecoverage-tools": "2.0.4",
     "azure-pipelines-tasks-java-common": "2.198.1",
     "azure-pipelines-tasks-packaging-common-v3": "^3.200.0",
     "base-64": "^0.1.0",

--- a/Tasks/MavenV3/task.json
+++ b/Tasks/MavenV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 200,
-        "Patch": 1
+        "Minor": 201,
+        "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
     "demands": [

--- a/Tasks/MavenV3/task.loc.json
+++ b/Tasks/MavenV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 200,
-    "Patch": 1
+    "Minor": 201,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [


### PR DESCRIPTION
**Task name**: MavenV2, MavenV3

**Description**:
Updated the `azure-pipelines-tasks-codecoverage-tools` package at the Maven tasks dependencies.
The new version of this package contains updates for the JaCoCo maven plugin for supporting the Java 17 (https://github.com/microsoft/azure-pipelines-tasks/pull/15899)

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/15868

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

This change was tested at the [Maven Canary project](https://github.com/microsoft/azure-pipelines-canary/tree/master/src/maven/DeepSpace) configured for supporting the Java 17