### PR TITLE
Update CopyFilesV2 task to skip cleaning target when it doesn't exist

### DIFF
--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -290,6 +290,37 @@ describe('CopyFiles L0 Suite', function () {
         done();
     });
 
+    it("skips cleaning when destination folder doesn't exist", (done: Mocha.Done) => {
+        this.timeout(1000);
+
+        let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndDestDoesntExist.js');
+        let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        runner.run();
+
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
+            'should have cleaned destDir/clean-subDir');
+        assert(
+            !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
+            'should have cleaned destDir/clean-file.txt');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        done();
+    });
+
     it('cleans if specified and target is file', (done: Mocha.Done) => {
         this.timeout(1000);
 

--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -297,15 +297,16 @@ describe('CopyFiles L0 Suite', function () {
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
 
+        // This will fail if stat is called with throwEnoent=true
         assert(
             runner.succeeded,
             'should have succeeded');
         assert(
             !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
-            'should have cleaned destDir/clean-subDir');
+            'should have skipped cleaning non-existent directory');
         assert(
             !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
-            'should have cleaned destDir/clean-file.txt');
+            'should have skipped cleaning non-existent directory');
         assert(
             runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
             'should have mkdirP destDir');

--- a/Tasks/CopyFilesV2/Tests/L0cleansIfSpecifiedAndDestDoesntExist.ts
+++ b/Tasks/CopyFilesV2/Tests/L0cleansIfSpecifiedAndDestDoesntExist.ts
@@ -1,0 +1,69 @@
+import fs = require('fs');
+import mockanswer = require('azure-pipelines-task-lib/mock-answer');
+import mockrun = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'copyfiles.js');
+let runner: mockrun.TaskMockRunner = new mockrun.TaskMockRunner(taskPath);
+runner.setInput('Contents', '**');
+runner.setInput('SourceFolder', path.normalize('/srcDir'));
+runner.setInput('TargetFolder', path.normalize('/destDir'));
+runner.setInput('CleanTargetFolder', 'true');
+runner.setInput('Overwrite', 'false');
+let answers = <mockanswer.TaskLibAnswers> {
+    checkPath: { },
+    find: { },
+    rmRF: { },
+};
+answers.checkPath[path.normalize('/srcDir')] = true;
+answers.find[path.normalize('/srcDir')] = [
+    path.normalize('/srcDir'),
+    path.normalize('/srcDir/someOtherDir'),
+    path.normalize('/srcDir/someOtherDir/file1.file'),
+    path.normalize('/srcDir/someOtherDir/file2.file'),
+];
+answers.rmRF[path.join(path.normalize('/destDir/clean-subDir'))] = { success: true };
+answers.rmRF[path.join(path.normalize('/destDir/clean-file.txt'))] = { success: true };
+runner.setAnswers(answers);
+
+fs.existsSync = (itemPath: string) => {
+    switch (itemPath) {
+        case path.normalize('/srcDir'):
+        case path.normalize('/srcDir/someOtherDir'):
+        case path.normalize('/srcDir/someOtherDir/file1.file'):
+        case path.normalize('/srcDir/someOtherDir/file2.file'):
+            return true;
+        default:
+            return false;
+    }
+}
+
+fs.statSync = (itemPath: string) => {
+    const itemStats: fs.Stats = new fs.Stats();
+    switch (itemPath) {
+        case path.normalize('/srcDir'):
+        case path.normalize('/srcDir/someOtherDir'):
+            itemStats.isDirectory = () => true;
+            break;
+        case path.normalize('/srcDir/someOtherDir/file1.file'):
+        case path.normalize('/srcDir/someOtherDir/file2.file'):
+            itemStats.isDirectory = () => false;
+            break;
+        default:
+            throw { code: 'ENOENT' };
+    }
+    return itemStats;
+}
+
+let origReaddirSync = fs.readdirSync;
+fs.readdirSync = (p: fs.PathLike, o?: any): any => {
+    console.log('HERE path ' + p);
+    let result = origReaddirSync(p);
+    return result;
+}
+
+// as a precaution, disable fs.chmodSync. it should not be called during this scenario.
+fs.chmodSync = null;
+runner.registerMock('fs', fs);
+
+runner.run();

--- a/Tasks/CopyFilesV2/copyfiles.ts
+++ b/Tasks/CopyFilesV2/copyfiles.ts
@@ -120,10 +120,11 @@ async function main(): Promise<void> {
 
             // stat the targetFolder path
             const targetFolderStats: fs.Stats = await retryHelper.RunWithRetry<fs.Stats>(
-                () => stats(targetFolder),
+                () => stats(targetFolder, false),
                 `stats for ${targetFolder}`
             );
 
+            // If there are no stats, the folder doesn't exist. Nothing to clean.
             if (targetFolderStats) {
                 if (targetFolderStats.isDirectory()) {
                     // delete the child items

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 208,
+        "Minor": 209,
         "Patch": 0
     },
     "releaseNotes": "Match pattern consistency.",

--- a/Tasks/CopyFilesV2/task.loc.json
+++ b/Tasks/CopyFilesV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 208,
+    "Minor": 209,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: CopyFilesV2

**Description**: Set `throwEnoent` to `false` when running `stat` on the target directory with `CleanTargetFolder: true`. This allows skipping cleaning the target folder when it doesn't exist.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** Y 
https://github.com/microsoft/azure-pipelines-tasks/issues/16706

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
