### PR TITLE
Hotfix NpmAuhenticateV0 post-job issue

### DIFF
--- a/Tasks/NpmAuthenticateV0/npmauthcleanup.ts
+++ b/Tasks/NpmAuthenticateV0/npmauthcleanup.ts
@@ -7,15 +7,17 @@ import * as path from 'path';
 async function run() {
     tl.setResourcePath(path.join(__dirname, 'task.json'));
     const npmrcPath = tl.getVariable("SAVE_NPMRC_PATH");
+    const workingFilePath = tl.getInput(constants.NpmAuthenticateTaskInput.WorkingFile);
     let indexFile = npmrcPath && path.join(npmrcPath, 'index.json');
-    if (indexFile && tl.exist(indexFile)) {
+    if (indexFile && tl.exist(indexFile) && tl.exist(workingFilePath)) {
         let indexFileText = fs.readFileSync(indexFile, 'utf8');
         let jsonObject = JSON.parse(indexFileText);
         let npmrcIndex = JSON.stringify(jsonObject[tl.getInput(constants.NpmAuthenticateTaskInput.WorkingFile)]);
-        util.restoreFileWithName(tl.getInput(constants.NpmAuthenticateTaskInput.WorkingFile), npmrcIndex, tl.getVariable("SAVE_NPMRC_PATH"));
+        util.restoreFileWithName(workingFilePath, npmrcIndex, tl.getVariable("SAVE_NPMRC_PATH"));
         console.log(tl.loc("RevertedChangesToNpmrc", tl.getInput(constants.NpmAuthenticateTaskInput.WorkingFile)));
-        if (fs.readdirSync(tl.getVariable("SAVE_NPMRC_PATH")).length == 1) {
-            tl.rmRF(tl.getVariable("NPM_AUTHENTICATE_TEMP_DIRECTORY"));
+        const tempDirectoryPath = tl.getVariable("NPM_AUTHENTICATE_TEMP_DIRECTORY");
+        if (tl.exist(tempDirectoryPath) && fs.readdirSync(tl.getVariable("SAVE_NPMRC_PATH")).length == 1) {
+            tl.rmRF(tempDirectoryPath);
         }
     }
     else {

--- a/Tasks/NpmAuthenticateV0/task.json
+++ b/Tasks/NpmAuthenticateV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 216,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NpmAuthenticateV0/task.loc.json
+++ b/Tasks/NpmAuthenticateV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 216,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**:  NpmAuhenticateV0

**Description**: 
The problem occurs when performing a Post-job if some previous task removed working directory of NpmAuthenticate task. The problem appeared after migrating to Node16. On Node10 it was a warning, on Node16 it became an exception.

**Changes**:
- Added the check for existing NpmAuthenticateTaskInput.WorkingFile
- Added the check for existing NPM_AUTHENTICATE_TEMP_DIRECTORY

**Documentation changes required:** N

**Added unit tests:** N

**Related issue**: https://github.com/microsoft/build-task-team/issues/4054

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
