### PR TITLE
Revert minimumAgentVersion for the Bash task

### DIFF
--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -21,7 +21,7 @@
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
-    "minimumAgentVersion": "2.206.1",
+    "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "Bash Script",
     "showEnvironmentVariables": true,
     "groups": [

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 211,
+        "Minor": 214,
         "Patch": 0
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -21,7 +21,7 @@
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
-  "minimumAgentVersion": "2.206.1",
+  "minimumAgentVersion": "2.115.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "showEnvironmentVariables": true,
   "groups": [

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 211,
+    "Minor": 214,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: BashV3

**Description**: This PR moves minimumAgentVersion back to 2.115.0 because it's not needed to run the task

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/17198

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
