### PR TITLE
AzurePowerShellV5: sanitize JSON representation of endpoint data

### DIFF
--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -52,7 +52,7 @@ if ($targetAzurePs -eq $latestVersion) {
 
 $serviceName = Get-VstsInput -Name ConnectedServiceNameARM -Require
 $endpointObject = Get-VstsEndpoint -Name $serviceName -Require
-$endpoint = ConvertTo-Json $endpointObject
+$endpoint = (ConvertTo-Json $endpointObject).Replace("'","''")
 
 try 
 {

--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -54,7 +54,7 @@ async function run() {
             targetAzurePs = ""
         }
 
-        var endpoint = JSON.stringify(endpointObject);
+        var endpoint = JSON.stringify(endpointObject).replace("'","''");
 
         if (scriptType.toUpperCase() == 'FILEPATH') {
             if (!tl.stats(scriptPath).isFile() || !scriptPath.toUpperCase().match(/\.PS1$/)) {


### PR DESCRIPTION
**Task name**: AzurePowerShellV5

**Description**: This is an attempt to escape single quotes in the endpoint's JSON. (Such as an apostrophe in the subscription name)

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** #15471 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
