### PR TITLE
[UseNodeV1] Update version of "azure-pipelines-tool-lib" to 2.0.3

### DIFF
--- a/Tasks/UseNodeV1/package-lock.json
+++ b/Tasks/UseNodeV1/package-lock.json
@@ -254,17 +254,38 @@
       }
     },
     "azure-pipelines-tool-lib": {
-      "version": "2.0.0-preview",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
-      "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.4.tgz",
+      "integrity": "sha512-LgAelZKJe3k/t3NsKSKzjeRviphns0w0p5tgwz8uHN70I9m2TToiOKl+fogrdXcM6+jiLBk5KTqrcRBqPpv/XA==",
       "requires": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
+        "azure-pipelines-task-lib": "^4.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "azure-pipelines-task-lib": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
+          "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
+          "requires": {
+            "minimatch": "3.0.5",
+            "mockery": "^2.1.0",
+            "q": "^1.5.1",
+            "semver": "^5.1.0",
+            "shelljs": "^0.8.5",
+            "sync-request": "6.1.0",
+            "uuid": "^3.0.1"
+          }
+        },
+        "mockery": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+          "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+        }
       }
     },
     "balanced-match": {

--- a/Tasks/UseNodeV1/package.json
+++ b/Tasks/UseNodeV1/package.json
@@ -29,7 +29,7 @@
     "azure-pipelines-task-lib": "^4.0.0-preview",
     "azure-pipelines-tasks-packaging-common": "2.1.0",
     "azure-pipelines-tasks-utility-common": "^3.198.1",
-    "azure-pipelines-tool-lib": "^2.0.0-preview",
+    "azure-pipelines-tool-lib": "^2.0.3",
     "typed-rest-client": "^1.8.4"
   },
   "devDependencies": {

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 213,
+        "Minor": 220,
         "Patch": 0
     },
     "satisfies": [

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 213,
+    "Minor": 220,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
**Task name**: UseNodeV1

**Description**: Need to update version of `azure-pipelines-tool-lib` to `2.0.3` since it contains fix around downloading Node tool

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

**How it was tested:**
Tested on self-hosted agent by replacing code of task with changes from the PR. Bandwidth connection was limited by application `NetLimiter` to `300 KB/s`. Throttling was simulated by application `TCPView`.
Successful run: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6408
Run with throttling issues: https://abtttestorg.visualstudio.com/Other/_build/results?buildId=6409

**Test Cases:**
Test pipeline
```yaml
strategy:
  matrix:
    'Node16':
      SomeVariable: 'somevalue'
    'Node10':
      AGENT_USE_NODE10: 'true'

steps:
- task: NodeTool@0
  inputs:
    versionSource: 'spec'
    versionSpec: '16.10.x'
```
1. Start self-hosted agent
2. Replace task `UseNode` with changes from the PR
3. Limit bandwidth connection to `300 KB/s` (`NetLimiter`, `@sitespeed.io/throttle`, etc.)
4. Run pipeline on the agent
5. During execution of task `UseNode` close TCP connection to `nodejs.org` server (`TCPView`, `tcpkill`, etc.)

Expected Result:
Task `UseNode` must be failed with error `Aborted`