### PR TITLE
MSAL - Pin Dependency Version

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.217.0",
+  "version": "3.217.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@azure/msal-node": "^1.14.5",
+    "@azure/msal-node": "1.14.5",
     "@types/jsonwebtoken": "^8.5.8",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.217.0",
+  "version": "3.217.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-arm-rest-v2

**Description**: Package dependency for "msal-node" is pinned to 1.14.5 due to Node10 deprecation.

See pages:
https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/CHANGELOG.md#1146
https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v8-to-v9

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
