### PR TITLE
Vulnerability fix for GitHubCommentV0

### DIFF
--- a/Tasks/GitHubCommentV0/package-lock.json
+++ b/Tasks/GitHubCommentV0/package-lock.json
@@ -264,9 +264,9 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -333,9 +333,9 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "requires": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -394,17 +394,18 @@
       }
     },
     "tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typed-rest-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.5.0.tgz",
-      "integrity": "sha512-DVZRlmsfnTjp6ZJaatcdyvvwYwbWvR4YDNFDqb+qdTxpvaVP99YCpBkA8rxsLtAPjBVoDe4fNsnMIdZTiPuKWg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
       "requires": {
-        "tunnel": "0.0.4",
-        "underscore": "1.8.3"
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "typedarray": {
@@ -419,9 +420,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/Tasks/GitHubCommentV0/package.json
+++ b/Tasks/GitHubCommentV0/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "main": "main.js",
   "dependencies": {
-    "@types/node": "^10.17.0",
     "@types/mocha": "^5.2.7",
+    "@types/node": "^10.17.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "3.0.6-preview.0",
-    "typed-rest-client": "1.5.0"
+    "typed-rest-client": "^1.8.9"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/GitHubCommentV0/task.json
+++ b/Tasks/GitHubCommentV0/task.json
@@ -12,7 +12,7 @@
     "preview": true,
     "version": {
         "Major": 0,
-        "Minor": 198,
+        "Minor": 212,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/GitHubCommentV0/task.json
+++ b/Tasks/GitHubCommentV0/task.json
@@ -12,7 +12,7 @@
     "preview": true,
     "version": {
         "Major": 0,
-        "Minor": 212,
+        "Minor": 214,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/GitHubCommentV0/task.loc.json
+++ b/Tasks/GitHubCommentV0/task.loc.json
@@ -12,7 +12,7 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 212,
+    "Minor": 214,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/GitHubCommentV0/task.loc.json
+++ b/Tasks/GitHubCommentV0/task.loc.json
@@ -12,7 +12,7 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 198,
+    "Minor": 212,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: GitHubCommentV0

**Description**: 

**Documentation changes required:** (Y/N) 

**Added unit tests:** (Y/N) 

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/PipelineTools/_componentGovernance/184/alert/79428?typeId=89471

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
- [x] node make.js build --task GitHubCommentV0
- [x] node make.js test --task GitHubCommentV0
