### PR TITLE
Hotfix - M216 - Revert Update AzureRmWebAppDeploymentV4 to NodeJS 16

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
@@ -40,7 +40,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
     ResourcesTests.ResourcesTests(); 
     
     if (tl.osType().match(/^Win/)) {
-        it('Runs successfully with XML Transformation (L1)', (done:Mocha.Done) => {
+        it('Runs successfully with XML Transformation (L1)', (done:MochaDone) => {
             this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
             let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L1XdtTransform.js");
@@ -53,7 +53,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
             done();
         });
 
-        it('Validate MSDeploy parameters', (done:Mocha.Done) => {
+        it('Validate MSDeploy parameters', (done:MochaDone) => {
             let tp = path.join(__dirname, "..", "node_modules","azure-pipelines-tasks-webdeployment-common","Tests","L0MSDeployUtility.js");
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
             tr.run();
@@ -69,7 +69,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         });
     }
 
-    it('Validate operations.ParameterParserUtility.parse()', (done:Mocha.Done) => {
+    it('Validate operations.ParameterParserUtility.parse()', (done:MochaDone) => {
         let tp = path.join(__dirname, 'L0ParameterParserUtility.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -80,7 +80,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Runs successfully with XML variable substitution', (done:Mocha.Done) => {
+    it('Runs successfully with XML variable substitution', (done:MochaDone) => {
         let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1XmlVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -98,7 +98,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Runs successfully with JSON variable substitution', (done:Mocha.Done) => {
+    it('Runs successfully with JSON variable substitution', (done:MochaDone) => {
         let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1JsonVarSub.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -115,7 +115,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Runs successfully with JSON variable substitution V2', (done:Mocha.Done) => {
+    it('Runs successfully with JSON variable substitution V2', (done:MochaDone) => {
         let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1JsonVarSubV2.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -135,7 +135,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Validate File Encoding', (done:Mocha.Done) => {
+    it('Validate File Encoding', (done:MochaDone) => {
         let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L1ValidateFileEncoding.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -157,7 +157,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('Validate azure-pipelines-tasks-webdeployment-common.utility.copyDirectory()', (done:Mocha.Done) => {
+    it('Validate azure-pipelines-tasks-webdeployment-common.utility.copyDirectory()', (done:MochaDone) => {
         let tp = path.join(__dirname, "..", "node_modules", "azure-pipelines-tasks-webdeployment-common", "Tests", 'L0CopyDirectory.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         tr.run();
@@ -167,7 +167,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         done();
     });
 
-    it('AzureRmWebAppDeploymentV4 DeploymentFactoryTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 DeploymentFactoryTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'DeploymentFactoryTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -188,7 +188,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 AzureRmWebAppDeploymentProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 AzureRmWebAppDeploymentProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'AzureRmWebAppDeploymentProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -204,7 +204,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 BuiltInLinuxWebAppDeploymentProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 BuiltInLinuxWebAppDeploymentProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'BuiltInLinuxWebAppDeploymentProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -226,7 +226,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 ContainerWebAppDeploymentProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 ContainerWebAppDeploymentProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'ContainerWebAppDeploymentProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -246,7 +246,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 WindowsWebAppRunFromZipProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 WindowsWebAppRunFromZipProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'WindowsWebAppRunFromZipProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -269,7 +269,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 WindowsWebAppWarDeployProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 WindowsWebAppWarDeployProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'WindowsWebAppWarDeployProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -289,7 +289,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 WindowsWebAppZipDeployProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 WindowsWebAppZipDeployProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'WindowsWebAppZipDeployProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -311,7 +311,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
     });
 
     
-    it('AzureRmWebAppDeploymentV4 WindowsWebAppWebDeployProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 WindowsWebAppWebDeployProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'WindowsWebAppWebDeployProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -334,7 +334,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 PublishProfileWebAppDeploymentProviderTests', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 PublishProfileWebAppDeploymentProviderTests', (done: MochaDone) => {
         let tp = path.join(__dirname,'PublishProfileWebAppDeploymentProviderTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {
@@ -350,7 +350,7 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
-    it('AzureRmWebAppDeploymentV4 Validate TaskParameters', (done: Mocha.Done) => {
+    it('AzureRmWebAppDeploymentV4 Validate TaskParameters', (done: MochaDone) => {
         let tp = path.join(__dirname,'TaskParametersTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         try {

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -75,9 +75,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.18.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.10.tgz",
-      "integrity": "sha512-XU1+v7h81p7145ddPfjv7jtWvkSilpcnON3mQ+bDi9Yuf7OI56efOglXRyXWgQ57xH3fEQgh7WOJMncRHVew5w=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "@types/q": {
       "version": "1.0.7",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^16.11.39",
+    "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
     "azure-pipelines-tasks-webdeployment-common": "4.208.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 216,
-        "Patch": 3
+        "Patch": 4
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",
@@ -496,9 +496,6 @@
     "instanceNameFormat": "Azure App Service Deploy: $(WebAppName)",
     "execution": {
         "Node10": {
-            "target": "azurermwebappdeployment.js"
-        },
-        "Node16": {
             "target": "azurermwebappdeployment.js"
         }
     },

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 216,
-    "Patch": 3
+    "Patch": 4
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",
@@ -496,9 +496,6 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
-      "target": "azurermwebappdeployment.js"
-    },
-    "Node16": {
       "target": "azurermwebappdeployment.js"
     }
   },


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV4

**Description**: 
Reverting Node16 upgrade for this task.
Cherry-pick from #17640

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
