### PR TITLE
AndroidSigningV2 migrated to node 16

### DIFF
--- a/Tasks/AndroidSigningV2/package-lock.json
+++ b/Tasks/AndroidSigningV2/package-lock.json
@@ -60,15 +60,15 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.2.tgz",
-      "integrity": "sha512-ZafpInsnjHKGemA5l3jwfeaI8jARrIv5aYCn3KPP4iNJHgMG2RtwyFGynIfpkUsHMfzC/370iyLru0NGAuSVWQ==",
+      "version": "4.0.0-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.0.0-preview.tgz",
+      "integrity": "sha512-BK+VOo42Bec72Wic6Vsm2MaAJezNyF05OYAQS5FuZJM5Z972lZqYpujtSc4BFKUhC3HO+F/Yf4xhAV2tZCzN9Q==",
       "requires": {
-        "minimatch": "3.0.4",
+        "minimatch": "3.0.5",
         "mockery": "^1.7.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
+        "shelljs": "^0.8.5",
         "sync-request": "6.1.0",
         "uuid": "^3.0.1"
       }
@@ -82,6 +82,22 @@
         "@types/q": "^1.5.4",
         "azure-devops-node-api": "10.2.2",
         "azure-pipelines-task-lib": "^3.1.0"
+      },
+      "dependencies": {
+        "azure-pipelines-task-lib": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
+          "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
+          "requires": {
+            "minimatch": "3.0.5",
+            "mockery": "^1.7.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -253,9 +269,9 @@
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/Tasks/AndroidSigningV2/package.json
+++ b/Tasks/AndroidSigningV2/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-task-lib": "^3.1.2",
+    "azure-pipelines-task-lib": "^4.0.0-preview",
     "azure-pipelines-tasks-securefiles-common": "2.1.0"
   },
   "devDependencies": {

--- a/Tasks/AndroidSigningV2/preandroidsigning.ts
+++ b/Tasks/AndroidSigningV2/preandroidsigning.ts
@@ -1,6 +1,6 @@
 import path = require('path');
-import secureFilesCommon = require('azure-pipelines-tasks-securefiles-common/securefiles-common');
 import tl = require('azure-pipelines-task-lib/task');
+import secureFilesCommon = require('azure-pipelines-tasks-securefiles-common/securefiles-common');
 
 async function run() {
     let keystoreFileId: string;

--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,13 +12,13 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 201,
+        "Minor": 210,
         "Patch": 0
     },
     "demands": [
         "JDK"
     ],
-    "minimumAgentVersion": "2.182.1",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "jarsignerOptions",
@@ -139,19 +139,19 @@
     ],
     "instanceNameFormat": "Signing and aligning APK file(s) $(files)",
     "prejobexecution": {
-        "Node10": {
+        "Node16": {
             "target": "preandroidsigning.js",
             "argumentFormat": ""
         }
     },
     "execution": {
-        "Node10": {
+        "Node16": {
             "target": "androidsigning.js",
             "argumentFormat": ""
         }
     },
     "postjobexecution": {
-        "Node10": {
+        "Node16": {
             "target": "postandroidsigning.js",
             "argumentFormat": ""
         }

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,13 +12,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 201,
+    "Minor": 210,
     "Patch": 0
   },
   "demands": [
     "JDK"
   ],
-  "minimumAgentVersion": "2.182.1",
+  "minimumAgentVersion": "2.206.1",
   "groups": [
     {
       "name": "jarsignerOptions",
@@ -139,19 +139,19 @@
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "prejobexecution": {
-    "Node10": {
+    "Node16": {
       "target": "preandroidsigning.js",
       "argumentFormat": ""
     }
   },
   "execution": {
-    "Node10": {
+    "Node16": {
       "target": "androidsigning.js",
       "argumentFormat": ""
     }
   },
   "postjobexecution": {
-    "Node10": {
+    "Node16": {
       "target": "postandroidsigning.js",
       "argumentFormat": ""
     }

--- a/make-util.js
+++ b/make-util.js
@@ -331,8 +331,8 @@ exports.ensureTool = ensureTool;
 
 var installNode = function (nodeVersion) {
     switch (nodeVersion || '') {
-        case '14':
-            nodeVersion = 'v14.10.1';
+        case '16':
+            nodeVersion = 'v16.15.1';
             break;
         case '10':
             nodeVersion = 'v10.21.0';
@@ -341,11 +341,8 @@ var installNode = function (nodeVersion) {
         case '':
             nodeVersion = 'v6.10.3';
             break;
-        case '5':
-            nodeVersion = 'v5.10.1';
-            break;
         default:
-            fail(`Unexpected node version '${nodeVersion}'. Supported versions: 5, 6, 10, 14`);
+            fail(`Unexpected node version '${nodeVersion}'. Supported versions: 6, 10, 16`);
     }
 
     if (nodeVersion === run('node -v')) {
@@ -1663,29 +1660,31 @@ var storeNonAggregatedZip = function (zipPath, release, commit) {
 }
 exports.storeNonAggregatedZip = storeNonAggregatedZip;
 
-var getTaskNodeVersion = function(buildPath, taskName) {
-    var taskJsonPath = path.join(buildPath, taskName, "task.json");
+const getTaskNodeVersion = function(buildPath, taskName) {
+    const taskJsonPath = path.join(buildPath, taskName, "task.json");
     if (!fs.existsSync(taskJsonPath)) {
-        console.warn('Unable to find task.json, defaulting to use Node 14');
-        return 14;
+        console.warn('Unable to find task.json, defaulting to use Node 16');
+        return 16;
     }
-    var taskJsonContents = fs.readFileSync(taskJsonPath, { encoding: 'utf-8' });
-    var taskJson = JSON.parse(taskJsonContents);
-    var execution = taskJson['execution'] || taskJson['prejobexecution'];
-    for (var key of Object.keys(execution)) {
-        if (key.toLowerCase() == 'node14') {
-            // Prefer node 14 and return immediately.
-            return 14;
+    const taskJsonContents = fs.readFileSync(taskJsonPath, { encoding: 'utf-8' });
+    const taskJson = JSON.parse(taskJsonContents);
+    const execution = taskJson['execution'] || taskJson['prejobexecution'] || taskJson['postjobexecution'];
+    const executionKeys = Object.keys(execution);
+    for (const key of executionKeys) {
+        if (key.toLowerCase() == 'node16') {
+            // Prefer node 16 and return immediately.
+            return 16;
         } else if (key.toLowerCase() == 'node10') {
             // Prefer node 10 and return immediately.
             return 10;
         } else if (key.toLowerCase() == 'node') {
+            // Prefer node 6 and return immediately.
             return 6;
         }
     }
 
-    console.warn('Unable to determine execution type from task.json, defaulting to use Node 10');
-    return 10;
+    console.warn('Unable to determine execution type from task.json, defaulting to use Node 16');
+    return 16;
 }
 exports.getTaskNodeVersion = getTaskNodeVersion;
 


### PR DESCRIPTION
**Task name:** AndroidSigningV2

**Description:** migration of the AndroidSigningV2 task to Node 16

**Documentation changes required:** No

**Added unit tests:** No

[Related issue](https://github.com/microsoft/build-task-team/issues/3442)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
