### PR TITLE
Update lodash in DownloadGitHubReleaseV0 to fix vulnerability

### DIFF
--- a/Tasks/DownloadGitHubReleaseV0/package-lock.json
+++ b/Tasks/DownloadGitHubReleaseV0/package-lock.json
@@ -3400,9 +3400,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/Tasks/DownloadGitHubReleaseV0/task.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.json
@@ -10,7 +10,7 @@
     "demands": [],
     "version": {
         "Major": 0,
-        "Minor": 205,
+        "Minor": 206,
         "Patch": 0
     },
     "minimumAgentVersion": "1.99.0",


### PR DESCRIPTION
Fixes CVE-2019-10744 in lodash 4.17.11. Severity: Critical