### PR TITLE
Removing service connection for feed authentication

### DIFF
--- a/ci/courtesy-push.yml
+++ b/ci/courtesy-push.yml
@@ -1,7 +1,7 @@
 steps:
 - task: NuGetToolInstaller@0
   inputs:
-    versionSpec: '5.4.0'
+    versionSpec: '6.0.0'
   displayName: 'Install nuget'
   condition: and(succeeded(), or(eq(variables['WEEK'], '3'), eq(variables['FORCE_COURTESY_PUSH'], 'true')))
 
@@ -17,8 +17,6 @@ steps:
   condition: and(succeeded(), or(eq(variables['WEEK'], '3'), eq(variables['FORCE_COURTESY_PUSH'], 'true')))
 
 - task: NuGetAuthenticate@0
-  inputs:
-    nuGetServiceConnections: 'Codex-Deps'
   displayName: 'Authenticate with nuget'
   condition: and(succeeded(), or(eq(variables['WEEK'], '3'), eq(variables['FORCE_COURTESY_PUSH'], 'true')))
 

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -12,9 +12,9 @@ steps:
 
 # Use NuGet 4
 - task: NuGetToolInstaller@0
-  displayName: Use NuGet 4
+  displayName: Use NuGet 6
   inputs:
-    versionSpec: 4.0.0
+    versionSpec: 6.0.0
 
 # npm install
 - script: npm install


### PR DESCRIPTION
Removing service connection for feed authentication

**Task name**: n/a

**Description**: Updating the azure-pipeline-tasks CI courtesy push job so it no longer uses a service connection. Additionally updating the NuGet tool version.

*Documentation changes required:** (Y/N) N.

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
