### PR TITLE
Fix Helm updatedependency option in v3+

### DIFF
--- a/Tasks/HelmDeployV0/Tests/L0.ts
+++ b/Tasks/HelmDeployV0/Tests/L0.ts
@@ -46,6 +46,7 @@ describe("HelmDeployV0 Suite", function () {
         process.env[shared.TestEnvVars.failOnStderr] = "true";
         process.env[shared.TestEnvVars.publishPipelineMetadata] = "true";
         process.env[shared.isHelmV3] = "true";
+        process.env[shared.TestEnvVars.updatedependency] = "true";
 
         tr.run();
         assert(tr.stdout.indexOf("changed mode of file") != -1, "Mode of kubeconfig file should have been changed to 600");
@@ -232,6 +233,7 @@ describe("HelmDeployV0 Suite", function () {
         process.env[shared.TestEnvVars.destination] = shared.testDestinationPath;
         process.env[shared.TestEnvVars.failOnStderr] = "false";
         process.env[shared.isHelmV3] = "true";
+        process.env[shared.TestEnvVars.updatedependency] = "true";
 
         tr.run();
         assert(tr.stdout.indexOf(`Successfully packaged chart and saved it to: ${shared.testDestinationPath}/testChartName.tgz`) != -1, "Chart should have been successfully packaged");

--- a/Tasks/HelmDeployV0/Tests/TestSetup.ts
+++ b/Tasks/HelmDeployV0/Tests/TestSetup.ts
@@ -107,9 +107,6 @@ if (process.env[shared.TestEnvVars.command] === shared.Commands.install) {
     if (process.env[shared.TestEnvVars.overrideValues])
         helmInstallCommand = helmInstallCommand.concat(` --set ${process.env[shared.TestEnvVars.overrideValues]}`);
 
-    if (process.env[shared.TestEnvVars.updatedependency])
-        helmInstallCommand = helmInstallCommand.concat(" --dep-up");
-
     if (process.env[shared.isHelmV3] === "true") {
         if (process.env[shared.TestEnvVars.releaseName])
             helmInstallCommand = helmInstallCommand.concat(` ${process.env[shared.TestEnvVars.releaseName]}`);
@@ -121,6 +118,13 @@ if (process.env[shared.TestEnvVars.command] === shared.Commands.install) {
 
     if (process.env[shared.TestEnvVars.waitForExecution])
         helmInstallCommand = helmInstallCommand.concat(" --wait");
+
+    if (process.env[shared.TestEnvVars.updatedependency])
+        if (process.env[shared.isHelmV3] === "true") {
+            helmInstallCommand = helmInstallCommand.concat(" --dependency-update");
+        } else {
+            helmInstallCommand = helmInstallCommand.concat(" --dep-up");
+        }
 
     if (process.env[shared.TestEnvVars.arguments])
         helmInstallCommand = helmInstallCommand.concat(` ${process.env[shared.TestEnvVars.arguments]}`);
@@ -219,13 +223,17 @@ if (process.env[shared.TestEnvVars.command] === shared.Commands.init) {
 if (process.env[shared.TestEnvVars.command] === shared.Commands.package) {
     let helmPackageCommand = `helm package${formatDebugFlag()}`;
 
-    if (process.env[shared.TestEnvVars.updatedependency])
-        helmPackageCommand = helmPackageCommand.concat(" --dependency-update");
-
     if (process.env[shared.TestEnvVars.save]) {
         if (process.env[shared.isHelmV3])
             helmPackageCommand = helmPackageCommand.concat(" --save");
     }
+
+    if (process.env[shared.TestEnvVars.updatedependency])
+        if (process.env[shared.isHelmV3] === "true") {
+            helmPackageCommand = helmPackageCommand.concat(" --dependency-update");
+        } else {
+            helmPackageCommand = helmPackageCommand.concat(" --dep-up");
+        }
 
     if (process.env[shared.TestEnvVars.version])
         helmPackageCommand = helmPackageCommand.concat(` --version ${process.env[shared.TestEnvVars.version]}`);

--- a/Tasks/HelmDeployV0/src/helmcommands/helminstall.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helminstall.ts
@@ -45,10 +45,6 @@ export function addArguments(helmCli: helmcli): void {
         helmCli.addArgument("--set ".concat(helmutil.replaceNewlinesWithCommas(overrideValues)));
     }
 
-    if (updatedependency) {
-        helmCli.addArgument("--dep-up");
-    }
-
     //Version check for Helm, as --name flag with install is no longer supported in Helm 3
     if (helmCli.isHelmV3()) {
         if (releaseName) {
@@ -64,6 +60,16 @@ export function addArguments(helmCli: helmcli): void {
 
     if (waitForExecution) {
         helmCli.addArgument("--wait");
+    }
+
+    //Version check for Helm, as --dep-up was renamed to --dependency-update in Helm 3
+    if (updatedependency) {
+        if (helmCli.isHelmV3()) {
+            helmCli.addArgument("--dependency-update");
+        }
+        else {
+            helmCli.addArgument("--dep-up");
+        }
     }
 
     if (argumentsInput) {

--- a/Tasks/HelmDeployV0/src/helmcommands/helmpackage.ts
+++ b/Tasks/HelmDeployV0/src/helmcommands/helmpackage.ts
@@ -13,12 +13,18 @@ export function addArguments(helmCli: helmcli): void {
     var save = tl.getBoolInput('save', false);
     var argumentsInput = tl.getInput("arguments", false);
 
-    if (updatedependency) {
-        helmCli.addArgument("--dependency-update");
-    }
-
     if (save && !helmCli.isHelmV3()) {
         helmCli.addArgument("--save ");
+    }
+
+    //Version check for Helm, as --dep-up was renamed to --dependency-update in Helm 3
+    if (updatedependency) {
+        if (helmCli.isHelmV3()) {
+            helmCli.addArgument("--dependency-update");
+        }
+        else {
+            helmCli.addArgument("--dep-up");
+        }
     }
 
     if (version) {

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 211,
+        "Minor": 212,
         "Patch": 1
     },
     "demands": [],


### PR DESCRIPTION
**Task name**:HelmDeployV0

**Description**: 

Fix the `updatedependency` flag for Helm v3+ - it currently only supports v2.

fixes #16281 

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y)

**Attached related issue:** (Y)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
