### PR TITLE
Updating Node16 to 16.17.1 version in make-util.js

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -332,7 +332,7 @@ exports.ensureTool = ensureTool;
 var installNode = function (nodeVersion) {
     switch (nodeVersion || '') {
         case '16':
-            nodeVersion = 'v16.15.1';
+            nodeVersion = 'v16.17.1';
             break;
         case '14':
             nodeVersion = 'v14.10.1';


### PR DESCRIPTION
**Description**: 
The current version of NodeJS (16.15.1) has vulnerabilities which have already been fixed in 16.17.1 NodeJS security release. NodeJS has already updated in the agent (https://github.com/microsoft/azure-pipelines-agent/pull/4084).

**Changes description**:
Node16 version in make-util.js updated to 16.17.1

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/3880

**Checklist**:
- [x] Checked that applied changes work as expected
