### PR TITLE
remove node modules

### DIFF
--- a/make.js
+++ b/make.js
@@ -146,6 +146,8 @@ CLI.build = function() {
         }
     });
 
+    const removeNodeModules = taskList.length > 1;
+
     taskList.forEach(function(taskName) {
         banner('Building: ' + taskName);
         var taskPath = path.join(tasksPath, taskName);
@@ -294,6 +296,22 @@ CLI.build = function() {
         console.log();
         console.log('> copying task resources');
         copyTaskResources(taskMake, taskPath, outDir);
+
+        if (removeNodeModules) {
+            const taskNodeModulesPath = path.join(taskPath, 'node_modules');
+
+            if (fs.existsSync(taskNodeModulesPath)) {
+                console.log('\n> removing node modules');
+                rm('-Rf', taskNodeModulesPath);
+            }
+
+            const taskTestsNodeModulesPath = path.join(taskPath, 'Tests', 'node_modules');
+
+            if (fs.existsSync(taskTestsNodeModulesPath)) {
+                console.log('\n> removing task tests node modules');
+                rm('-Rf', taskTestsNodeModulesPath);
+            }
+        }
     });
 
     banner('Build successful', true);


### PR DESCRIPTION
**Area:** CI

**Description:**
We have to remove `node_modules` from tasks sources folders when running the `node make.js build` command.
It is not necessary if a single task is being built.
This will resolve the issue of lack of space for the pipelines agent in the CI.

**Checklist**:
- [x] Checked that applied changes work as expected
