### PR TITLE
Fixing --set parameters for helm upgrade

### DIFF
--- a/Tasks/HelmDeployV0/src/utils.ts
+++ b/Tasks/HelmDeployV0/src/utils.ts
@@ -102,5 +102,5 @@ export function addVersion(helmCli: helmcli, version: string) {
 
 export function replaceNewlinesWithCommas(overrideValues: string): string {
     const keyValuePairs = overrideValues.split("\n").filter(pair => pair);
-    return keyValuePairs.join(",");
+    return keyValuePairs.map(pair => pair.replaceAll(",", "\\,")).join(",");
 }

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 211,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [


### PR DESCRIPTION
**Task name**: HelmDeploy

**Description**: Once, `overrideValues` passed to `HemlDeploy@0` with commas in value like this:

```yaml
  - task: HelmDeploy@0
    displayName: Deploy
    inputs:
      overrideValues: |
        testVar1="1,2,3"
```

the task fails since commas [should be escaped](https://github.com/helm/helm/issues/1556) in this case with `\,`.

Related issue: #16151

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
