### PR TITLE
Control labels with addPipelineData in docker task

### DIFF
--- a/common-npm-packages/docker-common-v2/pipelineutils.ts
+++ b/common-npm-packages/docker-common-v2/pipelineutils.ts
@@ -27,16 +27,16 @@ function addLabelWithValue(labelName: string, labelValue: string, labels: string
 }
 
 function addCommonLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
-    addLabel(hostName, "system.teamfoundationcollectionuri", "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", labels);
     if (addPipelineData) {
+        addLabel(hostName, "system.teamfoundationcollectionuri", "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", labels);
         addLabel(hostName, "system.teamproject", "SYSTEM_TEAMPROJECT", labels);
         addLabel(hostName, "build.repository.name", "BUILD_REPOSITORY_NAME", labels);
     }
 }
 
 function addBuildLabels(hostName: string, labels: string[], addPipelineData?: boolean): void {
-    addLabel(hostName, "build.sourceversion", "BUILD_SOURCEVERSION", labels);
     if (addPipelineData) {
+        addLabel(hostName, "build.sourceversion", "BUILD_SOURCEVERSION", labels);
         addLabel(hostName, "build.repository.uri", "BUILD_REPOSITORY_URI", labels);
         addLabel(hostName, "build.sourcebranchname", "BUILD_SOURCEBRANCHNAME", labels);
         addLabel(hostName, "build.definitionname", "BUILD_DEFINITIONNAME", labels);


### PR DESCRIPTION
system.teamfoundationcollectionuri and build.sourceversion are
controlled with addPipelineData boolean variable, which can be set
in pipeline.

**Task name**: DockerV2

**Description**: Control the mentioned docker image labels. Previously these labels were always added, and there was no option to remove them. This behavior caused the private repository URI to be exposed in the docker image.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/13268

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
