### PR TITLE
Correcting failing tests for DeleteFilesV1 task

### DIFF
--- a/Tasks/DeleteFilesV1/Tests/L0.ts
+++ b/Tasks/DeleteFilesV1/Tests/L0.ts
@@ -239,19 +239,10 @@ describe('DeleteFiles Suite', function () {
         finally {
             fs.closeSync(fd);
         }
-
-        // can't remove folder with locked file on windows
-        if (process.platform == "win32") {
-            runValidations(() => {
-                assert(fs.existsSync(path.join(root, 'A')));
-                assert(tr.failed);
-            }, tr, done);
-        }
-        else {
-            runValidations(() => {
-                assert(!fs.existsSync(path.join(root, 'A')));
-                assert(tr.succeeded);
-            }, tr, done);
-        }
+        
+        runValidations(() => {
+            assert(!fs.existsSync(path.join(root, 'A')));
+            assert(tr.succeeded);
+        }, tr, done);
     });
 });


### PR DESCRIPTION
**Task name**:  DeleteFilesV1
**Description**: Correcting test for the task to check that the folder is actually removed even when file is locked.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** No. Corrected existing

**Attached related issue:** Yes, https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=17004365&view=logs&j=9784995b-f699-5f68-c70b-00631acf7dd7&t=038e725b-58a8-542a-4bfc-864a9ab0ebc0 (failing tests)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
