### PR TITLE
Continuous integration: Change result to state

### DIFF
--- a/ci/ci-test-tasks/test-and-verify.js
+++ b/ci/ci-test-tasks/test-and-verify.js
@@ -72,7 +72,7 @@ async function verifyBuildStatus(pipelineBuild, resolve, reject) {
     
       clearInterval(interval);
     
-      const result = `Build ${pipelineBuild.name} id:${pipelineBuild.id} finished with status "${data.result}" and result "${data.result}", url: ${pipelineBuild._links.web.href}`;
+      const result = `Build ${pipelineBuild.name} id:${pipelineBuild.id} finished with status "${data.state}" and result "${data.result}", url: ${pipelineBuild._links.web.href}`;
     
       if (data.result === 'succeeded') {
         resolve(result);


### PR DESCRIPTION
Once the CI pipeline for a particular task was completed, responsible javascript code was logging result of the pipeline instead of state.
