### PR TITLE
Add arm64 Go download support for GoTool task

### DIFF
--- a/Tasks/GoToolV0/gotool.ts
+++ b/Tasks/GoToolV0/gotool.ts
@@ -87,7 +87,7 @@ async function acquireGo(version: string): Promise<string> {
 
 function getFileName(version: string): string {
     let platform: string = osPlat == "win32" ? "windows" : osPlat;
-    let arch: string = osArch == "x64" ? "amd64" : "386";
+    let arch: string = osArch == "x64" ? "amd64" : osArch == "arm64" ? "arm64" : "386";
     let ext: string = osPlat == "win32" ? "zip" : "tar.gz";
     let filename: string = util.format("go%s.%s-%s.%s", version, platform, arch, ext);
     return filename;

--- a/Tasks/GoToolV0/task.json
+++ b/Tasks/GoToolV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 198,
+        "Minor": 204,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/GoToolV0/task.loc.json
+++ b/Tasks/GoToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 198,
+    "Minor": 204,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: GoTool

**Description**: I intended to change the 386 architecture fallback to handle arm64 architecture for self-hosted arm64 machines.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
