### PR TITLE
Bug on windows machines in ci/verifyMinAgentDemands execution via pipeline (#3087)

### DIFF
--- a/Tasks/PublishPipelineArtifactV0/task.json
+++ b/Tasks/PublishPipelineArtifactV0/task.json
@@ -14,7 +14,7 @@
     },
     "groups": [],
     "demands": [],
-    "minimumAgentVersion": "2.199",
+    "minimumAgentVersion": "2.199.0",
     "preview": false,
     "deprecated": true,
     "inputs": [

--- a/Tasks/PublishPipelineArtifactV0/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV0/task.loc.json
@@ -14,7 +14,7 @@
   },
   "groups": [],
   "demands": [],
-  "minimumAgentVersion": "2.199",
+  "minimumAgentVersion": "2.199.0",
   "preview": false,
   "deprecated": true,
   "inputs": [

--- a/Tasks/PublishPipelineArtifactV1/task.json
+++ b/Tasks/PublishPipelineArtifactV1/task.json
@@ -15,7 +15,7 @@
     "groups": [],
     "demands": [],
     "preview": false,
-    "minimumAgentVersion": "2.199",
+    "minimumAgentVersion": "2.199.0",
     "inputs": [
         {
             "name": "path",

--- a/Tasks/PublishPipelineArtifactV1/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV1/task.loc.json
@@ -15,7 +15,7 @@
   "groups": [],
   "demands": [],
   "preview": false,
-  "minimumAgentVersion": "2.199",
+  "minimumAgentVersion": "2.199.0",
   "inputs": [
     {
       "name": "path",

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -37,13 +37,13 @@ steps:
 
 # Verify min agent version demands
 - task: Npm@1
-    inputs:
-      command: install
-      workingDir: ci/verifyMinAgentDemands
-    displayName: npm install min agent demands 
+  inputs:
+    command: install
+    workingDir: ci/verifyMinAgentDemands
+  displayName: npm install min agent demands 
 
  - script: node ./ci/verifyMinAgentDemands/index.js
-    displayName: Verify all min agent demands are valid (via npm)
+  displayName: Verify all min agent demands are valid (via npm)
 
 # Build
 - script: node make.js build --task "$(task_pattern)"

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -42,7 +42,7 @@ steps:
     workingDir: ci/verifyMinAgentDemands
   displayName: npm install min agent demands 
 
- - script: node ./ci/verifyMinAgentDemands/index.js
+- script: node ./ci/verifyMinAgentDemands/index.js
   displayName: Verify all min agent demands are valid (via npm)
 
 # Build

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -36,12 +36,14 @@ steps:
     PACKAGE_TOKEN: $(Package.Token)
 
 # Verify min agent version demands
-- script: |
-    cd ci
-    cd verifyMinAgentDemands
-    npm install
-    node index.js
-  displayName: Verify all min agent demands are valid
+- task: Npm@1
+    inputs:
+      command: install
+      workingDir: ci/verifyMinAgentDemands
+    displayName: npm install min agent demands 
+
+ - script: node ./ci/verifyMinAgentDemands/index.js
+    displayName: Verify all min agent demands are valid (via npm)
 
 # Build
 - script: node make.js build --task "$(task_pattern)"

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -20,12 +20,14 @@ steps:
   displayName: npm install
 
 # Verify min agent version demands
-- script: |
-    cd ci
-    cd verifyMinAgentDemands
-    npm install
-    node index.js
-  displayName: Verify all min agent demands are valid
+- task: Npm@1
+    inputs:
+      command: install
+      workingDir: ci/verifyMinAgentDemands
+    displayName: npm install min agent demands 
+
+ - script: node ./ci/verifyMinAgentDemands/index.js
+    displayName: Verify all min agent demands are valid (via npm)
 
 # Build
 - script: node make.js build --task "$(task)"

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -21,13 +21,13 @@ steps:
 
 # Verify min agent version demands
 - task: Npm@1
-    inputs:
-      command: install
-      workingDir: ci/verifyMinAgentDemands
-    displayName: npm install min agent demands 
+  inputs:
+    command: install
+    workingDir: ci/verifyMinAgentDemands
+  displayName: npm install min agent demands 
 
- - script: node ./ci/verifyMinAgentDemands/index.js
-    displayName: Verify all min agent demands are valid (via npm)
+- script: node ./ci/verifyMinAgentDemands/index.js
+  displayName: Verify all min agent demands are valid (via npm)
 
 # Build
 - script: node make.js build --task "$(task)"


### PR DESCRIPTION
**Task name**: ci/verifyMinAgentDemands

**Description**: 
When you access another batch file from a batch file, you need to use the CALL command to return control to the parent process. Otherwise control is passed to the batch file being executed. So CmdLineV2 Task was replaced with 2 separated commands.
Because npm install on windows is a batch file which call npm-cli.js and you cant use "call npm install" command on Linux-based machines

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/3087

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
