### PR TITLE
Updated PTRV2 task to version 2.203.0

### DIFF
--- a/Tasks/PublishTestResultsV2/make.json
+++ b/Tasks/PublishTestResultsV2/make.json
@@ -2,7 +2,7 @@
   "externals": {
     "archivePackages": [
       {
-        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/15862869/PublishTestResults.zip",
+        "url": "https://publishtestresults.blob.core.windows.net/publishtestresults/17144597/PublishTestResults.zip",
         "dest": "./"
       }
     ]

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 198,
+        "Minor": 203,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 198,
+    "Minor": 203,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
Updated PTR version from 2.198.0 to 2.203.0
Build: https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17144597&view=results
Release: https://dev.azure.com/mseng/AzureDevOps/_releaseProgress?_a=release-environment-logs&releaseId=17514848&environmentId=196776956