### PR TITLE
azure-pipelines-task-lib duplication issue in MSBuildV1

### DIFF
--- a/Tasks/MSBuildV1/make.json
+++ b/Tasks/MSBuildV1/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/msbuildhelpers/node_modules/vsts-task-lib"
+                "node_modules/azure-pipelines-tasks-msbuildhelpers/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 214,
+        "Minor": 217,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 214,
+    "Minor": 217,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
**Task name**: MSBuildV1

**Description**: 
- removed duplicate library(azure-pipelines-task-lib)

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
