### PR TITLE
Update Rename to json to only change the extension

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
@@ -430,7 +430,7 @@ class Utils {
             if(parseFloat(azcliversion)){
                 if(this.isBicepAvailable(azcliversion)){
                     await this.execBicepBuild(filePath)
-                    filePath = filePath.replace('.bicep', '.json')
+                    filePath.substring(0,filePath.lastIndexOf(".bicep"))+".json"
                     this.cleanupFileList.push(filePath)
                 }else{
                     throw new Error(tl.loc("IncompatibleAzureCLIVersion"));


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeployment

**Description**: #18136 fixes issue in this bug, which erroneously replaces any .bicep in filename 

**Documentation changes required:** (N

**Added unit tests:** N

**Attached related issue:** #18136 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
