### PR TITLE
Increase build all tasks ci job timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,9 +45,9 @@ jobs:
   - job: build_all_windows
     displayName: Build all tasks (Windows)
     condition: eq(variables.os, 'Windows_NT')
+    timeoutInMinutes: 240
     pool:
       vmImage: windows-2022
-    timeoutInMinutes: 120
     steps:
     - template: ci/build-all-steps.yml
       parameters:
@@ -92,6 +92,7 @@ jobs:
   - job: build_all_linux
     displayName: Build all tasks (Linux)
     condition: eq(variables.os, 'Linux')
+    timeoutInMinutes: 240
     pool:
       vmImage: ubuntu-18.04
     steps:
@@ -103,6 +104,7 @@ jobs:
   - job: build_all_darwin
     displayName: Build all tasks (macOS)
     condition: eq(variables.os, 'Darwin')
+    timeoutInMinutes: 240
     pool:
       vmImage: macos-11
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
   - job: build_all_windows
     displayName: Build all tasks (Windows)
     condition: eq(variables.os, 'Windows_NT')
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     pool:
       vmImage: windows-2022
     steps:
@@ -92,7 +92,7 @@ jobs:
   - job: build_all_linux
     displayName: Build all tasks (Linux)
     condition: eq(variables.os, 'Linux')
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     pool:
       vmImage: ubuntu-18.04
     steps:
@@ -104,7 +104,7 @@ jobs:
   - job: build_all_darwin
     displayName: Build all tasks (macOS)
     condition: eq(variables.os, 'Darwin')
-    timeoutInMinutes: 240
+    timeoutInMinutes: 180
     pool:
       vmImage: macos-11
     steps:


### PR DESCRIPTION
**Description:** this PR increases the timeout of jobs in the CI for building tasks on Windows, Linux, and macOS.
