### PR TITLE
Add support for VS2022 to SqlAzureDacpacDeployment

### DIFF
--- a/Tasks/SqlAzureDacpacDeploymentV1/FindSqlPackagePath.ps1
+++ b/Tasks/SqlAzureDacpacDeploymentV1/FindSqlPackagePath.ps1
@@ -441,7 +441,7 @@ function Get-VisualStudio_15_0 {
         # may be something like 15.2.
         Write-Verbose "Getting latest Visual Studio 15 setup instance."
         $output = New-Object System.Text.StringBuilder
-        Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,17.0) -latest -format json" -RequireExitCodeZero 2>&1 |
+        Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,18.0) -latest -format json" -RequireExitCodeZero 2>&1 |
             ForEach-Object {
                 if ($_ -is [System.Management.Automation.ErrorRecord]) {
                     Write-Verbose "STDERR: $($_.Exception.Message)"
@@ -460,7 +460,7 @@ function Get-VisualStudio_15_0 {
             # the same scheme. It appears to follow the 15.<UPDATE_NUMBER>.* versioning scheme.
             Write-Verbose "Getting latest BuildTools 15 setup instance."
             $output = New-Object System.Text.StringBuilder
-            Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,17.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
+            Invoke-VstsTool -FileName "$PSScriptRoot\vswhere.exe" -Arguments "-version [15.0,18.0) -products Microsoft.VisualStudio.Product.BuildTools -latest -format json" -RequireExitCodeZero 2>&1 |
                 ForEach-Object {
                     if ($_ -is [System.Management.Automation.ErrorRecord]) {
                         Write-Verbose "STDERR: $($_.Exception.Message)"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 202,
+        "Minor": 209,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 202,
+    "Minor": 209,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
**Task name**: SqlAzureDacpacDeployment

**Description**: Add support for VS2022 by bumping version support from 17 to 18 in VSWhere check.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y - https://github.com/microsoft/azure-pipelines-tasks/issues/15998

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
