### PR TITLE
Switch EsrpCodeSigning from V1 to V2

### DIFF
--- a/ci/sign-all-tasks.yml
+++ b/ci/sign-all-tasks.yml
@@ -3,12 +3,8 @@ parameters:
   type: string
 
 steps:
-# Remove UseDotNet step after migrating to EsrpCodeSigning@2
-- task: UseDotNet@2
-  inputs:
-    version: 2.1.x
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   inputs:
     ConnectedServiceName: AzurePipelinesTasksESRP
     FolderPath: '${{ parameters.layoutRoot }}'


### PR DESCRIPTION
Sign Task Nuget Packages task failed with the error message:
##[error]The process 'C:\Program Files\dotnet\dotnet.exe' failed with exit code 2147516566

There are two options.

- install .net core 2.1
- change to use esrp task version 2 and use dotnet 6 

This PR switches EsrpCodeSigning from V1 to V2. (I spoke with EsrpClient expert Roger Sun and he confirmed that this should be enough to safely upgrade to the second version)
