### PR TITLE
Replace webdeployment-common-v4 with Replace webdeployment-common

### DIFF
--- a/Tasks/AzureMysqlDeploymentV1/azuremysqldeploy.ts
+++ b/Tasks/AzureMysqlDeploymentV1/azuremysqldeploy.ts
@@ -21,7 +21,7 @@ async function run() {
     try {
         task.debug('Task execution started');
         task.setResourcePath(path.join( __dirname, 'task.json'));
-        task.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+        task.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
 
         // Get all task input parameters
         azureMysqlTaskParameter = new AzureMysqlTaskParameter();

--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -147,10 +147,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -162,43 +162,6 @@
         "winreg": "1.2.2",
         "xml2js": "0.4.13",
         "xmldom": "^0.1.27"
-      },
-      "dependencies": {
-        "decompress-zip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-          "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
-          "requires": {
-            "binary": "^0.3.0",
-            "graceful-fs": "^4.1.3",
-            "mkpath": "^0.1.0",
-            "nopt": "^3.0.1",
-            "q": "^1.1.2",
-            "readable-stream": "^1.1.8",
-            "touch": "0.0.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-        }
       }
     },
     "balanced-match": {
@@ -322,6 +285,43 @@
       "requires": {
         "buffer-crc32": "^0.2.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+        }
       }
     },
     "delayed-stream": {

--- a/Tasks/AzureMysqlDeploymentV1/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^2.208.0",
-    "azure-pipelines-tasks-webdeployment-common-v4": "^4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureMysqlDeploymentV1/sql/MysqlClient.ts
+++ b/Tasks/AzureMysqlDeploymentV1/sql/MysqlClient.ts
@@ -4,7 +4,7 @@ import { AzureMysqlTaskParameter } from '../models/AzureMysqlTaskParameter';
 import { Utility } from '../operations/MysqlUtiliy';
 import * as telemetry from '../telemetry';
 import task = require("azure-pipelines-task-lib/task");
-var packageUtility = require('azure-pipelines-tasks-webdeployment-common-v4/packageUtility.js');
+var packageUtility = require('azure-pipelines-tasks-webdeployment-common/packageUtility.js');
 import Q = require('q');
 
 export class MysqlClient implements ISqlClient {

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 208,
+        "Minor": 215,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 208,
+    "Minor": 215,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/AzureRmWebAppDeploymentProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/AzureRmWebAppDeploymentProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { AzureRmWebAppDeploymentProvider } from '../deploymentProvider/AzureRmWe
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/BuiltInLinuxWebAppDeploymentProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/BuiltInLinuxWebAppDeploymentProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { BuiltInLinuxWebAppDeploymentProvider } from '../deploymentProvider/Buil
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockLinuxAppSettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/BuiltInLinuxWebAppDeploymentProviderTests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/BuiltInLinuxWebAppDeploymentProviderTests.ts
@@ -43,7 +43,7 @@ export class BuiltInLinuxWebAppDeploymentProviderTests {
             }
         });
 
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
             generateTemporaryFolderForDeployment: function () {
                 return "webAppPkg";
             },
@@ -61,7 +61,7 @@ export class BuiltInLinuxWebAppDeploymentProviderTests {
             }
         });
         
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
             archiveFolder: function(A, B){
                 return "webAppPkg.zip";
             }

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/ContainerWebAppDeploymentProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/ContainerWebAppDeploymentProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { ContainerWebAppDeploymentProvider } from '../deploymentProvider/Contain
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockContainerDeploySettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/DeploymentFactoryL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/DeploymentFactoryL0Tests.ts
@@ -4,7 +4,7 @@ import { BuiltInLinuxWebAppDeploymentProvider } from '../deploymentProvider/Buil
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 
 export class DeploymentFactoryL0Tests  {
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
@@ -19,15 +19,15 @@ describe('AzureRmWebAppDeployment Suite', function() {
             tl.cp(path.join( __dirname, 'node_modules'), path.join(__dirname, '..', 'node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests'), '-rf', true);
         }
 
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.config'), '-f', false);
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web.Debug.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config'), '-f', false);
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters.xml'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters_test.xml'), '-f', false);
-        tl.cp(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web.config'), path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web_test.config'), '-f', false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.config'), '-f', false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web.Debug.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config'), '-f', false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters.xml'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters_test.xml'), '-f', false);
+        tl.cp(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web.config'), path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web_test.config'), '-f', false);
         done();
     });
     after(function() {
         try {
-            tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters_test.xml'));
+            tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters_test.xml'));
         }
         catch(error) {
             tl.debug(error);
@@ -43,18 +43,18 @@ describe('AzureRmWebAppDeployment Suite', function() {
         it('Runs successfully with XML Transformation (L1)', (done:MochaDone) => {
             this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
-            let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests","L1XdtTransform.js");
+            let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L1XdtTransform.js");
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
             tr.run();
 
-            var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web_test.config')));
-            var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform','Web_Expected.config')));
+            var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web_test.config')));
+            var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform','Web_Expected.config')));
             assert(ltx.equal(resultFile, expectFile) , 'Should Transform attributes on Web.config');
             done();
         });
 
         it('Validate MSDeploy parameters', (done:MochaDone) => {
-            let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests","L0MSDeployUtility.js");
+            let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L0MSDeployUtility.js");
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
             tr.run();
 
@@ -81,25 +81,25 @@ describe('AzureRmWebAppDeployment Suite', function() {
     });
 
     it('Runs successfully with XML variable substitution', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
-        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'Web_test.config')));
-        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'Web_Expected.config')));
+        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'Web_test.config')));
+        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'Web_Expected.config')));
         assert(ltx.equal(resultFile, expectFile) , 'Should have substituted variables in Web.config file');
-        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config')));
-        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_Expected.Debug.config')));
+        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config')));
+        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_Expected.Debug.config')));
         assert(ltx.equal(resultFile, expectFile) , 'Should have substituted variables in Web.Debug.config file');   
-        var resultParamFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'parameters_test.xml')));
-        var expectParamFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'parameters_Expected.xml')));
+        var resultParamFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'parameters_test.xml')));
+        var expectParamFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'parameters_Expected.xml')));
         assert(ltx.equal(resultParamFile, expectParamFile) , 'Should have substituted variables in parameters.xml file');
 
         done();
     });
 
     it('Runs successfully with JSON variable substitution', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1JsonVarSub.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1JsonVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -116,7 +116,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
     });
 
     it('Runs successfully with JSON variable substitution V2', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1JsonVarSubV2.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1JsonVarSubV2.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -136,7 +136,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
     });
 
     it('Validate File Encoding', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1ValidateFileEncoding.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1ValidateFileEncoding.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -157,8 +157,8 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Validate azure-pipelines-tasks-webdeployment-common-v4.utility.copyDirectory()', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L0CopyDirectory.js');
+    it('Validate azure-pipelines-tasks-webdeployment-common.utility.copyDirectory()', (done:MochaDone) => {
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L0CopyDirectory.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0GenerateWebConfigForNode.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0GenerateWebConfigForNode.ts
@@ -101,7 +101,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -112,7 +112,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
@@ -201,7 +201,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -212,7 +212,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0LinuxBuiltinImage.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0LinuxBuiltinImage.ts
@@ -101,7 +101,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -186,7 +186,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
         console.log("Successfully updated webApp app-settings");
     }
 });
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function () {
         return false;
     },
@@ -226,7 +226,7 @@ tr.registerMock('./kuduutility.js', {
     }
 });
 
-tr.registerMock("azure-pipelines-tasks-webdeployment-common-v4/ziputility.js",{
+tr.registerMock("azure-pipelines-tasks-webdeployment-common/ziputility.js",{
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsDefault.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsDefault.ts
@@ -97,7 +97,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -207,7 +207,7 @@ tr.registerMock('./kuduutility.js', {
     }
 });
 
-tr.registerMock("azure-pipelines-tasks-webdeployment-common-v4/ziputility.js",{
+tr.registerMock("azure-pipelines-tasks-webdeployment-common/ziputility.js",{
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFailArchive.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFailArchive.ts
@@ -99,7 +99,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -199,8 +199,8 @@ tr.registerMock('./kuduutility.js', {
     }
 });
 
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     archiveFolder: function(webAppPackage, webAppZipFile) {
         throw new Error('Folder Archiving Failed');
     },
@@ -209,7 +209,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
 });
 
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return true;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFailParamPkg.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFailParamPkg.ts
@@ -95,7 +95,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -197,7 +197,7 @@ tr.registerMock('./kuduutility.js', {
     }
 });
 
-tr.registerMock("azure-pipelines-tasks-webdeployment-common-v4/ziputility.js", {
+tr.registerMock("azure-pipelines-tasks-webdeployment-common/ziputility.js", {
     getArchivedEntries: function( webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFolderPkg.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsFolderPkg.ts
@@ -99,7 +99,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('webdeployment-common-v2/msdeployutility.js'); 
+var msDeployUtility = require('webdeployment-common/msdeployutility.js'); 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -210,13 +210,13 @@ tr.registerMock('./kuduutility.js', {
     }
 });
 
-tr.registerMock('webdeployment-common-v2/ziputility.js', {
+tr.registerMock('webdeployment-common/ziputility.js', {
     archiveFolder : function() {
          console.log('Folder Archiving Successful');
     }
 });
 
-tr.registerMock('webdeployment-common-v2/utility.js', {
+tr.registerMock('webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return true;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsParamFileinPkg.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsParamFileinPkg.ts
@@ -86,7 +86,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('webdeployment-common-v2/ziputility.js', {
+tr.registerMock('webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -96,7 +96,7 @@ tr.registerMock('webdeployment-common-v2/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('webdeployment-common-v2/msdeployutility.js'); 
+var msDeployUtility = require('webdeployment-common/msdeployutility.js'); 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsXdtTransformationFail.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0NonWindowsXdtTransformationFail.ts
@@ -93,7 +93,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -168,7 +168,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
         console.log("Successfully updated scmType to VSTSRM");
     }
 });
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     unzip: function() {
 
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0ParameterParserUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0ParameterParserUtility.ts
@@ -1,5 +1,5 @@
 import path = require('path');
-import * as ParameterParserUtility from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParserUtility from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 
 function validateParameterParserUtility() {
     var paramString = "-port 8080 -Release.ReleaseName Release-1173";

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsAllInput.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsAllInput.ts
@@ -99,7 +99,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -110,7 +110,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsDefault.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsDefault.ts
@@ -92,7 +92,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -103,7 +103,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsDefaultReleaseAnnotationFail.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsDefaultReleaseAnnotationFail.ts
@@ -92,7 +92,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function (webDeployPkg) {
         return {
             "entries": [
@@ -103,7 +103,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs: msDeployUtility.getMSDeployCmdArgs,

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFailDefault.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFailDefault.ts
@@ -85,7 +85,7 @@ let a: any = <any>{
 };
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -96,7 +96,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     shouldRetryMSDeploy: msDeployUtility.shouldRetryMSDeploy,
     redirectMSDeployErrorToConsole : msDeployUtility.redirectMSDeployErrorToConsole,

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFailSetParamFile.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFailSetParamFile.ts
@@ -87,7 +87,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFolderPkg.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsFolderPkg.ts
@@ -92,7 +92,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsManyPackage.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsManyPackage.ts
@@ -100,7 +100,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsNoPackage.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsNoPackage.ts
@@ -95,7 +95,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsParamFileinPkg.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsParamFileinPkg.ts
@@ -92,7 +92,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -103,7 +103,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsSpecificSlot.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsSpecificSlot.ts
@@ -96,7 +96,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries":[
@@ -107,7 +107,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsXdtTransformation.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsXdtTransformation.ts
@@ -107,7 +107,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -192,7 +192,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     unzip: function() {
 
     },
@@ -206,7 +206,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsXdtTransformationFail.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0WindowsXdtTransformationFail.ts
@@ -101,7 +101,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -178,7 +178,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0XdtTransformationFailMSBuildPackage.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0XdtTransformationFailMSBuildPackage.ts
@@ -100,7 +100,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 var kuduDeploymentLog = require('azurerest-common/kududeploymentstatusutility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -177,7 +177,7 @@ tr.registerMock('azurerest-common/azurerestutility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/PublishProfileWebAppDeploymentProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/PublishProfileWebAppDeploymentProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { PublishProfileWebAppDeploymentProvider } from '../deploymentProvider/Pu
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockRunFromZipSettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppRunFromZipProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppRunFromZipProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { WindowsWebAppRunFromZipProvider } from '../deploymentProvider/WindowsWe
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockRunFromZipSettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppRunFromZipProviderTests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppRunFromZipProviderTests.ts
@@ -44,7 +44,7 @@ export class WindowsWebAppRunFromZipProviderTests {
             }
         });
         
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
             generateTemporaryFolderForDeployment: function () {
                 return "webAppPkg";
             },
@@ -62,7 +62,7 @@ export class WindowsWebAppRunFromZipProviderTests {
             }
         });
         
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
             archiveFolder: function(A, B){
                 return "webAppPkg.zip";
             }

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppWarDeployProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppWarDeployProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { WindowsWebAppWarDeployProvider } from '../deploymentProvider/WindowsWeb
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockRunFromZipSettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppWebDeployProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppWebDeployProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { WindowsWebAppWebDeployProvider } from '../deploymentProvider/WindowsWeb
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockZipDeploySettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppZipDeployProviderL0Tests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppZipDeployProviderL0Tests.ts
@@ -4,7 +4,7 @@ import { WindowsWebAppZipDeployProvider } from '../deploymentProvider/WindowsWeb
 import { IWebAppDeploymentProvider } from '../deploymentProvider/IWebAppDeploymentProvider';
 import { TaskParametersUtility, TaskParameters, DeploymentType } from '../operations/TaskParameters';
 import { stringify } from 'querystring';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { getMockEndpoint } from '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
 import { mockAzureARMPreDeploymentSteps, mockZipDeploySettings }  from "./mock_utils";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppZipDeployProviderTests.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/WindowsWebAppZipDeployProviderTests.ts
@@ -43,7 +43,7 @@ export class WindowsWebAppZipDeployProviderTests {
             }
         });
 
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
             generateTemporaryFolderForDeployment: function () {
                 return "webAppPkg";
             },
@@ -61,7 +61,7 @@ export class WindowsWebAppZipDeployProviderTests {
             }
         });
         
-        tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+        tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
             archiveFolder: function(A, B){
                 return "webAppPkg.zip";
             }

--- a/Tasks/AzureRmWebAppDeploymentV4/azurermwebappdeployment.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/azurermwebappdeployment.ts
@@ -9,7 +9,7 @@ async function main() {
 
     try {
         tl.setResourcePath(path.join( __dirname, 'task.json'));
-        tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+        tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
         var taskParams: TaskParameters = TaskParametersUtility.getParameters();
         var deploymentFactory: DeploymentFactory = new DeploymentFactory(taskParams);
         var deploymentProvider = await deploymentFactory.GetDeploymentProvider();

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
@@ -8,9 +8,9 @@ import { AzureAppService } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-a
 import { Kudu } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-app-service-kudu';
 import { AzureAppServiceUtility } from '../operations/AzureAppServiceUtility';
 import tl = require('azure-pipelines-task-lib/task');
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import { addReleaseAnnotation } from '../operations/ReleaseAnnotationUtility';
-import { PackageUtility } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageUtility } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { AzureDeployPackageArtifactAlias } from '../operations/Constants';
 
 export class AzureRmWebAppDeploymentProvider implements IWebAppDeploymentProvider{

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
@@ -1,12 +1,12 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import path = require('path');
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 
-var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
+var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
 
 const linuxFunctionStorageSetting: string = '-WEBSITES_ENABLE_APP_SERVICE_STORAGE true';
 const linuxFunctionRuntimeSettingName: string = '-FUNCTIONS_WORKER_RUNTIME ';

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/ContainerWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/ContainerWebAppDeploymentProvider.ts
@@ -1,6 +1,6 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import { ContainerBasedDeploymentUtility } from '../operations/ContainerBasedDeploymentUtility';
 const linuxFunctionStorageSetting: string = '-WEBSITES_ENABLE_APP_SERVICE_STORAGE false';
 

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/DeploymentFactory.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/DeploymentFactory.ts
@@ -8,7 +8,7 @@ import { WindowsWebAppZipDeployProvider } from './WindowsWebAppZipDeployProvider
 import { WindowsWebAppRunFromZipProvider } from './WindowsWebAppRunFromZipProvider';
 import { ContainerWebAppDeploymentProvider } from './ContainerWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { WindowsWebAppWarDeployProvider } from './WindowsWebAppWarDeployProvider';
 
 export class DeploymentFactory {

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/PublishProfileWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/PublishProfileWebAppDeploymentProvider.ts
@@ -8,9 +8,9 @@ import tl = require('azure-pipelines-task-lib/task');
 import fs = require('fs');
 import path = require('path');
 
-var packageUtility = require('azure-pipelines-tasks-webdeployment-common-v4/packageUtility.js');
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var packageUtility = require('azure-pipelines-tasks-webdeployment-common/packageUtility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
 const DEFAULT_RETRY_COUNT = 3;
 

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppRunFromZipProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppRunFromZipProvider.ts
@@ -1,14 +1,14 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
 import { FileTransformsUtility } from '../operations/FileTransformsUtility';
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import { DeploymentType } from '../operations/TaskParameters';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { addReleaseAnnotation } from '../operations/ReleaseAnnotationUtility';
 const oldRunFromZipAppSetting: string = '-WEBSITE_RUN_FROM_ZIP';
 const runFromZipAppSetting: string = '-WEBSITE_RUN_FROM_PACKAGE 1';
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
 
 export class WindowsWebAppRunFromZipProvider extends AzureRmWebAppDeploymentProvider{
  

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppWarDeployProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppWarDeployProvider.ts
@@ -1,6 +1,6 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
-var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
+var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
 
 
 export class WindowsWebAppWarDeployProvider extends AzureRmWebAppDeploymentProvider{

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppWebDeployProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppWebDeployProvider.ts
@@ -1,13 +1,13 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
 import { FileTransformsUtility } from '../operations/FileTransformsUtility';
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import * as Constant from '../operations/Constants';
 import { WebDeployUtility } from '../operations/WebDeployUtility';
-import { Package } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { Package } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 
 const removeRunFromZipAppSetting: string = '-WEBSITE_RUN_FROM_ZIP -WEBSITE_RUN_FROM_PACKAGE';
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
 
 export class WindowsWebAppWebDeployProvider extends AzureRmWebAppDeploymentProvider{
  

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppZipDeployProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/WindowsWebAppZipDeployProvider.ts
@@ -1,12 +1,12 @@
 import { AzureRmWebAppDeploymentProvider } from './AzureRmWebAppDeploymentProvider';
 import tl = require('azure-pipelines-task-lib/task');
 import { FileTransformsUtility } from '../operations/FileTransformsUtility';
-import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import * as ParameterParser from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import { DeploymentType } from '../operations/TaskParameters';
-import { PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 const removeRunFromZipAppSetting: string = '-WEBSITE_RUN_FROM_PACKAGE -WEBSITE_RUN_FROM_ZIP';
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
 
 export class WindowsWebAppZipDeployProvider extends AzureRmWebAppDeploymentProvider{
     

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/ContainerBasedDeploymentUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/ContainerBasedDeploymentUtility.ts
@@ -3,7 +3,7 @@ import url = require('url');
 import util = require('util');
 import { AzureAppService } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-app-service';
 import { TaskParameters } from './TaskParameters';
-import { parse }  from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import { parse }  from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 import { AzureAppServiceUtility } from './AzureAppServiceUtility';
 
 enum registryTypes {

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/FileTransformsUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/FileTransformsUtility.ts
@@ -1,9 +1,9 @@
 import tl = require('azure-pipelines-task-lib/task');
 import { TaskParameters } from './TaskParameters';
-import { parse } from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common-v4/fileTransformationsUtility.js');
-var generateWebConfigUtil = require('azure-pipelines-tasks-webdeployment-common-v4/webconfigutil.js');
+import { parse } from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common/fileTransformationsUtility.js');
+var generateWebConfigUtil = require('azure-pipelines-tasks-webdeployment-common/webconfigutil.js');
 
 export class FileTransformsUtility {
 

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/KuduServiceUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/KuduServiceUtility.ts
@@ -10,8 +10,8 @@ import { Kudu } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-app-serv
 
 import webClient = require('azure-pipelines-tasks-azure-arm-rest-v2/webClient');
 
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
 const physicalRootPath: string = '/site/wwwroot';
 const deploymentFolder: string = 'site/deployments';
 const manifestFileName: string = 'manifest';

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/PublishProfileUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/PublishProfileUtility.ts
@@ -5,7 +5,7 @@ import * as Constant from './Constants';
 import path = require('path');
 import Q = require('q');
 
-var packageUtility = require('azure-pipelines-tasks-webdeployment-common-v4/packageUtility.js');
+var packageUtility = require('azure-pipelines-tasks-webdeployment-common/packageUtility.js');
 var parseString = require('xml2js').parseString;
 const ERROR_FILE_NAME = "error.txt";
 

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/TaskParameters.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/TaskParameters.ts
@@ -1,7 +1,7 @@
 import tl = require('azure-pipelines-task-lib/task');
 import * as Constant from '../operations/Constants'
-import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
-var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
+import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
+var webCommonUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
 
 export enum DeploymentType {
     webDeploy,

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/WarDeploymentUtilities.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/WarDeploymentUtilities.ts
@@ -6,7 +6,7 @@ import { AzureAppServiceUtility } from './AzureAppServiceUtility';
 import { TaskParameters } from './TaskParameters';
 import { sleepFor } from 'azure-pipelines-tasks-azure-arm-rest-v2/webClient';
 
-var msDeploy = require('azure-pipelines-tasks-webdeployment-common-v4/deployusingmsdeploy.js');
+var msDeploy = require('azure-pipelines-tasks-webdeployment-common/deployusingmsdeploy.js');
 
 export async function DeployWar(webPackage, taskParams: TaskParameters, msDeployPublishingProfile, kuduService: Kudu, appServiceUtility: AzureAppServiceUtility): Promise<void> {
     // get list of files before deploying to the web app.

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/WebDeployUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/WebDeployUtility.ts
@@ -2,10 +2,10 @@ import tl = require('azure-pipelines-task-lib/task');
 import fs = require('fs');
 import path = require('path');
 import { TaskParameters } from './TaskParameters';
-import { WebDeployArguments, WebDeployResult } from 'azure-pipelines-tasks-webdeployment-common-v4/msdeployutility';
-import {  executeWebDeploy } from 'azure-pipelines-tasks-webdeployment-common-v4/deployusingmsdeploy';
-import { Package } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
-import { copySetParamFileIfItExists } from 'azure-pipelines-tasks-webdeployment-common-v4/utility';
+import { WebDeployArguments, WebDeployResult } from 'azure-pipelines-tasks-webdeployment-common/msdeployutility';
+import {  executeWebDeploy } from 'azure-pipelines-tasks-webdeployment-common/deployusingmsdeploy';
+import { Package } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
+import { copySetParamFileIfItExists } from 'azure-pipelines-tasks-webdeployment-common/utility';
 import { AzureAppServiceUtility } from './AzureAppServiceUtility';
 const DEFAULT_RETRY_COUNT = 3;
 

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -147,10 +147,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -162,43 +162,6 @@
         "winreg": "1.2.2",
         "xml2js": "0.4.13",
         "xmldom": "^0.1.27"
-      },
-      "dependencies": {
-        "decompress-zip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-          "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
-          "requires": {
-            "binary": "^0.3.0",
-            "graceful-fs": "^4.1.3",
-            "mkpath": "^0.1.0",
-            "nopt": "^3.0.1",
-            "q": "^1.1.2",
-            "readable-stream": "^1.1.8",
-            "touch": "0.0.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-        }
       }
     },
     "balanced-match": {
@@ -363,6 +326,43 @@
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+        }
       }
     },
     "delayed-stream": {

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^2.208.0",
-    "azure-pipelines-tasks-webdeployment-common-v4": "^4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 214,
+        "Minor": 215,
         "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 214,
+    "Minor": 215,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureSpringCloudV0/azurespringclouddeployment.ts
+++ b/Tasks/AzureSpringCloudV0/azurespringclouddeployment.ts
@@ -11,7 +11,7 @@ export async function main() {
     console.log('Starting deployment task execution');
     tl.setResourcePath(path.join(__dirname, 'task.json'));
     tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-azure-arm-rest-v2/module.json'));
-    tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+    tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
     var taskParams: TaskParameters = TaskParametersUtility.getParameters();
     var deploymentProvider = new AzureSpringCloudDeploymentProvider(taskParams);
 

--- a/Tasks/AzureSpringCloudV0/deploymentProvider/AzureSpringCloudDeploymentProvider.ts
+++ b/Tasks/AzureSpringCloudV0/deploymentProvider/AzureSpringCloudDeploymentProvider.ts
@@ -1,6 +1,6 @@
 import path = require('path');
 import { v4 as uuidv4 } from 'uuid';
-import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { Actions, DeploymentType, TaskParameters } from '../operations/taskparameters';
 import { SourceType, AzureSpringCloud } from './azure-arm-spring-cloud';
 import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';

--- a/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-cloud.ts
+++ b/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-cloud.ts
@@ -6,7 +6,7 @@ import { ServiceClient } from 'azure-pipelines-tasks-azure-arm-rest-v2/AzureServ
 import { ToError } from 'azure-pipelines-tasks-azure-arm-rest-v2/AzureServiceClientBase';
 import { uploadFileToSasUrl } from './azure-storage';
 import https = require('https');
-import { parse } from 'azure-pipelines-tasks-webdeployment-common-v4/ParameterParserUtility';
+import { parse } from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';
 
 export const SourceType = {
     JAR: "Jar",

--- a/Tasks/AzureSpringCloudV0/operations/taskparameters.ts
+++ b/Tasks/AzureSpringCloudV0/operations/taskparameters.ts
@@ -1,4 +1,4 @@
-import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
+import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 
 export class Inputs {
     public static readonly connectedServiceName = 'ConnectedServiceName';

--- a/Tasks/AzureSpringCloudV0/package-lock.json
+++ b/Tasks/AzureSpringCloudV0/package-lock.json
@@ -328,10 +328,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -356,12 +356,12 @@
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "azure-pipelines-task-lib": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
-          "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
+          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
           "requires": {
             "minimatch": "3.0.5",
-            "mockery": "^1.7.0",
+            "mockery": "^2.1.0",
             "q": "^1.5.1",
             "semver": "^5.1.0",
             "shelljs": "^0.8.5",
@@ -383,6 +383,11 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        },
+        "mockery": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+          "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
         },
         "shelljs": {
           "version": "0.8.5",

--- a/Tasks/AzureSpringCloudV0/package.json
+++ b/Tasks/AzureSpringCloudV0/package.json
@@ -32,7 +32,7 @@
     "q": "1.4.1",
     "tar": "^6.1.11",
     "uuid": "3.1.0",
-    "azure-pipelines-tasks-webdeployment-common-v4": "4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "xml2js": "0.4.13"
   },
   "devDependencies": {

--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -18,7 +18,7 @@
     "preview": true,
     "version": {
         "Major": 0,
-        "Minor": 213,
+        "Minor": 215,
         "Patch": 0
     },
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureSpringCloudV0/task.loc.json
+++ b/Tasks/AzureSpringCloudV0/task.loc.json
@@ -18,7 +18,7 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 213,
+    "Minor": 215,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/FileTransformV1/filetransform.ts
+++ b/Tasks/FileTransformV1/filetransform.ts
@@ -1,13 +1,13 @@
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import { Package } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
-import { generateTemporaryFolderForDeployment } from 'azure-pipelines-tasks-webdeployment-common-v4/utility';
-import { archiveFolder } from 'azure-pipelines-tasks-webdeployment-common-v4/ziputility';
-import { advancedFileTransformations } from 'azure-pipelines-tasks-webdeployment-common-v4/fileTransformationsUtility';
+import { Package } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
+import { generateTemporaryFolderForDeployment } from 'azure-pipelines-tasks-webdeployment-common/utility';
+import { archiveFolder } from 'azure-pipelines-tasks-webdeployment-common/ziputility';
+import { advancedFileTransformations } from 'azure-pipelines-tasks-webdeployment-common/fileTransformationsUtility';
 
 async function main() {
     tl.setResourcePath(path.join( __dirname, 'task.json'));
-    tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+    tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
     let webPackage = new Package(tl.getPathInput('folderPath', true));
     let packagePath = webPackage.getPath();
     let fileType = tl.getInput("fileType", false);

--- a/Tasks/FileTransformV1/package-lock.json
+++ b/Tasks/FileTransformV1/package-lock.json
@@ -120,10 +120,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/FileTransformV1/package.json
+++ b/Tasks/FileTransformV1/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^16.11.39",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common-v4": "4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 214,
+        "Minor": 215,
         "Patch": 0
     },
     "instanceNameFormat": "File Transform: $(Package)",

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 214,
+    "Minor": 215,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/FileTransformV2/filetransform.ts
+++ b/Tasks/FileTransformV2/filetransform.ts
@@ -1,13 +1,13 @@
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
-import { Package } from 'azure-pipelines-tasks-webdeployment-common-v4/packageUtility';
-var deployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var zipUtility = require('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js');
-var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common-v4/fileTransformationsUtility.js');
+import { Package } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
+var deployUtility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var zipUtility = require('azure-pipelines-tasks-webdeployment-common/ziputility.js');
+var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common/fileTransformationsUtility.js');
 
 async function main() {
     tl.setResourcePath(path.join( __dirname, 'task.json'));
-    tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+    tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
     let webPackage = new Package(tl.getPathInput('folderPath', true));
     let packagePath = webPackage.getPath();
     let xmlTransformation = true;

--- a/Tasks/FileTransformV2/package-lock.json
+++ b/Tasks/FileTransformV2/package-lock.json
@@ -120,10 +120,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -141,41 +141,6 @@
           "version": "10.17.60",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
-        "decompress-zip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-          "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
-          "requires": {
-            "binary": "^0.3.0",
-            "graceful-fs": "^4.1.3",
-            "mkpath": "^0.1.0",
-            "nopt": "^3.0.1",
-            "q": "^1.1.2",
-            "readable-stream": "^1.1.8",
-            "touch": "0.0.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
         }
       }
     },
@@ -336,6 +301,43 @@
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+        }
       }
     },
     "delayed-stream": {

--- a/Tasks/FileTransformV2/package.json
+++ b/Tasks/FileTransformV2/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "16.11.39",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common-v4": "^4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 215,
-        "Patch": 0
+        "Patch": 1
     },
     "preview": "true",
     "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 215,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": "true",
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0.ts
@@ -9,17 +9,17 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
      var taskSrcPath = path.join(__dirname, '..','deployiiswebapp.js');
      this.timeout(60000);
      before((done) => {
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.config'), null, false);
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web.Debug.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config'), null, false);
-        tl.cp(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web.config'), path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web_test.config'), null, false);
-        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters.xml'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters_test.xml'), null, false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.config'), null, false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web.Debug.config'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config'), null, false);
+        tl.cp(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web.config'), path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web_test.config'), null, false);
+        tl.cp(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters.xml'), path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters_test.xml'), null, false);
         done();
     });
     after(function() {
-        tl.rmRF(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web_test.config'));
-        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.config'));
-        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_Test.Debug.config'));
-        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'parameters_test.xml'));
+        tl.rmRF(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web_test.config'));
+        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.config'));
+        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_Test.Debug.config'));
+        tl.rmRF(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'parameters_test.xml'));
     });
 
     if(!tl.osType().match(/^Win/)) {
@@ -148,13 +148,13 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
     it('Runs successfully with XDT Transformation (L1)', (done:MochaDone) => {
         this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
-        let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests","L1XdtTransform.js");
+        let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L1XdtTransform.js");
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
         if(tl.osType().match(/^Win/)) {
-            var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform', 'Web_test.config')));
-            var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XdtTransform','Web_Expected.config')));
+            var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform', 'Web_test.config')));
+            var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XdtTransform','Web_Expected.config')));
             assert(ltx.equal(resultFile, expectFile) , 'Should Transform attributes on Web.config');
         }
         else {
@@ -165,21 +165,21 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
 
 
     it('Runs successfully with XML variable substitution', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 		
-        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'Web_test.config')));
-        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests", 'L1XmlVarSub', 'Web_Expected.config')));
+        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname,  "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'Web_test.config')));
+        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests", 'L1XmlVarSub', 'Web_Expected.config')));
         assert(ltx.equal(resultFile, expectFile) , 'Should have substituted variables in Web.config file');
-        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config')));
-        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1XmlVarSub', 'Web_Expected.Debug.config')));
+        var resultFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_test.Debug.config')));
+        var expectFile = ltx.parse(fs.readFileSync(path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub', 'Web_Expected.Debug.config')));
         assert(ltx.equal(resultFile, expectFile) , 'Should have substituted variables in Web.Debug.config file');
         done();
     });
 
     it('Runs successfully with JSON variable substitution', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1JsonVarSub.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1JsonVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -196,7 +196,7 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
     });
 
     it('Validate File Encoding', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L1ValidateFileEncoding.js');
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1ValidateFileEncoding.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -217,8 +217,8 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
         done();
     });
 
-     it('Validate azure-pipelines-tasks-webdeployment-common-v4.utility.copyDirectory()', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common-v4", "Tests", 'L0CopyDirectory.js');
+     it('Validate azure-pipelines-tasks-webdeployment-common.utility.copyDirectory()', (done:MochaDone) => {
+        let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L0CopyDirectory.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 
@@ -228,7 +228,7 @@ describe('IISWebsiteDeploymentOnMachineGroup test suite', function() {
     });
 
     it('Validate MSDeploy parameters', (done:MochaDone) => {
-        let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common-v4","Tests","L0MSDeployUtility.js");
+        let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L0MSDeployUtility.js");
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
 

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsAllInput.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsAllInput.ts
@@ -52,8 +52,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 }
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsDefault.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsDefault.ts
@@ -41,8 +41,8 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 };
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsFailDefault.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsFailDefault.ts
@@ -46,8 +46,8 @@ let a: any = <any>{
 };
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsFailSetParamFile.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsFailSetParamFile.ts
@@ -26,7 +26,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 };
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
 var fs = require('fs');
 tr.registerMock('fs', {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsParamFileinPkg.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsParamFileinPkg.ts
@@ -58,9 +58,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
 };
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js');
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js');
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsXdtTransformation.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsXdtTransformation.ts
@@ -86,7 +86,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js'); 
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js'); 
 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
@@ -96,7 +96,7 @@ tr.registerMock('./msdeployutility.js', {
     }
 }); 
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/ziputility.js', {
     getArchivedEntries: function(webDeployPkg) {
         return {
             "entries": [
@@ -107,7 +107,7 @@ tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/ziputility.js', {
     }
 });
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsXdtTransformationFail.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/Tests/L0WindowsXdtTransformationFail.ts
@@ -86,7 +86,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
 
 import mockTask = require('azure-pipelines-task-lib/mock-task');
 
-var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common-v4/msdeployutility.js'); 
+var msDeployUtility = require('azure-pipelines-tasks-webdeployment-common/msdeployutility.js'); 
 tr.registerMock('./msdeployutility.js', {
     getMSDeployCmdArgs : msDeployUtility.getMSDeployCmdArgs,
     getMSDeployFullPath : function() {
@@ -95,7 +95,7 @@ tr.registerMock('./msdeployutility.js', {
     }
 }); 
 
-tr.registerMock('azure-pipelines-tasks-webdeployment-common-v4/utility.js', {
+tr.registerMock('azure-pipelines-tasks-webdeployment-common/utility.js', {
     isInputPkgIsFolder: function() {
         return false;    
     },

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/deployiiswebapp.ts
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/deployiiswebapp.ts
@@ -2,16 +2,16 @@
 import path = require('path');
 import fs = require('fs');
 
-var msDeploy = require('azure-pipelines-tasks-webdeployment-common-v4/deployusingmsdeploy.js');
-var utility = require('azure-pipelines-tasks-webdeployment-common-v4/utility.js');
-var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common-v4/fileTransformationsUtility.js');
+var msDeploy = require('azure-pipelines-tasks-webdeployment-common/deployusingmsdeploy.js');
+var utility = require('azure-pipelines-tasks-webdeployment-common/utility.js');
+var fileTransformationsUtility = require('azure-pipelines-tasks-webdeployment-common/fileTransformationsUtility.js');
 
 async function run()
 {
 	try
 	{
 		tl.setResourcePath(path.join( __dirname, 'task.json'));
-		tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+		tl.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
 		var webSiteName: string = tl.getInput('WebSiteName', true);
 		var virtualApplication: string = tl.getInput('VirtualApplication', false);
 		var webDeployPkg: string = tl.getPathInput('Package', true);

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
@@ -112,10 +112,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.208.0.tgz",
-      "integrity": "sha512-MwSxX0tTi/UGF85vQ+ypY5rDjJmTq/V+hSr1pyDdD4VT2gii9Z0N1DJyKGOZ/GVSV4Fb2URmyaYUgtfxHC0wWA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.208.0.tgz",
+      "integrity": "sha512-Avp9blAMauPMOYpJ5ezBhJ5sPd52x5C6cP5v9ftGESCzBiz+wLoKMaW6ttlyQ608Omjj6JtljjYiX8hocGpVoQ==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -127,43 +127,6 @@
         "winreg": "1.2.2",
         "xml2js": "0.4.13",
         "xmldom": "^0.1.27"
-      },
-      "dependencies": {
-        "decompress-zip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
-          "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
-          "requires": {
-            "binary": "^0.3.0",
-            "graceful-fs": "^4.1.3",
-            "mkpath": "^0.1.0",
-            "nopt": "^3.0.1",
-            "q": "^1.1.2",
-            "readable-stream": "^1.1.8",
-            "touch": "0.0.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-        }
       }
     },
     "balanced-match": {
@@ -323,6 +286,43 @@
       "requires": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "decompress-zip": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.3.tgz",
+      "integrity": "sha512-/fy1L4s+4jujqj3kNptWjilFw3E6De8U6XUFvqmh4npN3Vsypm3oT2V0bXcmbBWS+5j5tr4okYaFrOmyZkszEg==",
+      "requires": {
+        "binary": "^0.3.0",
+        "graceful-fs": "^4.1.3",
+        "mkpath": "^0.1.0",
+        "nopt": "^3.0.1",
+        "q": "^1.1.2",
+        "readable-stream": "^1.1.8",
+        "touch": "0.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+        }
       }
     },
     "delayed-stream": {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common-v4": "^4.208.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 208,
+        "Minor": 215,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 208,
+    "Minor": 215,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/mysqldeploy.ts
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/mysqldeploy.ts
@@ -11,7 +11,7 @@ async function run() {
     try {
         task.debug('Task execution started');
         task.setResourcePath(path.join( __dirname, 'task.json'));
-        task.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common-v4/module.json'));
+        task.setResourcePath(path.join( __dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
         // Get all task input parameters
         mysqlTaskParameter = new MysqlTaskParameter();
         task.debug('parsed task inputs');

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
@@ -124,10 +124,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-webdeployment-common-v4": {
+    "azure-pipelines-tasks-webdeployment-common": {
       "version": "4.210.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common-v4/-/azure-pipelines-tasks-webdeployment-common-v4-4.210.0.tgz",
-      "integrity": "sha512-vJc1WjLkLyOyqc1o312auvswvp8t2uMdKCmyuWEy1Zxd+OZnU3t7n1ccx1K2x4rJouOQbjCnVnrVGyOa4uozlw==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.210.0.tgz",
+      "integrity": "sha512-81MaOu4dJ5MCWMkZgslpwQVbW2mZNeNiC2oSzAXsrJKSv5RaVa+/D3ctnDL+CXDdIkgVDBeLlQ2b37bqg9653Q==",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
@@ -28,7 +28,7 @@
     "tar-stream": "1.5.2",
     "winreg": "1.2.2",
     "zip-stream": "1.1.0",
-    "azure-pipelines-tasks-webdeployment-common-v4": "4.210.0"
+    "azure-pipelines-tasks-webdeployment-common": "4.210.0"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/sql/MysqlClient.ts
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/sql/MysqlClient.ts
@@ -3,7 +3,7 @@ import { ISqlClient } from './ISqlClient';
 import { MysqlTaskParameter } from '../models/MysqlTaskParameter';
 import { Utility } from '../operations/MysqlUtiliy';
 import task = require("azure-pipelines-task-lib/task");
-var packageUtility = require('azure-pipelines-tasks-webdeployment-common-v4/packageUtility.js');
+var packageUtility = require('azure-pipelines-tasks-webdeployment-common/packageUtility.js');
 import Q = require('q');
 
 export class MysqlClient implements ISqlClient {

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 211,
+        "Minor": 215,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 211,
+    "Minor": 215,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
Access to [webdeployment-common](https://www.npmjs.com/package/azure-pipelines-tasks-webdeployment-common) npm package was lost a year ago, so [webdeployment-common-v4](https://www.npmjs.com/package/azure-pipelines-tasks-webdeployment-common-v4) version was created.
Now we have access to the original package back.

Missed versions were re-published to the original azure-pipelines-tasks-webdeployment-common.

Replaced `webdeployment-common-v4` with `webdeployment-common` in task dependencies:

- AzureMysqlDeploymentV1
- AzureRmWebAppDeploymentV4
- AzureSpringCloudV0
- FileTransformV1
- FileTransformV2
- IISWebAppDeploymentOnMachineGroupV0
- MysqlDeploymentOnMachineGroupV1

> Note: The source code of the webdeployment-common is now located in a new common [repository](https://github.com/microsoft/azure-pipelines-tasks-common-packages/tree/main/common-npm-packages), so webdeployment-common-v4 will be deprecated. We are going to migrate all common npm packages to this repo.

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
