### PR TITLE
Change default value of ErrorActionPreference input in PowerShellV2 task

### DIFF
--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 200,
+        "Minor": 202,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for macOS and Linux.",
@@ -85,7 +85,7 @@
             "type": "pickList",
             "label": "ErrorActionPreference",
             "required": false,
-            "defaultValue": "stop",
+            "defaultValue": "default",
             "options": {
                 "default": "Default",
                 "stop": "Stop",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 200,
+    "Minor": 202,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -85,7 +85,7 @@
       "type": "pickList",
       "label": "ms-resource:loc.input.label.errorActionPreference",
       "required": false,
-      "defaultValue": "stop",
+      "defaultValue": "default",
       "options": {
         "default": "Default",
         "stop": "Stop",


### PR DESCRIPTION
**Task name**: PowerShellV2

**Description**: Changed the default value for the ErrorActionPreference input from `stop` to `default`. To prevent the parameter from being added to the ps script again if it is already manually added in the script.

**Documentation changes required:** Y (need to change default value of ErrorActionPreference input in docs)

**Added unit tests:** N

**Attached related issue:** #16048

**Checklist**:
- [x] Task version was bumped
- [x] Checked that applied changes work as expected
