### PR TITLE
Block AzureStaticWebApp task on windows due to compatibility issues

### DIFF
--- a/Tasks/AzureStaticWebAppV0/index.ts
+++ b/Tasks/AzureStaticWebAppV0/index.ts
@@ -2,7 +2,7 @@ import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 import trm = require('azure-pipelines-task-lib/toolrunner');
 import fs = require('fs');
-
+import * as os from ('os');
 const appLocationInputName = 'app_location';
 const appBuildCommandInputName = 'app_build_command';
 const outputLocationInputName = 'output_location';
@@ -22,6 +22,14 @@ async function run() {
     try {
         tl.setResourcePath(path.join(__dirname, 'task.json'));
 
+        const osPlat: string = os.platform();
+
+        // Fail the task if os is windows
+        if (osPlat == 'win32') {
+            tl.setResult(tl.TaskResult.Failed, tl.loc('WindowsOsNotSupported'));
+            return;
+        }
+        
         var bash: trm.ToolRunner = tl.tool(tl.which('bash', true));
 
         var scriptPath: string = path.join(__dirname, 'launch-docker.sh');

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": "0",
-    "Minor": "217",
+    "Minor": "218",
     "Patch": "0"
   },
   "preview": true,
@@ -167,5 +167,8 @@
       "target": "index.js",
       "argumentFormat": ""
     }
+  },
+  "messages": {
+    "OnlyWindowsOsSupported": "This task is not supported on Windows agents. A Linux agent must be used."
   }
 }


### PR DESCRIPTION
**Task name**: AzureStaticWebAppV0

**Description**: Block task from running on windows agents due to compatibility issues. This task uses a Linux based docker container that is not compatible with windows MS or self-hosted agents.

**Documentation changes required:** Yes, to note this task is currently unsupported on windows agents.

**Added unit tests:** No additional unit tests needed for this

**Attached related issue:** #16089 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
