### PR TITLE
Updated VsTestV2 task to version 2.203.0 

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/16970602/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/17144597/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 202,
+        "Minor": 203,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 202,
+    "Minor": 203,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
Updated TestAgent version from 2.202.0 to 2.203.0
Build: https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=17144597&view=results

Changes already in release branch- https://github.com/microsoft/azure-pipelines-tasks/pull/16161