### PR TITLE
Fix vulnerabilities in GradleV3 task

### DIFF
--- a/Tasks/GradleV3/package-lock.json
+++ b/Tasks/GradleV3/package-lock.json
@@ -347,7 +347,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -523,9 +523,9 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "is-core-module": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
-      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -551,9 +551,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -574,13 +574,13 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },
@@ -723,9 +723,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -782,7 +782,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -832,12 +832,13 @@
       }
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "requires": {
-        "is-core-module": "^2.1.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "rimraf": {
@@ -869,9 +870,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -906,6 +907,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "sync-request": {
       "version": "6.1.0",
@@ -1004,7 +1010,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -112,7 +112,9 @@
         },
         {
             "name": "codeCoverageTool",
-            "aliases": ["codeCoverageToolOption"],
+            "aliases": [
+                "codeCoverageToolOption"
+            ],
             "type": "pickList",
             "label": "Code coverage tool",
             "required": false,
@@ -127,7 +129,9 @@
         },
         {
             "name": "classFilesDirectories",
-            "aliases": ["codeCoverageClassFilesDirectories"],
+            "aliases": [
+                "codeCoverageClassFilesDirectories"
+            ],
             "type": "string",
             "label": "Class files directories",
             "defaultValue": "build/classes/main/",
@@ -138,7 +142,9 @@
         },
         {
             "name": "classFilter",
-            "aliases": ["codeCoverageClassFilter"],
+            "aliases": [
+                "codeCoverageClassFilter"
+            ],
             "type": "string",
             "label": "Class inclusion/exclusion filters",
             "defaultValue": "",
@@ -149,7 +155,9 @@
         },
         {
             "name": "failIfCoverageEmpty",
-            "aliases": ["codeCoverageFailIfEmpty"],
+            "aliases": [
+                "codeCoverageFailIfEmpty"
+            ],
             "type": "boolean",
             "label": "Fail when code coverage results are missing",
             "defaultValue": "false",
@@ -160,7 +168,9 @@
         },
         {
             "name": "gradle5xOrHigher",
-            "aliases": ["codeCoverageGradle5xOrHigher"],
+            "aliases": [
+                "codeCoverageGradle5xOrHigher"
+            ],
             "type": "boolean",
             "label": "Gradle version >= 5.x",
             "defaultValue": "true",
@@ -171,7 +181,9 @@
         },
         {
             "name": "javaHomeSelection",
-            "aliases": ["javaHomeOption"],
+            "aliases": [
+                "javaHomeOption"
+            ],
             "type": "radio",
             "label": "Set JAVA_HOME by",
             "required": true,
@@ -185,7 +197,9 @@
         },
         {
             "name": "jdkVersion",
-            "aliases": ["jdkVersionOption"],
+            "aliases": [
+                "jdkVersionOption"
+            ],
             "type": "pickList",
             "label": "JDK version",
             "required": false,
@@ -205,7 +219,9 @@
         },
         {
             "name": "jdkUserInputPath",
-            "aliases": ["jdkDirectory"],
+            "aliases": [
+                "jdkDirectory"
+            ],
             "type": "string",
             "label": "JDK path",
             "required": true,
@@ -216,7 +232,9 @@
         },
         {
             "name": "jdkArchitecture",
-            "aliases": ["jdkArchitectureOption"],
+            "aliases": [
+                "jdkArchitectureOption"
+            ],
             "type": "pickList",
             "label": "JDK architecture",
             "defaultValue": "x64",
@@ -231,7 +249,9 @@
         },
         {
             "name": "gradleOpts",
-            "aliases": ["gradleOptions"],
+            "aliases": [
+                "gradleOptions"
+            ],
             "type": "string",
             "label": "Set GRADLE_OPTS",
             "required": false,
@@ -241,7 +261,9 @@
         },
         {
             "name": "sqAnalysisEnabled",
-            "aliases": ["sonarQubeRunAnalysis"],
+            "aliases": [
+                "sonarQubeRunAnalysis"
+            ],
             "type": "boolean",
             "label": "Run SonarQube or SonarCloud Analysis",
             "required": true,
@@ -265,7 +287,9 @@
         },
         {
             "name": "sqGradlePluginVersion",
-            "aliases": ["sonarQubeGradlePluginVersion"],
+            "aliases": [
+                "sonarQubeGradlePluginVersion"
+            ],
             "type": "string",
             "label": "SonarQube scanner for Gradle plugin version",
             "required": true,
@@ -276,7 +300,9 @@
         },
         {
             "name": "checkstyleAnalysisEnabled",
-            "aliases": ["checkStyleRunAnalysis"],
+            "aliases": [
+                "checkStyleRunAnalysis"
+            ],
             "type": "boolean",
             "label": "Run Checkstyle",
             "required": false,
@@ -286,7 +312,9 @@
         },
         {
             "name": "findbugsAnalysisEnabled",
-            "aliases": ["findBugsRunAnalysis"],
+            "aliases": [
+                "findBugsRunAnalysis"
+            ],
             "type": "boolean",
             "label": "Run FindBugs",
             "required": false,
@@ -296,7 +324,9 @@
         },
         {
             "name": "pmdAnalysisEnabled",
-            "aliases": ["pmdRunAnalysis"],
+            "aliases": [
+                "pmdRunAnalysis"
+            ],
             "type": "boolean",
             "label": "Run PMD",
             "required": false,
@@ -306,7 +336,9 @@
         },
         {
             "name": "spotBugsAnalysisEnabled",
-            "aliases": ["spotBugsAnalysis"],
+            "aliases": [
+                "spotBugsAnalysis"
+            ],
             "type": "boolean",
             "label": "Run SpotBugs",
             "required": true,
@@ -330,7 +362,9 @@
         },
         {
             "name": "spotbugsGradlePluginVersion",
-            "aliases": ["spotbugsGradlePluginVersion"],
+            "aliases": [
+                "spotbugsGradlePluginVersion"
+            ],
             "type": "string",
             "label": "Version number",
             "required": true,

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 205,
+        "Minor": 207,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -10,7 +10,7 @@
         "Build"
     ],
     "runsOn": [
-        "Agent", 
+        "Agent",
         "DeploymentGroup"
     ],
     "author": "Microsoft Corporation",

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -7,7 +7,7 @@
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=613720) or [see the Gradle documentation](https://docs.gradle.org/current/userguide/userguide.html)",
     "category": "Build",
     "visibility": ["Build"],
-    "runsOn": ["Agent","DeploymentGroup"],
+    "runsOn": ["Agent", "DeploymentGroup"],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
@@ -42,9 +42,7 @@
     "inputs": [
         {
             "name": "wrapperScript",
-            "aliases": [
-                "gradleWrapperFile"
-            ],
+            "aliases": ["gradleWrapperFile"],
             "type": "filePath",
             "label": "Gradle wrapper",
             "defaultValue": "gradlew",

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -6,8 +6,13 @@
     "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/gradle",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=613720) or [see the Gradle documentation](https://docs.gradle.org/current/userguide/userguide.html)",
     "category": "Build",
-    "visibility": ["Build"],
-    "runsOn": ["Agent", "DeploymentGroup"],
+    "visibility": [
+        "Build"
+    ],
+    "runsOn": [
+        "Agent", 
+        "DeploymentGroup"
+    ],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
@@ -42,7 +47,9 @@
     "inputs": [
         {
             "name": "wrapperScript",
-            "aliases": ["gradleWrapperFile"],
+            "aliases": [
+                "gradleWrapperFile"
+            ],
             "type": "filePath",
             "label": "Gradle wrapper",
             "defaultValue": "gradlew",
@@ -51,7 +58,9 @@
         },
         {
             "name": "cwd",
-            "aliases": ["workingDirectory"],
+            "aliases": [
+                "workingDirectory"
+            ],
             "type": "filePath",
             "label": "Working directory",
             "defaultValue": "",

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -6,13 +6,8 @@
     "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/gradle",
     "helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?LinkID=613720) or [see the Gradle documentation](https://docs.gradle.org/current/userguide/userguide.html)",
     "category": "Build",
-    "visibility": [
-        "Build"
-    ],
-    "runsOn": [
-        "Agent",
-        "DeploymentGroup"
-    ],
+    "visibility": ["Build"],
+    "runsOn": ["Agent","DeploymentGroup"],
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
@@ -58,9 +53,7 @@
         },
         {
             "name": "cwd",
-            "aliases": [
-                "workingDirectory"
-            ],
+            "aliases": ["workingDirectory"],
             "type": "filePath",
             "label": "Working directory",
             "defaultValue": "",
@@ -112,9 +105,7 @@
         },
         {
             "name": "codeCoverageTool",
-            "aliases": [
-                "codeCoverageToolOption"
-            ],
+            "aliases": ["codeCoverageToolOption"],
             "type": "pickList",
             "label": "Code coverage tool",
             "required": false,
@@ -129,9 +120,7 @@
         },
         {
             "name": "classFilesDirectories",
-            "aliases": [
-                "codeCoverageClassFilesDirectories"
-            ],
+            "aliases": ["codeCoverageClassFilesDirectories"],
             "type": "string",
             "label": "Class files directories",
             "defaultValue": "build/classes/main/",
@@ -142,9 +131,7 @@
         },
         {
             "name": "classFilter",
-            "aliases": [
-                "codeCoverageClassFilter"
-            ],
+            "aliases": ["codeCoverageClassFilter"],
             "type": "string",
             "label": "Class inclusion/exclusion filters",
             "defaultValue": "",
@@ -155,9 +142,7 @@
         },
         {
             "name": "failIfCoverageEmpty",
-            "aliases": [
-                "codeCoverageFailIfEmpty"
-            ],
+            "aliases": ["codeCoverageFailIfEmpty"],
             "type": "boolean",
             "label": "Fail when code coverage results are missing",
             "defaultValue": "false",
@@ -168,9 +153,7 @@
         },
         {
             "name": "gradle5xOrHigher",
-            "aliases": [
-                "codeCoverageGradle5xOrHigher"
-            ],
+            "aliases": ["codeCoverageGradle5xOrHigher"],
             "type": "boolean",
             "label": "Gradle version >= 5.x",
             "defaultValue": "true",
@@ -181,9 +164,7 @@
         },
         {
             "name": "javaHomeSelection",
-            "aliases": [
-                "javaHomeOption"
-            ],
+            "aliases": ["javaHomeOption"],
             "type": "radio",
             "label": "Set JAVA_HOME by",
             "required": true,
@@ -197,9 +178,7 @@
         },
         {
             "name": "jdkVersion",
-            "aliases": [
-                "jdkVersionOption"
-            ],
+            "aliases": ["jdkVersionOption"],
             "type": "pickList",
             "label": "JDK version",
             "required": false,
@@ -219,9 +198,7 @@
         },
         {
             "name": "jdkUserInputPath",
-            "aliases": [
-                "jdkDirectory"
-            ],
+            "aliases": ["jdkDirectory"],
             "type": "string",
             "label": "JDK path",
             "required": true,
@@ -232,9 +209,7 @@
         },
         {
             "name": "jdkArchitecture",
-            "aliases": [
-                "jdkArchitectureOption"
-            ],
+            "aliases": ["jdkArchitectureOption"],
             "type": "pickList",
             "label": "JDK architecture",
             "defaultValue": "x64",
@@ -249,9 +224,7 @@
         },
         {
             "name": "gradleOpts",
-            "aliases": [
-                "gradleOptions"
-            ],
+            "aliases": ["gradleOptions"],
             "type": "string",
             "label": "Set GRADLE_OPTS",
             "required": false,
@@ -261,9 +234,7 @@
         },
         {
             "name": "sqAnalysisEnabled",
-            "aliases": [
-                "sonarQubeRunAnalysis"
-            ],
+            "aliases": ["sonarQubeRunAnalysis"],
             "type": "boolean",
             "label": "Run SonarQube or SonarCloud Analysis",
             "required": true,
@@ -287,9 +258,7 @@
         },
         {
             "name": "sqGradlePluginVersion",
-            "aliases": [
-                "sonarQubeGradlePluginVersion"
-            ],
+            "aliases": ["sonarQubeGradlePluginVersion"],
             "type": "string",
             "label": "SonarQube scanner for Gradle plugin version",
             "required": true,
@@ -300,9 +269,7 @@
         },
         {
             "name": "checkstyleAnalysisEnabled",
-            "aliases": [
-                "checkStyleRunAnalysis"
-            ],
+            "aliases": ["checkStyleRunAnalysis"],
             "type": "boolean",
             "label": "Run Checkstyle",
             "required": false,
@@ -312,9 +279,7 @@
         },
         {
             "name": "findbugsAnalysisEnabled",
-            "aliases": [
-                "findBugsRunAnalysis"
-            ],
+            "aliases": ["findBugsRunAnalysis"],
             "type": "boolean",
             "label": "Run FindBugs",
             "required": false,
@@ -324,9 +289,7 @@
         },
         {
             "name": "pmdAnalysisEnabled",
-            "aliases": [
-                "pmdRunAnalysis"
-            ],
+            "aliases": ["pmdRunAnalysis"],
             "type": "boolean",
             "label": "Run PMD",
             "required": false,
@@ -336,9 +299,7 @@
         },
         {
             "name": "spotBugsAnalysisEnabled",
-            "aliases": [
-                "spotBugsAnalysis"
-            ],
+            "aliases": ["spotBugsAnalysis"],
             "type": "boolean",
             "label": "Run SpotBugs",
             "required": true,
@@ -362,9 +323,7 @@
         },
         {
             "name": "spotbugsGradlePluginVersion",
-            "aliases": [
-                "spotbugsGradlePluginVersion"
-            ],
+            "aliases": ["spotbugsGradlePluginVersion"],
             "type": "string",
             "label": "Version number",
             "required": true,

--- a/Tasks/GradleV3/task.loc.json
+++ b/Tasks/GradleV3/task.loc.json
@@ -6,13 +6,8 @@
   "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/gradle",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
-  "visibility": [
-    "Build"
-  ],
-  "runsOn": [
-    "Agent",
-    "DeploymentGroup"
-  ],
+  "visibility": ["Build"],
+  "runsOn": ["Agent", "DeploymentGroup"],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
@@ -47,9 +42,7 @@
   "inputs": [
     {
       "name": "wrapperScript",
-      "aliases": [
-        "gradleWrapperFile"
-      ],
+      "aliases": ["gradleWrapperFile"],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.wrapperScript",
       "defaultValue": "gradlew",
@@ -58,9 +51,7 @@
     },
     {
       "name": "cwd",
-      "aliases": [
-        "workingDirectory"
-      ],
+      "aliases": ["workingDirectory"],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.cwd",
       "defaultValue": "",
@@ -112,9 +103,7 @@
     },
     {
       "name": "codeCoverageTool",
-      "aliases": [
-        "codeCoverageToolOption"
-      ],
+      "aliases": ["codeCoverageToolOption"],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.codeCoverageTool",
       "required": false,
@@ -129,9 +118,7 @@
     },
     {
       "name": "classFilesDirectories",
-      "aliases": [
-        "codeCoverageClassFilesDirectories"
-      ],
+      "aliases": ["codeCoverageClassFilesDirectories"],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilesDirectories",
       "defaultValue": "build/classes/main/",
@@ -142,9 +129,7 @@
     },
     {
       "name": "classFilter",
-      "aliases": [
-        "codeCoverageClassFilter"
-      ],
+      "aliases": ["codeCoverageClassFilter"],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilter",
       "defaultValue": "",
@@ -155,9 +140,7 @@
     },
     {
       "name": "failIfCoverageEmpty",
-      "aliases": [
-        "codeCoverageFailIfEmpty"
-      ],
+      "aliases": ["codeCoverageFailIfEmpty"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.failIfCoverageEmpty",
       "defaultValue": "false",
@@ -168,9 +151,7 @@
     },
     {
       "name": "gradle5xOrHigher",
-      "aliases": [
-        "codeCoverageGradle5xOrHigher"
-      ],
+      "aliases": ["codeCoverageGradle5xOrHigher"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.gradle5xOrHigher",
       "defaultValue": "true",
@@ -181,9 +162,7 @@
     },
     {
       "name": "javaHomeSelection",
-      "aliases": [
-        "javaHomeOption"
-      ],
+      "aliases": ["javaHomeOption"], 
       "type": "radio",
       "label": "ms-resource:loc.input.label.javaHomeSelection",
       "required": true,
@@ -197,9 +176,7 @@
     },
     {
       "name": "jdkVersion",
-      "aliases": [
-        "jdkVersionOption"
-      ],
+      "aliases": ["jdkVersionOption"], 
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
       "required": false,
@@ -219,9 +196,7 @@
     },
     {
       "name": "jdkUserInputPath",
-      "aliases": [
-        "jdkDirectory"
-      ],
+      "aliases": ["jdkDirectory"],
       "type": "string",
       "label": "ms-resource:loc.input.label.jdkUserInputPath",
       "required": true,
@@ -232,9 +207,7 @@
     },
     {
       "name": "jdkArchitecture",
-      "aliases": [
-        "jdkArchitectureOption"
-      ],
+      "aliases": ["jdkArchitectureOption"],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkArchitecture",
       "defaultValue": "x64",
@@ -249,9 +222,7 @@
     },
     {
       "name": "gradleOpts",
-      "aliases": [
-        "gradleOptions"
-      ],
+      "aliases": ["gradleOptions"],
       "type": "string",
       "label": "ms-resource:loc.input.label.gradleOpts",
       "required": false,
@@ -261,9 +232,7 @@
     },
     {
       "name": "sqAnalysisEnabled",
-      "aliases": [
-        "sonarQubeRunAnalysis"
-      ],
+      "aliases": ["sonarQubeRunAnalysis"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqAnalysisEnabled",
       "required": true,
@@ -287,9 +256,7 @@
     },
     {
       "name": "sqGradlePluginVersion",
-      "aliases": [
-        "sonarQubeGradlePluginVersion"
-      ],
+      "aliases": ["sonarQubeGradlePluginVersion"],
       "type": "string",
       "label": "ms-resource:loc.input.label.sqGradlePluginVersion",
       "required": true,
@@ -300,9 +267,7 @@
     },
     {
       "name": "checkstyleAnalysisEnabled",
-      "aliases": [
-        "checkStyleRunAnalysis"
-      ],
+      "aliases": ["checkStyleRunAnalysis"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.checkstyleAnalysisEnabled",
       "required": false,
@@ -312,9 +277,7 @@
     },
     {
       "name": "findbugsAnalysisEnabled",
-      "aliases": [
-        "findBugsRunAnalysis"
-      ],
+      "aliases": ["findBugsRunAnalysis"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.findbugsAnalysisEnabled",
       "required": false,
@@ -324,9 +287,7 @@
     },
     {
       "name": "pmdAnalysisEnabled",
-      "aliases": [
-        "pmdRunAnalysis"
-      ],
+      "aliases": ["pmdRunAnalysis"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.pmdAnalysisEnabled",
       "required": false,
@@ -336,9 +297,7 @@
     },
     {
       "name": "spotBugsAnalysisEnabled",
-      "aliases": [
-        "spotBugsAnalysis"
-      ],
+      "aliases": ["spotBugsAnalysis"],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.spotBugsAnalysisEnabled",
       "required": true,
@@ -362,9 +321,7 @@
     },
     {
       "name": "spotbugsGradlePluginVersion",
-      "aliases": [
-        "spotbugsGradlePluginVersion"
-      ],
+      "aliases": ["spotbugsGradlePluginVersion"],
       "type": "string",
       "label": "ms-resource:loc.input.label.spotbugsGradlePluginVersion",
       "required": true,

--- a/Tasks/GradleV3/task.loc.json
+++ b/Tasks/GradleV3/task.loc.json
@@ -6,12 +6,17 @@
   "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/gradle",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
-  "visibility": ["Build"],
-  "runsOn": ["Agent", "DeploymentGroup"],
+  "visibility": [
+    "Build"
+  ],
+  "runsOn": [
+    "Agent",
+    "DeploymentGroup"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 205,
+    "Minor": 207,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -42,7 +47,9 @@
   "inputs": [
     {
       "name": "wrapperScript",
-      "aliases": ["gradleWrapperFile"],
+      "aliases": [
+        "gradleWrapperFile"
+      ],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.wrapperScript",
       "defaultValue": "gradlew",
@@ -51,7 +58,9 @@
     },
     {
       "name": "cwd",
-      "aliases": ["workingDirectory"],
+      "aliases": [
+        "workingDirectory"
+      ],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.cwd",
       "defaultValue": "",
@@ -103,7 +112,9 @@
     },
     {
       "name": "codeCoverageTool",
-      "aliases": ["codeCoverageToolOption"],
+      "aliases": [
+        "codeCoverageToolOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.codeCoverageTool",
       "required": false,
@@ -118,7 +129,9 @@
     },
     {
       "name": "classFilesDirectories",
-      "aliases": ["codeCoverageClassFilesDirectories"],
+      "aliases": [
+        "codeCoverageClassFilesDirectories"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilesDirectories",
       "defaultValue": "build/classes/main/",
@@ -129,7 +142,9 @@
     },
     {
       "name": "classFilter",
-      "aliases": ["codeCoverageClassFilter"],
+      "aliases": [
+        "codeCoverageClassFilter"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilter",
       "defaultValue": "",
@@ -140,7 +155,9 @@
     },
     {
       "name": "failIfCoverageEmpty",
-      "aliases": ["codeCoverageFailIfEmpty"],
+      "aliases": [
+        "codeCoverageFailIfEmpty"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.failIfCoverageEmpty",
       "defaultValue": "false",
@@ -151,7 +168,9 @@
     },
     {
       "name": "gradle5xOrHigher",
-      "aliases": ["codeCoverageGradle5xOrHigher"],
+      "aliases": [
+        "codeCoverageGradle5xOrHigher"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.gradle5xOrHigher",
       "defaultValue": "true",
@@ -162,7 +181,9 @@
     },
     {
       "name": "javaHomeSelection",
-      "aliases": ["javaHomeOption"],
+      "aliases": [
+        "javaHomeOption"
+      ],
       "type": "radio",
       "label": "ms-resource:loc.input.label.javaHomeSelection",
       "required": true,
@@ -176,7 +197,9 @@
     },
     {
       "name": "jdkVersion",
-      "aliases": ["jdkVersionOption"],
+      "aliases": [
+        "jdkVersionOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
       "required": false,
@@ -196,7 +219,9 @@
     },
     {
       "name": "jdkUserInputPath",
-      "aliases": ["jdkDirectory"],
+      "aliases": [
+        "jdkDirectory"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.jdkUserInputPath",
       "required": true,
@@ -207,7 +232,9 @@
     },
     {
       "name": "jdkArchitecture",
-      "aliases": ["jdkArchitectureOption"],
+      "aliases": [
+        "jdkArchitectureOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkArchitecture",
       "defaultValue": "x64",
@@ -222,7 +249,9 @@
     },
     {
       "name": "gradleOpts",
-      "aliases": ["gradleOptions"],
+      "aliases": [
+        "gradleOptions"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.gradleOpts",
       "required": false,
@@ -232,7 +261,9 @@
     },
     {
       "name": "sqAnalysisEnabled",
-      "aliases": ["sonarQubeRunAnalysis"],
+      "aliases": [
+        "sonarQubeRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqAnalysisEnabled",
       "required": true,
@@ -256,7 +287,9 @@
     },
     {
       "name": "sqGradlePluginVersion",
-      "aliases": ["sonarQubeGradlePluginVersion"],
+      "aliases": [
+        "sonarQubeGradlePluginVersion"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.sqGradlePluginVersion",
       "required": true,
@@ -267,7 +300,9 @@
     },
     {
       "name": "checkstyleAnalysisEnabled",
-      "aliases": ["checkStyleRunAnalysis"],
+      "aliases": [
+        "checkStyleRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.checkstyleAnalysisEnabled",
       "required": false,
@@ -277,7 +312,9 @@
     },
     {
       "name": "findbugsAnalysisEnabled",
-      "aliases": ["findBugsRunAnalysis"],
+      "aliases": [
+        "findBugsRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.findbugsAnalysisEnabled",
       "required": false,
@@ -287,7 +324,9 @@
     },
     {
       "name": "pmdAnalysisEnabled",
-      "aliases": ["pmdRunAnalysis"],
+      "aliases": [
+        "pmdRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.pmdAnalysisEnabled",
       "required": false,
@@ -297,7 +336,9 @@
     },
     {
       "name": "spotBugsAnalysisEnabled",
-      "aliases": ["spotBugsAnalysis"],
+      "aliases": [
+        "spotBugsAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.spotBugsAnalysisEnabled",
       "required": true,
@@ -321,7 +362,9 @@
     },
     {
       "name": "spotbugsGradlePluginVersion",
-      "aliases": ["spotbugsGradlePluginVersion"],
+      "aliases": [
+        "spotbugsGradlePluginVersion"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.spotbugsGradlePluginVersion",
       "required": true,

--- a/Tasks/GradleV3/task.loc.json
+++ b/Tasks/GradleV3/task.loc.json
@@ -162,7 +162,7 @@
     },
     {
       "name": "javaHomeSelection",
-      "aliases": ["javaHomeOption"], 
+      "aliases": ["javaHomeOption"],
       "type": "radio",
       "label": "ms-resource:loc.input.label.javaHomeSelection",
       "required": true,
@@ -176,7 +176,7 @@
     },
     {
       "name": "jdkVersion",
-      "aliases": ["jdkVersionOption"], 
+      "aliases": ["jdkVersionOption"],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
       "required": false,


### PR DESCRIPTION
**Task name**: GradleV3

**Description**:
- Fixed minor vulnerabilities by running the ```npm audit fix``` command.


**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** [[Governance alerts] GradleV3 task (shelljs) #3068](https://github.com/microsoft/build-task-team/issues/3068)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected ( run unit tests and test on canary pipeline)
