### PR TITLE
Update npmauth to handle retries cleanly (#15914)

### DIFF
--- a/Tasks/NpmAuthenticateV0/npmauth.ts
+++ b/Tasks/NpmAuthenticateV0/npmauth.ts
@@ -118,6 +118,9 @@ async function main(): Promise<void> {
 main().catch(error => {
     if(tl.getVariable("NPM_AUTHENTICATE_TEMP_DIRECTORY")) {
         tl.rmRF(tl.getVariable("NPM_AUTHENTICATE_TEMP_DIRECTORY"));
+        // Clear the variables after we rm-rf the main root directory
+        tl.setVariable("SAVE_NPMRC_PATH", "", false);
+        tl.setVariable("NPM_AUTHENTICATE_TEMP_DIRECTORY", "", false);
     } 
     tl.setResult(tl.TaskResult.Failed, error);
 });

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 198,
+        "Minor": 201,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 198,
+    "Minor": 201,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
* Update npmauth.ts

* Update task.json

* Update task.loc.json

* Update npmauth.ts

* RED

Co-authored-by: Zheng Hao Tang <zhentan@microsoft.com>

**Task name**: NpmAuthenticate

**Description**: Cherry pick a retry change to releases branch for hotfix

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N/A

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
