### PR TITLE
Bump vm2 from 3.9.16 to 3.9.17 in /Tasks/AppCenterTestV1

### DIFF
--- a/Tasks/AppCenterTestV1/package-lock.json
+++ b/Tasks/AppCenterTestV1/package-lock.json
@@ -3452,9 +3452,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.16",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
-      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "requires": {
         "acorn": "^8.7.0",
         "acorn-walk": "^8.2.0"

--- a/Tasks/AppCenterTestV1/task.json
+++ b/Tasks/AppCenterTestV1/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 1,
         "Minor": 221,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.144.0",
     "groups": [

--- a/Tasks/AppCenterTestV1/task.loc.json
+++ b/Tasks/AppCenterTestV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 221,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [


### PR DESCRIPTION
**Task name**: AppCenterTestV1

**Description**: Update vm2 to fix [CVE-2023-30547](https://github.com/patriksimek/vm2/security/advisories/GHSA-ch3r-j5x3-6q2m)

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected