### PR TITLE
change task version to previous one

### DIFF
--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 214,
+        "Minor": 213,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 214,
+    "Minor": 213,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**:  Upgraded dependency of the InstallAppleCertificateV2

**Description**: Macos13 has problem with sha1, we need to add -sha1 paramters to openssl command

**Documentation changes required:** N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [https://github.com/microsoft/azure-pipelines-tasks/issues/17084](https://github.com/microsoft/azure-pipelines-tasks/issues/17084)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
