### PR TITLE
Limiting Write-Host to only multiple jobs

### DIFF
--- a/Tasks/Common/RemoteDeployer/JobHelper.ps1
+++ b/Tasks/Common/RemoteDeployer/JobHelper.ps1
@@ -120,7 +120,9 @@ function Get-JobResults {
                     $jobInfo.JobRetrievelCount = 0
                     $jobState = $job.State.ToString().ToLowerInvariant()
                     Write-Verbose "JobId: '$jobid', JobState: '$jobState', ComputerName: '$computerName'"
-                    Write-Host "================================================ $computerName ================================================"
+                    if($jobsInfo.Count -gt 1) {
+                        Write-Host "================================================ $computerName ================================================"
+                    }
                     Receive-Job -Job $job |
                         ForEach-Object {
                             if($_.VstsRemoteDeployerJobResult -eq $true) { 


### PR DESCRIPTION


**Task name**: Added if condition for Write-Host to limit only when running on multiple target machines.

**Description**: Pipeline output looks ugly when running task PowerShellOnTargetMachines@3 on a single machine.

**Documentation changes required:** N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [<Please add link to related issue here>](https://github.com/microsoft/azure-pipelines-tasks/issues/16086)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
