### PR TITLE
Added retrials for KeyVault secrets downloading on request timeout

### DIFF
--- a/Tasks/AzureKeyVaultV1/operations/azure-arm-keyvault.ts
+++ b/Tasks/AzureKeyVaultV1/operations/azure-arm-keyvault.ts
@@ -59,7 +59,8 @@ export class KeyVaultClient extends azureServiceClient.ServiceClient {
 
                 return response;
             } catch(error) {
-                if (retriableErrorCodes.indexOf(error.code) != -1 && ++retryCount < maxRetryCount) {
+                if ((retriableErrorCodes.indexOf(error.code) != -1 || error.toString().indexOf('Request timeout: ') != -1)
+                && ++retryCount < maxRetryCount) {
                     tl.debug(util.format("Encountered an error. Will retry. Error:%s. Message: %s.", error.code, error.message));
                     await webClient.sleepFor(timeToWait);
                     timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;

--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 208,
+        "Minor": 211,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
+++ b/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
@@ -59,10 +59,12 @@ export class KeyVaultClient extends azureServiceClient.ServiceClient {
 
                 return response;
             } catch(error) {
-                if (retriableErrorCodes.indexOf(error.code) != -1 && ++retryCount < maxRetryCount) {
+                if ((retriableErrorCodes.indexOf(error.code) != -1 || error.toString().indexOf('Request timeout: ') != -1)
+                && ++retryCount < maxRetryCount) {
                     tl.debug(util.format("Encountered an error. Will retry. Error:%s. Message: %s.", error.code, error.message));
                     await webClient.sleepFor(timeToWait);
                     timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;
+                    ++retryCount;
                 }
                 else {
                     throw error;

--- a/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
+++ b/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
@@ -64,6 +64,7 @@ export class KeyVaultClient extends azureServiceClient.ServiceClient {
                     tl.debug(util.format("Encountered an error. Will retry. Error:%s. Message: %s.", error.code, error.message));
                     await webClient.sleepFor(timeToWait);
                     timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;
+                    ++retryCount;
                 }
                 else {
                     throw error;

--- a/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
+++ b/Tasks/AzureKeyVaultV2/operations/azure-arm-keyvault.ts
@@ -64,7 +64,6 @@ export class KeyVaultClient extends azureServiceClient.ServiceClient {
                     tl.debug(util.format("Encountered an error. Will retry. Error:%s. Message: %s.", error.code, error.message));
                     await webClient.sleepFor(timeToWait);
                     timeToWait = timeToWait * retryIntervalInSeconds + retryIntervalInSeconds;
-                    ++retryCount;
                 }
                 else {
                     throw error;

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 208,
+        "Minor": 211,
         "Patch": 0
     },
     "demands": [],


### PR DESCRIPTION
**Task name**: AzureKeyVaultV2

**Description**: Extended retry logic for KeyVaultClient added addition processing for request timeouts that were not handled by the previous logic.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
