### PR TITLE
NuGetCommandV2 add 4.9.6 nuget.exe

### DIFF
--- a/Tasks/NuGetCommandV2/make.json
+++ b/Tasks/NuGetCommandV2/make.json
@@ -28,6 +28,10 @@
                 "dest": "./NuGet/4.1.0/"
             },
             {
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGet/4.9.6/NuGet.zip",
+                "dest": "./NuGet/4.9.6/"
+            },
+            {
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/NuGet/5.4.0/NuGet.zip",
                 "dest": "./NuGet/5.4.0/"
             },

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 219,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 219,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: NuGetCommandV2

**Description**: Add blob reference to nuget 4.9.6 binary. Tested it locally by manually deleting the nuget 4.9.6 from my local agent.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
