### PR TITLE
Revert AzureAppServiceManageV0 to 210 state

### DIFF
--- a/Tasks/AzureAppServiceManageV0/package-lock.json
+++ b/Tasks/AzureAppServiceManageV0/package-lock.json
@@ -4,28 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@azure/msal-common": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-8.0.0.tgz",
-      "integrity": "sha512-KLGVmWoDcpWl/SKb4TZUjWm+l3lim4tUwAAvCM8N8rSHu8r0NtMTySMWBv7d3G8as1SvC4nr3eTae1+9hTp4wg=="
-    },
-    "@azure/msal-node": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.3.tgz",
-      "integrity": "sha512-95fuxbSq/5PNlxWybQID8ShFBMjYSN0XvHUPmelwgsgJiO3F+TN5SpIvjgLGa+aMVAxEYq6TvKXK+I3qm1EMqQ==",
-      "requires": {
-        "@azure/msal-common": "^8.0.0",
-        "jsonwebtoken": "^8.5.1",
-        "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
-      }
-    },
     "@types/concat-stream": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
@@ -43,9 +21,9 @@
       }
     },
     "@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.8.tgz",
+      "integrity": "sha512-zm6xBQpFDIDM6o9r6HSgDeIcLy82TKWctCXEPbJJcXb5AKmi5BNNdLXneixK4lplX3PqIVcwLBCGE/kAGnlD4A==",
       "requires": {
         "@types/node": "*"
       }
@@ -120,11 +98,10 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.213.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.213.0.tgz",
-      "integrity": "sha512-KW0Yw0YcTcArOEcXVNcyKvM/cbNpCgmvluNrcCr/o/Kpf7mlI7t9YeW9Gv+844/LAb5vreg5mPm9GX9XW8mLCA==",
+      "version": "2.208.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-2.208.0.tgz",
+      "integrity": "sha512-pNs84s8A+Us/nd8MyE6zyiwREFJjZR/rI5JIVri2pxXkiJVOw5+bRHYR1CfIAlxq451PuTEgykH0m5tWcBWhOQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.2",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -143,7 +120,7 @@
         "q": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-          "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         }
       }
     },

--- a/Tasks/AzureAppServiceManageV0/package.json
+++ b/Tasks/AzureAppServiceManageV0/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.213.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^2.198.2",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
     "q": "1.4.1",
     "xml2js": "0.4.13"

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 214,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.102.0",
     "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 214,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: Reverting AzureAppServiceManageV0 to 05596e2855cd5645dbf0cd03b6a062865d008073

**Description**: Reverting AzureAppServiceManageV0 to 05596e2855cd5645dbf0cd03b6a062865d008073, bump version to 0.214.1

**Documentation changes required:** N/A

**Added unit tests:** N/A

**Attached related issue:** 361242034

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected - **N/A -- revert needed**
