### PR TITLE
Add azure-pipelines-courtesy.yml

### DIFF
--- a/azure-pipelines-courtesy.yml
+++ b/azure-pipelines-courtesy.yml
@@ -3,6 +3,13 @@ trigger:
 - releases/*
 - node6hotfixes/*
 
+resources:
+  repositories:
+  - repository: AzureDevOps
+    type: git
+    endpoint: AzureDevOps
+    name: AzureDevOps/AzureDevOps
+
 parameters:
 - name: build_single_task
   displayName: Build Single Task


### PR DESCRIPTION
Temporarily add azure-pipelines-courtesy.yml for courtesy push pipeline.

We can't use resources in pipelines triggered by GH (There is a bug in azure devops: https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2012404)

Since we need AzureDevOps repository only for courtesy push, I removed it from azure-pipelines.yml
