### PR TITLE
Bumped JavaToolInstaller version to the current sprint (205)

### DIFF
--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 200,
-        "Patch": 1
+        "Minor": 205,
+        "Patch": 0
     },
     "satisfies": [
         "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 200,
-    "Patch": 1
+    "Minor": 205,
+    "Patch": 0
   },
   "satisfies": [
     "Java",


### PR DESCRIPTION
**Task name**: JavaToolInstallerV0

**Description**: bumped task version to 205 - since [PR](https://github.com/microsoft/azure-pipelines-tasks/pull/16184) changes will go with 205 ADO release.

**Documentation changes required:** N

**Added unit tests:** not required

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected - n/a
