### PR TITLE
[PublishPipelineMetadataV0] Revert migration to Node16

### DIFF
--- a/Tasks/PublishPipelineMetadataV0/package-lock.json
+++ b/Tasks/PublishPipelineMetadataV0/package-lock.json
@@ -26,9 +26,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.18.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
-      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg=="
+      "version": "10.17.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.48.tgz",
+      "integrity": "sha512-Agl6xbYP6FOMDeAsr3QVZ+g7Yzg0uhPHWx0j5g4LFdUBHVtqtU+gH660k/lCEe506jJLOGbEzsnqPDTZGJQLag=="
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -87,13 +87,6 @@
         "azure-pipelines-tool-lib": "^1.0.2",
         "js-yaml": "3.13.1",
         "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        }
       }
     },
     "azure-pipelines-tool-lib": {
@@ -277,13 +270,6 @@
       "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "requires": {
         "@types/node": "^10.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        }
       }
     },
     "inflight": {

--- a/Tasks/PublishPipelineMetadataV0/package.json
+++ b/Tasks/PublishPipelineMetadataV0/package.json
@@ -5,7 +5,7 @@
   "main": "publishmetadata.js",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^16.11.39",
+    "@types/node": "^10.17.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-tasks-utility-common": "^3.210.0"
   },

--- a/Tasks/PublishPipelineMetadataV0/task.json
+++ b/Tasks/PublishPipelineMetadataV0/task.json
@@ -11,7 +11,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 212,
+        "Minor": 217,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/PublishPipelineMetadataV0/task.json
+++ b/Tasks/PublishPipelineMetadataV0/task.json
@@ -11,18 +11,14 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 216,
+        "Minor": 212,
         "Patch": 0
     },
-    "minimumAgentVersion": "2.144.0",
     "preview": true,
     "instanceNameFormat": "Publishing Metadata for pipeline $(System.DefinitionName) to Evidence store",
     "showEnvironmentVariables": true,
     "execution": {
         "Node10": {
-            "target": "publishmetadata.js"
-        },
-        "Node16": {
             "target": "publishmetadata.js"
         }
     }

--- a/Tasks/PublishPipelineMetadataV0/task.loc.json
+++ b/Tasks/PublishPipelineMetadataV0/task.loc.json
@@ -11,18 +11,14 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 216,
+    "Minor": 212,
     "Patch": 0
   },
-  "minimumAgentVersion": "2.144.0",
   "preview": true,
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "showEnvironmentVariables": true,
   "execution": {
     "Node10": {
-      "target": "publishmetadata.js"
-    },
-    "Node16": {
       "target": "publishmetadata.js"
     }
   },

--- a/Tasks/PublishPipelineMetadataV0/task.loc.json
+++ b/Tasks/PublishPipelineMetadataV0/task.loc.json
@@ -11,7 +11,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 212,
+    "Minor": 217,
     "Patch": 0
   },
   "preview": true,


### PR DESCRIPTION
**Task name**: PublishPipelineMetadataV0

**Description**: Revert, since the task contains task-lib < 4.0.1 (dependency of utility-common) which doesn't have the max-buffer fix.

1. Revert "Upgrade PublishPipelineMetadataV0 to NodeJS16 ([17281](https://github.com/microsoft/azure-pipelines-tasks/pull/17281))" 
2. Update task version to 217

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
