### PR TITLE
Update sign-all-tasks.yml

### DIFF
--- a/ci/sign-all-tasks.yml
+++ b/ci/sign-all-tasks.yml
@@ -3,6 +3,11 @@ parameters:
   type: string
 
 steps:
+# Remove UseDotNet step after migrating to EsrpCodeSigning@2
+- task: UseDotNet@2
+  inputs:
+    version: 2.1.x
+
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   inputs:
     ConnectedServiceName: AzurePipelinesTasksESRP


### PR DESCRIPTION
Sign Task Nuget Packages task failed with the error message:
##[error]The process 'C:\Program Files\dotnet\dotnet.exe' failed with exit code 2147516566

There are two options.

- install .net core 2.1
- change to use esrp task version 2 and use dotnet 6 

This PR adds UseDotNet@2 task before esrp code signing 
