### PR TITLE
Fixed PATH leak

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -628,6 +628,10 @@ var addPath = function (directory) {
 
     var existing = process.env['PATH'];
     if (existing) {
+        // move directory to top
+        if (existing.indexOf(directory) !== -1) {
+            existing = existing.replace(directory + separator, '');
+        }
         process.env['PATH'] = directory + separator + existing;
     }
     else {


### PR DESCRIPTION
**Description**: The main problem is that if we switch nodejs handlers we put them on the top of the path, and because of it PATH becomes too long, instead of it we could just look if we already have a directory in the PATH and push it to the top;