### PR TITLE
Bumped lodash dev dependency in common-npm-packages/azure-arm-rest-v2/Tests

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/Tests/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/Tests/package-lock.json
@@ -60,9 +60,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "minimist": {

--- a/common-npm-packages/azure-arm-rest-v2/Tests/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/Tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-arm-rest-v2",
-  "version": "2.0.0",
+  "version": "2.205.0",
   "description": "Test - Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-    "version": "2.198.2",
+    "version": "2.205.0",
     "description": "Common Lib for Azure ARM REST apis",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Versions of lodash before 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep allows a malicious user to modify the prototype of Object via {constructor: {prototype: {...}}} causing the addition or modification of an existing property that will exist on all objects.

**Task name**: common-npm-packages/azure-arm-rest-v2/Tests

**Description**:

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
