### PR TITLE
Add symbol retention field to PublishSymbolsV2

### DIFF
--- a/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
+++ b/Tasks/PublishSymbolsV2/Publish-Symbols.ps1
@@ -72,7 +72,7 @@ function Publish-Symbols([string]$symbolServiceUri, [string]$requestName, [strin
         $args = "publish --service `"$symbolServiceUri`" --name `"$requestName`" --directory `"$sourcePath`"" 
 
         if ( $expirationInDays ) {
-             $args  += " --expirationInDays `"$expirationInDays`""
+            $args  += " --expirationInDays `"$expirationInDays`""
         }
 
         if ( $personalAccessToken ) {

--- a/Tasks/PublishSymbolsV2/PublishSymbols.ps1
+++ b/Tasks/PublishSymbolsV2/PublishSymbols.ps1
@@ -99,7 +99,10 @@ try {
         [string]$SymbolsProduct = Get-VstsInput -Name 'SymbolsProduct' -Default (Get-VstsTaskVariable -Name 'Build.DefinitionName' -Require)
         [string]$SymbolsVersion = Get-VstsInput -Name 'SymbolsVersion' -Default (Get-VstsTaskVariable -Name 'Build.BuildNumber' -Require)
         [string]$SymbolsArtifactName = Get-VstsInput -Name 'SymbolsArtifactName'
+    } elseif ($symbolServerType -eq "TeamServices") {
+        [int]$SymbolExpirationInDays = Get-VstsInput -Name 'SymbolExpirationInDays' -AsInt -Default '36530'
     }
+
     [bool]$SkipIndexing = -not (Get-VstsInput -Name 'IndexSources' -AsBool)
     [bool]$CompressSymbols = (Get-VstsInput -Name 'CompressSymbols' -AsBool)
     [bool]$TreatNotIndexedAsWarning = Get-VstsInput -Name 'TreatNotIndexedAsWarning' -AsBool
@@ -161,9 +164,7 @@ try {
         } else {
             Write-Verbose "SymbolsPath was not set, publish symbols step was skipped."
         }
-    }
-    elseif ($symbolServerType -eq "TeamServices") {
-
+    } elseif ($symbolServerType -eq "TeamServices") {
         [string]$RequestName = (Get-VstsTaskVariable -Name 'System.TeamProject' -Require) + "/" + 
                                (Get-VstsTaskVariable -Name 'Build.DefinitionName' -Require)  + "/" + 
                                (Get-VstsTaskVariable -Name 'Build.BuildNumber' -Require)  + "/" + 
@@ -228,7 +229,15 @@ try {
         [string] $requestUrl = "#$SymbolServiceUri/_apis/Symbol/requests?requestName=$encodedRequestName"
         Write-VstsAssociateArtifact -Name "$RequestName" -Path $requestUrl -Type "SymbolRequest" -Properties @{}
 
-        & "$PSScriptRoot\Publish-Symbols.ps1" -SymbolServiceUri $SymbolServiceUri -RequestName $RequestName -SourcePath $SourcePath -SourcePathListFileName $tmpFileName -IndexableFileFormats `"$IndexableFileFormats`" -PersonalAccessToken $PersonalAccessToken -ExpirationInDays 36530 -DetailedLog $DetailedLog
+        & "$PSScriptRoot\Publish-Symbols.ps1" `
+            -SymbolServiceUri $SymbolServiceUri `
+            -RequestName $RequestName `
+            -SourcePath $SourcePath `
+            -SourcePathListFileName $tmpFileName `
+            -IndexableFileFormats `"$IndexableFileFormats`" `
+            -PersonalAccessToken $PersonalAccessToken `
+            -ExpirationInDays $SymbolExpirationInDays `
+            -DetailedLog $DetailedLog
 
         if (Test-Path -Path $tmpFileName) {
             del $tmpFileName

--- a/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishSymbolsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -18,6 +18,8 @@
   "loc.input.help.SymbolsPath": "The file share that hosts your symbols. This value will be used in the call to `symstore.exe add` as the `/s` parameter.",
   "loc.input.label.CompressSymbols": "Compress symbols",
   "loc.input.help.CompressSymbols": "Compress symbols when publishing to file share.",
+  "loc.input.label.SymbolExpirationInDays": "Symbol Expiration (in days)",
+  "loc.input.help.SymbolExpirationInDays": "The number of days that symbols should be retained.",
   "loc.input.label.IndexableFileFormats": "Symbol file formats to publish",
   "loc.input.help.IndexableFileFormats": "Which debug formats to publish to the symbol server",
   "loc.input.label.DetailedLog": "Verbose logging",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
     "preview": false,
     "version": {
         "Major": 2,
-        "Minor": 199,
+        "Minor": 202,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
@@ -88,6 +88,15 @@
             "required": true,
             "helpMarkDown": "Compress symbols when publishing to file share.",
             "visibleRule": "SymbolServerType = FileShare"
+        },
+        {
+            "name": "SymbolExpirationInDays",
+            "type": "string",
+            "label": "Symbol Expiration (in days)",
+            "defaultValue": "36530",
+            "required": false,
+            "helpMarkDown": "The number of days that symbols should be retained.",
+            "visibleRule": "PublishSymbols = true && SymbolServerType = TeamServices"
         },
         {
             "name": "IndexableFileFormats",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 199,
+    "Minor": 202,
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
@@ -88,6 +88,15 @@
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.CompressSymbols",
       "visibleRule": "SymbolServerType = FileShare"
+    },
+    {
+      "name": "SymbolExpirationInDays",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.SymbolExpirationInDays",
+      "defaultValue": "36530",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.SymbolExpirationInDays",
+      "visibleRule": "PublishSymbols = true && SymbolServerType = TeamServices"
     },
     {
       "name": "IndexableFileFormats",


### PR DESCRIPTION
**Task name**: PublishSymbolsV2

**Description**: Added an optional field "Symbol Expiration (in days)" which allows the symbol retention to be specified at the task level.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
