### PR TITLE
[GradleV2] Add support of generation JaCoCo reports for android projects

### DIFF
--- a/Tasks/GradleV2/Tests/L0.ts
+++ b/Tasks/GradleV2/Tests/L0.ts
@@ -767,7 +767,7 @@ describe('Gradle L0 Suite', function () {
             tr.run();
 
             assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.invokedToolCount === 2, 'should have only run gradle 2 times');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
             assert(tr.stderr.length === 0, 'should not have written to stderr');
             assert(tr.ran(gradleWrapper + ` properties`), 'should have run Gradle with properties');
             assert(tr.ran(gradleWrapper + ` clean build jacocoTestReport`), 'should have run Gradle with code coverage');
@@ -794,7 +794,7 @@ describe('Gradle L0 Suite', function () {
             tr.run();
 
             assert(tr.failed, 'task should have failed');
-            assert(tr.invokedToolCount === 2, 'should have only run gradle 2 times');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
             assert(tr.stderr.length === 0, 'should not have written to stderr');
             assert(tr.stdout.indexOf('loc_mock_NoCodeCoverage') > -1, 'should have given an error message');
             assert(tr.ran(gradleWrapper + ` properties`), 'should have run Gradle with properties');
@@ -820,7 +820,7 @@ describe('Gradle L0 Suite', function () {
             tr.run();
 
             assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.invokedToolCount === 2, 'should have only run gradle 2 times');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
             assert(tr.stderr.length === 0, 'should not have written to stderr');
             assert(tr.ran(`${gradleWrapper} properties`), 'should have run Gradle with properties');
             assert(tr.ran(`${gradleWrapper} clean build jacocoTestReport`), 'should have run Gradle with code coverage');
@@ -846,7 +846,7 @@ describe('Gradle L0 Suite', function () {
             tr.run();
 
             assert(tr.succeeded, 'task should have succeeded');
-            assert(tr.invokedToolCount === 2, 'should have only run gradle 2 times');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
             assert(tr.stderr.length === 0, 'should not have written to stderr');
             assert(tr.ran(`${gradleWrapper} properties`), 'should have run Gradle with properties');
             assert(tr.ran(`${gradleWrapper} clean build jacocoTestReport`), 'should have run Gradle with code coverage');

--- a/Tasks/GradleV2/Tests/L0.ts
+++ b/Tasks/GradleV2/Tests/L0.ts
@@ -862,6 +862,56 @@ describe('Gradle L0 Suite', function () {
         }
     });
 
+    it('should pass parameter \'isAndroidProject\' as \'true\' to ICodeCoverageEnabler for android projects', function (done) {
+        let tp: string = path.join(__dirname, 'L0AndroidProject.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+        try {
+            createTemporaryFolders();
+
+            tr.run();
+
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
+            assert(tr.stderr.length === 0, 'should not have written to stderr');
+            assert(tr.ran(`${gradleWrapper} buildEnvironment`), 'should have run Gradle with buildEnvironment');
+            assert(tr.stdOutContained('"isAndroidProject":"true"'), 'should contain information that parameter \'isAndroidProject\' is \'true\'');
+            
+            cleanTemporaryFolders();
+            done();
+        } catch (err) {
+            console.log(tr.stdout);
+            console.log(tr.stderr);
+            console.log(err);
+            done(err);
+        }
+    });
+    
+    it('should pass parameter \'isAndroidProject\' as \'false\' to ICodeCoverageEnabler for non-android projects', function (done) {
+        let tp: string = path.join(__dirname, 'L0NotAndroidProject.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        
+        try {
+            createTemporaryFolders();
+
+            tr.run();
+
+            assert(tr.succeeded, 'task should have succeeded');
+            assert(tr.invokedToolCount === 3, 'should have only run gradle 3 times');
+            assert(tr.stderr.length === 0, 'should not have written to stderr');
+            assert(tr.ran(`${gradleWrapper} buildEnvironment`), 'should have run Gradle with buildEnvironment');
+            assert(tr.stdOutContained('"isAndroidProject":"false"'), 'should contain information that parameter \'isAndroidProject\' is \'false\'');
+            
+            cleanTemporaryFolders();
+            done();
+        } catch (err) {
+            console.log(tr.stdout);
+            console.log(tr.stderr);
+            console.log(err);
+            done(err);
+        }
+    });
+
     // /* BEGIN Tools tests */
     function verifyModuleResult(results: AnalysisResult[], moduleName: string , expectedViolationCount: number, expectedFileCount: number, expectedReports: string[]) {
         let analysisResults = results.filter(ar => ar.moduleName === moduleName);

--- a/Tasks/GradleV2/Tests/L0AndroidProject.ts
+++ b/Tasks/GradleV2/Tests/L0AndroidProject.ts
@@ -1,0 +1,69 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'gradletask.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('wrapperScript', 'gradlew');
+tr.setInput('cwd', '/home/repo/src');
+tr.setInput('javaHomeSelection', 'JDKVersion');
+tr.setInput('jdkVersion', 'default');
+tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+tr.setInput('codeCoverageTool', 'jacoco');
+tr.setInput('failIfCoverageEmpty', 'false');
+tr.setInput('gradle5xOrHigher', 'false');
+
+tr.setInput('tasks', 'build');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'checkPath': {
+        'gradlew': true,
+        'gradlew.bat': true,
+        '/home/repo/src': true
+    },
+    'exec': {
+        'gradlew.bat properties': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew properties': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': '+--- com.android.application:com.android.application.gradle.plugin:7.2.2'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': '+--- com.android.application:com.android.application.gradle.plugin:7.2.2'
+        },
+        'gradlew.bat clean build jacocoTestReport': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew clean build jacocoTestReport': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        }
+    },
+    'rmRF': {
+        [path.join('/home/repo/src', 'CCReport43F6D5EF')]: {
+            success: true
+        }
+    },
+    'stats': {
+        [path.join('/home/repo/src', 'build.gradle')]: {
+            isFile() {
+                return true;
+            }
+        }
+    },
+    'exist': {
+        [path.join('/home/repo/src', 'CCReport43F6D5EF/summary.xml')]: true
+    }
+};
+tr.setAnswers(a);
+
+tr.run();

--- a/Tasks/GradleV2/Tests/L0JacocoGradle4x.ts
+++ b/Tasks/GradleV2/Tests/L0JacocoGradle4x.ts
@@ -33,6 +33,14 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             'code': 0,
             'stdout': 'More sample gradle output'
         },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
         'gradlew.bat clean build jacocoTestReport': {
             'code': 0,
             'stdout': 'More sample gradle output'

--- a/Tasks/GradleV2/Tests/L0JacocoGradle5x.ts
+++ b/Tasks/GradleV2/Tests/L0JacocoGradle5x.ts
@@ -33,6 +33,14 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             'code': 0,
             'stdout': 'More sample gradle output'
         },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
         'gradlew.bat clean build jacocoTestReport': {
             'code': 0,
             'stdout': 'More sample gradle output'

--- a/Tasks/GradleV2/Tests/L0NoCodeCoverageFail.ts
+++ b/Tasks/GradleV2/Tests/L0NoCodeCoverageFail.ts
@@ -31,6 +31,14 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             'code': 0,
             'stdout': 'More sample gradle output'
         },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
         'gradlew.bat clean build jacocoTestReport': {
             'code': 0,
             'stdout': 'More sample gradle output'

--- a/Tasks/GradleV2/Tests/L0NoCodeCoverageSucceed.ts
+++ b/Tasks/GradleV2/Tests/L0NoCodeCoverageSucceed.ts
@@ -31,6 +31,14 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
             'code': 0,
             'stdout': 'More sample gradle output'
         },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
         'gradlew.bat clean build jacocoTestReport': {
             'code': 0,
             'stdout': 'More sample gradle output'

--- a/Tasks/GradleV2/Tests/L0NotAndroidProject.ts
+++ b/Tasks/GradleV2/Tests/L0NotAndroidProject.ts
@@ -1,0 +1,69 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'gradletask.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('wrapperScript', 'gradlew');
+tr.setInput('cwd', '/home/repo/src');
+tr.setInput('javaHomeSelection', 'JDKVersion');
+tr.setInput('jdkVersion', 'default');
+tr.setInput('testResultsFiles', '**/build/test-results/TEST-*.xml');
+tr.setInput('codeCoverageTool', 'jacoco');
+tr.setInput('failIfCoverageEmpty', 'false');
+tr.setInput('gradle5xOrHigher', 'false');
+
+tr.setInput('tasks', 'build');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'checkPath': {
+        'gradlew': true,
+        'gradlew.bat': true,
+        '/home/repo/src': true
+    },
+    'exec': {
+        'gradlew.bat properties': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew properties': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew.bat buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle outpu'
+        },
+        'gradlew buildEnvironment': {
+            'code': 0,
+            'stdout': 'More sample gradle outpu'
+        },
+        'gradlew.bat clean build jacocoTestReport': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        },
+        'gradlew clean build jacocoTestReport': {
+            'code': 0,
+            'stdout': 'More sample gradle output'
+        }
+    },
+    'rmRF': {
+        [path.join('/home/repo/src', 'CCReport43F6D5EF')]: {
+            success: true
+        }
+    },
+    'stats': {
+        [path.join('/home/repo/src', 'build.gradle')]: {
+            isFile() {
+                return true;
+            }
+        }
+    },
+    'exist': {
+        [path.join('/home/repo/src', 'CCReport43F6D5EF/summary.xml')]: true
+    }
+};
+tr.setAnswers(a);
+
+tr.run();

--- a/Tasks/GradleV2/gradletask.ts
+++ b/Tasks/GradleV2/gradletask.ts
@@ -209,7 +209,6 @@ async function run() {
         let inputTasks: string[] = tl.getDelimitedInput('tasks', ' ', true);
         let buildOutput: BuildOutput = new BuildOutput(tl.getVariable('System.DefaultWorkingDirectory'), BuildEngine.Gradle);
         let gradle5xOrHigher: boolean = tl.getBoolInput('gradle5xOrHigher');
-        let isAndroidProj: boolean = isAndroidProject(wrapperScript);
 
         //START: Get gradleRunner ready to run
         let gradleRunner: ToolRunner = tl.tool(wrapperScript);
@@ -254,6 +253,8 @@ async function run() {
                 }
                 summaryFile = path.join(reportDirectory, summaryFileName);
                 // END: determine isMultiModule
+                
+                let isAndroidProj: boolean = isAndroidProject(wrapperScript);
 
                 // Clean the report directory before enabling code coverage
                 tl.rmRF(reportDirectory);

--- a/Tasks/GradleV2/gradletask.ts
+++ b/Tasks/GradleV2/gradletask.ts
@@ -68,7 +68,8 @@ function enableCodeCoverage(wrapperScript: string, isCodeCoverageOpted: boolean,
                             classFilter: string, classFilesDirectories: string,
                             codeCoverageTool: string, workingDirectory: string,
                             reportDirectoryName: string, summaryFileName: string,
-                            isMultiModule: boolean, gradle5xOrHigher: boolean, isAndroidProject: boolean): Q.Promise<boolean> {
+                            isMultiModule: boolean, gradle5xOrHigher: boolean, 
+                            isAndroidProject: boolean): Q.Promise<boolean> {
     let buildProps: { [key: string]: string } = {};
     buildProps['buildfile'] = path.join(workingDirectory, 'build.gradle');
     buildProps['classfilter'] = classFilter;

--- a/Tasks/GradleV2/task.json
+++ b/Tasks/GradleV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 208,
+        "Minor": 211,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",

--- a/Tasks/GradleV2/task.loc.json
+++ b/Tasks/GradleV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 208,
+    "Minor": 211,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: GradleV2

**Description**: GradleV2 is not able to generate code coverage for android projects due to the fact that such projects don't have plugin 'java' *which adds task `jacocoTestReport` actually) and the plugin cannot be added since it's incompatible with android projects.

Change log:
- added new method `isAndroidProject` to task `GradleV2`. The method determines if building project is android related
- added logic to pass information if building project is android related to `ICodeCoverageEnabler`
- covered new logic by tests

**Documentation changes required:** (Y/N) need to mention that `GradleV2` can generate `JaCoCo` reports for android projects now

**Added unit tests:** (Y/N) Y

**Attached related issue:** (Y/N) Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
