### PR TITLE
Vulnerability fix for VsTestPlatformToolInstallerV1

### DIFF
--- a/Tasks/VsTestPlatformToolInstallerV1/Tests/L0.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/Tests/L0.ts
@@ -59,13 +59,12 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 
         // Start the run
         tr.run();
-
         // Asserts
         assert(tr.stderr.length === 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, `Task should have succeeded`);
@@ -88,7 +87,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.listPackagesReturnCode] = '0';
         process.env[testConstants.downloadPackageReturnCode] = '0';
 
@@ -122,7 +121,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[testConstants.expectedTestPlatformVersion] = 'x';
         process.env[testConstants.listPackagesReturnCode] = '1';
         process.env[testConstants.downloadPackageReturnCode] = '0';
-        process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\15.6.0`;
+        process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\17.5.0`;
 
         // Start the run
         tr.run();
@@ -178,10 +177,10 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.listPackagesReturnCode] = '0';
         process.env[testConstants.downloadPackageReturnCode] = '1';
-        process.env[testConstants.findLocalToolSecondCallReturnValue] = `VsTest\\15.6.0`;
+        process.env[testConstants.findLocalToolSecondCallReturnValue] = `VsTest\\17.5.0`;
 
         // Start the run
         tr.run();
@@ -210,7 +209,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.listPackagesReturnCode] = '0';
         process.env[testConstants.downloadPackageReturnCode] = '1';
 
@@ -243,13 +242,12 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.versionSelector] = 'latestStable';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 
         // Start the run
         tr.run();
-
         // Asserts
         assert(tr.stderr.length === 0 || tr.errorIssues.length, 'should not have written to stderr');
         assert(tr.succeeded, `Task should have succeeded`);
@@ -274,7 +272,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[constants.testPlatformVersion] = '';
         process.env[testConstants.expectedTestPlatformVersion] = 'x';
         process.env[testConstants.listPackagesReturnCode] = '0';
-        process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\15.6.0`;
+        process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\17.5.0`;
         process.env[testConstants.listPackagesOutput] = '';
 
         // Start the run
@@ -301,8 +299,8 @@ describe('VsTestPlatformToolInstaller Suite', function() {
 
         // Set the inputs
         process.env[constants.versionSelector] = 'specificVersion';
-        process.env[constants.testPlatformVersion] = '15.6.0-preview-20171108-02';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[constants.testPlatformVersion] = '17.5.0-preview-20221003-04';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
 
         // Start the run
@@ -327,8 +325,8 @@ describe('VsTestPlatformToolInstaller Suite', function() {
 
         // Set the inputs
         process.env[constants.versionSelector] = 'specificVersion';
-        process.env[constants.testPlatformVersion] = '15.6.0-preview-20171108-02';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[constants.testPlatformVersion] = '17.5.0-preview-20221003-04';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.downloadPackageReturnCode] = '0';
 
         // Start the run
@@ -361,7 +359,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[testConstants.packageSource] = 'somecustomfeed';
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 
@@ -396,7 +394,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[testConstants.configFile] = `${process.env[constants.agentTempDirectory]}\\somefeedid.config`;
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 
@@ -432,7 +430,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[testConstants.configFile] = `${process.env[constants.agentTempDirectory]}\\somefeedid.config`;
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 
@@ -469,7 +467,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         process.env[constants.versionSelector] = 'latestPreRelease';
         process.env[testConstants.configFile] = `${process.env[constants.agentTempDirectory]}\\somefeedid.config`;
         process.env[constants.testPlatformVersion] = '';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.listPackagesReturnCode] = '0';
         process.env[testConstants.downloadPackageReturnCode] = '0';
 
@@ -570,7 +568,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.packageFeedSelector] = constants.netShare;
         process.env[testConstants.packageSource] = '\\somesharepath';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[testConstants.findLocalToolFirstCallReturnValue] = `VsTest\\${process.env[testConstants.expectedTestPlatformVersion]}`;
         process.env[constants.netShare] = `\\\\somesharepath\\Microsoft.Testplatform.${process.env[testConstants.expectedTestPlatformVersion]}.nupkg`;
         process.env[testConstants.listPackagesReturnCode] = '0';
@@ -597,7 +595,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
 
         // Set the inputs
         process.env[constants.packageFeedSelector] = constants.netShare;
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[constants.netShare] = `\\\\somesharepath\\Microsoft.Testplatform.${process.env[testConstants.expectedTestPlatformVersion]}.nupkg`;
         process.env[testConstants.packageSource] = process.env[constants.netShare];
         process.env[testConstants.listPackagesReturnCode] = '0';
@@ -624,7 +622,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
 
         // Set the inputs
         process.env[constants.packageFeedSelector] = constants.netShare;
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[constants.netShare] = `\\\\somesharepath\\Microsoft.Testplatform.${process.env[testConstants.expectedTestPlatformVersion]}.nupkg`;
         process.env[testConstants.packageSource] = process.env[constants.netShare];
         process.env[testConstants.listPackagesReturnCode] = '0';
@@ -654,7 +652,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
 
         // Set the inputs
         process.env[constants.packageFeedSelector] = constants.netShare;
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[constants.netShare] = `\\\\somesharepath\\Microsoft.Testplatform.${process.env[testConstants.expectedTestPlatformVersion]}.nupkg`;
         process.env[testConstants.packageSource] = process.env[constants.netShare];
         process.env[testConstants.listPackagesReturnCode] = '0';
@@ -684,7 +682,7 @@ describe('VsTestPlatformToolInstaller Suite', function() {
         // Set the inputs
         process.env[constants.packageFeedSelector] = constants.netShare;
         process.env[testConstants.packageSource] = '\\somesharepath';
-        process.env[testConstants.expectedTestPlatformVersion] = '15.6.0-preview-20171108-02';
+        process.env[testConstants.expectedTestPlatformVersion] = '17.5.0-preview-20221003-04';
         process.env[constants.netShare] = `\\\\somesharepath\\Miiiicrosoft.Testplatform.${process.env[testConstants.expectedTestPlatformVersion]}.nupkg`;
         process.env[testConstants.listPackagesReturnCode] = '0';
 

--- a/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/Tests/TestSetup.ts
@@ -112,9 +112,9 @@ let listPackagesCommandOutput;
 if (process.env[testConstants.listPackagesOutput] !== undefined) {
     listPackagesCommandOutput = process.env[testConstants.listPackagesOutput];
 } else {
-    listPackagesCommandOutput = 'Microsoft.TestPlatform 15.6.0'
-         + (process.env[constants.versionSelector] === 'latestPreRelease' ? '-preview-20171108-02' : '')
-         + '\r\nMicrosoft.TestPlatform.Build 15.5.0\r\nMicrosoft.TestPlatform.CLI 15.5.0\r\nMicrosoft.TestPlatform.ObjectModel 15.5.0\r\nMicrosoft.TestPlatform.Portable 15.6.0-preview-20171108-02\r\nMicrosoft.TestPlatform.TestHost 15.5.0\r\nMicrosoft.TestPlatform.TranslationLayer 15.5.0';
+    listPackagesCommandOutput = 'Microsoft.TestPlatform 17.5.0'
+         + (process.env[constants.versionSelector] === 'latestPreRelease' ? '-preview-20221003-04' : '')
+         + '\r\nMicrosoft.TestPlatform.Build 17.4.0\r\nMicrosoft.TestPlatform.CLI 17.4.0\r\nMicrosoft.TestPlatform.ObjectModel 17.4.0\r\nMicrosoft.TestPlatform.Portable 17.5.0-preview-20221003-04\r\nMicrosoft.TestPlatform.TestHost 17.4.0\r\nMicrosoft.TestPlatform.TranslationLayer 17.4.0';
 }
 
 // Construct the answers object
@@ -189,7 +189,7 @@ taskToolLibMock.cleanVersion = function(version: string): string {
 taskToolLibMock.cacheDir = function(toolRoot: string, packageName: string, version: string): string {
     return path.join(packageName, version);
 };
-tr.registerMock('vsts-task-tool-lib/tool', taskToolLibMock);
+tr.registerMock('azure-pipelines-tool-lib/tool', taskToolLibMock);
 
 // Create mock for getVariable
 const tl = require('azure-pipelines-task-lib/mock-task');

--- a/Tasks/VsTestPlatformToolInstallerV1/networkshareinstaller.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/networkshareinstaller.ts
@@ -1,6 +1,6 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
-import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as perf from 'performance-now';
 import * as ci from './cieventlogger';
 import * as constants from './constants';

--- a/Tasks/VsTestPlatformToolInstallerV1/nugetdownloadhelper.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/nugetdownloadhelper.ts
@@ -1,5 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
-import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as path from 'path';
 import * as perf from 'performance-now';
 import * as ci from './cieventlogger';

--- a/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
+++ b/Tasks/VsTestPlatformToolInstallerV1/nugetfeedinstaller.ts
@@ -1,5 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
-import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as toolLib from 'azure-pipelines-tool-lib/tool';
 import * as path from 'path';
 import { exec } from 'child_process';
 import * as perf from 'performance-now';

--- a/Tasks/VsTestPlatformToolInstallerV1/package-lock.json
+++ b/Tasks/VsTestPlatformToolInstallerV1/package-lock.json
@@ -40,6 +40,11 @@
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
             "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
         },
+        "@types/semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+        },
         "@types/uuid": {
             "version": "8.3.4",
             "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
@@ -86,6 +91,37 @@
                         "interpret": "^1.0.0",
                         "rechoir": "^0.6.2"
                     }
+                }
+            }
+        },
+        "azure-pipelines-tool-lib": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.3.2.tgz",
+            "integrity": "sha512-PtYcd3E2ouwZhLuaOpWA00FYoLjRuJs1V8mNu3u6lBnqeYd4jh/8VL/of6nchm8f2NM6Div+EEnbOcmWvcptPg==",
+            "requires": {
+                "@types/semver": "^5.3.0",
+                "@types/uuid": "^3.4.5",
+                "azure-pipelines-task-lib": "^3.1.10",
+                "semver": "^5.7.0",
+                "semver-compare": "^1.0.0",
+                "typed-rest-client": "^1.8.6",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "@types/uuid": {
+                    "version": "3.4.10",
+                    "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+                    "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -291,14 +327,6 @@
                 "mime-db": "1.52.0"
             }
         },
-        "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "requires": {
-                "brace-expansion": "^1.1.7"
-            }
-        },
         "mockery": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
@@ -408,12 +436,7 @@
         "semver-compare": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
-        },
-        "shelljs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E="
+            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
         },
         "side-channel": {
             "version": "1.0.4",
@@ -482,17 +505,18 @@
             }
         },
         "tunnel": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "typed-rest-client": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-0.11.0.tgz",
-            "integrity": "sha1-DvQTUtYo7i4IePtYpniRZF9qG0E=",
+            "version": "1.8.9",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+            "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
             "requires": {
-                "tunnel": "0.0.4",
-                "underscore": "1.8.3"
+                "qs": "^6.9.1",
+                "tunnel": "0.0.6",
+                "underscore": "^1.12.1"
             }
         },
         "typedarray": {
@@ -507,9 +531,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -520,33 +544,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
             "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        },
-        "vsts-task-tool-lib": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/vsts-task-tool-lib/-/vsts-task-tool-lib-0.4.1.tgz",
-            "integrity": "sha1-mYLTv14YS95SqpdCGJROEGJzRWU=",
-            "requires": {
-                "semver": "^5.3.0",
-                "semver-compare": "^1.0.0",
-                "typed-rest-client": "^0.11.0",
-                "uuid": "^3.0.1",
-                "vsts-task-lib": "^2.0.7"
-            },
-            "dependencies": {
-                "vsts-task-lib": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/vsts-task-lib/-/vsts-task-lib-2.2.1.tgz",
-                    "integrity": "sha512-FYllK73r1K7+sPUtWKZ4tihskJgpGB3YdNX4qr1YO0cmhFAWHm9FfEVxmKdlNeIyDtu3NyRb4wVUz0Gwi5LyGA==",
-                    "requires": {
-                        "minimatch": "^3.0.0",
-                        "mockery": "^1.7.0",
-                        "q": "^1.1.2",
-                        "semver": "^5.1.0",
-                        "shelljs": "^0.3.0",
-                        "uuid": "^3.0.1"
-                    }
-                }
-            }
         },
         "wrappy": {
             "version": "1.0.2",

--- a/Tasks/VsTestPlatformToolInstallerV1/package.json
+++ b/Tasks/VsTestPlatformToolInstallerV1/package.json
@@ -24,13 +24,13 @@
     },
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
-        "performance-now": "0.2.0",
-        "azure-pipelines-task-lib": "^3.1.7",
-        "vsts-task-tool-lib": "0.4.1",
-        "@types/node": "^10.17.0",
         "@types/mocha": "^5.2.7",
+        "@types/node": "^10.17.0",
+        "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
-        "@types/q": "^1.5.0"
+        "azure-pipelines-task-lib": "^3.1.7",
+        "azure-pipelines-tool-lib": "^1.3.2",
+        "performance-now": "0.2.0"
     },
     "devDependencies": {
         "typescript": "4.0.2"

--- a/Tasks/VsTestPlatformToolInstallerV1/task.json
+++ b/Tasks/VsTestPlatformToolInstallerV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 212,
+        "Minor": 214,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/VsTestPlatformToolInstallerV1/task.loc.json
+++ b/Tasks/VsTestPlatformToolInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 212,
+    "Minor": 214,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: VsTestPlatformToolInstallerV1

**Description**: 

**Documentation changes required:** (Y/N) 

**Added unit tests:** (Y/N) 

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/PipelineTools/_componentGovernance/184/alert/79428?typeId=12858

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
- [x]  node make.js build --task VsTestPlatformToolInstallerV1
- [x]  node make.js test --task VsTestPlatformToolInstallerV1