### PR TITLE
adding no_proxy to nuget.config

### DIFF
--- a/Tasks/UseDotNetV2/nugetinstaller.ts
+++ b/Tasks/UseDotNetV2/nugetinstaller.ts
@@ -47,7 +47,7 @@ import * as nuGetGetter from 'azure-pipelines-tasks-packaging-common/nuget/NuGet
         nuget = tl.tool(nugetPath);
         nuget.arg('config');
         nuget.arg('-set');
-        nuget.arg('no_prxy=' + proxyConfig.proxyBypassHosts);
+        nuget.arg('no_proxy=' + proxyConfig.proxyBypassHosts);
         nuget.exec({} as trm.IExecOptions);
     }
 }

--- a/Tasks/UseDotNetV2/nugetinstaller.ts
+++ b/Tasks/UseDotNetV2/nugetinstaller.ts
@@ -42,5 +42,12 @@ import * as nuGetGetter from 'azure-pipelines-tasks-packaging-common/nuget/NuGet
         nuget.arg('-set');
         nuget.arg('http_proxy.password=' + proxyConfig.proxyPassword);
         nuget.exec({} as trm.IExecOptions);
+      
+         // Set no_proxy
+        nuget = tl.tool(nugetPath);
+        nuget.arg('config');
+        nuget.arg('-set');
+        nuget.arg('no_prxy=' + proxyConfig.proxyBypassHosts);
+        nuget.exec({} as trm.IExecOptions);
     }
 }


### PR DESCRIPTION
Adding no_proxy key to nuget.config for the build user NuGet.config file because it is missing currently and breaking for other Nuget tasks that should not use the proxy

**Task name**: UseDotNetV2

**Description**: Adding configuration to Nuget.config for the build user

**Documentation changes required:** N

**Added unit tests:**N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
