### PR TITLE
Update migrateNode16 guild #3536

### DIFF
--- a/docs/migrateNode16.md
+++ b/docs/migrateNode16.md
@@ -18,7 +18,7 @@
 ```
 1. Upgrade `azure-pipelines-task-lib` to `^4.0.0-preview`, `azure-pipelines-tool-lib` to `^2.0.0-preview` in package.json dependencies, If a task has these packages.
 
-2. Change execution handlers in `task.json` from `Node` to `Node16`
+2. Add `Node16` execution handlers in `task.json`
    * **Note**: _the `target` property should be the main file targetted for the task to execute._
 
 <table>
@@ -42,6 +42,10 @@
 
 ```json
   "execution": {
+    "Node10": {
+      "target": "bash.js",
+      "argumentFormat": ""
+    },
     "Node16": {
       "target": "bash.js",
       "argumentFormat": ""
@@ -51,13 +55,6 @@
 </td>
 </tr>
 </table>
-
-4. Also in the `task.json` file, if the `minimumAgentVersion` isn't present or is less than `2.206.1`, change it to `2.206.1`.
-   * Agent version `2.206.1` is the [first version to support Node16 handlers](https://github.com/microsoft/azure-pipelines-agent/releases/tag/v2.206.1) and the `minimumAgentVersion` will trigger an [automatic upgrade](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/agents?view=azure-devops&tabs=browser#agent-version-and-upgrades) of `2.x.y` agents less than `2.206.1`.
-
-```json
-  "minimumAgentVersion": "2.206.1"
-```
 
 ## Common packages dependent on `azure-pipeline-task-lib` and `azure-pipeline-tool-lib`
 


### PR DESCRIPTION
**Task name**: Documentation

**Description**: 
- Because we decided to not bum minAgentVersion and do not remove node10 handler need to update the relative doc.

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
