### PR TITLE
Fix #16935 UseDotNetV2 not setting "no_proxy" nuget config on Windows

### DIFF
--- a/Tasks/UseDotNetV2/nugetinstaller.ts
+++ b/Tasks/UseDotNetV2/nugetinstaller.ts
@@ -42,5 +42,14 @@ import * as nuGetGetter from 'azure-pipelines-tasks-packaging-common/nuget/NuGet
         nuget.arg('-set');
         nuget.arg('http_proxy.password=' + proxyConfig.proxyPassword);
         nuget.exec({} as trm.IExecOptions);
+
+         // Set no_proxy
+         if(proxyConfig.proxyBypassHosts) {
+            nuget = tl.tool(nugetPath);
+            nuget.arg('config');
+            nuget.arg('-set');
+            nuget.arg('no_proxy=' + proxyConfig.proxyBypassHosts.join(','));
+            nuget.exec({} as trm.IExecOptions);    
+         }
     }
 }

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 207,
-        "Patch": 2
+        "Minor": 212,
+        "Patch": 0
     },
     "satisfies": [
         "DotNetCore"


### PR DESCRIPTION
**Task name**: UseDotNetV2

**Description**: Fixed #16935 UseDotNetV2 not setting "no_proxy" nuget config on Windows Agents

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #16935

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

Please note: I could not test this