### PR TITLE
Removed growl dependency in Tasks/DownloadBuildArtifactsV0

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/package-lock.json
+++ b/Tasks/DownloadBuildArtifactsV0/package-lock.json
@@ -357,11 +357,6 @@
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
           "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA="
         },
-        "growl": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
-          "integrity": "sha1-Sy3sjZB+k9szZiTc7AGDUC+MlCg="
-        },
         "handlebars": {
           "version": "4.7.7",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 200,
+        "Minor": 205,
         "Patch": 1
     },
     "groups": [

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 200,
+    "Minor": 205,
     "Patch": 1
   },
   "groups": [


### PR DESCRIPTION
The only one package 'growl' was removed by running: npm audit fix command.
Affected package: artifact-engine.

Affected versions 1.10.2< of growl do not properly sanitize input prior to passing it into a shell command, allowing for arbitrary command execution.