### PR TITLE
Bumped azure-arm-rest to remove lodash vulnerability in Tasks/JenkinsDownloadArtifactsV1

### DIFF
--- a/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
@@ -155,9 +155,9 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-1.0.0.tgz",
-      "integrity": "sha512-OSkE9wtw9wSxBVvK9d5Kyiv+mu8zQvZzZAzEfRMg6+/HX1D0tjvHjx4JinwENRwf0Wse2YOUrDAAuVHoQgYzkw==",
+      "version": "1.205.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-1.205.0.tgz",
+      "integrity": "sha512-UfWA3auj1HI2dx4/UDjQlHGKxTRxHzOOpoJxQcMCjV7XIWixGM/UdgOrabv3trvhd53eOzZWRRbqWMwtZVrUFg==",
       "requires": {
         "jsonwebtoken": "7.3.0",
         "q": "1.4.1",
@@ -168,7 +168,7 @@
         "q": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+          "integrity": "sha512-/CdEdaw49VZVmyIDGUQKDDT53c7qBkO6g5CefWz91Ae+l4+cRtcDYwMTXh6me4O8TMldeGHG3N2Bl84V78Ywbg=="
         },
         "vsts-task-lib": {
           "version": "2.0.5",

--- a/Tasks/JenkinsDownloadArtifactsV1/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package.json
@@ -13,7 +13,7 @@
     "@types/uuid": "^8.3.0",
     "artifact-engine": "0.1.26",
     "azure-pipelines-task-lib": "^3.1.7",
-    "azure-pipelines-tasks-azure-arm-rest": "1.0.0",
+    "azure-pipelines-tasks-azure-arm-rest": "1.205.0",
     "azure-storage": "2.10.4",
     "decompress-zip": "0.3.3",
     "fs-extra": "5.0.0",

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -18,7 +18,7 @@
     "demands": [],
     "version": {
         "Major": 1,
-        "Minor": 203,
+        "Minor": 206,
         "Patch": 0
     },
     "groups": [

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 203,
+    "Minor": 206,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
**Task name**: Tasks/JenkinsDownloadArtifactsV1

**Description**: Bumped azure-arm-rest because it contained a lodash vulnerability in its Tests and it is detected as a CG issue in the Tasks/JenkinsDownloadArtifactsV1.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected - checked in the local pipeline with Jenkins running in a docker container.
