### PR TITLE
Azure App Service Settings - Remove required flag from Resource group

### DIFF
--- a/Tasks/AzureAppServiceSettingsV1/task.json
+++ b/Tasks/AzureAppServiceSettingsV1/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 207,
         "Patch": 0
     },
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureAppServiceSettingsV1/task.json
+++ b/Tasks/AzureAppServiceSettingsV1/task.json
@@ -56,7 +56,7 @@
             "type": "pickList",
             "label": "Resource group",
             "defaultValue": "",
-            "required": true,
+            "required": false,
             "properties": {
                 "EditableOptions": "True"
             },


### PR DESCRIPTION
**Task name**: Azure App Service Settings

**Description**: If resource group is empty, then the typescript fetches this based on the web app name, so this should not be required for the user to complete

**Documentation changes required:** (Y/N)  N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it

- [ ] Checked that applied changes work as expected
