### PR TITLE
use `@tsconfig/node10`

### DIFF
--- a/Tasks/BashV3/package-lock.json
+++ b/Tasks/BashV3/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
     "@types/concat-stream": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",

--- a/Tasks/BashV3/package.json
+++ b/Tasks/BashV3/package.json
@@ -25,6 +25,7 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
+    "@tsconfig/node10": "1.0.9",
     "typescript": "4.0.2"
   }
 }

--- a/Tasks/BashV3/task.json
+++ b/Tasks/BashV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 226,
-        "Patch": 0
+        "Patch": 1
     },
     "releaseNotes": "Script task consistency. Added support for multiple lines and added support for Windows.",
     "minimumAgentVersion": "2.115.0",

--- a/Tasks/BashV3/task.loc.json
+++ b/Tasks/BashV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 226,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.115.0",

--- a/Tasks/BashV3/tsconfig.json
+++ b/Tasks/BashV3/tsconfig.json
@@ -1,6 +1,7 @@
 {
+    "extends": "@tsconfig/node10/tsconfig.json",
     "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
+        "noImplicitAny": false,
+        "strictNullChecks": false,
     }
 }


### PR DESCRIPTION
**Task name**: BashV3

**Description**: Migrate from custom `tsconfig.json` to [`@tsconfig/node10`][1]. See #18118 for more information

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #18118

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected


[1]: https://www.npmjs.com/package/@tsconfig/node10