### PR TITLE
FindbugsTool.ts: Collect stats for all packages and return values in correct order (#10123, #10124)

### DIFF
--- a/common-npm-packages/codeanalysis-common/Common/FindbugsTool.ts
+++ b/common-npm-packages/codeanalysis-common/Common/FindbugsTool.ts
@@ -109,7 +109,7 @@ export class FindbugsTool extends BaseTool {
 
         // Extract violation and file count data from the sourceFile attribute of ClassStats
         let filesToViolations: Map<string, number> = new Map(); // Maps files -> number of violations
-        data.BugCollection.FindBugsSummary[0].PackageStats[0].ClassStats.forEach((classStats:any) => {
+        data.BugCollection.FindBugsSummary[0].forEach((packageStats: any) => packageStats.ClassStats.forEach((classStats:any) => {
             // The below line takes the sourceFile attribute of the classStats tag - it looks like this in the XML
             // <ClassStats class="main.java.TestClassWithErrors" sourceFile="TestClassWithErrors.java" ... />
             let sourceFile: string = classStats.$.sourceFile;
@@ -124,7 +124,7 @@ export class FindbugsTool extends BaseTool {
                 let oldBugCount: number = filesToViolations.get(sourceFile);
                 filesToViolations.set(sourceFile, oldBugCount + newBugCount);
             }
-        });
+        }));
 
         // Sum violations across all files for violationCount
         for (let violations of filesToViolations.values()) {
@@ -134,6 +134,6 @@ export class FindbugsTool extends BaseTool {
         // Number of <K,V> pairs in filesToViolations is fileCount
         fileCount = filesToViolations.size;
 
-        return [violationCount, fileCount];
+        return [fileCount, violationCount];
     }
 }


### PR DESCRIPTION
**Task name**: Maven task

**Description**: Collect stats for all packages and return values in correct order.
Same content as the PR https://github.com/microsoft/azure-pipelines-tasks/pull/10124, but the PR was created again because of a change in the directory of the FindbugsTool.ts file.

**Documentation changes required:** (N)

**Added unit tests:** (N)

**Attached related issue:** (Y) #10123

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
