### PR TITLE
Tasks/646 gradle code coverage

### DIFF
--- a/Tasks/GradleV2/gradletask.ts
+++ b/Tasks/GradleV2/gradletask.ts
@@ -112,7 +112,7 @@ function isAndroidProject(wrapperScript: string): boolean {
     if (typeof data !== 'undefined' && data) {
         // com.android.application is a Gradle plugin to build android projects
         const regex: RegExp = new RegExp('com\.android\.application');
-        let andpoidGradlePlugin: RegExpExecArray = regex.exec(data);
+        const andpoidGradlePlugin: RegExpExecArray = regex.exec(data);
         if (typeof andpoidGradlePlugin !== 'undefined' && andpoidGradlePlugin && andpoidGradlePlugin.length > 0) {
             tl.debug('It\'s Android project');
             return true;

--- a/Tasks/GradleV2/task.json
+++ b/Tasks/GradleV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 208,
+        "Minor": 210,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -143,9 +143,9 @@ gradle.afterEvaluate {
         description = "Generates Jacoco coverage report for project."
         project.tasks.getByName('test').finalizedBy jacocoTestReport
                 
-        getClassDirectories().setFrom fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
-        getExecutionData().setFrom fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
-        getSourceDirectories().setFrom files("\${project.projectDir}/src/main/java")
+        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
+        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
+        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${project.projectDir}/src/main/java")
 
         reports {
             xml.required  = true
@@ -181,9 +181,9 @@ subprojects {
             description = "Generates Jacoco coverage report for project."
             project.tasks.getByName('test').finalizedBy jacocoTestReport
                     
-            getClassDirectories().setFrom fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
-            getExecutionData().setFrom fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
-            getSourceDirectories().setFrom files("\${project.projectDir}/src/main/java")
+            ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
+            ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
+            ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${project.projectDir}/src/main/java")
 
             reports {
                 xml.required  = true
@@ -201,9 +201,9 @@ gradle.projectsEvaluated {
         group = "Reporting"
         description = "Generates overall Jacoco coverage report."
 
-        getExecutionData().setFrom files(subprojects.jacocoTestReport.executionData)
-        getSourceDirectories().setFrom files(subprojects.jacocoTestReport.sourceDirectories)
-        getClassDirectories().setFrom files(subprojects.jacocoTestReport.classDirectories)
+        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} files(subprojects.jacocoTestReport.executionData)
+        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files(subprojects.jacocoTestReport.sourceDirectories)
+        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} files(subprojects.jacocoTestReport.classDirectories)
 
         reports {
             html.required = true

--- a/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
+++ b/common-npm-packages/codecoverage-tools/codecoverageconstants.ts
@@ -134,18 +134,18 @@ allprojects {
     apply plugin: 'jacoco'
 }
 
-gradle.afterEvaluate {
+gradle.projectsEvaluated {
     def jacocoExcludes = [${excludeFilter}]
     def jacocoIncludes = [${includeFilter}]
 
     task jacocoTestReport (type:JacocoReport, dependsOn: 'test') {
         group = "Reporting"
-        description = "Generates Jacoco coverage report for project."
-        project.tasks.getByName('test').finalizedBy jacocoTestReport
+        description = "Generates Jacoco coverage report for rootProject."
+        rootProject.tasks.getByName('test').finalizedBy jacocoTestReport
                 
-        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
-        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${project.buildDir}/outputs/unit_test_code_coverage", includes: ['**/*.exec'])
-        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${project.projectDir}/src/main/java")
+        ${getFormattedFileCollectionAssignGradle('classDirectories', gradle5xOrHigher)} fileTree(dir: "\${rootProject.buildDir}/${classFileDirectory}",  excludes: jacocoExcludes, includes: jacocoIncludes)
+        ${getFormattedFileCollectionAssignGradle('executionData', gradle5xOrHigher)} fileTree(dir: "\${rootProject.buildDir}/jacoco", includes: ['**/*.exec'])
+        ${getFormattedFileCollectionAssignGradle('sourceDirectories', gradle5xOrHigher)} files("\${rootProject.projectDir}/src/main/java")
 
         reports {
             xml.required  = true

--- a/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
+++ b/common-npm-packages/codecoverage-tools/jacoco/jacoco.gradle.ccenabler.ts
@@ -24,6 +24,7 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let classFileDirs = ccProps["classfilesdirectories"];
         let reportDir = ccProps["reportdirectory"];
         let gradle5xOrHigher = ccProps["gradle5xOrHigher"] && ccProps["gradle5xOrHigher"] === "true";
+        let isAndroidProject = ccProps["isAndroidProject"] && ccProps["isAndroidProject"] === "true";
         let codeCoveragePluginData = null;
 
         let filter = _this.extractFilters(classFilter);
@@ -31,9 +32,13 @@ export class JacocoGradleCodeCoverageEnabler extends cc.JacocoCodeCoverageEnable
         let jacocoInclude = _this.applyFilterPattern(filter.includeFilter);
 
         if (isMultiModule) {
-            codeCoveragePluginData = ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            codeCoveragePluginData = isAndroidProject
+                ? ccc.jacocoGradleAndroidMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher)
+                : ccc.jacocoGradleMultiModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
         } else {
-            codeCoveragePluginData = ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
+            codeCoveragePluginData = isAndroidProject
+                ? ccc.jacocoGradleAndroidSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher)
+                : ccc.jacocoGradleSingleModuleEnable(jacocoExclude.join(","), jacocoInclude.join(","), classFileDirs, reportDir, gradle5xOrHigher);
         }
 
         try {


### PR DESCRIPTION
**Task name**: GradleV2

**Description**: GradleV2 is not able to generate code coverage for android projects due to the fact that such projects don't have plugin 'java' *which adds task `jacocoTestReport` actually) and the plugin cannot be added since it's incompatible with android projects.

Change log:
- added two new methods `jacocoGradleAndroidSingleModuleEnable` and `jacocoGradleAndroidMultiModuleEnable` which returns correct gradle-configuration for android projects to common npm package `codecoverage-tools`
- added new method `isAndroidProject` to task `GradleV2`. The method determines if building project is android related
- implemented logic to call the added methods `jacocoGradleAndroidSingleModuleEnable` and `jacocoGradleAndroidMultiModuleEnable` if customer builds android project

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** [issue: 646](https://github.com/microsoft/build-task-team/issues/646)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
