### PR TITLE
Upgrade GradleV3 to NodeJS16

### DIFF
--- a/Tasks/GradleV3/package-lock.json
+++ b/Tasks/GradleV3/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-dVL3RISC1jdrXilyqmPIga6LmjHwrDbWQoUyHuf/bGjP+HiNtyFJ3Gga1FCu55UYOqbuUGLPzkGkcsplkpSm8Q=="
     },
     "@types/concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "requires": {
         "@types/node": "*"
       }
@@ -20,7 +20,7 @@
     "@types/form-data": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
       "requires": {
         "@types/node": "*"
       }
@@ -31,9 +31,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "10.17.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
-      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
+      "version": "16.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.10.tgz",
+      "integrity": "sha512-XU1+v7h81p7145ddPfjv7jtWvkSilpcnON3mQ+bDi9Yuf7OI56efOglXRyXWgQ57xH3fEQgh7WOJMncRHVew5w=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -41,9 +41,9 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/semver": {
       "version": "7.3.9",
@@ -64,7 +64,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -95,17 +95,27 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "azure-pipelines-task-lib": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.6.tgz",
-      "integrity": "sha512-aOHWzKt0EdTv+o3dTDx80T4AVtLH94iqtJxC7PozATiKH4iVi4Jgt+phV/4KfmnYNHSv/RxKIW9GcNFWFKh7Ug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.1.0.tgz",
+      "integrity": "sha512-8CNC9PcP+4eS76QcIDmPmBfrrao9xpy/M0Uts4TWk3chfr3uOXFGf0DYHVTJGF9180g51kyVXYTObicouq0KZQ==",
       "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+        "minimatch": "3.0.5",
+        "mockery": "^2.1.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
+        "shelljs": "^0.8.5",
         "sync-request": "6.1.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "azure-pipelines-tasks-codeanalysis-common": {
@@ -124,6 +134,35 @@
         "xml2js": "^0.4.17"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
+          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
+          "requires": {
+            "minimatch": "3.0.5",
+            "mockery": "^2.1.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.5",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+              "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
         "glob": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
@@ -155,6 +194,25 @@
         "xml2js": "^0.4.17"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
+          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
+          "requires": {
+            "minimatch": "3.0.5",
+            "mockery": "^2.1.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          }
+        },
         "cheerio": {
           "version": "1.0.0-rc.6",
           "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.6.tgz",
@@ -166,6 +224,14 @@
             "htmlparser2": "^6.1.0",
             "parse5": "^6.0.1",
             "parse5-htmlparser2-tree-adapter": "^6.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -181,6 +247,40 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
+          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
+          "requires": {
+            "minimatch": "3.0.5",
+            "mockery": "^2.1.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -219,9 +319,18 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "caseless": {
       "version": "0.12.0",
@@ -417,10 +526,20 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -470,6 +589,11 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -498,6 +622,13 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "http-signature": {
@@ -530,9 +661,9 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -545,7 +676,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "isstream": {
       "version": "0.1.2",
@@ -629,9 +760,9 @@
       }
     },
     "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
     },
     "nth-check": {
       "version": "2.1.1",
@@ -645,6 +776,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
     "once": {
       "version": "1.4.0",
@@ -662,7 +798,7 @@
     "parse-cache-control": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "parse5": {
       "version": "6.0.1",
@@ -698,9 +834,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "promise": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "requires": {
         "asap": "~2.0.6"
       }
@@ -718,12 +854,15 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -839,6 +978,16 @@
         "rechoir": "^0.6.2"
       }
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "sshpk": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
@@ -946,7 +1095,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
       "version": "4.0.2",
@@ -965,7 +1114,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/Tasks/GradleV3/package.json
+++ b/Tasks/GradleV3/package.json
@@ -8,9 +8,9 @@
     "url": "https://github.com/Microsoft/vso-agent-tasks/issues"
   },
   "dependencies": {
-    "@types/node": "^10.17.0",
+    "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7",
-    "azure-pipelines-task-lib": "^3.1.6",
+    "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tasks-codecoverage-tools": "2.201.0",
     "azure-pipelines-tasks-java-common": "2.198.1",
     "azure-pipelines-tasks-codeanalysis-common": "2.0.3"

--- a/Tasks/GradleV3/task.json
+++ b/Tasks/GradleV3/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 208,
+        "Minor": 216,
         "Patch": 0
     },
     "releaseNotes": "Configuration of the SonarQube analysis was moved to the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarqube) or [SonarCloud](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarcloud) extensions, in task `Prepare Analysis Configuration`",
@@ -377,6 +377,10 @@
     "instanceNameFormat": "gradlew $(tasks)",
     "execution": {
         "Node10": {
+            "target": "gradletask.js",
+            "argumentFormat": ""
+        },
+        "Node16": {
             "target": "gradletask.js",
             "argumentFormat": ""
         }

--- a/Tasks/GradleV3/task.loc.json
+++ b/Tasks/GradleV3/task.loc.json
@@ -6,12 +6,17 @@
   "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/build/gradle",
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "category": "Build",
-  "visibility": ["Build"],
-  "runsOn": ["Agent", "DeploymentGroup"],
+  "visibility": [
+    "Build"
+  ],
+  "runsOn": [
+    "Agent",
+    "DeploymentGroup"
+  ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 208,
+    "Minor": 216,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -42,7 +47,9 @@
   "inputs": [
     {
       "name": "wrapperScript",
-      "aliases": ["gradleWrapperFile"],
+      "aliases": [
+        "gradleWrapperFile"
+      ],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.wrapperScript",
       "defaultValue": "gradlew",
@@ -51,7 +58,9 @@
     },
     {
       "name": "cwd",
-      "aliases": ["workingDirectory"],
+      "aliases": [
+        "workingDirectory"
+      ],
       "type": "filePath",
       "label": "ms-resource:loc.input.label.cwd",
       "defaultValue": "",
@@ -103,7 +112,9 @@
     },
     {
       "name": "codeCoverageTool",
-      "aliases": ["codeCoverageToolOption"],
+      "aliases": [
+        "codeCoverageToolOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.codeCoverageTool",
       "required": false,
@@ -118,7 +129,9 @@
     },
     {
       "name": "classFilesDirectories",
-      "aliases": ["codeCoverageClassFilesDirectories"],
+      "aliases": [
+        "codeCoverageClassFilesDirectories"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilesDirectories",
       "defaultValue": "build/classes/main/",
@@ -129,7 +142,9 @@
     },
     {
       "name": "classFilter",
-      "aliases": ["codeCoverageClassFilter"],
+      "aliases": [
+        "codeCoverageClassFilter"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.classFilter",
       "defaultValue": "",
@@ -140,7 +155,9 @@
     },
     {
       "name": "failIfCoverageEmpty",
-      "aliases": ["codeCoverageFailIfEmpty"],
+      "aliases": [
+        "codeCoverageFailIfEmpty"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.failIfCoverageEmpty",
       "defaultValue": "false",
@@ -151,7 +168,9 @@
     },
     {
       "name": "gradle5xOrHigher",
-      "aliases": ["codeCoverageGradle5xOrHigher"],
+      "aliases": [
+        "codeCoverageGradle5xOrHigher"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.gradle5xOrHigher",
       "defaultValue": "true",
@@ -162,7 +181,9 @@
     },
     {
       "name": "javaHomeSelection",
-      "aliases": ["javaHomeOption"],
+      "aliases": [
+        "javaHomeOption"
+      ],
       "type": "radio",
       "label": "ms-resource:loc.input.label.javaHomeSelection",
       "required": true,
@@ -176,7 +197,9 @@
     },
     {
       "name": "jdkVersion",
-      "aliases": ["jdkVersionOption"],
+      "aliases": [
+        "jdkVersionOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkVersion",
       "required": false,
@@ -196,7 +219,9 @@
     },
     {
       "name": "jdkUserInputPath",
-      "aliases": ["jdkDirectory"],
+      "aliases": [
+        "jdkDirectory"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.jdkUserInputPath",
       "required": true,
@@ -207,7 +232,9 @@
     },
     {
       "name": "jdkArchitecture",
-      "aliases": ["jdkArchitectureOption"],
+      "aliases": [
+        "jdkArchitectureOption"
+      ],
       "type": "pickList",
       "label": "ms-resource:loc.input.label.jdkArchitecture",
       "defaultValue": "x64",
@@ -222,7 +249,9 @@
     },
     {
       "name": "gradleOpts",
-      "aliases": ["gradleOptions"],
+      "aliases": [
+        "gradleOptions"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.gradleOpts",
       "required": false,
@@ -232,7 +261,9 @@
     },
     {
       "name": "sqAnalysisEnabled",
-      "aliases": ["sonarQubeRunAnalysis"],
+      "aliases": [
+        "sonarQubeRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.sqAnalysisEnabled",
       "required": true,
@@ -256,7 +287,9 @@
     },
     {
       "name": "sqGradlePluginVersion",
-      "aliases": ["sonarQubeGradlePluginVersion"],
+      "aliases": [
+        "sonarQubeGradlePluginVersion"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.sqGradlePluginVersion",
       "required": true,
@@ -267,7 +300,9 @@
     },
     {
       "name": "checkstyleAnalysisEnabled",
-      "aliases": ["checkStyleRunAnalysis"],
+      "aliases": [
+        "checkStyleRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.checkstyleAnalysisEnabled",
       "required": false,
@@ -277,7 +312,9 @@
     },
     {
       "name": "findbugsAnalysisEnabled",
-      "aliases": ["findBugsRunAnalysis"],
+      "aliases": [
+        "findBugsRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.findbugsAnalysisEnabled",
       "required": false,
@@ -287,7 +324,9 @@
     },
     {
       "name": "pmdAnalysisEnabled",
-      "aliases": ["pmdRunAnalysis"],
+      "aliases": [
+        "pmdRunAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.pmdAnalysisEnabled",
       "required": false,
@@ -297,7 +336,9 @@
     },
     {
       "name": "spotBugsAnalysisEnabled",
-      "aliases": ["spotBugsAnalysis"],
+      "aliases": [
+        "spotBugsAnalysis"
+      ],
       "type": "boolean",
       "label": "ms-resource:loc.input.label.spotBugsAnalysisEnabled",
       "required": true,
@@ -321,7 +362,9 @@
     },
     {
       "name": "spotbugsGradlePluginVersion",
-      "aliases": ["spotbugsGradlePluginVersion"],
+      "aliases": [
+        "spotbugsGradlePluginVersion"
+      ],
       "type": "string",
       "label": "ms-resource:loc.input.label.spotbugsGradlePluginVersion",
       "required": true,
@@ -334,6 +377,10 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
+      "target": "gradletask.js",
+      "argumentFormat": ""
+    },
+    "Node16": {
       "target": "gradletask.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
**Task name**: GradleV3 

**Description**: 
- Bumped task version
- Updated packages
- Added node 16 execution handler

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/build-task-team/issues/3956

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
