### PR TITLE
Revert the `DownloadPackageV0` task `Node16` migration

### DIFF
--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 218,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",
@@ -90,10 +90,6 @@
     "instanceNameFormat": "Download Package",
     "execution": {
         "Node10": {
-            "target": "download.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
             "target": "download.js",
             "argumentFormat": ""
         }

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 218,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",
@@ -90,10 +90,6 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
-      "target": "download.js",
-      "argumentFormat": ""
-    },
-    "Node16": {
       "target": "download.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
**Task name:** DownloadPackageV0

**Description:** this PR reverts [the `DownloadPackageV0` task `Node16` migration](https://github.com/microsoft/azure-pipelines-tasks/pull/17251)

**Documentation changes required:** No

**Added unit tests:** No

**Checklist:**
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
