### PR TITLE
Update pypy3 default version to 3.9

### DIFF
--- a/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UsePythonVersionV0/Strings/resources.resjson/en-US/resources.resjson
@@ -17,6 +17,6 @@
   "loc.messages.ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
   "loc.messages.ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
   "loc.messages.VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-  "loc.messages.ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.6`)",
+  "loc.messages.ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.9`)",
   "loc.messages.PythonVersionRetirement": "Python 3.5 has reached its end of life and will be removed from the ms-hosted images on January, 24. Please update Python version if you use ms-hosted agents. For more information about this - https://github.com/actions/virtual-environments"
 }

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -14,7 +14,7 @@
     "minimumAgentVersion": "2.182.1",
     "version": {
         "Major": 0,
-        "Minor": 200,
+        "Minor": 205,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -77,7 +77,7 @@
         "ToolNotFoundMicrosoftHosted": "If this is a Microsoft-hosted agent, check that this image supports side-by-side versions of %s at %s.",
         "ToolNotFoundSelfHosted": "If this is a self-hosted agent, see how to configure side-by-side %s versions at %s.",
         "VersionNotFound": "Version spec %s for architecture %s did not match any version in Agent.ToolsDirectory.",
-        "ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.6`)",
+        "ExactVersionNotRecommended": "Specifying an exact version is not recommended on Microsoft-Hosted agents. Patch versions of Python can be replaced by new ones on Hosted agents without notice, which will cause builds to fail unexpectedly. It is recommended to specify only major or major and minor version (Example: `3` or `3.9`)",
         "PythonVersionRetirement": "Python 3.5 has reached its end of life and will be removed from the ms-hosted images on January, 24. Please update Python version if you use ms-hosted agents. For more information about this - https://github.com/actions/virtual-environments"
     },
     "restrictions": {

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -14,7 +14,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 0,
-    "Minor": 200,
+    "Minor": 205,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/UsePythonVersionV0/usepythonversion.ts
+++ b/Tasks/UsePythonVersionV0/usepythonversion.ts
@@ -37,7 +37,7 @@ function binDir(installDir: string, platform: Platform): string {
     }
 }
 
-function pypyNotFoundError(versionSpec: '2' | '3.6') {
+function pypyNotFoundError(versionSpec: '2' | '3.9') {
     throw new Error([
         task.loc('PyPyNotFound', versionSpec),
         // 'Python' is intentional here
@@ -52,7 +52,7 @@ function pypyNotFoundError(versionSpec: '2' | '3.6') {
 // For example, PyPy 7.0 contains Python 2.7, 3.5, and 3.6-alpha.
 // We only care about the Python version, so we don't use the PyPy version for the tool cache.
 
-function usePyPy(versionSpec: '2' | '3.6', parameters: TaskParameters, platform: Platform): void {
+function usePyPy(versionSpec: '2' | '3.9', parameters: TaskParameters, platform: Platform): void {
     const findPyPy = tool.findLocalTool.bind(undefined, 'PyPy', versionSpec);
     let installDir: string | null = findPyPy(parameters.architecture);
 
@@ -145,8 +145,8 @@ export async function usePythonVersion(parameters: Readonly<TaskParameters>, pla
         case 'PYPY2':
             return usePyPy('2', parameters, platform);
         case 'PYPY3':
-            // keep pypy3 pointing to 3.6 for backward compatibility
-            return usePyPy('3.6', parameters, platform);
+            // keep pypy3 pointing to 3.9 for backward compatibility
+            return usePyPy('3.9', parameters, platform);
         default:
             return await useCpythonVersion(parameters, platform);
     }


### PR DESCRIPTION
**Task name**: UsePythonVersionV0

**Description**: PyPy3.6 (python3.6) is not present in [ubuntu-22.04 image](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2204-Readme.md#pypy).
Need to replace this version of one which present in all images.

**Documentation changes required:** Y

**Added unit tests:**: N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected - tested in images: windows-2019, windows-2022, ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-10.15, macos-11
