### PR TITLE
The lines commented out were a fix for NuGet and dotnet versions whic…

### DIFF
--- a/Tasks/Common/packaging-common/nuget/NuGetConfigHelper2.ts
+++ b/Tasks/Common/packaging-common/nuget/NuGetConfigHelper2.ts
@@ -93,14 +93,6 @@ export class NuGetConfigHelper2 {
                     // Removing source first
                     this.removeSourceFromTempNugetConfig(source);
 
-                    // Cannot add tag that starts with number as a child node of PackageSourceCredentials because of
-                    // Bug in nuget 4.9.1 and dotnet 2.1.500
-                    // https://github.com/NuGet/Home/issues/7517
-                    // https://github.com/NuGet/Home/issues/7524
-                    // so working around this by prefixing source with string
-                    tl.debug('Prefixing internal source feed name ' + source.feedName + ' with feed-');
-                    source.feedName = 'feed-' + source.feedName;
-
                     // Re-adding source with creds
                     this.addSourceWithUsernamePasswordToTempNuGetConfig(source, "VssSessionToken", this.authInfo.internalAuthInfo.accessToken);
                 }


### PR DESCRIPTION
…h are probably no longer even supported. You can't simply rename a package source as other sections of the file rely on those names, e.g. <packageSourceMapping> The packageSourceMapping section is about to become more commonly used as central package management complains about it be missing if there is more than one package source.

**Task name**: This is used by NuGetCommand@2

**Description**: As mentioned about, I removed lines that renamed a package source

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) I reported issue here, https://github.com/microsoft/azure-pipelines-tasks/issues/17056

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
