### PR TITLE
Users/mkonjikovac/default callback value

### DIFF
--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Text",
   "loc.input.help.body": "JSON-formatierter Nachrichtentext für die Anforderung.",
   "loc.input.label.waitForCompletion": "Abschlussereignis",
-  "loc.input.help.waitForCompletion": "Standardwert \"ApiResponse\". Mögliche Werte: \"ApiResponse\" bzw. \"Callback\", wenn die Azure-Funktion einen Rückruf zum Aktualisieren des Zeitachsendatensatzes ausführt.",
+  "loc.input.help.waitForCompletion": "Standardwert \"Callback\". Mögliche Werte: \"ApiResponse\" bzw. \"Callback\", wenn die Azure-Funktion einen Rückruf zum Aktualisieren des Zeitachsendatensatzes ausführt.",
   "loc.input.label.successCriteria": "Erfolgskriterien",
   "loc.input.help.successCriteria": "Kriterien, die definieren, wann die Aufgabe übergeben wird. Ohne Kriterium hat der Antwortinhalt keinen Einfluss auf das Ergebnis. Beispiel: Für die Antwort \"{\"status\" : \"successful\"}\" kann der Ausdruck \"eq(root['status'], 'successful')\" lauten. [Weitere Informationen](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/en-US/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Body",
   "loc.input.help.body": "JSON-formatted message body for the request.",
   "loc.input.label.waitForCompletion": "Completion event",
-  "loc.input.help.waitForCompletion": "Default value \"ApiResponse\". Available values: \"ApiResponse\", \"Callback\" call where the Azure function calls back to update the timeline record​.",
+  "loc.input.help.waitForCompletion": "Default value \"Callback\". Available values: \"ApiResponse\", \"Callback\" call where the Azure function calls back to update the timeline record​.",
   "loc.input.label.successCriteria": "Success criteria",
   "loc.input.help.successCriteria": "Criteria which defines when to pass the task. No criteria means the response content does not influence the result. Example:- For response {\"status\" : \"successful\"}, the expression can be eq(root['status'], 'successful'). [More information](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Cuerpo",
   "loc.input.help.body": "Cuerpo del mensaje con formato JSON de la solicitud.",
   "loc.input.label.waitForCompletion": "Evento de finalización",
-  "loc.input.help.waitForCompletion": "Valor predeterminado \"ApiResponse\". Valores disponibles: llamada \"ApiResponse\" o \"Callback\" donde la función devuelve la llamada para actualizar el registro de la escala de tiempo.",
+  "loc.input.help.waitForCompletion": "Valor predeterminado \"Callback\". Valores disponibles: llamada \"ApiResponse\" o \"Callback\" donde la función devuelve la llamada para actualizar el registro de la escala de tiempo.",
   "loc.input.label.successCriteria": "Criterios de éxito",
   "loc.input.help.successCriteria": "Criterios que definen cuándo se debe pasar la tarea. Si no hay ningún criterio, significa que el contenido de la respuesta no influye en el resultado. Ejemplo: para la respuesta {\"status\" : \"successful\"}, la expresión puede ser eq(root['status'], 'successful'). [Más información](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Corps",
   "loc.input.help.body": "Corps du message de la requête au format JSON.",
   "loc.input.label.waitForCompletion": "Événement de complétion",
-  "loc.input.help.waitForCompletion": "La valeur par défaut est \"ApiResponse\". Valeurs disponibles : \"ApiResponse\", \"Callback\" quand la fonction Azure effectue un rappel pour mettre à jour l'enregistrement de chronologie​.",
+  "loc.input.help.waitForCompletion": "La valeur par défaut est \"Callback\". Valeurs disponibles : \"ApiResponse\", \"Callback\" quand la fonction Azure effectue un rappel pour mettre à jour l'enregistrement de chronologie​.",
   "loc.input.label.successCriteria": "Critères de réussite",
   "loc.input.help.successCriteria": "Critères qui définissent la réussite de la tâche. L'absence de critères signifie que le contenu de la réponse n'influence pas le résultat. Exemple : - Pour une réponse de type {\"état\" : \"réussite\"}, l'expression peut être eq(root['état'], 'réussite'). [Plus d'informations](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Corpo",
   "loc.input.help.body": "Corpo del messaggio in formato JSON per la richiesta.",
   "loc.input.label.waitForCompletion": "Evento di completamento",
-  "loc.input.help.waitForCompletion": "Valore predefinito \"ApiResponse\". I valori disponibili sono \"ApiResponse\" e \"Callback\", ovvero una chiamata in cui viene richiamata la funzione di Azure per aggiornare il record della sequenza temporale.",
+  "loc.input.help.waitForCompletion": "Valore predefinito \"Callback\". I valori disponibili sono \"ApiResponse\" e \"Callback\", ovvero una chiamata in cui viene richiamata la funzione di Azure per aggiornare il record della sequenza temporale.",
   "loc.input.label.successCriteria": "Criteri di superamento",
   "loc.input.help.successCriteria": "Criteri che consentono di definire quando passare l'attività. L'assenza di criteri indica che il contenuto della risposta non influisce sul risultato. Esempio: per la risposta {\"status\" : \"successful\"}, l'espressione può essere eq(root['status'], 'successful'). [Altre informazioni](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "本文",
   "loc.input.help.body": "要求の JSON 形式のメッセージ本文です。",
   "loc.input.label.waitForCompletion": "完了イベント",
-  "loc.input.help.waitForCompletion": "既定値は \"ApiResponse\"。使用可能な値: \"ApiResponse\"、\"Callback\" 呼び出し (タイムライン レコードを更新するために Azure の関数をコールバックする場合)。",
+  "loc.input.help.waitForCompletion": "既定値は \"Callback\"。使用可能な値: \"ApiResponse\"、\"Callback\" 呼び出し (タイムライン レコードを更新するために Azure の関数をコールバックする場合)。",
   "loc.input.label.successCriteria": "成功の条件",
   "loc.input.help.successCriteria": "タスクを渡す場合を定義する条件。条件を指定しない場合は、応答コンテンツは結果に影響しないことを意味します。例: 応答 {\"status\" : \"successful\"} に対して、式は eq(root['status'], 'successful') になります。[詳細情報](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "본문",
   "loc.input.help.body": "요청에 대한 JSON 형식의 메시지 본문입니다.",
   "loc.input.label.waitForCompletion": "완료 이벤트",
-  "loc.input.help.waitForCompletion": "기본값은 \"ApiResponse\"입니다. 사용 가능한 값: \"ApiResponse\", \"Callback\" 호출(Azure 함수가 타임라인 레코드를 업데이트하기 위해 콜백하는 경우).",
+  "loc.input.help.waitForCompletion": "기본값은 \"Callback\"입니다. 사용 가능한 값: \"ApiResponse\", \"Callback\" 호출(Azure 함수가 타임라인 레코드를 업데이트하기 위해 콜백하는 경우).",
   "loc.input.label.successCriteria": "성공 조건",
   "loc.input.help.successCriteria": "작업을 전달하는 시기를 정의하는 조건입니다. 조건이 없으면 응답 콘텐츠가 결과에 영향을 주지 않습니다. 예: - 응답이 {\"status\" : \"successful\"}인 경우 식은 eq(root['status'], 'successful')일 수 있습니다. [자세한 정보](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "Текст",
   "loc.input.help.body": "Текст сообщения для запроса в формате JSON.",
   "loc.input.label.waitForCompletion": "Событие завершения",
-  "loc.input.help.waitForCompletion": "Значение по умолчанию — ApiResponse. Доступные значения: ApiResponse, Callback; последнее — вызов, при котором функция Azure совершает обратный вызов, чтобы обновить запись временной шкалы.",
+  "loc.input.help.waitForCompletion": "Значение по умолчанию — Callback. Доступные значения: ApiResponse, Callback; последнее — вызов, при котором функция Azure совершает обратный вызов, чтобы обновить запись временной шкалы.",
   "loc.input.label.successCriteria": "Критерии успеха",
   "loc.input.help.successCriteria": "Условие, которое определяет, когда должна передаваться задача. Отсутствие условия означает, что содержимое ответа не влияет на результат. Пример: для ответа {\"status\" : \"successful\"} выражением может быть eq(root['status'], 'successful'). [Дополнительные сведения](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "正文",
   "loc.input.help.body": "请求的 JSON 格式消息正文。",
   "loc.input.label.waitForCompletion": "完成事件",
-  "loc.input.help.waitForCompletion": "默认值 \"ApiResponse\"。可用值: \"ApiResponse\"，“回调”调用，Azure 函数在其中回调以更新时间线记录。",
+  "loc.input.help.waitForCompletion": "默认值 \"Callback\"。可用值: \"ApiResponse\"，“回调”调用，Azure 函数在其中回调以更新时间线记录。",
   "loc.input.label.successCriteria": "成功标准",
   "loc.input.help.successCriteria": "用于定义何时传递任务的条件。无条件意味着响应内容不会影响结果。示例: - 对于响应 {\"status\" : \"successful\"}，该表达式可以是 eq(root['status'], 'successful')。[详细信息](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -17,7 +17,7 @@
   "loc.input.label.body": "本文",
   "loc.input.help.body": "要求的 JSON 格式訊息本文。",
   "loc.input.label.waitForCompletion": "完成事件",
-  "loc.input.help.waitForCompletion": "預設值 \"ApiResponse\"。可用值: \"ApiResponse\"、\"Callback\" 呼叫，Azure 函式回呼以更新時間軸記錄。",
+  "loc.input.help.waitForCompletion": "預設值 \"Callback\"。可用值: \"ApiResponse\"、\"Callback\" 呼叫，Azure 函式回呼以更新時間軸記錄。",
   "loc.input.label.successCriteria": "成功準則",
   "loc.input.help.successCriteria": "定義何時傳遞工作的準則。沒有準則表示回應內容不會影響結果。範例:- 對於回應 {\"status\" : \"successful\"}，運算式可以是 eq(root['status'], 'successful')。[詳細資訊](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/AzureFunctionV1/task.json
+++ b/Tasks/AzureFunctionV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 217,
         "Patch": 0
     },
     "instanceNameFormat": "Azure Function: $(function)",
@@ -102,9 +102,9 @@
             "name": "waitForCompletion",
             "type": "pickList",
             "label": "Completion event",
-            "defaultValue": "false",
+            "defaultValue": "true",
             "required": true,
-            "helpMarkDown": "Default value \"ApiResponse\". Available values: \"ApiResponse\", \"Callback\" call where the Azure function calls back to update the timeline record​.",
+            "helpMarkDown": "Default value \"Callback\". Available values: \"ApiResponse\", \"Callback\" call where the Azure function calls back to update the timeline record​.",
             "groupName": "completionOptions",
             "options": {
                 "true": "Callback",

--- a/Tasks/AzureFunctionV1/task.loc.json
+++ b/Tasks/AzureFunctionV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 217,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -102,7 +102,7 @@
       "name": "waitForCompletion",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.waitForCompletion",
-      "defaultValue": "false",
+      "defaultValue": "true",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.waitForCompletion",
       "groupName": "completionOptions",

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL-Suffix und Parameter",
   "loc.input.help.urlSuffix": "Die angegebene Zeichenfolge wird an die URL gehängt. Beispiel: Wenn die Dienstverbindungs-URL https:...TestProj/_apis/Release/releases und das URL-Suffix \"/2/environments/1\" lautet, wird die Dienstverbindungs-URL zu https:.../TestProj/_apis/Release/releases/2/environments/1. Wenn das URL-Suffix \"?definitionId=1&releaseCount=1\" lautet, wird die Dienstverbindungs-URL zu https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Abschlussereignis",
-  "loc.input.help.waitForCompletion": "Der Standardwert lautet \"ApiResponse\". Mögliche Werte: \"ApiResponse\" bzw. \"Callback\", wenn die REST-API einen Rückruf zum Aktualisieren des Zeitachsendatensatzes ausführt.",
+  "loc.input.help.waitForCompletion": "Der Standardwert lautet \"Callback\". Mögliche Werte: \"ApiResponse\" bzw. \"Callback\", wenn die REST-API einen Rückruf zum Aktualisieren des Zeitachsendatensatzes ausführt.",
   "loc.input.label.successCriteria": "Erfolgskriterien",
   "loc.input.help.successCriteria": "Kriterien, die definieren, wann die Aufgabe übergeben wird. Ohne Kriterium hat der Antwortinhalt keinen Einfluss auf das Ergebnis. Beispiel: Für die Antwort \"{\"status\" : \"successful\"}\" kann der Ausdruck \"eq(root['status'], 'successful')\" lauten. [Weitere Informationen](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Invoke REST API",
-  "loc.helpMarkDown": "[More information](https://go.microsoft.com/fwlink/?linkid=870236)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=870236)",
   "loc.description": "Invoke a REST API as a part of your pipeline.",
   "loc.instanceNameFormat": "Invoke REST API: $(method)",
   "loc.group.displayName.completionOptions": "Advanced",
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL suffix and parameters",
   "loc.input.help.urlSuffix": "Given string append to the URL. Example: If the service connection URL is https:...TestProj/_apis/Release/releases and the URL suffix is /2/environments/1, the service connection URL becomes https:.../TestProj/_apis/Release/releases/2/environments/1. If the URL suffix is ?definitionId=1&releaseCount=1 then the service connection URL becomes https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Completion event",
-  "loc.input.help.waitForCompletion": "Default value \"ApiResponse\". Available values :  \"ApiResponse\", \"Callback\" call where the REST API calls back to update the timeline record​.",
+  "loc.input.help.waitForCompletion": "Default value \"Callback\". Available values :  \"ApiResponse\", \"Callback\" call where the REST API calls back to update the timeline record​.",
   "loc.input.label.successCriteria": "Success criteria",
   "loc.input.help.successCriteria": "Criteria which defines when to pass the task. No criteria means response content does not influence the result. Example:- For response {\"status\" : \"successful\"}, the expression can be eq(root['status'], 'successful'). [More information](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "Parámetros y sufijo de dirección URL",
   "loc.input.help.urlSuffix": "La cadena especificada se anexa a la dirección URL. Ejemplo: Si la dirección URL de la conexión de servicio es https:...TestProj/_apis/Release/releases and the URL suffix is /2/environments/1, dicha dirección pasa a ser https:.../TestProj/_apis/Release/releases/2/environments/1. Si el sufijo de la dirección URL es ?definitionId=1&releaseCount=1, la dirección URL de la conexión de servicio será https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Evento de finalización",
-  "loc.input.help.waitForCompletion": "Valor predeterminado \"ApiResponse\". Valores disponibles: \"ApiResponse\", llamada \"Callback\" en la que la API de REST devuelve una llamada para actualizar el registro de la escala de tiempo.",
+  "loc.input.help.waitForCompletion": "Valor predeterminado \"Callback\". Valores disponibles: \"ApiResponse\", llamada \"Callback\" en la que la API de REST devuelve una llamada para actualizar el registro de la escala de tiempo.",
   "loc.input.label.successCriteria": "Criterios de éxito",
   "loc.input.help.successCriteria": "Criterios que definen cuándo se debe pasar la tarea. Si no hay ningún criterio, significa que el contenido de la respuesta no influye en el resultado. Ejemplo: Para la respuesta {\"status\" : \"successful\"}, la expresión puede ser eq(root['status'], 'successful'). [Más información](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "Suffixe et paramètres d'URL",
   "loc.input.help.urlSuffix": "La chaîne donnée est ajoutée à l'URL. Exemple : si l'URL de la connexion de service est https:...TestProj/_apis/Release/releases et si le suffixe de l'URL est /2/environments/1, l'URL de la connexion de service devient https:.../TestProj/_apis/Release/releases/2/environments/1. Si le suffixe de l'URL est ?definitionId=1&releaseCount=1 l'URL de la connexion de service devient https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Événement de complétion",
-  "loc.input.help.waitForCompletion": "La valeur par défaut est \"ApiResponse\". Valeurs disponibles : \"ApiResponse\", \"Callback\" quand l'API REST effectue un rappel pour mettre à jour l'enregistrement de chronologie​.",
+  "loc.input.help.waitForCompletion": "La valeur par défaut est \"Callback\". Valeurs disponibles : \"ApiResponse\", \"Callback\" quand l'API REST effectue un rappel pour mettre à jour l'enregistrement de chronologie​.",
   "loc.input.label.successCriteria": "Critères de réussite",
   "loc.input.help.successCriteria": "Critères qui définissent la réussite de la tâche. L'absence de critères signifie que le contenu de la réponse n'influence pas le résultat. Exemple : - Pour une réponse de type {\"état\" : \"réussite\"}, l'expression peut être eq(root['état'], 'réussite'). [Plus d'informations](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "Parametri e suffisso dell'URL",
   "loc.input.help.urlSuffix": "Stringa specificata da accodare all'URL. Esempio: se l'URL della connessione al servizio è https:...TestProj/_apis/Release/releases e il suffisso dell'URL è /2/environments/1, l'URL della connessione al servizio diventerà https:.../TestProj/_apis/Release/releases/2/environments/1. Se il suffisso dell'URL è ?definitionId=1&releaseCount=1, l'URL della connessione al servizio diventerà https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Evento di completamento",
-  "loc.input.help.waitForCompletion": "Valore predefinito \"ApiResponse\". I valori disponibili sono \"ApiResponse\" e \"Callback\", ovvero una chiamata in cui viene richiamata l'API REST per aggiornare il record della sequenza temporale.",
+  "loc.input.help.waitForCompletion": "Valore predefinito \"Callback\". I valori disponibili sono \"ApiResponse\" e \"Callback\", ovvero una chiamata in cui viene richiamata l'API REST per aggiornare il record della sequenza temporale.",
   "loc.input.label.successCriteria": "Criteri di superamento",
   "loc.input.help.successCriteria": "Criteri che consentono di definire quando passare l'attività. L'assenza di criteri indica che il contenuto della risposta non influisce sul risultato. Esempio: per la risposta {\"status\" : \"successful\"}, l'espressione può essere eq(root['status'], 'successful'). [Altre informazioni](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL サフィックスとパラメーター",
   "loc.input.help.urlSuffix": "指定した文字列が URL に追加されます。例: サービス接続 URL が「https:...TestProj/_apis/Release/releases」で、URL サフィックスが「/2/environments/1」の場合、サービス接続 URL は「https:.../TestProj/_apis/Release/releases/2/environments/1」になります。URL サフィックスが「?definitionId=1&releaseCount=1」の場合、サービス接続 URL は「https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1」になります。",
   "loc.input.label.waitForCompletion": "完了イベント",
-  "loc.input.help.waitForCompletion": "既定値は \"ApiResponse\" です。使用可能な値: \"ApiResponse\"、\"Callback\" 呼び出し (REST API によってタイムライン レコードの更新をコールバックする場合)。",
+  "loc.input.help.waitForCompletion": "既定値は \"Callback\" です。使用可能な値: \"ApiResponse\"、\"Callback\" 呼び出し (REST API によってタイムライン レコードの更新をコールバックする場合)。",
   "loc.input.label.successCriteria": "成功の条件",
   "loc.input.help.successCriteria": "いつタスクを渡すかを定義する条件。条件を指定しない場合、応答の内容は結果には影響しません。例: - 応答 {\"status\" : \"successful\"} の場合、式は eq(root['status'], 'successful') とすることができます。[詳細](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL 접미사 및 매개 변수",
   "loc.input.help.urlSuffix": "문자열이 지정되면 URL 뒤에 추가합니다. 예: 서비스 연결 URL이 https:...TestProj/_apis/Release/releases이고 URL 접미사가 /2/environments/1이면 서비스 연결 URL은 https:.../TestProj/_apis/Release/releases/2/environments/1이 됩니다. URL 접미사가 ?definitionId=1&releaseCount=1이면 서비스 연결 URL은 https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1이 됩니다.",
   "loc.input.label.waitForCompletion": "완료 이벤트",
-  "loc.input.help.waitForCompletion": "기본값은 \"ApiResponse\"이고, 사용 가능한 값은 \"ApiResponse\", \"Callback\" 호출(REST API는 타임라인 레코드를 업데이트하기 위해 여기서 콜백함)입니다.",
+  "loc.input.help.waitForCompletion": "기본값은 \"Callback\"이고, 사용 가능한 값은 \"ApiResponse\", \"Callback\" 호출(REST API는 타임라인 레코드를 업데이트하기 위해 여기서 콜백함)입니다.",
   "loc.input.label.successCriteria": "성공 조건",
   "loc.input.help.successCriteria": "작업을 전달하는 시기를 정의하는 조건입니다. 조건이 없으면 응답 콘텐츠가 결과에 영향을 주지 않습니다. 예: - 응답이 {\"status\" : \"successful\"}인 경우 식은 eq(root['status'], 'successful')일 수 있습니다. [자세한 정보](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "Суффикс и параметры URL-адреса",
   "loc.input.help.urlSuffix": "Добавление указанной строки к URL-адресу. Пример: если URL-адрес подключения к службе имеет вид https:...TestProj/_apis/Release/releases, а суффикс URL-адреса — /2/environments/1, URL-адрес подключения к службе принимает вид https:.../TestProj/_apis/Release/releases/2/environments/1. Если суффикс URL-адреса — ?definitionId=1&releaseCount=1, URL-адрес подключения к службе принимает вид https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1.",
   "loc.input.label.waitForCompletion": "Событие завершения",
-  "loc.input.help.waitForCompletion": "Значение по умолчанию: \"ApiResponse\". Доступные значения: \"ApiResponse\", \"Callback\"; последнее — вызов, при котором REST API совершает обратный вызов, чтобы обновить запись временной шкалы.",
+  "loc.input.help.waitForCompletion": "Значение по умолчанию: \"Callback\". Доступные значения: \"ApiResponse\", \"Callback\"; последнее — вызов, при котором REST API совершает обратный вызов, чтобы обновить запись временной шкалы.",
   "loc.input.label.successCriteria": "Критерии успеха",
   "loc.input.help.successCriteria": "Условие, которое определяет, когда должна передаваться задача. Отсутствие условия означает, что содержимое ответа не влияет на результат. Пример: для ответа {\"status\" : \"successful\"} выражением может быть eq(root['status'], 'successful'). [Дополнительные сведения](https://go.microsoft.com/fwlink/?linkid=842996)​"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL 后缀和参数",
   "loc.input.help.urlSuffix": "将给定字符串追加到 URL。例如: 如果服务连接 URL 为 https:...TestProj/_apis/Release/releases，且 URL 后缀为 /2/environments/1，则服务连接 URL 变为 https:.../TestProj/_apis/Release/releases/2/environments/1。如果 URL 后缀为 ?definitionId=1&releaseCount=1，则服务连接 URL 变为 https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1。",
   "loc.input.label.waitForCompletion": "完成事件",
-  "loc.input.help.waitForCompletion": "默认值 \"ApiResponse\"。可用值: \"ApiResponse\"，\"Callback\" 调用 REST API 回调到的位置来更新时间线记录。",
+  "loc.input.help.waitForCompletion": "默认值 \"Callback\"。可用值: \"ApiResponse\"，\"Callback\" 调用 REST API 回调到的位置来更新时间线记录。",
   "loc.input.label.successCriteria": "成功标准",
   "loc.input.help.successCriteria": "定义何时传递任务的条件。无条件意味着响应内容不会影响结果。示例: - 对于响应 {\"status\" : \"successful\"}，该表达式可以是 eq(root['status'], 'successful')。[详细信息](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/InvokeRestApiV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -18,7 +18,7 @@
   "loc.input.label.urlSuffix": "URL 尾碼及參數",
   "loc.input.help.urlSuffix": "附加至 URL 的指定字串。範例: 如果服務連線 URL 是 https:...TestProj/_apis/Release/releases，而 URL 尾碼是 /2/environments/1，服務連線 URL 就會變成 https:.../TestProj/_apis/Release/releases/2/environments/1。如果 URL 尾碼是 ?definitionId=1&releaseCount=1，服務連線 URL 則會變成 https//...TestProj/_apis/Release/releases?definitionId=1&releaseCount=1。",
   "loc.input.label.waitForCompletion": "完成事件",
-  "loc.input.help.waitForCompletion": "預設值 \"ApiResponse\"。可用的值 :  \"ApiResponse\" 和 \"Callback\" 呼叫，REST API 對其回呼以更新時間軸記錄。",
+  "loc.input.help.waitForCompletion": "預設值 \"Callback\"。可用的值 :  \"ApiResponse\" 和 \"Callback\" 呼叫，REST API 對其回呼以更新時間軸記錄。",
   "loc.input.label.successCriteria": "成功準則",
   "loc.input.help.successCriteria": "定義何時傳遞工作的準則。沒有準則表示回應內容不會影響結果。範例:- 若為回應 {\"status\" : \"successful\"}，運算式可以是 eq(root['status'], 'successful')。[詳細資訊](https://go.microsoft.com/fwlink/?linkid=842996)"
 }

--- a/Tasks/InvokeRestApiV1/task.json
+++ b/Tasks/InvokeRestApiV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 217,
         "Patch": 0
     },
     "instanceNameFormat": "Invoke REST API: $(method)",
@@ -126,9 +126,9 @@
             "name": "waitForCompletion",
             "type": "pickList",
             "label": "Completion event",
-            "defaultValue": "false",
+            "defaultValue": "true",
             "required": true,
-            "helpMarkDown": "Default value \"ApiResponse\". Available values :  \"ApiResponse\", \"Callback\" call where the REST API calls back to update the timeline record​.",
+            "helpMarkDown": "Default value \"Callback\". Available values :  \"ApiResponse\", \"Callback\" call where the REST API calls back to update the timeline record​.",
             "groupName": "completionOptions",
             "options": {
                 "true": "Callback",

--- a/Tasks/InvokeRestApiV1/task.loc.json
+++ b/Tasks/InvokeRestApiV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 217,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -126,7 +126,7 @@
       "name": "waitForCompletion",
       "type": "pickList",
       "label": "ms-resource:loc.input.label.waitForCompletion",
-      "defaultValue": "false",
+      "defaultValue": "true",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.waitForCompletion",
       "groupName": "completionOptions",


### PR DESCRIPTION
**Task name**: AzureFunctionV1 and InvokeRestApiV1

**Description**: Default value is changed to Callback insted of ApiResponse for input waitForCompletion

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2002413

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
