### PR TITLE
Add a note about too recent versions of Node

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -52,6 +52,11 @@ v4.2.0
 5.6.0
 ```
 
+**Note:** to recent Node versions will not work with all of the tooling in this
+repository. Before we improve it to support latest versions, consider using
+Node 10. You can use [Volta](https://volta.sh) to manage multiple Node versions
+on your system.
+
 To install npm separately:
 
 ```


### PR DESCRIPTION
Running the build and test scripts won't work because of changes to the sync request APIs in recent Node versions. I have added a recommendation to stick with ~ Node 10 or so.

I don't know the exact major from which this is broken, but we should focus on fixing the tooling over finding the exact version of old Node the contributors must use anyway, so this will do for now.
