### PR TITLE
Backport changes from arm-rest v1 package

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-storage.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-storage.ts
@@ -125,6 +125,24 @@ export class StorageAccounts {
          return deferred.promise;
      }
 
+    public async getClassicOrArmAccountByName(accountName: string, options: any): Promise<Model.StorageAccount> {
+        const httpRequest = new webClient.WebRequest();
+        httpRequest.method = 'GET';
+        httpRequest.headers = this.client.setCustomHeaders(options);
+        // TODO: I think we should use newer api versions in the future?
+        httpRequest.uri = `https://management.azure.com/resources?api-version=2014-04-01-preview&%24filter=(subscriptionId%20eq%20'${this.client.subscriptionId}')%20and%20(resourceType%20eq%20'microsoft.storage%2Fstorageaccounts'%20or%20resourceType%20eq%20'microsoft.classicstorage%2Fstorageaccounts')%20and%20(name%20eq%20'${accountName}')`;
+
+        const res = await this.client.beginRequest(httpRequest);
+
+        if (res.statusCode == 200 && res.body.value) {
+            const storageAccounts: Model.StorageAccount[] = res.body.value;
+
+            return storageAccounts[0];
+        } else {
+            throw azureServiceClientBase.ToError(res);
+        }
+    }
+
     public async listKeys(resourceGroupName: string, accountName: string, options, storageAccountType?: string): Promise<string[]> {
         if (resourceGroupName === null || resourceGroupName === undefined || typeof resourceGroupName.valueOf() !== 'string') {
             throw new Error(tl.loc("ResourceGroupCannotBeNull"));

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.219.0",
+  "version": "3.219.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.219.0",
+  "version": "3.219.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Backported changes from arm-rest-v1 to v2 for consistency.

Parent PR: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/112