### PR TITLE
Fixes #17255 - Allow --results-directory to be specified

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -514,6 +514,22 @@ describe('DotNetCoreExe Suite', function () {
         done();
     });
 
+    it('test command with publish test results allows results directory to be explicitly defined', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let tp = path.join(__dirname, './TestCommandTests/publishtestsWithExplicitResultsDirectory.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert(tr.invokedToolCount == 1, 'should have run dotnet once');
+        assert(tr.ran('c:\\path\\dotnet.exe test c:\\agent\\home\\directory\\temp.csproj --logger trx --results-directory c:\\customDirectory'), 'it should have run dotnet test');
+        assert(tr.stdOutContained('dotnet output'), "should have dotnet output");
+        assert(tr.stdOutContained('vso[results.publish type=VSTest;mergeResults=false;publishRunAttachments=true;resultFiles=c:\\customDirectory\\sample.trx;]'), "should publish trx");
+        assert(tr.succeeded, 'should have succeeded');
+        assert.strictEqual(tr.errorIssues.length, 0, 'should have no errors');
+        done();
+    });
+
     it('test command without publish test results', (done: MochaDone) => {
         this.timeout(1000);
 

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithExplicitResultsDirectory.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/publishtestsWithExplicitResultsDirectory.ts
@@ -1,0 +1,73 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import util = require('../DotnetMockHelper');
+
+const taskPath = path.join(__dirname, '../..', 'dotnetcore.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const nmh: util.DotnetMockHelper = new util.DotnetMockHelper(tmr);
+
+nmh.setNugetVersionInputDefault();
+tmr.setInput('command', 'test');
+tmr.setInput('projects', 'temp.csproj');
+tmr.setInput('BuildConfiguration', 'config');
+tmr.setInput('BuildPlatform', 'x86');
+tmr.setInput('publishTestResults', 'true');
+tmr.setInput('arguments', '--results-directory c:\\customDirectory');
+
+const a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'osType': {},
+    'checkPath': {
+        'c:\\agent\\home\\directory\\temp.csproj': true,
+        'c:\\path\\dotnet.exe': true
+    },
+    'which': {
+        'dotnet': 'c:\\path\\dotnet.exe'
+    },
+    'exec': {
+        'c:\\path\\dotnet.exe test c:\\agent\\home\\directory\\temp.csproj --logger trx --results-directory c:\\customDirectory': {
+            'code': 0,
+            'stdout': 'dotnet output',
+            'stderr': ''
+        }
+    },
+    'exist': {
+        'D:\\src\\github\\vsts-tasks\\Tests\\Nuget': true
+    },
+    'stats': {
+        'c:\\agent\\home\\directory\\temp.csproj': {
+            'isFile': true
+        }
+    },
+    'findMatch': {
+        'temp.csproj': ['c:\\agent\\home\\directory\\temp.csproj'],
+        '**/*.trx': ['c:\\customDirectory\\sample.trx']
+    },
+    "rmRF": {
+        "c:\\customDirectory\\sample.trx": {
+            "success": true
+        }
+    }
+};
+
+// Create mock for getVariable
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.getVariable = function(variable: string) {
+    if (variable.toUpperCase() === "Agent.TempDirectory".toUpperCase())
+    {
+        return process.env[variable.toUpperCase()];
+    }
+    else
+    {
+        return tl.getVariable(variable);
+    }    
+};
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+nmh.setAnswers(a);
+nmh.registerNugetUtilityMock(['c:\\agent\\home\\directory\\temp.csproj']);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+tmr.run();

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -144,13 +144,17 @@ export class dotNetExe {
         const dotnetPath = tl.which('dotnet', true);
         tl.loc('DeprecatingDotnet2_2');
         const enablePublishTestResults: boolean = tl.getBoolInput('publishTestResults', false) || false;
-        const resultsDirectory = tl.getVariable('Agent.TempDirectory');
+        var resultsDirectory = tl.getVariable('Agent.TempDirectory');
         if (enablePublishTestResults && enablePublishTestResults === true) {
-            this.arguments = ` --logger trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
-        }
+            const containsResultDirectoryArgument: boolean = this.arguments.includes('--results-directory');
+            if (!containsResultDirectoryArgument)
+                this.arguments = ` --logger trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
+            else {
+                this.arguments = ` --logger trx `.concat(this.arguments);
+                resultsDirectory = this.getResultsDirectoryArgument();
+            }
 
-        // Remove old trx files
-        if (enablePublishTestResults && enablePublishTestResults === true) {
+            // Remove old trx files
             this.removeOldTestResultFiles(resultsDirectory);
         }
 
@@ -343,6 +347,72 @@ export class dotNetExe {
             else if (isOutputOption) {
                 this.outputArgument = token;
                 isOutputOption = false;
+            }
+
+            token = nextArg();
+        }
+    }
+
+    private getResultsDirectoryArgument(): string {
+        if (!this.arguments || !this.arguments.trim()) {
+            return;
+        }
+
+        var argString = this.arguments.trim();
+        var isResultsDirectoryOption = false;
+        var inQuotes = false;
+        var escaped = false;
+        var arg = '';
+        var i = 0;
+        var append = function (c) {
+            // we only escape double quotes.
+            if (escaped && c !== '"') {
+                arg += '\\';
+            }
+            arg += c;
+            escaped = false;
+        };
+        var nextArg = function () {
+            arg = '';
+            for (; i < argString.length; i++) {
+                var c = argString.charAt(i);
+                if (c === '"') {
+                    if (!escaped) {
+                        inQuotes = !inQuotes;
+                    }
+                    else {
+                        append(c);
+                    }
+                    continue;
+                }
+                if (c === "\\" && inQuotes && !escaped) {
+                    escaped = true;
+                    continue;
+                }
+                if (c === ' ' && !inQuotes) {
+                    if (arg.length > 0) {
+                        return arg.trim();
+                    }
+                    continue;
+                }
+                append(c);
+            }
+
+            if (arg.length > 0) {
+                return arg.trim();
+            }
+
+            return null;
+        }
+
+        var token = nextArg();
+        while (token) {
+            var tokenUpper = token.toUpperCase();
+            if (tokenUpper === "--RESULTS-DIRECTORY") {
+                isResultsDirectoryOption = true;
+            }
+            else if (isResultsDirectoryOption) {
+                return token;
             }
 
             token = nextArg();

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 2,
-        "Minor": 171,
-        "Patch": 4
+        "Minor": 221,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.115.0",
     "instanceNameFormat": "dotnet $(command)",


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: Allow --results-directory to be specified when `publishTestResults` is not disabled.

**Documentation changes required:** N

**Added unit tests:** Y, added a unit test

**Attached related issue:** Y #17255 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
