### PR TITLE
Hotfix - M216 - Revert Update AzureAppServiceManageV0 to NodeJS 16

### DIFF
--- a/Tasks/AzureAppServiceManageV0/package-lock.json
+++ b/Tasks/AzureAppServiceManageV0/package-lock.json
@@ -75,9 +75,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.11.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.68.tgz",
-      "integrity": "sha512-JkRpuVz3xCNCWaeQ5EHLR/6woMbHZz/jZ7Kmc63AkU+1HxnoUugzSWMck7dsR4DvNYX8jp9wTi9K7WvnxOIQZQ=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "@types/q": {
       "version": "1.0.7",

--- a/Tasks/AzureAppServiceManageV0/package.json
+++ b/Tasks/AzureAppServiceManageV0/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^16.11.39",
+    "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 216,
-        "Patch": 2
+        "Patch": 3
     },
     "minimumAgentVersion": "1.102.0",
     "instanceNameFormat": "$(Action): $(WebAppName)",
@@ -287,10 +287,7 @@
     "execution": {
         "Node10": {
             "target": "azureappservicemanage.js"
-        },
-        "Node16": {
-            "target": "azureappservicemanage.js"
-          }
+        }
     },
     "messages": {
         "ErrorNoSuchDeployingMethodExists": "Error : Deploy method MSDeploy does not exists for Azure Web App: %s",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 216,
-    "Patch": 2
+    "Patch": 3
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -286,9 +286,6 @@
   ],
   "execution": {
     "Node10": {
-      "target": "azureappservicemanage.js"
-    },
-    "Node16": {
       "target": "azureappservicemanage.js"
     }
   },


### PR DESCRIPTION
**Task name**: AzureAppServiceManageV0

**Description**: 
Reverting Node16 upgrade for this task.
Cherry-pick from #17654

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
