### PR TITLE
add stages to the ci-test-tasks pipeline

### DIFF
--- a/ci/ci-test-tasks/main.yml
+++ b/ci/ci-test-tasks/main.yml
@@ -10,64 +10,78 @@ parameters:
 trigger: none
 pr: none
 
-jobs:
-  - ${{ each task in split(parameters.tasks, ',') }}:
-    - job: ${{ task }}_verify_testing_pipeline
-      condition: eq(variables['build.reason'], 'Manual')
-      displayName: Verify testing pipeline (${{ task }})
-      pool:
-        vmImage: windows-2022
-      steps:
-      - template: ./verify-task.yml
-        parameters:
-          task: ${{ task }}
-          BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
-  
-    - job: ${{ task }}_build_task
-      dependsOn: ${{ task }}_verify_testing_pipeline
-      displayName: Build Task (${{ task }})
-      pool:
-        vmImage: windows-2022
-      steps:
-      - template: ./build-task.yml
-        parameters:
-          task: ${{ task }}
-          push: false
-          publishArtifact: true
-          patchVersion: true
-          version: '0.9999.9999'
-          BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+stages:
+- stage: Verify
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:
+      - job: ${{ task }}_verify_testing_pipeline
+        condition: eq(variables['build.reason'], 'Manual')
+        displayName: Verify testing pipeline (${{ task }})
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./verify-task.yml
+          parameters:
+            task: ${{ task }}
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
 
-    - job: ${{ task }}_upload_task
-      displayName: Upload (${{ task }})
-      dependsOn: ${{ task }}_build_task
-      pool:
-        vmImage: windows-2022
-      steps:
-      - template: ./upload-task.yml
-        parameters:
-          task: ${{ task }}
-          BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
-   
-    - job: ${{ task }}_test_task
-      displayName: Test (${{ task }})
-      dependsOn: ${{ task }}_upload_task
-      pool:
-        vmImage: windows-2022
-      steps:
-      - template: ./test-task.yml
-        parameters:
-          task: ${{ task }}
-          BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
-   
-    - job: ${{ task }}_clean_up
-      condition: in(dependencies.${{ task }}_upload_task.result, 'Succeeded', 'SucceededWithIssues', 'Failed')
-      displayName: Clean up (${{ task }})
-      dependsOn: ${{ task }}_test_task
-      pool:
-        vmImage: windows-2022
-      steps:
-      - template: ./clean-up.yml
-        parameters:
-          task: ${{ task }}
-          BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+- stage: Build
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:
+      - job: ${{ task }}_build_task
+        dependsOn: ${{ task }}_verify_testing_pipeline
+        displayName: Build Task (${{ task }})
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./build-task.yml
+          parameters:
+            task: ${{ task }}
+            push: false
+            publishArtifact: true
+            patchVersion: true
+            version: '0.999.0'
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+
+- stage: Upload
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:
+      - job: ${{ task }}_upload_task
+        displayName: Upload (${{ task }})
+        dependsOn: ${{ task }}_build_task
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./upload-task.yml
+          parameters:
+            task: ${{ task }}
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+
+- stage: Test
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:
+      - job: ${{ task }}_test_task
+        displayName: Test (${{ task }})
+        dependsOn: ${{ task }}_upload_task
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./test-task.yml
+          parameters:
+            task: ${{ task }}
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+
+- stage: Clean up
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:    
+      - job: ${{ task }}_clean_up
+        condition: in(dependencies.${{ task }}_upload_task.result, 'Succeeded', 'SucceededWithIssues', 'Failed')
+        displayName: Clean up (${{ task }})
+        dependsOn: ${{ task }}_test_task
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./clean-up.yml
+          parameters:
+            task: ${{ task }}
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}

--- a/ci/ci-test-tasks/main.yml
+++ b/ci/ci-test-tasks/main.yml
@@ -68,7 +68,7 @@ stages:
             task: ${{ task }}
             BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
 
-- stage: Clean up
+- stage: CleanUp
   jobs:
     - ${{ each task in split(parameters.tasks, ',') }}:    
       - job: ${{ task }}_clean_up

--- a/ci/ci-test-tasks/main.yml
+++ b/ci/ci-test-tasks/main.yml
@@ -84,7 +84,6 @@ stages:
   jobs:
     - ${{ each task in split(parameters.tasks, ',') }}:    
       - job: ${{ task }}_clean_up
-        condition: in(dependencies.${{ task }}_upload_task.result, 'Succeeded', 'SucceededWithIssues', 'Failed')
         displayName: Clean up (${{ task }})
         pool:
           vmImage: windows-2022

--- a/ci/ci-test-tasks/main.yml
+++ b/ci/ci-test-tasks/main.yml
@@ -29,7 +29,6 @@ stages:
   jobs:
     - ${{ each task in split(parameters.tasks, ',') }}:
       - job: ${{ task }}_build_task
-        dependsOn: ${{ task }}_verify_testing_pipeline
         displayName: Build Task (${{ task }})
         pool:
           vmImage: windows-2022
@@ -48,7 +47,6 @@ stages:
     - ${{ each task in split(parameters.tasks, ',') }}:
       - job: ${{ task }}_upload_task
         displayName: Upload (${{ task }})
-        dependsOn: ${{ task }}_build_task
         pool:
           vmImage: windows-2022
         steps:
@@ -62,7 +60,6 @@ stages:
     - ${{ each task in split(parameters.tasks, ',') }}:
       - job: ${{ task }}_test_task
         displayName: Test (${{ task }})
-        dependsOn: ${{ task }}_upload_task
         pool:
           vmImage: windows-2022
         steps:
@@ -77,7 +74,6 @@ stages:
       - job: ${{ task }}_clean_up
         condition: in(dependencies.${{ task }}_upload_task.result, 'Succeeded', 'SucceededWithIssues', 'Failed')
         displayName: Clean up (${{ task }})
-        dependsOn: ${{ task }}_test_task
         pool:
           vmImage: windows-2022
         steps:

--- a/ci/ci-test-tasks/main.yml
+++ b/ci/ci-test-tasks/main.yml
@@ -41,6 +41,18 @@ stages:
             patchVersion: true
             version: '0.999.0'
             BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
+- stage: PreDelete
+  jobs:
+    - ${{ each task in split(parameters.tasks, ',') }}:    
+      - job: ${{ task }}_pre_delete
+        displayName: Pre delete (${{ task }})
+        pool:
+          vmImage: windows-2022
+        steps:
+        - template: ./clean-up.yml
+          parameters:
+            task: ${{ task }}
+            BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
 
 - stage: Upload
   jobs:
@@ -68,7 +80,7 @@ stages:
             task: ${{ task }}
             BuildSourceVersion: ${{ parameters.BuildSourceVersion }}
 
-- stage: CleanUp
+- stage: PostDelete
   jobs:
     - ${{ each task in split(parameters.tasks, ',') }}:    
       - job: ${{ task }}_clean_up


### PR DESCRIPTION
Since some tests share the same ID, tfx is not handling deletion of the task as expected so we can run into a race condition testing a number of tasks with the same IDs. As a temporary fix, stages would ensure we will not delete any uploaded task version until all tests are finished