### PR TITLE
Added relevant message to JavaToolInstaller

### DIFF
--- a/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
+++ b/Tasks/JavaToolInstallerV0/FileExtractor/JavaFilesExtractor.ts
@@ -200,7 +200,9 @@ export class JavaFilesExtractor {
                 rootDirectoriesArray.push(rootItem);
             }
         });
-
+        if(rootDirectoriesArray.length == 0) {
+            throw new Error(taskLib.loc('WrongArchiveFile'));
+        }
         let jdkDirectory: string;
         if (rootDirectoriesArray.find(dir => dir === BIN_FOLDER)){
             jdkDirectory = pathToStructure;

--- a/Tasks/JavaToolInstallerV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/JavaToolInstallerV0/Strings/resources.resjson/en-US/resources.resjson
@@ -56,6 +56,7 @@
   "loc.messages.JavaNotPreinstalled": "Java %s is not preinstalled on this agent",
   "loc.messages.UsePreinstalledJava": "Use preinstalled JDK from %s",
   "loc.messages.WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside.",
+  "loc.messages.WrongArchiveFile": "Archive file is wrong. There is not any folder which contains JDK",
   "loc.messages.ShareAccessError": "Network shared resource not available: (%s)",
   "loc.messages.UnsupportedDMGStructure": "JDK file is not supported. Verify if JDK file contains exactly one folder inside.",
   "loc.messages.NoPKGFile": "Could not find PKG file.",

--- a/Tasks/JavaToolInstallerV0/package-lock.json
+++ b/Tasks/JavaToolInstallerV0/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "java-tool-installer",
-    "version": "0.211.0",
+    "version": "0.216.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/Tasks/JavaToolInstallerV0/package-lock.json
+++ b/Tasks/JavaToolInstallerV0/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "java-tool-installer",
-    "version": "0.216.0",
+    "private": true,
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/Tasks/JavaToolInstallerV0/package.json
+++ b/Tasks/JavaToolInstallerV0/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-tool-installer",
-    "version": "0.216.0",
+    "private":"true",
     "description": "Java Tool Installer",
     "main": "javaToolInstaller.js",
     "scripts": {

--- a/Tasks/JavaToolInstallerV0/package.json
+++ b/Tasks/JavaToolInstallerV0/package.json
@@ -1,6 +1,6 @@
 {
     "name": "java-tool-installer",
-    "version": "0.211.0",
+    "version": "0.216.0",
     "description": "Java Tool Installer",
     "main": "javaToolInstaller.js",
     "scripts": {

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 211,
+        "Minor": 216,
         "Patch": 0
     },
     "satisfies": [
@@ -204,6 +204,7 @@
         "JavaNotPreinstalled": "Java %s is not preinstalled on this agent",
         "UsePreinstalledJava": "Use preinstalled JDK from %s",
         "WrongArchiveStructure": "JDK file is not valid. Verify if JDK file contains only one root folder with 'bin' inside.",
+        "WrongArchiveFile": "Archive file is wrong. There is not any folder which contains JDK",
         "ShareAccessError": "Network shared resource not available: (%s)",
         "UnsupportedDMGStructure": "JDK file is not supported. Verify if JDK file contains exactly one folder inside.",
         "NoPKGFile": "Could not find PKG file.",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 211,
+    "Minor": 216,
     "Patch": 0
   },
   "satisfies": [
@@ -204,6 +204,7 @@
     "JavaNotPreinstalled": "ms-resource:loc.messages.JavaNotPreinstalled",
     "UsePreinstalledJava": "ms-resource:loc.messages.UsePreinstalledJava",
     "WrongArchiveStructure": "ms-resource:loc.messages.WrongArchiveStructure",
+    "WrongArchiveFile": "ms-resource:loc.messages.WrongArchiveFile",
     "ShareAccessError": "ms-resource:loc.messages.ShareAccessError",
     "UnsupportedDMGStructure": "ms-resource:loc.messages.UnsupportedDMGStructure",
     "NoPKGFile": "ms-resource:loc.messages.NoPKGFile",


### PR DESCRIPTION
**Task name**: Add error message to JavaToolInstallerV0

**Description**:  When archive folder doesn't contain correct structure the exception throws with non-relevant message

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
