### PR TITLE
Revert "Upgrade HelmDeployV0 to NodeJS16 (#17284)"

### DIFF
--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -54,9 +54,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg=="
+      "version": "10.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -154,25 +154,122 @@
       }
     },
     "azure-pipelines-task-lib": {
-      "version": "4.0.0-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.0.0-preview.tgz",
-      "integrity": "sha512-BK+VOo42Bec72Wic6Vsm2MaAJezNyF05OYAQS5FuZJM5Z972lZqYpujtSc4BFKUhC3HO+F/Yf4xhAV2tZCzN9Q==",
+      "version": "3.0.6-preview.0",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.0.6-preview.0.tgz",
+      "integrity": "sha512-Fx+7p5GzvYqVXOQI+LhPk56Pio9yBeEyypKZoPI9cQyti8WTVkmJ7YZwn9HRXurftcLumi2Xq+TC3PwnDq5U5Q==",
       "requires": {
-        "minimatch": "3.0.5",
+        "minimatch": "3.0.4",
         "mockery": "^1.7.0",
         "q": "^1.5.1",
         "semver": "^5.1.0",
-        "shelljs": "^0.8.5",
+        "shelljs": "^0.8.4",
         "sync-request": "6.1.0",
         "uuid": "^3.0.1"
       },
       "dependencies": {
-        "minimatch": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-          "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "http-basic": {
+          "version": "8.1.3",
+          "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+          "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+          "requires": {
+            "caseless": "^0.12.0",
+            "concat-stream": "^1.6.2",
+            "http-response-object": "^3.0.1",
+            "parse-cache-control": "^1.0.1"
+          }
+        },
+        "http-response-object": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+          "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+          "requires": {
+            "@types/node": "^10.0.3"
+          }
+        },
+        "promise": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+          "integrity": "sha512-W04AqnILOL/sPRXziNicCjSNRruLAuIHEOVBazepu0545DDNGYHz7ar9ZgZ1fMU8/MA4mVxp5rkBWRi6OXIy3Q==",
+          "requires": {
+            "asap": "~2.0.6"
+          }
+        },
+        "q": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+          "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+        },
+        "shelljs": {
+          "version": "0.8.5",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+          "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+          "requires": {
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
+          }
+        },
+        "sync-request": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+          "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+          "requires": {
+            "http-response-object": "^3.0.1",
+            "sync-rpc": "^1.2.1",
+            "then-request": "^6.0.0"
+          }
+        },
+        "then-request": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+          "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+          "requires": {
+            "@types/concat-stream": "^1.6.0",
+            "@types/form-data": "0.0.33",
+            "@types/node": "^8.0.0",
+            "@types/qs": "^6.2.31",
+            "caseless": "~0.12.0",
+            "concat-stream": "^1.6.0",
+            "form-data": "^2.2.0",
+            "http-basic": "^8.1.1",
+            "http-response-object": "^3.0.1",
+            "promise": "^8.0.0",
+            "qs": "^6.4.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "8.10.66",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+              "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+            }
           }
         }
       }
@@ -196,11 +293,6 @@
         "typed-rest-client": "1.8.4"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "@types/q": {
           "version": "1.5.4",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
@@ -298,11 +390,6 @@
         "azure-pipelines-task-lib": "^3.1.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "@types/q": {
           "version": "1.5.5",
           "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
@@ -344,11 +431,6 @@
         "semver": "^5.4.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        },
         "@types/uuid": {
           "version": "3.4.10",
           "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
@@ -682,13 +764,6 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        }
       }
     },
     "https-proxy-agent": {

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^16.11.39",
+    "@types/node": "^10.17.0",
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^4.0.0-preview",
+    "azure-pipelines-task-lib": "^3.0.6-preview.0",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
     "azure-pipelines-tasks-kubernetes-common-v2": "^2.212.0",
     "azure-pipelines-tasks-securefiles-common": "^2.207.0",

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 217,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [],
     "groups": [
@@ -521,9 +521,6 @@
     },
     "postjobexecution": {
         "Node10": {
-            "target": "src//deletesecurefiles.js"
-        },
-        "Node16": {
             "target": "src//deletesecurefiles.js"
         }
     },

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 217,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "groups": [
@@ -521,9 +521,6 @@
   },
   "postjobexecution": {
     "Node10": {
-      "target": "src//deletesecurefiles.js"
-    },
-    "Node16": {
       "target": "src//deletesecurefiles.js"
     }
   },


### PR DESCRIPTION
**Task name**: HelmDeployV0 

**Description**: 
Revert, since the task contains task-lib < 4.0.1 which doesn't have the max-buffer fix + the task has multiple task-lib runners.
- Revert https://github.com/microsoft/azure-pipelines-tasks/pull/17284
- Update task version to 217

This reverts commit 942a6d188d2f7255942e8ca1a6a71aa9f358ca17.
 Conflicts:
	Tasks/HelmDeployV0/package.json
	Tasks/HelmDeployV0/task.json
	Tasks/HelmDeployV0/task.loc.json

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
