### PR TITLE
[Localization] Remove common-packages-utility-common-v2 from LocProject

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -34,12 +34,6 @@
           },
           {
             "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
-            "SourceFile": "common-npm-packages\\utility-common-v2\\Strings\\resources.resjson\\en-US\\resources.resjson",
-            "CopyOption": "LangIDOnPath",
-            "OutputPath": "common-npm-packages\\utility-common-v2\\Strings\\resources.resjson"
-          },
-          {
-            "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
             "SourceFile": "Tasks\\AndroidSigningV2\\Strings\\resources.resjson\\en-US\\resources.resjson",
             "CopyOption": "LangIDOnPath",
             "OutputPath": "Tasks\\AndroidSigningV2\\Strings\\resources.resjson"


### PR DESCRIPTION
This PR removes `common-npm-packages\utility-common-v2\` from the LocProject file to unblock the translation pipeline.