### PR TITLE
[CI Checks] Change target `macOS` image from `10.15` to `11.00`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
   displayName: Build all tasks (macOS)
   condition: and(succeeded(), not(variables.task), eq(variables.os, 'Darwin'))
   pool:
-    vmImage: macos-10.15
+    vmImage: macos-11
   steps:
   - template: ci/build-all-steps.yml
     parameters:
@@ -141,6 +141,6 @@ jobs:
   displayName: Build shared npm packages (macOS)
   condition: and(succeeded(), not(variables.task), eq(variables.os, 'Darwin'))
   pool:
-    vmImage: macos-10.15
+    vmImage: macos-11
   steps:
   - template: ci/build-common-npm.yml


### PR DESCRIPTION
**Task name**: 
- N/A

**Description**: 
The `macOS` image `v10.15` will be deprecated soon. To avoid issues related to the brownout we need to update our CI to target `macOS 11`.

_Changelog_:
- `macOS` image version was updated: `10.15` -> `11`

_About Node_:
For `macOS 10.15` and `macOS 11` virtual images the `Node.js v16.16.0` is used by default, so it seems any additional changes are not required.

- [macos-10.15-Readme.md](https://github.dev/actions/virtual-environments/blob/8c24b03a8df7e9923c69a4b1aed4313cf7679c20/images/macos/macos-10.15-Readme.md#L29)
- [macos-11-Readme.md](https://github.dev/actions/virtual-environments/blob/8c24b03a8df7e9923c69a4b1aed4313cf7679c20/images/macos/macos-11-Readme.md#L28)

_Related announcement_:
- actions/virtual-environments/issues/5583

**Documentation changes required**: 
- N/A

**Added unit tests**: 
- N/A

**Attached related issue**: 
- No

**Checklist**:
-  ~Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it~
- [x] Checked that applied changes work as expected
