### PR TITLE
Updated the JavaToolInstallerV0 task dependencies to fix CG vulnerabilities

### DIFF
--- a/Tasks/JavaToolInstallerV0/package-lock.json
+++ b/Tasks/JavaToolInstallerV0/package-lock.json
@@ -20,6 +20,14 @@
                 "@types/node": "*"
             }
         },
+        "@types/jsonwebtoken": {
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+            "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/mocha": {
             "version": "5.2.7",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -2601,15 +2609,16 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest-v2": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-2.0.4.tgz",
-            "integrity": "sha512-viGbcDugStW3RmKtIlIxOfHYCMsYrk00bm++H9neCx/jbdv3eERsfaigViWcWGhjtn0i+KNOfeU248/oPuVw7A==",
+            "version": "2.208.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-2.208.0.tgz",
+            "integrity": "sha512-pNs84s8A+Us/nd8MyE6zyiwREFJjZR/rI5JIVri2pxXkiJVOw5+bRHYR1CfIAlxq451PuTEgykH0m5tWcBWhOQ==",
             "requires": {
+                "@types/jsonwebtoken": "^8.5.8",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^10.17.0",
                 "@types/q": "1.5.4",
                 "azure-pipelines-task-lib": "^3.1.0",
-                "jsonwebtoken": "7.3.0",
+                "jsonwebtoken": "^8.5.1",
                 "q": "1.5.1",
                 "typed-rest-client": "1.8.4"
             },
@@ -2617,27 +2626,7 @@
                 "q": {
                     "version": "1.5.1",
                     "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-                    "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-                },
-                "tunnel": {
-                    "version": "0.0.6",
-                    "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-                    "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
-                },
-                "typed-rest-client": {
-                    "version": "1.8.4",
-                    "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
-                    "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
-                    "requires": {
-                        "qs": "^6.9.1",
-                        "tunnel": "0.0.6",
-                        "underscore": "^1.12.1"
-                    }
-                },
-                "underscore": {
-                    "version": "1.13.1",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
-                    "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+                    "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
                 }
             }
         },
@@ -2752,7 +2741,7 @@
         "buffer-equal-constant-time": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -3024,33 +3013,10 @@
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
-        "isemail": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-            "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-        },
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-        },
-        "joi": {
-            "version": "6.10.1",
-            "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-            "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-            "requires": {
-                "hoek": "2.x.x",
-                "isemail": "1.x.x",
-                "moment": "2.x.x",
-                "topo": "1.x.x"
-            },
-            "dependencies": {
-                "hoek": {
-                    "version": "2.16.3",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                }
-            }
         },
         "js-yaml": {
             "version": "3.13.1",
@@ -3095,15 +3061,20 @@
             "integrity": "sha512-LkDEYtKnPFI9hQ/IURETe6F1dUH80cbRkaF6RaViSwoSNPwaxQpi6TgJGvJKyLQ2/9pQW+XCxK3hBoR44RAjkg=="
         },
         "jsonwebtoken": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.3.0.tgz",
-            "integrity": "sha1-hRGNanDj/M3xQ4n056HD+cip+7o=",
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
             "requires": {
-                "joi": "^6.10.1",
-                "jws": "^3.1.4",
+                "jws": "^3.2.2",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
                 "lodash.once": "^4.0.0",
-                "ms": "^0.7.1",
-                "xtend": "^4.0.1"
+                "ms": "^2.1.1",
+                "semver": "^5.6.0"
             }
         },
         "jsprim": {
@@ -3136,10 +3107,40 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+        },
+        "lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+        },
+        "lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+        },
+        "lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+        },
         "lodash.once": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
         },
         "md5.js": {
             "version": "1.3.5",
@@ -3177,15 +3178,10 @@
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
             "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
         },
-        "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
-        },
         "ms": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
-            "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "oauth-sign": {
             "version": "0.9.0",
@@ -3435,21 +3431,6 @@
                 }
             }
         },
-        "topo": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-            "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-            "requires": {
-                "hoek": "2.x.x"
-            },
-            "dependencies": {
-                "hoek": {
-                    "version": "2.16.3",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                }
-            }
-        },
         "tough-cookie": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -3560,11 +3541,6 @@
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         }
     }
 }

--- a/Tasks/JavaToolInstallerV0/package.json
+++ b/Tasks/JavaToolInstallerV0/package.json
@@ -28,7 +28,7 @@
         "@types/q": "^1.0.7",
         "azp-tasks-az-blobstorage-provider-v2": "2.206.0",
         "azure-pipelines-task-lib": "^3.1.2",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "2.0.4",
+        "azure-pipelines-tasks-azure-arm-rest-v2": "^2.208.0",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
         "azure-pipelines-tool-lib": "^1.0.2"
     },

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 206,
+        "Minor": 208,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 206,
+    "Minor": 208,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: JavaToolInstallerV0

**Description**: 
Updated the `azure-pipelines-tasks-azure-arm-rest-v2` dependency for fixing vulnerabilities: 
- https://github.com/advisories/GHSA-8hfj-j24r-96c4
- https://github.com/advisories/GHSA-wc69-rhjr-hc9g
- https://github.com/advisories/GHSA-jp4x-w63m-7wgm

**Risks analysis checklist:**
* [x] There are no risky dependency updates
* [x] Changes have been tested
* [x] Enough test coverage for changes and current test coverage for the task doesn't look poor
* [x] We understand how the task works, how changes affect its behavior
* [x] There are no breaking changes
* [x] There are no other concerns
* [x] I have not discovered any new uncovered test/use cases

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/2867

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected - ran unit tests locally, buddy-tested with windows-2022/19, ubuntu-22/20/18.04 and macos-12/11/10.15 images
