### PR TITLE
AzureKeyVault@2 remove duplicate %AZP25 encoding

### DIFF
--- a/Tasks/AzureKeyVaultV2/operations/KeyVault.ts
+++ b/Tasks/AzureKeyVaultV2/operations/KeyVault.ts
@@ -6,8 +6,6 @@ import tl = require("azure-pipelines-task-lib/task");
 import * as path from 'path';
 import * as fs from 'fs';
 
-const DECODE_PERCENTS = "DECODE_PERCENTS";
-
 export class SecretsToErrorsMapping {
     public errorsMap: { [key: string]: string; };
 
@@ -184,13 +182,6 @@ export class KeyVault {
     private setVaultVariable(secretName: string, secretValue: string): void {
         if (!secretValue) {
             return;
-        }
-
-        // Encode percent explicitely as the task lib does not encode % to %AZP25 as of now.
-        let decodePercents = tl.getVariable(DECODE_PERCENTS);
-        if (decodePercents && decodePercents.toUpperCase() === "TRUE") {
-            secretName = secretName.replace(/%/g, '%AZP25');
-            secretValue = secretValue.replace(/%/g, '%AZP25');
         }
 
         // Support multiple stages using different key vaults with the same secret name but with different version identifiers

--- a/Tasks/AzureKeyVaultV2/task-runner.ts
+++ b/Tasks/AzureKeyVaultV2/task-runner.ts
@@ -4,8 +4,6 @@ import path = require("path");
 import keyVaultTaskParameters = require("./models/KeyVaultTaskParameters");
 import keyVault = require("./operations/KeyVault");
 
-const DECODE_PERCENTS = "DECODE_PERCENTS";
-
 export class TaskRunner {
     public static async runInContext(isPreJobContext: boolean): Promise<void> {
         const runAsPreJob: boolean = tl.getBoolInput('RunAsPreJob', true);
@@ -21,13 +19,6 @@ export class TaskRunner {
             const taskManifestPath = path.join(__dirname, "task.json");
             tl.debug("Setting resource path to " + taskManifestPath);
             tl.setResourcePath(taskManifestPath);
-
-            // Decode percent in agent
-            let decodePercents = tl.getVariable(DECODE_PERCENTS);
-            if (!decodePercents) {
-                tl.debug("Setting DECODE_PERCENTS as true to decode %AZP25 to %");
-                tl.setVariable(DECODE_PERCENTS, "True", false);
-            }
 
             const secretsToErrorsMap = new keyVault.SecretsToErrorsMapping();
             const vaultParameters = new keyVaultTaskParameters.KeyVaultTaskParameters();

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 216,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureKeyVaultV2/task.loc.json
+++ b/Tasks/AzureKeyVaultV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 216,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",


### PR DESCRIPTION
**Task name**: AzureKeyVault@2

**Description**: 

This issue occurs on both release and build pipelines. In general the problem is that since certain moment build agents started to require % character coming in as values of variables be encoded as %AZP25. See more details [here](https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md). Originally this was not done automatically by azure-pipelines-task-lib in `tl.setVartiable`. Thus it was implemented by AzureKeyVault@2 task itself (all % are encoded as %AZP25 before calling `setVariable`). Later this functionality was introduced even by azure-pipelines-task-lib so that latest versions of `tl.setVariable` does this [encoding automatically](https://github.com/microsoft/azure-pipelines-task-lib/blob/5f76bee724ad65d0186392fd2407dfd119fa4332/node/taskcommand.ts#L94). Once we have updated AKV task to use the latest version of azure-pipelines-task-lib % character started to be encoded two times. See this example:
1. Original value of variable - "hello%world",
1. Encoded by AKV - "hello%AZP25world" (% was replaced by %AZP25),
1. Encoded by task lib - "hello%AZP25AZP25world" (% was again replaced by %AZP25)
1. When retrieved by tl.GetVariable - "hello%AZP25world" (%AZP25 was replaced by %).

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2019418

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
