### PR TITLE
[CP -> M216] NuGetRestoreV1 Hotfix : remove incorrect l0 tests

### DIFF
--- a/Tasks/NuGetRestoreV1/Tests/L0.ts
+++ b/Tasks/NuGetRestoreV1/Tests/L0.ts
@@ -168,34 +168,6 @@ describe('NuGetRestore Suite', function () {
         done();
     });
 
-    it('restore select nuget.org source warns', (done: Mocha.Done) => {
-        this.timeout(1000);
-
-        let tp = path.join(__dirname, './nugetOrgBehaviorWarn.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
-        assert(tr.invokedToolCount == 1, 'should have run NuGet once');
-        assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with nuget.org source');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
-        assert(tr.succeeded, 'should have succeeded with issues');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
-    });
-
-    it('restore select nuget.org source fails', (done: Mocha.Done) => {
-        this.timeout(1000);
-
-        let tp = path.join(__dirname, './nugetOrgBehaviorFail.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
-        assert(tr.invokedToolCount == 0, 'should not run nuget');
-        assert(tr.failed, 'should have Failed');
-        assert.equal(tr.errorIssues.length, 2, "should have 2 errors");
-        done();
-    });
-
     it('restore select nuget.org source succeeds with config', (done: Mocha.Done) => {
         this.timeout(1000);
 

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 214,
+        "Minor": 216,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 214,
+    "Minor": 216,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
* NuGetRestoreV1 remove failing untestable l0 tests

* bump task

* revert

**Task name**: NuGetRestoreV1

**Description**: remove failing L0 tests
**Documentation changes required:** (Y/N) n

**Added unit tests:** (Y/N) n

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
