### PR TITLE
Reverted cmdline percent encoding changes

### DIFF
--- a/Tasks/CmdLineV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/CmdLineV2/Strings/resources.resjson/en-US/resources.resjson
@@ -9,8 +9,6 @@
   "loc.input.label.workingDirectory": "Working Directory",
   "loc.input.label.failOnStderr": "Fail on Standard Error",
   "loc.input.help.failOnStderr": "If this is true, this task will fail if any errors are written to the StandardError stream.",
-  "loc.input.label.disablePercentEscaping": "Disable percent escaping",
-  "loc.input.help.disablePercentEscaping": "By default percent is being escaped in script output - since task always executes script as batch file. Set this to true if you want to disable this behavior.",
   "loc.messages.GeneratingScript": "Generating script.",
   "loc.messages.JS_ExitCode": "Bash exited with code '%s'.",
   "loc.messages.JS_Stderr": "Bash wrote one or more lines to the standard error stream.",

--- a/Tasks/CmdLineV2/cmdline.ps1
+++ b/Tasks/CmdLineV2/cmdline.ps1
@@ -20,15 +20,11 @@ PROCESS {
         $input_failOnStderr = Get-VstsInput -Name 'failOnStderr' -AsBool
         $input_script = Get-VstsInput -Name 'script'
         $input_workingDirectory = Get-VstsInput -Name 'workingDirectory' -Require
-        $input_disablePercentEscaping = Get-VstsInput -Name 'disablePercentEscaping' -AsBool
         Assert-VstsPath -LiteralPath $input_workingDirectory -PathType 'Container'
 
         # Generate the script contents.
         Write-Host (Get-VstsLocString -Key 'GeneratingScript')
         $contents = "$input_script".Replace("`r`n", "`n").Replace("`n", "`r`n")
-        if (!$input_disablePercentEscaping) {
-            $contents = Mask-Percents -Contents $contents
-        }
 
         if ($contents.IndexOf("`n") -lt 0 -and $contents.IndexOf("##vso[", ([System.StringComparison]::OrdinalIgnoreCase)) -lt 0) {
             # Print one-liner scripts.

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 200,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines.",
     "showEnvironmentVariables": true,
@@ -58,15 +58,6 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "If this is true, this task will fail if any errors are written to the StandardError stream.",
-            "groupName": "advanced"
-        },
-        {
-            "name": "disablePercentEscaping",
-            "type": "boolean",
-            "label": "Disable percent escaping",
-            "defaultValue": "false",
-            "required": false,
-            "helpMarkDown": "By default percent is being escaped in script output - since task always executes script as batch file. Set this to true if you want to disable this behavior.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/CmdLineV2/task.loc.json
+++ b/Tasks/CmdLineV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 200,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "showEnvironmentVariables": true,
@@ -58,15 +58,6 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.failOnStderr",
-      "groupName": "advanced"
-    },
-    {
-      "name": "disablePercentEscaping",
-      "type": "boolean",
-      "label": "ms-resource:loc.input.label.disablePercentEscaping",
-      "defaultValue": "false",
-      "required": false,
-      "helpMarkDown": "ms-resource:loc.input.help.disablePercentEscaping",
       "groupName": "advanced"
     }
   ],


### PR DESCRIPTION
**Task name**: CmdLineV2

**Description**: Reverted back changes from [PR ](https://github.com/microsoft/azure-pipelines-tasks/pull/15694) due to regression with the case when there are environment variables used in pipeline.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected - in progress
