### PR TITLE
AzurePolicyCheckGate: Configure retry logic

### DIFF
--- a/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
@@ -11,5 +11,5 @@
   "loc.input.label.Resources": "Resource name",
   "loc.input.help.Resources": "Select name of Azure resources for which you want to check the policy compliance.",
   "loc.input.label.RetryDuration": "Retry duration",
-  "loc.input.help.RetryDuration": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​."
+  "loc.input.help.RetryDuration": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​. Minimal period is 2 minutes."
 }

--- a/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzurePolicyV0/Strings/resources.resjson/en-US/resources.resjson
@@ -3,10 +3,13 @@
   "loc.helpMarkDown": "",
   "loc.description": "Security and compliance assessment for Azure Policy",
   "loc.instanceNameFormat": "Check Policy Compliance",
+  "loc.group.displayName.advancedOptions": "Advanced",
   "loc.input.label.ConnectedServiceName": "Azure subscription",
   "loc.input.help.ConnectedServiceName": "Select the Azure Resource Manager subscription to enforce the policies.",
   "loc.input.label.ResourceGroupName": "Resource group",
   "loc.input.help.ResourceGroupName": "Provide name of a resource group.",
   "loc.input.label.Resources": "Resource name",
-  "loc.input.help.Resources": "Select name of Azure resources for which you want to check the policy compliance."
+  "loc.input.help.Resources": "Select name of Azure resources for which you want to check the policy compliance.",
+  "loc.input.label.RetryDuration": "Retry duration",
+  "loc.input.help.RetryDuration": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​."
 }

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -15,9 +15,16 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 198,
+        "Minor": 221,
         "Patch": 0
     },
+    "groups": [
+        {
+            "name": "advancedOptions",
+            "displayName": "Advanced",
+            "isExpanded": false
+        }
+    ],
     "inputs": [
         {
             "name": "ConnectedServiceName",
@@ -49,6 +56,15 @@
                 "DisableManageLink": "True",
                 "EditableOptions": "False"
             }
+        },
+        {
+            "name": "RetryDuration",
+            "type": "string",
+            "label": "Retry duration",
+            "defaultValue": "00:00:30",
+            "required": false,
+            "helpMarkDown": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​.",
+            "groupName": "advancedOptions"
         }
     ],
     "dataSourceBindings": [
@@ -90,6 +106,10 @@
                         "EndpointUrl": "$(locationUrl)",
                         "Method": "GET",
                         "Expression": "and(eq(response['statuscode'], 'OK'), eq(response['content']['status'], 'Succeeded'))"
+                    },
+                    "ExecutionOptions": {
+                        "ContinuePollingExpression": "eq(response['statuscode'], 'Accepted')",
+                        "DurationBetweenRetries": "$(RetryDuration)"
                     }
                 },
                 {

--- a/Tasks/AzurePolicyV0/task.json
+++ b/Tasks/AzurePolicyV0/task.json
@@ -61,9 +61,9 @@
             "name": "RetryDuration",
             "type": "string",
             "label": "Retry duration",
-            "defaultValue": "00:00:30",
+            "defaultValue": "00:02:00",
             "required": false,
-            "helpMarkDown": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​.",
+            "helpMarkDown": "Defines period which task will wait until it retry to call Azure API in case that previous response code was \"Accepted\"​. Minimal period is 2 minutes.",
             "groupName": "advancedOptions"
         }
     ],

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -15,9 +15,16 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 198,
+    "Minor": 221,
     "Patch": 0
   },
+  "groups": [
+    {
+      "name": "advancedOptions",
+      "displayName": "ms-resource:loc.group.displayName.advancedOptions",
+      "isExpanded": false
+    }
+  ],
   "inputs": [
     {
       "name": "ConnectedServiceName",
@@ -49,6 +56,15 @@
         "DisableManageLink": "True",
         "EditableOptions": "False"
       }
+    },
+    {
+      "name": "RetryDuration",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.RetryDuration",
+      "defaultValue": "00:00:30",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.RetryDuration",
+      "groupName": "advancedOptions"
     }
   ],
   "dataSourceBindings": [
@@ -90,6 +106,10 @@
             "EndpointUrl": "$(locationUrl)",
             "Method": "GET",
             "Expression": "and(eq(response['statuscode'], 'OK'), eq(response['content']['status'], 'Succeeded'))"
+          },
+          "ExecutionOptions": {
+            "ContinuePollingExpression": "eq(response['statuscode'], 'Accepted')",
+            "DurationBetweenRetries": "$(RetryDuration)"
           }
         },
         {

--- a/Tasks/AzurePolicyV0/task.loc.json
+++ b/Tasks/AzurePolicyV0/task.loc.json
@@ -61,7 +61,7 @@
       "name": "RetryDuration",
       "type": "string",
       "label": "ms-resource:loc.input.label.RetryDuration",
-      "defaultValue": "00:00:30",
+      "defaultValue": "00:02:00",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.RetryDuration",
       "groupName": "advancedOptions"


### PR DESCRIPTION
**Task name**: AzurePolicyCheckGateV0

**Description**: When calling Azure policy check API, Azure might response with `Accepted` status code. See more details [here](https://learn.microsoft.com/en-us/azure/governance/policy/how-to/get-compliance-data#on-demand-evaluation-scan---rest). In such cases task was failing because response did not contain required properties. This PR adds configuration to retry requests until response status code is not `Accepted`.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
