### PR TITLE
remove condition that prevents AppServiceApplicationUrl from being updated after deployment

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/azurermwebappdeployment.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/azurermwebappdeployment.ts
@@ -28,7 +28,7 @@ async function main() {
         tl.setResult(tl.TaskResult.Failed, error);
     }
     finally {
-        if(deploymentProvider != null && isDeploymentSuccess == false) {
+        if(deploymentProvider != null) {
             await deploymentProvider.UpdateDeploymentStatus(isDeploymentSuccess);
         }
         Endpoint.dispose();

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 205,
-        "Patch": 13
+        "Minor": 207,
+        "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 205,
-    "Patch": 13
+    "Minor": 207,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV4

**Description**: Remove the condition that prevents the variable AppServiceApplicationUrl from being updated after deployment.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y https://github.com/microsoft/azure-pipelines-tasks/issues/16467

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
