### PR TITLE
Added azureSubscription input to resolve SubscriptionId for OIDC token fetching

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
@@ -416,7 +416,10 @@ export class ApplicationTokenCredentials {
         if (!serviceConnectionId) {
             serviceConnectionId = tl.getInput("ConnectedServiceName", false);
             if (!serviceConnectionId) {
-                throw new Error(tl.loc("serviceConnectionIdCannotBeEmpty"));
+                serviceConnectionId = tl.getInput("azureSubscription", false);
+                if (!serviceConnectionId) {
+                    throw new Error(tl.loc("serviceConnectionIdCannotBeEmpty"));
+                }
             }
         }
         const projectId: string = tl.getVariable("System.TeamProjectId");

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.220.2",
+  "version": "3.220.3",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: common lib - azure-arm-rest-v2

**Description**: Added azureSubscription input to resolve SubscriptionId for OIDC token fetching

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
