### PR TITLE
Bump the sprint number

### DIFF
--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 210,
+        "Minor": 211,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 210,
+    "Minor": 211,
     "Patch": 0
   },
   "preview": true,


### PR DESCRIPTION
**Task name**: ContainerStructureTest

**Description**: This has not gotten merged the last time around and the sprint number has since changed so to help the CG alert go away I am bumping it to match.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
