### PR TITLE
fix security - do not output all error object to log

### DIFF
--- a/ci/ci-test-tasks/run-main-and-verify.js
+++ b/ci/ci-test-tasks/run-main-and-verify.js
@@ -46,7 +46,7 @@ function runMainPipeline(id, tasks) {
   return axios.post(`${apiUrl}/${id}/runs?${apiVersion}`, {"templateParameters": {tasks, BuildSourceVersion: BUILD_SOURCEVERSION}}, { auth })
   .then(res => res.data)
   .catch(err => {
-    err.stack = 'Error running main pipeline: ' + err.stack;
+    err.message = 'Error running main pipeline: ' + err.message;
     throw err;
   })
 }
@@ -67,7 +67,7 @@ async function verifyBuildStatus(pipelineBuild, resolve, reject) {
     
       clearInterval(interval);
     
-      const result = `Build ${pipelineBuild.name} id:${pipelineBuild.id} finished with status "${data.result}" and result "${data.result}", url: ${pipelineBuild._links.web.href}`;
+      const result = `Build ${pipelineBuild.name} id:${pipelineBuild.id} finished with status "${data.state}" and result "${data.result}", url: ${pipelineBuild._links.web.href}`;
     
       if (data.result === 'succeeded') {
         resolve(result);
@@ -87,7 +87,7 @@ async function verifyBuildStatus(pipelineBuild, resolve, reject) {
       }
     
       clearInterval(interval);
-      err.stack = 'Error verifying build status: ' + err.stack;
+      err.message = 'Error verifying build status: ' + err.message;
       reject(err); 
     })
   }, intervalDelayMs)
@@ -106,5 +106,5 @@ function reportMissingTestPipelines(missingTestPipelines) {
 }
 
 process.on('uncaughtException', err => {
-  console.error(err.stack);
+  console.error(err.message);
 });

--- a/ci/ci-test-tasks/test-and-verify.js
+++ b/ci/ci-test-tasks/test-and-verify.js
@@ -40,7 +40,7 @@ function fetchPipelines() {
   return axios.get(`${apiUrl}?${apiVersion}`, { auth })
   .then(res => res.data.value)
   .catch(err => {
-    err.stack = 'Error fetching pipelines: ' + err.stack;
+    err.message = 'Error fetching pipelines: ' + err.message;
     throw err;
   });
 }
@@ -51,7 +51,7 @@ function runTestPipeline(pipeline) {
   return axios.post(`${apiUrl}/${pipeline.id}/runs?${apiVersion}`, {}, { auth })
   .then(res => res.data)
   .catch(err => {
-    err.stack = `Error running ${pipeline.name} pipeline, pipelineId ${pipeline.id}: ` + err.stack;
+    err.message = `Error running ${pipeline.name} pipeline, pipelineId ${pipeline.id}: ` + err.message;
     throw err;
   })
 }
@@ -92,12 +92,12 @@ async function verifyBuildStatus(pipelineBuild, resolve, reject) {
       }
     
       clearInterval(interval);
-      err.stack = 'Error verifying build status: ' + err.stack;
+      err.message = 'Error verifying build status: ' + err.message;
       reject(err); 
     })
   }, intervalDelayMs)
 }
 
 process.on('uncaughtException', err => {
-  console.error(err.stack);
+  console.error(err.message);
 });


### PR DESCRIPTION
ci-test-tasks: fix security - do not output all error objects to the std output