### PR TITLE
Removed set-value dependency in Tasks/DownloadBuildArtifactsV0

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/Tests/L0.ts
+++ b/Tasks/DownloadBuildArtifactsV0/Tests/L0.ts
@@ -1,6 +1,6 @@
-import fs = require('fs');
 import assert = require('assert');
 import path = require('path');
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('DownloadBuildArtifactsV0 Suite', function () {
     before(() => {
@@ -9,8 +9,57 @@ describe('DownloadBuildArtifactsV0 Suite', function () {
     after(() => {
     });
 
-    it('Does a basic hello world test', function(done: MochaDone) {
-        // TODO - add real tests
+    it('No build type provided should fail', (done) => {
+      const tp: string = path.join(__dirname, 'L0NoBuildTypeProvidedFail.js');
+      const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      try {
+          tr.run();
+          assert(tr.stdOutContained('Input required: buildType'));
+          assert(tr.failed, 'task should have failed');
+          done();
+
+      } catch (err) {
+          console.log(tr.stdout);
+          console.log(tr.stderr);
+          console.log(err);
+          done(err);
+      };
+  });
+  
+  it('No download path provided should fail', (done) => {
+    const tp: string = path.join(__dirname, 'L0NoDownloadPathProvidedFail.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    try {
+        tr.run();
+        assert(tr.stdOutContained('Input required: downloadPath'));
+        assert(tr.failed, 'task should have failed');
         done();
-    });
+
+    } catch (err) {
+        console.log(tr.stdout);
+        console.log(tr.stderr);
+        console.log(err);
+        done(err);
+    };
+  });
+
+  it('No download type provided should fail', (done) => {
+    const tp: string = path.join(__dirname, 'L0NoDownloadTypeProvidedFail.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    try {
+        tr.run();
+        assert(tr.stdOutContained('Input required: downloadType'));
+        assert(tr.failed, 'task should have failed');
+        done();
+
+    } catch (err) {
+        console.log(tr.stdout);
+        console.log(tr.stderr);
+        console.log(err);
+        done(err);
+    };
+  });
 });

--- a/Tasks/DownloadBuildArtifactsV0/Tests/L0NoBuildTypeProvidedFail.ts
+++ b/Tasks/DownloadBuildArtifactsV0/Tests/L0NoBuildTypeProvidedFail.ts
@@ -1,0 +1,7 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'main.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.run();

--- a/Tasks/DownloadBuildArtifactsV0/Tests/L0NoDownloadPathProvidedFail.ts
+++ b/Tasks/DownloadBuildArtifactsV0/Tests/L0NoDownloadPathProvidedFail.ts
@@ -1,0 +1,9 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'main.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('buildType', 'specific');
+
+tr.run();

--- a/Tasks/DownloadBuildArtifactsV0/Tests/L0NoDownloadTypeProvidedFail.ts
+++ b/Tasks/DownloadBuildArtifactsV0/Tests/L0NoDownloadTypeProvidedFail.ts
@@ -1,0 +1,10 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'main.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('buildType', 'specific');
+tr.setInput('downloadPath', 'user/bin')
+
+tr.run();

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 200,
+        "Minor": 205,
         "Patch": 1
     },
     "groups": [

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 200,
+    "Minor": 205,
     "Patch": 1
   },
   "groups": [


### PR DESCRIPTION
The dependency package was removed by running: npm audit fix.
Affected package where set-value was is: artifact-engine

This affects the package set-value before 2.0.1, and starting with 3.0.0 but prior to 4.0.1. A type confusion vulnerability can lead to a bypass of https://github.com/advisories/GHSA-4g88-fppr-53pp when the user-provided keys used in the path parameter are arrays.