### PR TITLE
[ContainerStructureTestV0] Fixed test publishing for non-pushed images (#12396)

### DIFF
--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -1,102 +1,102 @@
 {
-    "id": "39bc2c9b-55b7-4835-89cd-6cc699ef7220",
-    "name": "ContainerStructureTest",
-    "friendlyName": "Container Structure Test",
-    "description": "Uses container-structure-test (https://github.com/GoogleContainerTools/container-structure-test) to validate the structure of an image based on four categories of tests - command tests, file existence tests, file content tests and metadata tests",
-    "helpUrl": "https://aka.ms/containerstructuretest",
-    "helpMarkDown": "[Learn more about this task](https://aka.ms/containerstructuretest)",
-    "category": "Test",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
     "author": "Microsoft Corporation",
-    "version": {
-        "Major": 0,
-        "Minor": 201,
-        "Patch": 0
-    },
-    "preview": true,
+    "category": "Test",
     "demands": [],
-    "minimumAgentVersion": "2.0.0",
+    "description": "Uses container-structure-test (https://github.com/GoogleContainerTools/container-structure-test) to validate the structure of an image based on four categories of tests - command tests, file existence tests, file content tests and metadata tests",
+    "execution": {
+        "Node": {
+            "argumentFormat": "",
+            "target": "containerstructuretest.js"
+        }
+    },
+    "friendlyName": "Container Structure Test",
     "groups": [
         {
-            "name": "containerRepository",
             "displayName": "Container Repository",
-            "isExpanded": true
+            "isExpanded": true,
+            "name": "containerRepository"
         }
     ],
+    "helpMarkDown": "[Learn more about this task](https://aka.ms/containerstructuretest)",
+    "helpUrl": "https://aka.ms/containerstructuretest",
+    "id": "39bc2c9b-55b7-4835-89cd-6cc699ef7220",
     "inputs": [
         {
-            "name": "dockerRegistryServiceConnection",
-            "type": "connectedService:dockerregistry",
-            "label": "Docker registry service connection",
             "groupName": "containerRepository",
+            "helpMarkDown": "Select a Docker registry service connection. Required for commands that need to authenticate with a registry.",
+            "label": "Docker registry service connection",
+            "name": "dockerRegistryServiceConnection",
             "required": true,
-            "helpMarkDown": "Select a Docker registry service connection. Required for commands that need to authenticate with a registry."
+            "type": "connectedService:dockerregistry"
         },
         {
-            "name": "repository",
-            "label": "Container repository",
-            "type": "string",
-            "helpMarkDown": "Name of the repository.",
             "defaultValue": "",
             "groupName": "containerRepository",
-            "required": true,
+            "helpMarkDown": "Name of the repository.",
+            "label": "Container repository",
+            "name": "repository",
             "properties": {
                 "EditableOptions": "True"
-            }
-        },
-        {
-            "name": "tag",
-            "type": "string",
-            "defaultValue": "$(Build.BuildId)",
-            "label": "Tag",
-            "groupName": "containerRepository",
-            "helpMarkDown": "The tag is used in pulling the image from docker registry service connection"
-        },
-        {
-            "name": "configFile",
-            "type": "filePath",
-            "label": "Config file path",
+            },
             "required": true,
-            "helpMarkDown": "Config files path, that contains container structure tests. Either .yaml or .json files"
+            "type": "string"
         },
         {
-            "name": "testRunTitle",
-            "type": "string",
-            "label": "Test run title",
+            "defaultValue": "$(Build.BuildId)",
+            "groupName": "containerRepository",
+            "helpMarkDown": "The tag is used in pulling the image from docker registry service connection",
+            "label": "Tag",
+            "name": "tag",
+            "type": "string"
+        },
+        {
+            "helpMarkDown": "Config files path, that contains container structure tests. Either .yaml or .json files",
+            "label": "Config file path",
+            "name": "configFile",
+            "required": true,
+            "type": "filePath"
+        },
+        {
             "defaultValue": "",
+            "helpMarkDown": "Provide a name for the Test Run.",
+            "label": "Test run title",
+            "name": "testRunTitle",
             "required": false,
-            "helpMarkDown": "Provide a name for the Test Run."
+            "type": "string"
         },
         {
-            "name": "failTaskOnFailedTests",
-            "type": "boolean",
-            "label": "Fail task if there are test failures",
             "defaultValue": "false",
+            "helpMarkDown": "Fail the task if there are any test failures. Check this option to fail the task if test failures are detected.",
+            "label": "Fail task if there are test failures",
+            "name": "failTaskOnFailedTests",
             "required": false,
-            "helpMarkDown": "Fail the task if there are any test failures. Check this option to fail the task if test failures are detected."
+            "type": "boolean"
         }
     ],
     "instanceNameFormat": "Container Structure Test $(testFile)",
-    "execution": {
-        "Node": {
-            "target": "containerstructuretest.js",
-            "argumentFormat": ""
-        }
-    },
     "messages": {
-        "NoMatchingFilesFound": "No test files matching '%s' were found.",
-        "ErrorTestResultsPublisher": "Error while executing Test: %s.",
-        "ErrorFailTaskOnFailedTests": "There are one or more test failures detected in test. Detailed summary of published test results can be viewed in the Tests tab.",
-        "FileNotFoundException": "Unable to find the file: %s.",
-        "DownloadException": "Unable to download the file: %s",
-        "ErrorInExecutingCommand": "Error in executing the command: %s",
-        "WritingDockerConfigToTempFile": "Writing Docker config to temp file. File path: %s, Docker config: %s",
-        "FileContentSynced": "Synced the file content to the disk. The content is %s.",
         "ConnectingToDockerHost": "DOCKER_HOST variable is set. Docker will try to connect to the Docker host: %s",
         "DockerHostVariableWarning": "DOCKER_HOST variable is set. Please ensure that the Docker daemon is running on: %s",
-        "NotSupportedOS": "Container Structure test task is not supported in OS: %s"
-    }
+        "DownloadException": "Unable to download the file: %s",
+        "ErrorFailTaskOnFailedTests": "There are one or more test failures detected in test. Detailed summary of published test results can be viewed in the Tests tab.",
+        "ErrorInExecutingCommand": "Error in executing the command: %s",
+        "ErrorTestResultsPublisher": "Error while executing Test: %s.",
+        "FileContentSynced": "Synced the file content to the disk. The content is %s.",
+        "FileNotFoundException": "Unable to find the file: %s.",
+        "NoMatchingFilesFound": "No test files matching '%s' were found.",
+        "NotSupportedOS": "Container Structure test task is not supported in OS: %s",
+        "WritingDockerConfigToTempFile": "Writing Docker config to temp file. File path: %s, Docker config: %s"
+    },
+    "minimumAgentVersion": "2.0.0",
+    "name": "ContainerStructureTest",
+    "preview": true,
+    "version": {
+        "Major": 0,
+        "Minor": 204,
+        "Patch": 0
+    },
+    "visibility": [
+        "Build",
+        "Release"
+    ]
 }


### PR DESCRIPTION
**Task name**: ContainerStructureTestV0

**Description**: Added support to publish test results for non-pushed images.

The task currently presumes any tested image is already pushed to a registry. It then skips a check if a repository digest exists, forcefully coercing a `null` to a `string` for type-checking purposes. This results on an argument exception being captured by the agent runner, as a `null` lacks the `split` method.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** #12396

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
