### PR TITLE
Vulnerability fix for JavaToolInstallerV0

### DIFF
--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 209,
+        "Minor": 210,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 209,
+    "Minor": 210,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: JavaToolInstallerV0

**Description**: latest vulnerability fix for task JavaToolInstallerV0

**Documentation changes required:** (Y/N) 

**Added unit tests:** (Y/N) 

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/PipelineTools/_componentGovernance/184/alert/83629?typeId=12858

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] node make.js build --task JavaToolInstallerV0
- [x] node make.js test --task JavaToolInstallerV0
