### PR TITLE
"Build single tasks" happen on Windows agents

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,6 +105,8 @@ jobs:
 - job: buildSingle
   displayName: Build single task
   condition: and(succeeded(), variables.task)
+  pool:
+    vmImage: windows-2022
   steps:
   - template: ci/build-single-steps.yml
 


### PR DESCRIPTION
**Description**: When building a single task (e.g. for hotfix), build the task on Windows agents

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Failure in build on linux: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=17134231&view=logs&j=3e13d126-0b89-5035-9868-7a56405ed192
