### PR TITLE
Allow using Service Connection for PackerBuild task with custom template

### DIFF
--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -103,6 +103,21 @@ describe('PackerBuild Suite V1', function() {
             done();
         });
 
+        it('Writes packer var files successfully for both custom template and service connection', (done:MochaDone) => {
+            let tp = path.join(__dirname, 'L0CustomTemplateAndConnectedService.js');
+            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+            let match1 = 'writing to file C:\\somefolder\\somevarfile.json content: {"client_id":"abcdef","drop-location":"C:\\\\folder 1\\\\folder-2"}';
+            let match2 = 'writing to file C:\\somefolder\\somevarfile.json content: {"subscription_id":"sId","client_id":"spId","client_secret":"spKey","tenant_id":"tenant"}';
+
+            tr.run();
+
+            assert(tr.invokedToolCount == 4, 'should have invoked tool four times. actual: ' + tr.invokedToolCount);
+            assert(tr.stdout.indexOf(match1) > -1, 'correctly writes contents of var file (containing azure spn details)');
+            assert(tr.stdout.indexOf(match2) > -1, 'correctly writes contents of var file (containing template variables)');
+
+            done();
+        });
+
         it('Runs successfully for windows custom image', (done:MochaDone) => {
             let tp = path.join(__dirname, 'L0WindowsCustomImage.js');
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/PackerBuildV1/Tests/L0CustomTemplateAndConnectedService.ts
+++ b/Tasks/PackerBuildV1/Tests/L0CustomTemplateAndConnectedService.ts
@@ -1,0 +1,108 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..\\src\\main.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('templateType', 'custom');
+tr.setInput('customTemplateLocation', 'C:\\custom.template.json');
+tr.setInput('imageUri', 'imageUri');
+tr.setInput('imageStorageAccount', 'imageStorageAccount');
+tr.setInput("additionalBuilderParameters", "{}");
+tr.setInput("customTemplateParameters", "{\"client_id\": \"abcdef\", \"drop-location\":\"C:\\\\folder 1\\\\folder-2\"}");
+tr.setInput('ConnectedServiceName', 'AzureRMSpn');
+
+process.env["ENDPOINT_URL_AzureRMSpn"] = "https://management.azure.com/";
+process.env["ENDPOINT_AUTH_SCHEME_AzureRMSpn"] = "ServicePrincipal";
+process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALID"] = "spId";
+process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_SERVICEPRINCIPALKEY"] = "spKey";
+process.env["ENDPOINT_AUTH_PARAMETER_AzureRMSpn_TENANTID"] = "tenant";
+process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONNAME"] = "sName";
+process.env["ENDPOINT_DATA_AzureRMSpn_SUBSCRIPTIONID"] =  "sId";
+process.env["ENDPOINT_DATA_AzureRMSpn_ENVIRONMENTAUTHORITYURL"] = "https://login.windows.net/";
+process.env["ENDPOINT_DATA_AzureRMSpn_ACTIVEDIRECTORYSERVICEENDPOINTRESOURCEID"] = "https://login.windows.net/";
+process.env["ENDPOINT_DATA_AzureRMSpn_GRAPHURL"] = "https://graph.windows.net/";
+process.env["RELEASE_RELEASENAME"] = "Release-1";
+
+// provide answers for task mock
+let a: any = <any>{
+    "which": {
+        "packer": "packer"
+    },
+    "checkPath": {
+        "packer": true,
+        "C:\\custom.template.json": true
+    },
+    "exec": {
+        "packer --version": {
+            "code": 0,
+            "stdout": "1.2.4"
+        },
+        "packer fix -validate=false C:\\custom.template.json": {
+            "code": 0,
+            "stdout": "{ \"some-key\": \"some-value\" }"
+        },
+        "packer validate -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json C:\\custom.template-fixed.json": {
+            "code": 0,
+            "stdout": "Executed Successfully"
+        },
+        "packer build -force -color=false -var-file=C:\\somefolder\\somevarfile.json -var-file=C:\\somefolder\\somevarfile.json C:\\custom.template-fixed.json": {
+            "code": process.env["__packer_build_fails__"] === "true" ? 1 : 0,
+            "stdout": process.env["__packer_build_fails__"] === "true" ? "packer build failed\r\nsome error" : "Executed Successfully\nOSDiskUri: https://bishalpackerimages.blob.core.windows.net/system/Microsoft.Compute/Images/packer/packer-osDisk.e2e08a75-2d73-49ad-97c2-77f8070b65f5.vhd\nStorageAccountLocation: SouthIndia",
+         }
+    },
+    "exist": {
+        "C:\\": true,
+        "packer": true
+    },
+    "rmRF": {
+        "C:\\": { 'success': true }
+    },
+    "osType": {
+        "osType": "Windows_NT"
+    }
+};
+
+var ut = require('../src/utilities');
+var utMock = {
+    IsNullOrEmpty : ut.IsNullOrEmpty,
+    HasItems : ut.HasItems,
+    StringWritable: ut.StringWritable,
+    PackerVersion: ut.PackerVersion,
+    isGreaterVersion: ut.isGreaterVersion,
+    deleteDirectory: function(dir) {
+        console.log("rmRF " + dir);
+    },
+    copyFile: function(source: string, destination: string) {
+        if(process.env["__copy_fails__"] === "true") {
+            throw "copy failed";
+        } else {
+            console.log('copying ' + source + ' to ' + destination);
+        }
+    },
+    generateTemporaryFilePath: function () {
+        return "C:\\somefolder\\somevarfile.json";
+    },
+    getPackerVarFileContent: function(variables) {
+        return ut.getPackerVarFileContent(variables);
+    },
+    writeFile: function(filePath: string, content: string) {
+        console.log("writing to file " + filePath + " content: " + content);
+    },
+    findMatch: function(root: string, patterns: string[] | string) {
+        return [patterns];
+    },
+    getCurrentTime: function() {
+        return 100;
+    },
+    getCurrentDirectory: function() {
+        return "basedir\\currdir";
+    }
+};
+
+tr.registerMock('./utilities', utMock);
+tr.registerMock('../utilities', utMock);
+
+tr.setAnswers(a);
+tr.run();

--- a/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
+++ b/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
@@ -18,15 +18,15 @@ export default class AzureSpnTemplateVariablesProvider implements definitions.IT
         }
 
         var taskParameters = packerHost.getTaskParameters();
+        var connectedService = taskParameters.serviceEndpoint;
 
         // if custom template is used, SPN variables are not required
-        if(taskParameters.templateType === constants.TemplateTypeCustom) {
+        if(taskParameters.templateType === constants.TemplateTypeCustom && !connectedService) {
             this._spnVariables = new Map<string, string>();
             return this._spnVariables;
         }
 
         this._spnVariables = new Map<string, string>();
-        var connectedService = taskParameters.serviceEndpoint;
         var subscriptionId: string = tl.getEndpointDataParameter(connectedService, "SubscriptionId", true)
         this._spnVariables.set(constants.TemplateVariableSubscriptionIdName, subscriptionId);
         this._spnVariables.set(constants.TemplateVariableClientIdName, tl.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalid', false));

--- a/Tasks/PackerBuildV1/src/taskParameters.ts
+++ b/Tasks/PackerBuildV1/src/taskParameters.ts
@@ -48,6 +48,7 @@ export default class TaskParameters {
                 this.customTemplateLocation = tl.getPathInput(constants.CustomTemplateLocationInputType, true, true);
                 console.log(tl.loc("ParsingCustomTemplateParameters"));
                 this.customTemplateParameters = JSON.parse(tl.getInput("customTemplateParameters"));
+                this.serviceEndpoint = tl.getInput(constants.ConnectedServiceInputName);
                 this.packerVersionString = tl.getInput(constants.PackerVersionInputName);
             } else {
                 this.serviceEndpoint = tl.getInput(constants.ConnectedServiceInputName, true);

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -23,8 +23,8 @@
         {
             "name": "AzureDetails",
             "displayName": "Azure Details",
-            "isExpanded": true,
-            "visibleRule": "templateType = builtin"
+            "isExpanded": "templateType = builtin",
+            "visibleRule": true
         },
         {
             "name": "DeploymentInputs",

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 208,
+        "Minor": 209,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 208,
+    "Minor": 209,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -23,8 +23,8 @@
     {
       "name": "AzureDetails",
       "displayName": "ms-resource:loc.group.displayName.AzureDetails",
-      "isExpanded": true,
-      "visibleRule": "templateType = builtin"
+      "isExpanded": "templateType = builtin",
+      "visibleRule": true
     },
     {
       "name": "DeploymentInputs",


### PR DESCRIPTION
**Task name**: PackerBuildV1

**Description**: Allow using Service Connection for PackerBuild task with custom template. To reuse Service Connection when building images from custom templates rather than passing all Azure connection details manually.

**Documentation changes required:** Perhaps, yes.

**Added unit tests:** Added.

**Attached related issue:** Not created.

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
