### PR TITLE
Updated vm2 package in Tasks/AppCenterDistributeV3

### DIFF
--- a/Tasks/AppCenterDistributeV3/package-lock.json
+++ b/Tasks/AppCenterDistributeV3/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "vsts-tasks-appcenterdistribute",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "dependencies": {
     "@tootallnate/once": {
@@ -16,6 +16,16 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -936,9 +946,13 @@
       }
     },
     "vm2": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.5.tgz",
-      "integrity": "sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng=="
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.9.tgz",
+      "integrity": "sha512-xwTm7NLh/uOjARRBs8/95H0e8fT3Ukw5D/JJWhxMbhKzNh1Nu981jQKvkep9iKYNxzlVrdzD0mlBGkDKZWprlw==",
+      "requires": {
+        "acorn": "^8.7.0",
+        "acorn-walk": "^8.2.0"
+      }
     },
     "vsts-task-lib": {
       "version": "2.0.6",

--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 200,
+        "Minor": 204,
         "Patch": 0
     },
     "releaseNotes": "Added support for forwarding Android mapping to App Center Diagnostics. Added missing descriptions.",

--- a/Tasks/AppCenterDistributeV3/task.loc.json
+++ b/Tasks/AppCenterDistributeV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 200,
+    "Minor": 204,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
The package vm2 before 3.9.6 are vulnerable to Sandbox Bypass via direct access to host error objects generated by node internals during generation of a stacktraces, which can lead to execution of arbitrary code on the host machine.

CVE-2021-23555
