### PR TITLE
Get rid of kubernetes-common-v2 folder and package

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV1/make.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/make.json
@@ -3,8 +3,7 @@
         {
             "items": [
                 "node_modules/azure-pipelines-tasks-docker-common-v2/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-kubernetes-common-v2/node_modules/azure-pipelines-task-lib",
-                "node_modules/utility-common-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-kubernetes-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"

--- a/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
@@ -264,10 +264,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-kubernetes-common-v2": {
+    "azure-pipelines-tasks-kubernetes-common": {
       "version": "2.212.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-kubernetes-common-v2/-/azure-pipelines-tasks-kubernetes-common-v2-2.212.0.tgz",
-      "integrity": "sha512-962gC72DvSE4n3gKRPgd7AB7qOoQYQ5FdQz8QXxIe+uO5xWXhs+jm+79XcKXOSQm7vnL4X0/wGYW1Yc4jkA02g==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-kubernetes-common/-/azure-pipelines-tasks-kubernetes-common-2.212.0.tgz",
+      "integrity": "sha512-tUvpcX/EXMBpIzpsKpgcYPil4uWs1FvdRxR1edy3fey/t7p7yZszuGtVETygWURfvDiOwKDpAJL8olaPf+derA==",
       "requires": {
         "@types/mocha": "5.2.7",
         "@types/node": "10.17.0",
@@ -286,20 +286,6 @@
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
           "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
-        },
-        "azure-pipelines-task-lib": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
-          "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
-          "requires": {
-            "minimatch": "3.0.5",
-            "mockery": "^2.1.0",
-            "q": "^1.5.1",
-            "semver": "^5.1.0",
-            "shelljs": "^0.8.5",
-            "sync-request": "6.1.0",
-            "uuid": "^3.0.1"
-          }
         },
         "azure-pipelines-tool-lib": {
           "version": "1.3.2",
@@ -321,30 +307,6 @@
               "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
             }
           }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "shelljs": {
-          "version": "0.8.5",
-          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-          "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-          "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
-          }
-        },
-        "tunnel": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "typed-rest-client": {
           "version": "1.8.9",

--- a/Tasks/AzureFunctionOnKubernetesV1/package.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package.json
@@ -21,7 +21,7 @@
     "@types/uuid": "^9.0.0",
     "azure-pipelines-task-lib": "^3.1.0",
     "azure-pipelines-tasks-docker-common-v2": "^2.211.0",
-    "azure-pipelines-tasks-kubernetes-common-v2": "^2.212.0",
+    "azure-pipelines-tasks-kubernetes-common": "^2.212.0",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.3",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "js-yaml": "3.13.1"

--- a/Tasks/AzureFunctionOnKubernetesV1/src/clusters/generickubernetescluster.ts
+++ b/Tasks/AzureFunctionOnKubernetesV1/src/clusters/generickubernetescluster.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import tl = require('azure-pipelines-task-lib/task');
-import kubectlutility = require("azure-pipelines-tasks-kubernetes-common-v2/kubectlutility");
+import kubectlutility = require("azure-pipelines-tasks-kubernetes-common/kubectlutility");
 
 export async function getKubeConfig(): Promise<string> {
     var kubernetesServiceEndpoint = tl.getInput("kubernetesServiceEndpoint", true);

--- a/Tasks/AzureFunctionOnKubernetesV1/src/deploy.ts
+++ b/Tasks/AzureFunctionOnKubernetesV1/src/deploy.ts
@@ -5,11 +5,11 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from "azure-pipelines-task-lib/toolrunner";
 import { CommandHelper } from './utils/commandHelper';
 import { DockerConnection } from './dockerConnection';
-import { Kubectl, Resource } from 'azure-pipelines-tasks-kubernetes-common-v2/kubectl-object-model';
+import { Kubectl, Resource } from 'azure-pipelines-tasks-kubernetes-common/kubectl-object-model';
 import * as FileHelper from './utils/fileHelper';
-import * as KubernetesConstants from 'azure-pipelines-tasks-kubernetes-common-v2/kubernetesconstants';
-import * as KubernetesManifestUtility from 'azure-pipelines-tasks-kubernetes-common-v2/kubernetesmanifestutility';
-import * as CommonUtils from 'azure-pipelines-tasks-kubernetes-common-v2/utility';
+import * as KubernetesConstants from 'azure-pipelines-tasks-kubernetes-common/kubernetesconstants';
+import * as KubernetesManifestUtility from 'azure-pipelines-tasks-kubernetes-common/kubernetesmanifestutility';
+import * as CommonUtils from 'azure-pipelines-tasks-kubernetes-common/utility';
 import ClusterConnection from './clusterconnection';
 
 const secretName = tl.getInput('secretName');

--- a/Tasks/AzureFunctionOnKubernetesV1/src/utils/commandHelper.ts
+++ b/Tasks/AzureFunctionOnKubernetesV1/src/utils/commandHelper.ts
@@ -3,8 +3,8 @@
 import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as tr from "azure-pipelines-task-lib/toolrunner";
-import * as FuncKubernetesUtility from 'azure-pipelines-tasks-kubernetes-common-v2/funckubernetesutility';
-import * as CommonUtils from 'azure-pipelines-tasks-kubernetes-common-v2/utility';
+import * as FuncKubernetesUtility from 'azure-pipelines-tasks-kubernetes-common/funckubernetesutility';
+import * as CommonUtils from 'azure-pipelines-tasks-kubernetes-common/utility';
 import { DockerConnection } from "../dockerConnection";
 
 export class CommandHelper {

--- a/Tasks/AzureFunctionOnKubernetesV1/src/utils/utilities.ts
+++ b/Tasks/AzureFunctionOnKubernetesV1/src/utils/utilities.ts
@@ -8,7 +8,7 @@ import * as os from "os";
 import * as util from "util";
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
 
-import kubectlutility = require("azure-pipelines-tasks-kubernetes-common-v2/kubectlutility");
+import kubectlutility = require("azure-pipelines-tasks-kubernetes-common/kubectlutility");
 
 export function getTempDirectory(): string {
     return tl.getVariable('agent.tempDirectory') || os.tmpdir();

--- a/Tasks/AzureFunctionOnKubernetesV1/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.json
@@ -14,8 +14,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 217,
-        "Patch": 1
+        "Minor": 218,
+        "Patch": 0
     },
     "demands": [],
     "groups": [

--- a/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 217,
-    "Patch": 1
+    "Minor": 218,
+    "Patch": 0
   },
   "demands": [],
   "groups": [


### PR DESCRIPTION
**Task name**:  AzureFunctionOnKubernetesV1

**Description**: 
- migrate azure-pipelines-tasks-kubernetes-common-v2 to azure-pipelines-tasks-kubernetes-common
- remove utility-common-v2 from make.json

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
