### PR TITLE
fix legacy tests falling after updating mocha to version  6.2.4

### DIFF
--- a/make.js
+++ b/make.js
@@ -405,7 +405,7 @@ target.test = function() {
 
 target.testLegacy = function() {
     ensureTool('tsc', '--version', 'Version 2.3.4');
-    ensureTool('mocha', '--version', '5.2.0');
+    ensureTool('mocha', '--version', '6.2.3');
 
     if (options.suite) {
         fail('The "suite" parameter has been deprecated. Use the "task" parameter instead.');


### PR DESCRIPTION
**Task name**: -

**Description**:  Fix issue that legacy tests falling after the mocha update in #16192 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #16192 

**Checklist**:
- [ ] Task version was bumped - not applicable
- [x] Checked that applied changes work as expected
