### PR TITLE
Bumped task version in Tasks/Common/AzureRmDeploy-common

### DIFF
--- a/Tasks/Common/AzureRmDeploy-common/Tests/package.json
+++ b/Tasks/Common/AzureRmDeploy-common/Tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-arm-rest",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Test - Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: Tasks/Common/AzureRmDeploy-common

**Description**: 
Bumped task version in Tasks/Common/AzureRmDeploy-common
Related PR:
https://github.com/microsoft/azure-pipelines-tasks/pull/16296

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
