### PR TITLE
CI — the `build_single_task` job — generate the hotfix artifact and to push to the NuGet feed at the same time

### DIFF
--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -52,7 +52,7 @@ steps:
     searchFolder: $(System.DefaultWorkingDirectory)/testresults
 
 # Stage tasks individually into the package directory
-- script: node ./ci/stage-package.js ${{ not(parameters.push) }} individually
+- script: node ./ci/stage-package.js true individually
   displayName: Stage tasks individually into the package directory
 
 # Sign task zip as nuget package
@@ -61,22 +61,20 @@ steps:
     layoutRoot: $(Build.SourcesDirectory)\_package\tasks-layout
 
 # Stage all the tasks into a single zip for upload
-- script: node ./ci/stage-package.js ${{ not(parameters.push) }}
+- script: node ./ci/stage-package.js true
   displayName: Stage all the tasks into a single zip for upload
 
-- ${{ if not(parameters.push) }}:
+# Stage hotfix
+- script: node ./ci/stage-hotfix.js "${{ parameters.task }}"
+  displayName: Stage hotfix
 
-  # Stage hotfix
-  - script: node ./ci/stage-hotfix.js "${{ parameters.task }}"
-    displayName: Stage hotfix
-
-  # Publish hotfix artifact
-  - task: PublishBuildArtifacts@1
-    displayName: Publish hotfix artifact
-    inputs:
-      pathToPublish: _package/hotfix-layout
-      artifactName: hotfix
-      publishLocation: container
+# Publish hotfix artifact
+- task: PublishBuildArtifacts@1
+  displayName: Publish hotfix artifact
+  inputs:
+    pathToPublish: _package/hotfix-layout
+    artifactName: hotfix
+    publishLocation: container
 
 - ${{ if parameters.push }}:
 

--- a/ci/stage-milestone.js
+++ b/ci/stage-milestone.js
@@ -20,12 +20,10 @@ util.expandTasks(artifactZipPath, artifactPath);
 // link the artifact
 fs.readdirSync(artifactPath).forEach(function (itemName) {
     var itemSourcePath = path.join(artifactPath, itemName);
-    if (!fs.lstatSync(itemSourcePath).isDirectory()) {
-        throw new Error(`Expected item to be a directory: ${itemSourcePath}`);
+    if (fs.lstatSync(itemSourcePath).isDirectory()) {
+        var itemDestPath = path.join(util.milestoneLayoutPath, itemName);
+        fs.symlinkSync(itemSourcePath, itemDestPath, 'junction');
     }
-
-    var itemDestPath = path.join(util.milestoneLayoutPath, itemName);
-    fs.symlinkSync(itemSourcePath, itemDestPath, 'junction');
 });
 
 // create the nuspec file


### PR DESCRIPTION
**Description:** adding the ability to run the pipeline once instead of twice during the hotfix process, to generate the hotfix artifact, and to push to the NuGet feed, at the same time.