### PR TITLE
Remove duplicate libraries from ContainerBuildV0

### DIFF
--- a/Tasks/ContainerBuildV0/make.json
+++ b/Tasks/ContainerBuildV0/make.json
@@ -2,9 +2,10 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-arm-rest/node_modules/vsts-task-lib",
+                "node_modules/azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
                 "node_modules/buildctl-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/ContainerBuildV0/task.json
+++ b/Tasks/ContainerBuildV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 216,
-        "Patch": 1
+        "Minor": 217,
+        "Patch": 0
     },
     "demands": [],
     "satisfies": [

--- a/Tasks/ContainerBuildV0/task.loc.json
+++ b/Tasks/ContainerBuildV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 216,
-    "Patch": 1
+    "Minor": 217,
+    "Patch": 0
   },
   "demands": [],
   "satisfies": [


### PR DESCRIPTION
**Task name**: ContainerBuildV0

**Description**: Updated make.json to remove duplicate azure-pipelines-task-lib in azure-arm-rest-v2 and azure-ipelines-tool-lib

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=19194134&view=logs&j=55b94f1c-9d32-5114-bc90-83768ebbe0df&t=de3e29aa-4e66-5d6e-8041-57c3e6769b0f&l=18

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
