### PR TITLE
1999508 DTS [Pipelines Agents Tasks UI]: Problem with the "Publish to Azure Service Bus" task in DevOps release pipeline

### DIFF
--- a/Tasks/PublishToAzureServiceBusV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishToAzureServiceBusV1/Strings/resources.resjson/en-US/resources.resjson
@@ -1,6 +1,6 @@
 {
   "loc.friendlyName": "Publish To Azure Service Bus",
-  "loc.helpMarkDown": "[More Information](https://go.microsoft.com/fwlink/?linkid=870237)",
+  "loc.helpMarkDown": "[Learn more about this task](https://go.microsoft.com/fwlink/?linkid=870237)",
   "loc.description": "Sends a message to Azure Service Bus using a service connection (no agent is required)",
   "loc.instanceNameFormat": "Publish to Azure Service Bus",
   "loc.group.displayName.advancedProperties": "Advanced",
@@ -17,5 +17,7 @@
   "loc.input.label.signatureKey": "Signature Property Key",
   "loc.input.help.signatureKey": "Key where you want signature to be in Message Properties. If left Empty, default is 'signature' in message properties",
   "loc.input.label.waitForCompletion": "Wait for task completion",
-  "loc.input.help.waitForCompletion": "If this is true, this task will wait for TaskCompleted event for the specified task timeout."
+  "loc.input.help.waitForCompletion": "If this is true, this task will wait for TaskCompleted event for the specified task timeout.",
+  "loc.input.label.useDataContractSerializer": "Use .NET data contract serailizer",
+  "loc.input.help.useDataContractSerializer": "For more details go to task documentation"
 }

--- a/Tasks/PublishToAzureServiceBusV1/task.json
+++ b/Tasks/PublishToAzureServiceBusV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 198,
+        "Minor": 217,
         "Patch": 0
     },
     "groups": [
@@ -97,6 +97,14 @@
             "defaultValue": "false",
             "required": true,
             "helpMarkDown": "If this is true, this task will wait for TaskCompleted event for the specified task timeout."
+        },
+        {
+            "name": "useDataContractSerializer",
+            "type": "boolean",
+            "label": "Use .NET data contract serailizer",
+            "required": true,
+            "defaultValue": "true",
+            "helpMarkDown": "For more details go to task documentation"
         }
     ],
     "instanceNameFormat": "Publish to Azure Service Bus",
@@ -115,6 +123,7 @@
                 "sessionId": "$(sessionId)",
                 "certificateString": "{{#notEquals signPayload 'false' 1}}{{#notEquals endpoint.signPayload 'false' 1}}$(certificateString){{/notEquals}}{{else}}{{/notEquals}}",
                 "signaturePropertyKey": "$(signatureKey)",
+                "useDataContractSerializer": "$(useDataContractSerializer)",
                 "messageProperties": {
                     "PlanUrl": "$(system.CollectionUri)",
                     "ProjectId": "$(system.TeamProjectId)",

--- a/Tasks/PublishToAzureServiceBusV1/task.loc.json
+++ b/Tasks/PublishToAzureServiceBusV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 198,
+    "Minor": 217,
     "Patch": 0
   },
   "groups": [
@@ -97,6 +97,14 @@
       "defaultValue": "false",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.waitForCompletion"
+    },
+    {
+      "name": "useDataContractSerializer",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.useDataContractSerializer",
+      "required": true,
+      "defaultValue": "true",
+      "helpMarkDown": "ms-resource:loc.input.help.useDataContractSerializer"
     }
   ],
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -115,6 +123,7 @@
         "sessionId": "$(sessionId)",
         "certificateString": "{{#notEquals signPayload 'false' 1}}{{#notEquals endpoint.signPayload 'false' 1}}$(certificateString){{/notEquals}}{{else}}{{/notEquals}}",
         "signaturePropertyKey": "$(signatureKey)",
+        "useDataContractSerializer": "$(useDataContractSerializer)",
         "messageProperties": {
           "PlanUrl": "$(system.CollectionUri)",
           "ProjectId": "$(system.TeamProjectId)",


### PR DESCRIPTION

**Task name**: PublishToAzureServiceBus

**Description**:  As of now we are doing the data serializer by default. Which results in other language applications unable to process the message. So we added a new field based on the user selection Data serialization will happen

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
