### PR TITLE
fix aysnc header cherrypick 

### DIFF
--- a/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-cloud.ts
+++ b/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-cloud.ts
@@ -35,7 +35,7 @@ class UploadTarget {
     }
 }
 
-const ASYNC_OPERATION_HEADER = 'azure-asyncoperation';
+const LOCATION_HEADER = 'location';
 
 export class AzureSpringCloud {
 
@@ -120,7 +120,7 @@ export class AzureSpringCloud {
         } else {
             tl.debug('App update initiated.')
             //If the operation is asynchronous, block pending its conclusion.
-            var operationStatusUrl = response.headers[ASYNC_OPERATION_HEADER];
+            var operationStatusUrl = response.headers[LOCATION_HEADER];
             if (operationStatusUrl) {
                 tl.debug('Awaiting operation completion.');
                 try {
@@ -285,7 +285,7 @@ export class AzureSpringCloud {
         } else {
             tl.debug('App update initiated.')
             //If the operation is asynchronous, block pending its conclusion.
-            var operationStatusUrl = response.headers[ASYNC_OPERATION_HEADER];
+            var operationStatusUrl = response.headers[LOCATION_HEADER];
             if (operationStatusUrl) {
                 tl.debug('Awaiting operation completion.');
                 try {

--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 206,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.104.1",
     "groups": [

--- a/Tasks/AzureSpringCloudV0/task.loc.json
+++ b/Tasks/AzureSpringCloudV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 206,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [


### PR DESCRIPTION
**Task name**: AzureSpringCloudV0

**Description**: Our aysnc operation await logic has a bug that it will return when the aync opetion has not completed. We fix this bug in this PR refer to this doc: https://github.com/Azure/azure-resource-manager-rpc/blob/master/v1.0/async-api-reference.md#202-accepted-and-location-headers

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
