### PR TITLE
Upgrade DotNetCoreCLIV2 to Node16

### DIFF
--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -380,7 +380,7 @@ export class dotNetExe {
             var fileBuffer: Buffer = fs.readFileSync(projectfile);
             var webConfigContent: string;
 
-            var fileEncodings = ['utf8', 'utf16le'];
+            var fileEncodings:Array<BufferEncoding> = ['utf8', 'utf16le'];
 
             for (var i = 0; i < fileEncodings.length; i++) {
                 tl.debug("Trying to decode with " + fileEncodings[i]);

--- a/Tasks/DotNetCoreCLIV2/package-lock.json
+++ b/Tasks/DotNetCoreCLIV2/package-lock.json
@@ -44,9 +44,9 @@
             "integrity": "sha512-SwFMxO68Z6ERGFpPYBdmgfS5LloELzY16h/PMAhnxMog91JcHI5AJjW0HN56cGUPhV0nDb8xNWsJkhuDzr4lAQ=="
         },
         "@types/node": {
-            "version": "10.17.59",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-            "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+            "version": "16.18.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
+            "integrity": "sha512-9qGjJ5GyShZjUfx2ArBIGM+xExdfLvvaCyQR0t6yRXKPcWCVYF/WemtX/uIU3r7FYECXRXkIiw2Vnhn6y8d+pw=="
         },
         "@types/q": {
             "version": "1.5.2",
@@ -112,7 +112,7 @@
                 "sprintf-js": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+                    "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
                 }
             }
         },
@@ -144,12 +144,12 @@
             }
         },
         "azure-pipelines-task-lib": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
-            "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.1.0.tgz",
+            "integrity": "sha512-8CNC9PcP+4eS76QcIDmPmBfrrao9xpy/M0Uts4TWk3chfr3uOXFGf0DYHVTJGF9180g51kyVXYTObicouq0KZQ==",
             "requires": {
                 "minimatch": "3.0.5",
-                "mockery": "^1.7.0",
+                "mockery": "^2.1.0",
                 "q": "^1.5.1",
                 "semver": "^5.1.0",
                 "shelljs": "^0.8.5",
@@ -168,21 +168,21 @@
             }
         },
         "azure-pipelines-tasks-packaging-common": {
-            "version": "2.198.1",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-2.198.1.tgz",
-            "integrity": "sha512-iApnFFlGy8oGo2wacMExApsFqPeElcL1dRj8mxOHLrFVw2XzncJ5zl0tEskLcQoN25heWySxU5lQ1AMMvpmSXA==",
+            "version": "3.214.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.214.0.tgz",
+            "integrity": "sha512-TLn0BDm/igBwmKbEoLuGUUeijpDKRBVbi5hU72RvsAuAAFV3PHZgg/l0yHvPKS8BDDQ5zUS6g/Yo+9t8mSg09A==",
             "requires": {
                 "@types/ini": "1.3.30",
                 "@types/ltx": "2.8.0",
                 "@types/mocha": "^5.2.6",
                 "@types/mockery": "1.4.29",
-                "@types/node": "^10.17.0",
+                "@types/node": "^16.11.39",
                 "@types/q": "1.5.2",
                 "adm-zip": "^0.4.11",
                 "azure-devops-node-api": "10.2.2",
-                "azure-pipelines-task-lib": "^3.1.0",
-                "azure-pipelines-tool-lib": "^1.0.2",
-                "ini": "^1.3.4",
+                "azure-pipelines-task-lib": "^4.0.0-preview",
+                "azure-pipelines-tool-lib": "^2.0.0-preview",
+                "ini": "^1.3.8",
                 "ip-address": "^5.8.9",
                 "ltx": "^2.6.2",
                 "q": "^1.5.0",
@@ -198,35 +198,76 @@
                         "tunnel": "0.0.6",
                         "typed-rest-client": "^1.8.4"
                     }
+                },
+                "azure-pipelines-tool-lib": {
+                    "version": "2.0.0-preview",
+                    "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
+                    "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
+                    "requires": {
+                        "@types/semver": "^5.3.0",
+                        "@types/uuid": "^3.4.5",
+                        "azure-pipelines-task-lib": "^4.0.0-preview",
+                        "semver": "^5.7.0",
+                        "semver-compare": "^1.0.0",
+                        "typed-rest-client": "^1.8.6",
+                        "uuid": "^3.3.2"
+                    },
+                    "dependencies": {
+                        "typed-rest-client": {
+                            "version": "1.8.9",
+                            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+                            "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+                            "requires": {
+                                "qs": "^6.9.1",
+                                "tunnel": "0.0.6",
+                                "underscore": "^1.12.1"
+                            }
+                        }
+                    }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
         "azure-pipelines-tasks-utility-common": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.0.2.tgz",
-            "integrity": "sha512-9L6ETcAGWrSEXBsPbbavwp3qi1WxWTbG6OeeYPyUsZsASn3HDc/QMAcmUfsyPmvteIeiIz7JN8DxGFVZlkUBbw==",
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
+            "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
             "requires": {
-                "@types/node": "^10.17.0",
-                "azure-pipelines-task-lib": "^3.1.0",
-                "azure-pipelines-tool-lib": "^1.0.1",
+                "@types/node": "^16.11.39",
+                "azure-pipelines-task-lib": "^4.0.0-preview",
+                "azure-pipelines-tool-lib": "^2.0.0-preview",
                 "js-yaml": "3.13.1",
                 "semver": "^5.4.1"
             }
         },
         "azure-pipelines-tool-lib": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.2.tgz",
-            "integrity": "sha512-0wWAqIY1n9UvcHP3AKLWIVd5fTPKaUOZJ50bNwW3NMpFlfpxZDAi8Ck9wvVm9oBdwHVYZsQy3WfK71DiBWQiHg==",
+            "version": "2.0.0-preview",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
+            "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
             "requires": {
                 "@types/semver": "^5.3.0",
                 "@types/uuid": "^3.4.5",
-                "azure-pipelines-task-lib": "^3.1.0",
+                "azure-pipelines-task-lib": "^4.0.0-preview",
                 "semver": "^5.7.0",
                 "semver-compare": "^1.0.0",
-                "typed-rest-client": "^1.8.4",
+                "typed-rest-client": "^1.8.6",
                 "uuid": "^3.3.2"
             },
             "dependencies": {
+                "typed-rest-client": {
+                    "version": "1.8.9",
+                    "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
+                    "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+                    "requires": {
+                        "qs": "^6.9.1",
+                        "tunnel": "0.0.6",
+                        "underscore": "^1.12.1"
+                    }
+                },
                 "uuid": {
                     "version": "3.4.0",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -477,6 +518,13 @@
             "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
             "requires": {
                 "@types/node": "^10.0.3"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "10.17.60",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+                    "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+                }
             }
         },
         "ieee754": {
@@ -519,9 +567,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-            "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
             "requires": {
                 "has": "^1.0.3"
             }
@@ -580,17 +628,17 @@
             }
         },
         "minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "mockery": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-            "integrity": "sha512-gUQA33ayi0tuAhr/rJNZPr7Q7uvlBt4gyJPbi0CDcAfIzIrDu1YgGMFgmAu3stJqBpK57m7+RxUbcS+pt59fKQ=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+            "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
         },
         "normalize-path": {
             "version": "2.1.1",
@@ -634,9 +682,9 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "promise": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-            "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+            "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
             "requires": {
                 "asap": "~2.0.6"
             }
@@ -838,6 +886,11 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
             "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
             "dev": true
+        },
+        "underscore": {
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/Tasks/DotNetCoreCLIV2/package.json
+++ b/Tasks/DotNetCoreCLIV2/package.json
@@ -18,12 +18,12 @@
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.17.0",
+        "@types/node": "^16.11.39",
         "archiver": "1.2.0",
         "azure-devops-node-api": "11.2.0",
-        "azure-pipelines-task-lib": "^3.3.1",
-        "azure-pipelines-tasks-packaging-common": "^2.198.1",
-        "azure-pipelines-tasks-utility-common": "^3.0.0-preview.0",
+        "azure-pipelines-task-lib": "^4.1.0",
+        "azure-pipelines-tasks-packaging-common": "^3.214.0",
+        "azure-pipelines-tasks-utility-common": "^3.212.0",
         "uuid": "3.2.1"
     },
     "devDependencies": {

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 214,
+        "Minor": 215,
         "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
@@ -515,6 +515,10 @@
     ],
     "execution": {
         "Node10": {
+            "target": "dotnetcore.js",
+            "argumentFormat": ""
+        },
+        "Node16": {
             "target": "dotnetcore.js",
             "argumentFormat": ""
         }

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 214,
+    "Minor": 215,
     "Patch": 0
   },
   "minimumAgentVersion": "2.115.0",
@@ -515,6 +515,10 @@
   ],
   "execution": {
     "Node10": {
+      "target": "dotnetcore.js",
+      "argumentFormat": ""
+    },
+    "Node16": {
       "target": "dotnetcore.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: 
- Upgraded @types/node, azure-pipelines-task-lib and azure-pipelines-tool-lib
- bumped task version
- Added node16 execution handler

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
