### PR TITLE
Updating m215 versions of AzureKeyVault to republish with dependency update

### DIFF
--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 215,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV1/task.loc.json
+++ b/Tasks/AzureKeyVaultV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 215,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 215,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureKeyVaultV2/task.loc.json
+++ b/Tasks/AzureKeyVaultV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 215,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",


### PR DESCRIPTION
**Task name**: AzureKeyVaultV1/AzureKeyVaultV2

**Description**: Updating m215 versions of AzureKeyVault to republish with dependency update

**Documentation changes required:** N/A

**Added unit tests:** N/A

**Attached related issue:** ICM#360037242

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected **Not needed -- just version bump**
