### PR TITLE
Revert "[AzureCLIV1] Update task-lib"

### DIFF
--- a/Tasks/AzureCLIV1/package-lock.json
+++ b/Tasks/AzureCLIV1/package-lock.json
@@ -51,12 +51,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "azure-pipelines-task-lib": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.1.0.tgz",
-      "integrity": "sha512-8CNC9PcP+4eS76QcIDmPmBfrrao9xpy/M0Uts4TWk3chfr3uOXFGf0DYHVTJGF9180g51kyVXYTObicouq0KZQ==",
+      "version": "4.0.0-preview",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.0.0-preview.tgz",
+      "integrity": "sha512-BK+VOo42Bec72Wic6Vsm2MaAJezNyF05OYAQS5FuZJM5Z972lZqYpujtSc4BFKUhC3HO+F/Yf4xhAV2tZCzN9Q==",
       "requires": {
         "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
+        "mockery": "^1.7.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
         "shelljs": "^0.8.5",
@@ -282,9 +282,9 @@
       }
     },
     "mockery": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha512-gUQA33ayi0tuAhr/rJNZPr7Q7uvlBt4gyJPbi0CDcAfIzIrDu1YgGMFgmAu3stJqBpK57m7+RxUbcS+pt59fKQ=="
     },
     "object-inspect": {
       "version": "1.12.2",
@@ -320,9 +320,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
-      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.2.0.tgz",
+      "integrity": "sha512-+CMAlLHqwRYwBMXKCP+o8ns7DN+xHDUiI+0nArsiJ9y+kJVPLFxEaSw6Ha9s9H0tftxg2Yzl25wqj9G7m5wLZg==",
       "requires": {
         "asap": "~2.0.6"
       }

--- a/Tasks/AzureCLIV1/package.json
+++ b/Tasks/AzureCLIV1/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "azure-pipelines-task-lib": "^4.1.0",
+    "azure-pipelines-task-lib": "^4.0.0-preview",
     "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7",
     "@types/q": "1.0.7"

--- a/Tasks/AzureCLIV1/task.json
+++ b/Tasks/AzureCLIV1/task.json
@@ -20,7 +20,7 @@
     "version": {
         "Major": 1,
         "Minor": 213,
-        "Patch": 1
+        "Patch": 0
     },
     "minimumAgentVersion": "2.0.0",
     "instanceNameFormat": "Azure CLI $(scriptPath)",

--- a/Tasks/AzureCLIV1/task.loc.json
+++ b/Tasks/AzureCLIV1/task.loc.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 1,
     "Minor": 213,
-    "Patch": 1
+    "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
Reverts microsoft/azure-pipelines-tasks#17488 
Since the hotfix was postponed. The task override is enough for now. See the [discussion](https://teams.microsoft.com/l/message/19:6acc33ecc58b432ba572f44cdc7f5ea9@thread.tacv2/1671115190119?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4802c244-888f-4d31-a20f-cc5070e9a374&parentMessageId=1670998672170&teamName=Azure%20DevOps&channelName=Akvelon%20Pipelines&createdTime=1671115190119&allowXTenantAccess=false)

