### PR TITLE
The VALUE for WEBSITE_RUN_FROM_PACKAGE must be 1

### DIFF
--- a/Tasks/AzureFunctionAppV1/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
+++ b/Tasks/AzureFunctionAppV1/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
@@ -9,7 +9,7 @@ var zipUtility = require('azure-pipelines-tasks-azurermdeploycommon-v3/webdeploy
 
 const linuxFunctionStorageSetting: string = '-WEBSITES_ENABLE_APP_SERVICE_STORAGE true';
 const linuxFunctionRuntimeSettingName: string = '-FUNCTIONS_WORKER_RUNTIME ';
-const premiumPlanRunsFromPackage: string = ' -WEBSITE_RUN_FROM_PACKAGE true';
+const premiumPlanRunsFromPackage: string = ' -WEBSITE_RUN_FROM_PACKAGE 1';
 
 const linuxFunctionRuntimeSettingValue = new Map([
     [ 'DOCKER|microsoft/azure-functions-dotnet-core2.0:2.0', 'dotnet ' ],

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 200,
-        "Patch": 1
+        "Minor": 202,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.104.1",
     "groups": [

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 202,
-        "Patch": 0
+        "Minor": 204,
+        "Patch": 2
     },
     "minimumAgentVersion": "2.104.1",
     "groups": [

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 200,
-    "Patch": 1
+    "Minor": 202,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 202,
-    "Patch": 0
+    "Minor": 204,
+    "Patch": 2
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [


### PR DESCRIPTION
The value for WEBSITE_RUN_FROM_PACKAGE must be 1. If the value is 'true', it will be ignored at deployment and cause the deployment to fail from the pipeline.

**Task name**: AzureFunctionApp@1

**Description**: The value for 'WEBSITE_RUN_FROM_PACKAGE' is set to 'true' in the current source code of this task but it must be 1. If 'true' is set to this app setting, the deployment may fail with "An unknown error has occurred. Check the diagnostic log for details." and you can find "Deployment lock failure" in a trace file for App Service. This can happen especially with Functions on Linux. And if the value is set to "true", the zip file is deployed to the file server for App Service and extracted to /home/site/wwwroot but not mounted. So, /home/site/wwwroot is not set to ReadOnly. This happens because 'true' is not an expected value for 'WEBSITE_RUN_FROM_PACKAGE' and it's ignored. If the value is set to 1, the zip file is mounted and  /home/site/wwwroot is set to ReadOnly.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
