### PR TITLE
Cumulative MSAL Update - Pin Dependency Version

### DIFF
--- a/Tasks/AzureAppServiceManageV0/package-lock.json
+++ b/Tasks/AzureAppServiceManageV0/package-lock.json
@@ -5,39 +5,20 @@
   "requires": true,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -152,11 +133,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -170,11 +151,6 @@
         "typed-rest-client": "1.8.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "@types/q": {
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
@@ -493,11 +469,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -532,14 +503,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.50.0",
@@ -844,11 +807,6 @@
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureAppServiceManageV0/package.json
+++ b/Tasks/AzureAppServiceManageV0/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
     "q": "1.4.1",
     "xml2js": "0.4.13"

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 1
+        "Patch": 2
     },
     "minimumAgentVersion": "1.102.0",
     "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureFileCopyV2/package-lock.json
+++ b/Tasks/AzureFileCopyV2/package-lock.json
@@ -4,39 +4,18 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@types/concat-stream": {
@@ -128,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -415,11 +394,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -454,14 +428,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -748,11 +714,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureFileCopyV2/package.json
+++ b/Tasks/AzureFileCopyV2/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/package-lock.json
+++ b/Tasks/AzureFileCopyV3/package-lock.json
@@ -4,39 +4,18 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@types/concat-stream": {
@@ -128,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -415,11 +394,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -454,14 +428,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -748,11 +714,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureFileCopyV3/package.json
+++ b/Tasks/AzureFileCopyV3/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/package-lock.json
+++ b/Tasks/AzureFileCopyV4/package-lock.json
@@ -4,39 +4,18 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@types/concat-stream": {
@@ -128,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -415,11 +394,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -454,14 +428,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -748,11 +714,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureFileCopyV4/package.json
+++ b/Tasks/AzureFileCopyV4/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/package-lock.json
+++ b/Tasks/AzureFileCopyV5/package-lock.json
@@ -4,39 +4,18 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
-      },
-      "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@types/concat-stream": {
@@ -128,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -415,11 +394,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -454,14 +428,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -748,11 +714,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureFileCopyV5/package.json
+++ b/Tasks/AzureFileCopyV5/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureKeyVaultV1/npm-shrinkwrap.json
+++ b/Tasks/AzureKeyVaultV1/npm-shrinkwrap.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -147,11 +128,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -448,11 +429,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -487,14 +463,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -802,11 +770,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureKeyVaultV1/package.json
+++ b/Tasks/AzureKeyVaultV1/package.json
@@ -8,7 +8,7 @@
     "@types/uuid": "^8.3.0",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.0.1-preview",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4"
   },
   "devDependencies": {

--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 1,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV1/task.loc.json
+++ b/Tasks/AzureKeyVaultV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV2/npm-shrinkwrap.json
+++ b/Tasks/AzureKeyVaultV2/npm-shrinkwrap.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -147,11 +128,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -443,11 +424,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -482,14 +458,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -797,11 +765,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureKeyVaultV2/package.json
+++ b/Tasks/AzureKeyVaultV2/package.json
@@ -8,7 +8,7 @@
     "@types/uuid": "^8.3.0",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.0.1-preview",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4"
   },
   "devDependencies": {

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureKeyVaultV2/task.loc.json
+++ b/Tasks/AzureKeyVaultV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -5,39 +5,20 @@
   "requires": true,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -175,11 +156,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -635,14 +616,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "ltx": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.0.tgz",
@@ -1022,11 +995,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zip-stream": {
       "version": "1.1.0",

--- a/Tasks/AzureMysqlDeploymentV1/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzurePowerShellV4/package-lock.json
+++ b/Tasks/AzurePowerShellV4/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -144,11 +125,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -479,11 +460,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -518,14 +494,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.45.0",
@@ -813,11 +781,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzurePowerShellV4/package.json
+++ b/Tasks/AzurePowerShellV4/package.json
@@ -8,7 +8,7 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.0.7",
         "azure-pipelines-task-lib": "3.1.10",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
         "azure-pipelines-tasks-utility-common": "^3.0.3"
     },
     "devDependencies": {

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/package-lock.json
+++ b/Tasks/AzurePowerShellV5/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -144,11 +125,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -471,11 +452,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -510,14 +486,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.51.0",
@@ -809,11 +777,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzurePowerShellV5/package.json
+++ b/Tasks/AzurePowerShellV5/package.json
@@ -8,7 +8,7 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.0.7",
         "azure-pipelines-task-lib": "3.1.10",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
         "azure-pipelines-tasks-utility-common": "^3.0.3"
     },
     "devDependencies": {

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzureResourceGroupDeploymentV2/package-lock.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -126,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -384,11 +365,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -423,14 +399,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.44.0",
@@ -707,11 +675,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureResourceGroupDeploymentV2/package.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "typed-rest-client": "^1.8.9"
   },

--- a/Tasks/AzureResourceGroupDeploymentV2/task.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 2,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/package-lock.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -126,11 +107,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -418,11 +399,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -457,14 +433,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.52.0",
@@ -751,11 +719,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/package.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^3.3.1",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "typed-rest-client": "^1.8.9"
   },

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 3,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
@@ -5,39 +5,20 @@
   "requires": true,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -175,11 +156,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -638,14 +619,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "ltx": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.0.tgz",
@@ -1018,11 +991,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/Tasks/AzureRmWebAppDeploymentV3/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -5,39 +5,20 @@
   "requires": true,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -175,11 +156,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -679,14 +660,6 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "ltx": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.8.0.tgz",
@@ -1082,11 +1055,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zip-stream": {
       "version": "1.2.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-webdeployment-common": "4.208.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 217,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 217,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureSpringCloudV0/package-lock.json
+++ b/Tasks/AzureSpringCloudV0/package-lock.json
@@ -127,39 +127,20 @@
       }
     },
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -373,11 +354,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -1079,14 +1060,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "ltx": {
       "version": "2.8.0",

--- a/Tasks/AzureSpringCloudV0/package.json
+++ b/Tasks/AzureSpringCloudV0/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "JSONPath": "^0.11.2",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "moment": "^2.29.4",
     "nock": "9.0.11",
     "q": "1.4.1",

--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.104.1",
     "groups": [

--- a/Tasks/AzureSpringCloudV0/task.loc.json
+++ b/Tasks/AzureSpringCloudV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureVmssDeploymentV0/package-lock.json
+++ b/Tasks/AzureVmssDeploymentV0/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2621,11 +2602,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -3157,11 +3138,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3196,14 +3172,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -3640,11 +3608,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/AzureVmssDeploymentV0/package.json
+++ b/Tasks/AzureVmssDeploymentV0/package.json
@@ -8,7 +8,7 @@
     "artifact-engine": "1.1.0",
     "azp-tasks-az-blobstorage-provider-v2": "^2.0.0-preview.0",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-utility-common": "^3.0.0-preview.0",
     "moment": "^2.29.4"
   },

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureVmssDeploymentV0/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -3,39 +3,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -197,11 +178,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -817,11 +798,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -856,14 +832,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.44.0",
@@ -1224,11 +1192,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -5,7 +5,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-kubernetes-common-v2": "^2.212.0",
     "azure-pipelines-tasks-securefiles-common": "^2.207.0",
     "azure-pipelines-tasks-utility-common": "^3.210.0",

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/JavaToolInstallerV0/package-lock.json
+++ b/Tasks/JavaToolInstallerV0/package-lock.json
@@ -4,39 +4,20 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@azure/msal-common": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-            "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+            "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
         },
         "@azure/msal-node": {
-            "version": "1.14.6",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-            "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+            "version": "1.14.5",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+            "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
             "requires": {
-                "@azure/msal-common": "^9.0.2",
-                "jsonwebtoken": "^9.0.0",
+                "@azure/msal-common": "^9.0.1",
+                "jsonwebtoken": "^8.5.1",
                 "uuid": "^8.3.0"
             },
             "dependencies": {
-                "jsonwebtoken": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-                    "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-                    "requires": {
-                        "jws": "^3.2.2",
-                        "lodash": "^4.17.21",
-                        "ms": "^2.1.1",
-                        "semver": "^7.3.8"
-                    }
-                },
-                "semver": {
-                    "version": "7.3.8",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-                    "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2644,11 +2625,11 @@
             }
         },
         "azure-pipelines-tasks-azure-arm-rest-v2": {
-            "version": "3.217.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-            "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+            "version": "3.217.1",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+            "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
             "requires": {
-                "@azure/msal-node": "^1.14.5",
+                "@azure/msal-node": "1.14.5",
                 "@types/jsonwebtoken": "^8.5.8",
                 "@types/mocha": "^5.2.7",
                 "@types/node": "^10.17.0",
@@ -3256,11 +3237,6 @@
                 "safe-buffer": "^5.0.1"
             }
         },
-        "lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-        },
         "lodash.includes": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3295,14 +3271,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-        },
-        "lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "requires": {
-                "yallist": "^4.0.0"
-            }
         },
         "md5.js": {
             "version": "1.3.5",
@@ -3759,11 +3727,6 @@
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
-        },
-        "yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
     }
 }

--- a/Tasks/JavaToolInstallerV0/package.json
+++ b/Tasks/JavaToolInstallerV0/package.json
@@ -29,7 +29,7 @@
         "@types/q": "^1.0.7",
         "azp-tasks-az-blobstorage-provider-v2": "2.206.0",
         "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
         "azure-pipelines-tool-lib": "^2.0.0-preview"
     },

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "satisfies": [
         "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "satisfies": [
     "Java",

--- a/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -2615,11 +2596,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -2966,9 +2947,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -3242,11 +3223,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -3281,14 +3257,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "md5.js": {
       "version": "1.3.4",
@@ -3795,11 +3763,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/JenkinsDownloadArtifactsV1/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package.json
@@ -13,7 +13,7 @@
     "@types/uuid": "^8.3.0",
     "artifact-engine": "1.1.0",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-storage": "2.10.4",
     "decompress-zip": "0.3.3",
     "fs-extra": "5.0.0",

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "groups": [
         {

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/PackerBuildV0/package-lock.json
+++ b/Tasks/PackerBuildV0/package-lock.json
@@ -4,39 +4,20 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@azure/msal-common": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.0.tgz",
-      "integrity": "sha512-Ai7SUJPkHOVUNAjepKp753ZXI8Haw5snTNIu+Vi6fdNPAH1KCuxSyWeBZT6hLDJSgfmYf/kazZqz7Q0BjyAGTA=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw=="
     },
     "@azure/msal-node": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.6.tgz",
-      "integrity": "sha512-em/qqFL5tLMxMPl9vormAs13OgZpmQoJbiQ/GlWr+BA77eCLoL+Ehr5xRHowYo+LFe5b+p+PJVkRvT+mLvOkwA==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
       "requires": {
-        "@azure/msal-common": "^9.0.2",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "jsonwebtoken": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-          "requires": {
-            "jws": "^3.2.2",
-            "lodash": "^4.17.21",
-            "ms": "^2.1.1",
-            "semver": "^7.3.8"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -138,11 +119,11 @@
       }
     },
     "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.217.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.0.tgz",
-      "integrity": "sha512-ONFeCwmoabmuiVOZGOyPmxW5y/KCa/QQvRx8QiO/YPsMRf9qNfQWsVM71X/rf1lsp1cQcijlD3ptB1NP8/BMhw==",
+      "version": "3.217.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
+      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
       "requires": {
-        "@azure/msal-node": "^1.14.5",
+        "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
@@ -469,11 +450,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -508,14 +484,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "mime-db": {
       "version": "1.44.0",
@@ -814,11 +782,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/Tasks/PackerBuildV0/package.json
+++ b/Tasks/PackerBuildV0/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "^1.0.7",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.0",
+    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "decompress-zip": "^0.3.3",
     "moment": "^2.29.4"
   },

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
**Task name**: 
AzureAppServiceManageV0
AzureFileCopyV2
AzureFileCopyV3
AzureFileCopyV4
AzureFileCopyV5
AzureKeyVaultV1
AzureKeyVaultV2
AzureMysqlDeploymentV1
AzurePowerShellV4
AzurePowerShellV5
AzureResourceGroupDeploymentV2
AzureResourceManagerTemplateDeploymentV3
AzureRmWebAppDeploymentV3
AzureRmWebAppDeploymentV4
AzureSpringCloudV0
AzureVmssDeploymentV0
HelmDeployV0
JavaToolInstallerV0
JenkinsDownloadArtifactsV1
PackerBuildV0

**Description**: Cumulative update for pinning "msal-node" to 1.14.5
Related #17674 

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

<img width="222" alt="image" src="https://user-images.githubusercontent.com/2474419/214858395-27453730-3ed7-4b7b-a853-1c41860776d3.png">

<img width="257" alt="image" src="https://user-images.githubusercontent.com/2474419/214858503-d5260650-13b8-4221-a423-ec7b042d7598.png">

<img width="157" alt="image" src="https://user-images.githubusercontent.com/2474419/214858861-1261f8f7-87c5-460d-b0b4-885c50b7560e.png">

