### PR TITLE
Replace msbuildhelpers-v3 with msbuildhelpers

### DIFF
--- a/Tasks/MSBuildV1/MSBuild.ps1
+++ b/Tasks/MSBuildV1/MSBuild.ps1
@@ -11,7 +11,7 @@ $msbuildTelemetry = [PSCustomObject]@{
 }
 
 # Import the helpers.
-Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers-v3\MSBuildHelpers.psm1"
+Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers\MSBuildHelpers.psm1"
 
 try {
     Import-VstsLocStrings "$PSScriptRoot\Task.json"

--- a/Tasks/MSBuildV1/msbuild.ts
+++ b/Tasks/MSBuildV1/msbuild.ts
@@ -1,7 +1,7 @@
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
-import msbuildHelpers = require('azure-pipelines-tasks-msbuildhelpers-v3/msbuildhelpers');
+import msbuildHelpers = require('azure-pipelines-tasks-msbuildhelpers/msbuildhelpers');
 import { TelemetryPayload, emitTelemetry } from './telemetryHelper';
 
 async function run() {

--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -58,10 +58,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-msbuildhelpers-v3": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers-v3/-/azure-pipelines-tasks-msbuildhelpers-v3-3.210.0.tgz",
-      "integrity": "sha512-T0xRWQ2CKi1y6BJcGF3H/1WqAjvTan5B0LWEl+ag9+1S53gVck6lmHDEZb+jE7rc1VhQ0HB+cdh8nxMljaOFzA==",
+    "azure-pipelines-tasks-msbuildhelpers": {
+      "version": "3.210.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.210.1.tgz",
+      "integrity": "sha512-A1o27RKXYkH36WtPZk9TwZQzYBWHb84g9OYHZzdiQyXLTHfnnILmAoowTjQAkWl1jbhTDWsPBROQ7DUCIJ5/hA==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.39",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-msbuildhelpers-v3": "^3.210.0"
+    "azure-pipelines-tasks-msbuildhelpers": "^3.210.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 212,
+        "Minor": 214,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 212,
+    "Minor": 214,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/VSBuild.ps1
+++ b/Tasks/VSBuildV1/VSBuild.ps1
@@ -13,7 +13,7 @@ $vsBuildTelemetry = [PSCustomObject]@{
 # Import the helpers.
 . $PSScriptRoot\Get-VSPath.ps1
 . $PSScriptRoot\Select-VSVersion.ps1
-Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers-v3\MSBuildHelpers.psm1"
+Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers\MSBuildHelpers.psm1"
 
 try {
     Import-VstsLocStrings "$PSScriptRoot\Task.json"

--- a/Tasks/VSBuildV1/package-lock.json
+++ b/Tasks/VSBuildV1/package-lock.json
@@ -58,10 +58,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-msbuildhelpers-v3": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers-v3/-/azure-pipelines-tasks-msbuildhelpers-v3-3.210.0.tgz",
-      "integrity": "sha512-T0xRWQ2CKi1y6BJcGF3H/1WqAjvTan5B0LWEl+ag9+1S53gVck6lmHDEZb+jE7rc1VhQ0HB+cdh8nxMljaOFzA==",
+    "azure-pipelines-tasks-msbuildhelpers": {
+      "version": "3.210.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.210.1.tgz",
+      "integrity": "sha512-A1o27RKXYkH36WtPZk9TwZQzYBWHb84g9OYHZzdiQyXLTHfnnILmAoowTjQAkWl1jbhTDWsPBROQ7DUCIJ5/hA==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/VSBuildV1/package.json
+++ b/Tasks/VSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.1.2",
-    "azure-pipelines-tasks-msbuildhelpers-v3": "^3.210.0"
+    "azure-pipelines-tasks-msbuildhelpers": "^3.210.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 212,
+        "Minor": 214,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 212,
+    "Minor": 214,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
+++ b/Tasks/XamarinAndroidV1/XamarinAndroid.ps1
@@ -21,7 +21,7 @@ try {
     [string]$jdkArchitecture = Get-VstsInput -Name jdkArchitecture
 
     # Import the helpers.
-    Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers-v3\MSBuildHelpers.psm1"
+    Import-Module -Name "$PSScriptRoot\node_modules\azure-pipelines-tasks-msbuildhelpers\MSBuildHelpers.psm1"
     . $PSScriptRoot\Get-JavaDevelopmentKitPath.ps1
 
     # Resolve project patterns.

--- a/Tasks/XamarinAndroidV1/make.json
+++ b/Tasks/XamarinAndroidV1/make.json
@@ -3,7 +3,7 @@
         {
             "items": [
                 "node_modules/azure-pipelines-tasks-java-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-msbuildhelpers-v3/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-msbuildhelpers/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/XamarinAndroidV1/package-lock.json
+++ b/Tasks/XamarinAndroidV1/package-lock.json
@@ -121,10 +121,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-msbuildhelpers-v3": {
-      "version": "3.210.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers-v3/-/azure-pipelines-tasks-msbuildhelpers-v3-3.210.0.tgz",
-      "integrity": "sha512-T0xRWQ2CKi1y6BJcGF3H/1WqAjvTan5B0LWEl+ag9+1S53gVck6lmHDEZb+jE7rc1VhQ0HB+cdh8nxMljaOFzA==",
+    "azure-pipelines-tasks-msbuildhelpers": {
+      "version": "3.210.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.210.1.tgz",
+      "integrity": "sha512-A1o27RKXYkH36WtPZk9TwZQzYBWHb84g9OYHZzdiQyXLTHfnnILmAoowTjQAkWl1jbhTDWsPBROQ7DUCIJ5/hA==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -148,14 +148,6 @@
             "shelljs": "^0.8.5",
             "sync-request": "6.1.0",
             "uuid": "^3.0.1"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
           }
         }
       }

--- a/Tasks/XamarinAndroidV1/package.json
+++ b/Tasks/XamarinAndroidV1/package.json
@@ -23,7 +23,7 @@
     "@types/q": "^1.5.1",
     "azure-pipelines-task-lib": "^4.0.0-preview",
     "azure-pipelines-tasks-java-common": "^2.198.1",
-    "azure-pipelines-tasks-msbuildhelpers-v3": "^3.210.0"
+    "azure-pipelines-tasks-msbuildhelpers": "^3.210.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/XamarinAndroidV1/task.json
+++ b/Tasks/XamarinAndroidV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 213,
+        "Minor": 214,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/XamarinAndroidV1/task.loc.json
+++ b/Tasks/XamarinAndroidV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 213,
+    "Minor": 214,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/XamariniOSV2/make.json
+++ b/Tasks/XamariniOSV2/make.json
@@ -2,7 +2,7 @@
 	"rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-msbuildhelpers-v3/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-msbuildhelpers/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/XamariniOSV2/package-lock.json
+++ b/Tasks/XamariniOSV2/package-lock.json
@@ -64,14 +64,14 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-msbuildhelpers-v3": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers-v3/-/azure-pipelines-tasks-msbuildhelpers-v3-3.198.0.tgz",
-      "integrity": "sha512-iVHtNuDGwfvArYxVu0hS60OTKrH/Etcshe1t1ClVda7frVDBDYZeo7REDbrnsHgdyrJRLeIpb1jdgCfS65O0Dg==",
+    "azure-pipelines-tasks-msbuildhelpers": {
+      "version": "3.210.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.210.1.tgz",
+      "integrity": "sha512-A1o27RKXYkH36WtPZk9TwZQzYBWHb84g9OYHZzdiQyXLTHfnnILmAoowTjQAkWl1jbhTDWsPBROQ7DUCIJ5/hA==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
-        "azure-pipelines-task-lib": "^3.1.0"
+        "azure-pipelines-task-lib": "^3.3.1"
       },
       "dependencies": {
         "@types/node": {

--- a/Tasks/XamariniOSV2/package.json
+++ b/Tasks/XamariniOSV2/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^16.11.39",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-msbuildhelpers-v3": "^3.198.0"
+    "azure-pipelines-tasks-msbuildhelpers": "^3.198.0"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/XamariniOSV2/task.json
+++ b/Tasks/XamariniOSV2/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 213,
+        "Minor": 214,
         "Patch": 0
     },
     "releaseNotes": "iOS signing set up has been removed from the task. Use `Secure Files` with supporting tasks `Install Apple Certificate` and `Install Apple Provisioning Profile` to setup signing. Updated options to work better with `Visual Studio for Mac`.",

--- a/Tasks/XamariniOSV2/task.loc.json
+++ b/Tasks/XamariniOSV2/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 213,
+    "Minor": 214,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/XamariniOSV2/xamarinios.ts
+++ b/Tasks/XamariniOSV2/xamarinios.ts
@@ -1,6 +1,6 @@
 ﻿import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
-import msbuildhelpers = require('azure-pipelines-tasks-msbuildhelpers-v3/msbuildhelpers');
+import msbuildhelpers = require('azure-pipelines-tasks-msbuildhelpers/msbuildhelpers');
 import os = require('os');
 
 import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';


### PR DESCRIPTION
Access to `msbuildhelpers` npm package was lost a year ago, so `-v3` version was created.
Now we have access to the original package back.

Replaced `msbuildhelpers-v3` with `msbuildhelpers` in task dependencies, because we got access to msbuildhelpers package.

- VSBuildV1
- MSBuildV1
- XamarinAndroidV1
- XamariniOSV2

> note that msbuildhelpers-v3: 3.210.0 was changed to msbuildhelpers 3.210.1 since there is no 210.0 version in msbuildhelpers. But these versions are identical.

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
