### PR TITLE
Vulnerability fix for UseDotNetV2

### DIFF
--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 207,
-        "Patch": 2
+        "Minor": 211,
+        "Patch": 0
     },
     "satisfies": [
         "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 207,
-    "Patch": 2
+    "Minor": 211,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"

--- a/make.js
+++ b/make.js
@@ -139,7 +139,7 @@ CLI.gendocs = function() {
 CLI.build = function() {
     CLI.clean();
 
-    ensureTool('tsc', '--version', 'Version 2.3.4');
+    ensureTool('tsc', '--version', 'Version 4.8.3');
     ensureTool('npm', '--version', function (output) {
         if (semver.lt(output, '5.6.0')) {
             fail('Expected 5.6.0 or higher. To fix, run: npm install -g npm');
@@ -306,7 +306,7 @@ CLI.build = function() {
 // node make.js test --task ShellScript --suite L0
 //
 CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */ argv) {
-    ensureTool('tsc', '--version', 'Version 2.3.4');
+    ensureTool('tsc', '--version', 'Version 4.8.3');
     ensureTool('mocha', '--version', '6.2.3');
 
     // build the general tests and ps test infra
@@ -392,7 +392,7 @@ CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */
 //
 
 CLI.testLegacy = function(/** @type {{ suite: string; node: string; task: string }} */ argv) {
-    ensureTool('tsc', '--version', 'Version 2.3.4');
+    ensureTool('tsc', '--version', 'Version 4.8.3');
     ensureTool('mocha', '--version', '6.2.3');
 
     if (argv.suite) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1114,9 +1114,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "shelljs": "^0.8.5",
     "sync-request": "4.1.0",
     "typed-rest-client": "^1.8.9",
-    "typescript": "2.3.4",
+    "typescript": "^4.8.3",
     "validator": "^13.7.0"
   }
 }


### PR DESCRIPTION
**Task name**: UseDotNetV2

**Description**: Latest vulnerability fix for task UseDotNetV2

**Documentation changes required:** (Y/N) 

**Added unit tests:** (Y/N) 

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/PipelineTools/_componentGovernance/184/alert/79428?typeId=103930

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] node make.js build --task UseDotNetV2
- [x] node make.js test --task UseDotNetV2
