### PR TITLE
[ContainerStructureTestV0] Revert migration to node16

### DIFF
--- a/Tasks/ContainerStructureTestV0/make.json
+++ b/Tasks/ContainerStructureTestV0/make.json
@@ -1,12 +1,4 @@
 {
-    "rm": [
-        {
-            "items": [
-                "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib"
-            ],
-            "options": "-Rf"
-        }
-    ],
     "externals": {
       "files": [
         {

--- a/Tasks/ContainerStructureTestV0/package-lock.json
+++ b/Tasks/ContainerStructureTestV0/package-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.18.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.7.tgz",
-      "integrity": "sha512-SghuoXv8ghvkrKjTyvhRTeNzivPzGQ8pe09PPGdyqsExiKvBYV/6E3imvjsaJuW8ca61qQN2+SoSzyEHS9r2LA=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -87,12 +87,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "azure-pipelines-task-lib": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.1.0.tgz",
-      "integrity": "sha512-8CNC9PcP+4eS76QcIDmPmBfrrao9xpy/M0Uts4TWk3chfr3uOXFGf0DYHVTJGF9180g51kyVXYTObicouq0KZQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
+      "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
       "requires": {
         "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
+        "mockery": "^1.7.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
         "shelljs": "^0.8.5",
@@ -107,11 +107,6 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
-        },
-        "mockery": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-          "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
         }
       }
     },
@@ -129,49 +124,10 @@
         "q": "1.4.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "@types/q": {
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
           "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
-        },
-        "azure-pipelines-task-lib": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
-          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
-          "requires": {
-            "minimatch": "3.0.5",
-            "mockery": "^2.1.0",
-            "q": "^1.5.1",
-            "semver": "^5.1.0",
-            "shelljs": "^0.8.5",
-            "sync-request": "6.1.0",
-            "uuid": "^3.0.1"
-          },
-          "dependencies": {
-            "q": {
-              "version": "1.5.1",
-              "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-              "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
-            }
-          }
-        },
-        "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "mockery": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-          "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
         },
         "q": {
           "version": "1.4.1",
@@ -181,25 +137,85 @@
       }
     },
     "azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.198.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.198.1.tgz",
+      "integrity": "sha512-XxXLwrz06lSXP31JGCcgp2DCuVwcKLCjma55DtsjDe8L8sngKfmTBIiSuZe41aP+KlRtqo8n1I/FBQNPWxGw9w==",
       "requires": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "^10.17.0",
+        "azure-pipelines-task-lib": "^3.1.0",
+        "azure-pipelines-tool-lib": "^1.0.2",
         "js-yaml": "3.13.1",
         "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "@types/uuid": {
+          "version": "3.4.10",
+          "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
+          "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
+        },
+        "azure-pipelines-task-lib": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.2.0.tgz",
+          "integrity": "sha512-7mO6/B1HwGISpP8z0UiNw/O9mu34lQpAm7jlU/jTNdwfL4RCsHJkUFD86zN+8wVFVgwBNskBaZtem4fmCxdklQ==",
+          "requires": {
+            "minimatch": "3.0.4",
+            "mockery": "^1.7.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          }
+        },
+        "azure-pipelines-tool-lib": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.0.2.tgz",
+          "integrity": "sha512-0wWAqIY1n9UvcHP3AKLWIVd5fTPKaUOZJ50bNwW3NMpFlfpxZDAi8Ck9wvVm9oBdwHVYZsQy3WfK71DiBWQiHg==",
+          "requires": {
+            "@types/semver": "^5.3.0",
+            "@types/uuid": "^3.4.5",
+            "azure-pipelines-task-lib": "^3.1.0",
+            "semver": "^5.7.0",
+            "semver-compare": "^1.0.0",
+            "typed-rest-client": "^1.8.4",
+            "uuid": "^3.3.2"
+          }
+        },
+        "shelljs": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+          "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "typed-rest-client": {
+          "version": "1.8.6",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
+          "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
+          "requires": {
+            "qs": "^6.9.1",
+            "tunnel": "0.0.6",
+            "underscore": "^1.12.1"
+          }
+        }
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "2.0.0-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
-      "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.3.1.tgz",
+      "integrity": "sha512-6XrjayeYI7QeL2tGP3FPgHggWHAYe4opESnZ9a3UsbtWYdZu3dldBbOlJZpkAxfKCpjRDYMuq6SP1MUsOOm0kA==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
+        "azure-pipelines-task-lib": "^3.1.10",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
@@ -404,13 +420,6 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        }
       }
     },
     "inflight": {
@@ -489,12 +498,17 @@
       }
     },
     "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mockery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
+      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/Tasks/ContainerStructureTestV0/package.json
+++ b/Tasks/ContainerStructureTestV0/package.json
@@ -18,13 +18,13 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^16.11.39",
+    "@types/node": "^10.17.0",
     "@types/q": "^1.0.7",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^4.1.0",
+    "azure-pipelines-task-lib": "^3.3.1",
     "azure-pipelines-tasks-docker-common-v2": "2.198.1",
-    "azure-pipelines-tasks-utility-common": "^3.212.0",
-    "azure-pipelines-tool-lib": "^2.0.0-preview",
+    "azure-pipelines-tasks-utility-common": "3.198.1",
+    "azure-pipelines-tool-lib": "^1.3.1",
     "typed-rest-client": "^1.8.9"
   },
   "devDependencies": {

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 211,
-        "Patch": 2
+        "Minor": 217,
+        "Patch": 0
     },
     "preview": true,
     "demands": [],

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 216,
-        "Patch": 0
+        "Minor": 211,
+        "Patch": 2
     },
     "preview": true,
     "demands": [],
@@ -82,10 +82,6 @@
     "instanceNameFormat": "Container Structure Test $(testFile)",
     "execution": {
         "Node10": {
-            "target": "containerstructuretest.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
             "target": "containerstructuretest.js",
             "argumentFormat": ""
         }

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 211,
-    "Patch": 2
+    "Minor": 217,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 216,
-    "Patch": 0
+    "Minor": 211,
+    "Patch": 2
   },
   "preview": true,
   "demands": [],
@@ -82,10 +82,6 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
-      "target": "containerstructuretest.js",
-      "argumentFormat": ""
-    },
-    "Node16": {
       "target": "containerstructuretest.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
**Task name**: ContainerStructureTestV0

**Description**: Revert, since the task contains multiple task-lib versions. 

1. Revert "Upgrade ContainerStructureTestV0 to NodeJS16" https://github.com/microsoft/azure-pipelines-tasks/pull/17455
2. Update task version to 217 

This reverts commit https://github.com/microsoft/azure-pipelines-tasks/commit/be7f0a0c3d8b763a6b3659a0c26a38f1164e5821.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
