### PR TITLE
HelmInstallerV0 Chmod changes from "777" to "644"

### DIFF
--- a/Tasks/HelmInstallerV0/src/helminstaller.ts
+++ b/Tasks/HelmInstallerV0/src/helminstaller.ts
@@ -41,7 +41,7 @@ export async function downloadHelm(version: string): Promise<string> {
         throw new Error(tl.loc("HelmNotFoundInFolder", cachedToolpath))
     }
 
-    fs.chmodSync(helmpath, "777");
+    fs.chmodSync(helmpath, "644");
     return helmpath;
 }
 

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 210,
+        "Minor": 212,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 210,
+    "Minor": 212,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: HelmInstallerV0

**Description**: Chmod changes from "777" to "644"

**Documentation changes required:** (Y/N) <N> 

**Added unit tests:** (Y/N) <N>

**Attached related issue:** (Y/N)  [Bug 1983871](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1983871): Azure Pipelines Tasks Elevation of Privilege CRM:0022008783

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
- [x] node make.js build --task HelmInstallerV0
- [x] node make.js test --task HelmInstallerV0


