### PR TITLE
Include task switching CodeGen to make.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ ModelManifest.xml
 /Package
 LoadTest.code-workspace
 .idea/
+_dotnetsdk/

--- a/BuildConfigGen/BuildConfigGen.csproj
+++ b/BuildConfigGen/BuildConfigGen.csproj
@@ -5,7 +5,8 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<WarningsAsErrors>Nullable</WarningsAsErrors>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
+    <RollForward >LatestMinor</RollForward>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -109,7 +109,7 @@ steps:
 
   # Push to feed
   - script: |
-      cd $(Build.SourcesDirectory)\_package\nuget-packages\$(task)
+      cd $(Build.SourcesDirectory)\_package\nuget-packages\${{ parameters.task }}
       push.cmd
     displayName: Push Nuget package
 

--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -28,6 +28,8 @@ var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
 var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
+var genTaskPath = path.join(__dirname, '..', '_generated');
+
 exports.buildTasksPath = buildTasksPath;
 exports.packagePath = packagePath;
 exports.tasksLayoutPath = tasksLayoutPath;
@@ -47,6 +49,7 @@ exports.aggregatePackageName = aggregatePackageName;
 exports.aggregateNuspecPath = aggregateNuspecPath;
 exports.publishLayoutPath = publishLayoutPath;
 exports.publishPushCmdPath = publishPushCmdPath;
+exports.genTaskPath = genTaskPath;
 
 //------------------------------------------------------------------------------
 // generic functions
@@ -470,6 +473,14 @@ var resolveTaskList = function(taskPattern) {
             .map(function (item) {
                 return path.basename(item);
             });
+
+        // If base tasks was not found, try to find the task in the _generated tasks folder
+        if (taskList.length == 0) { 
+            taskList = matchFind(taskPattern, genTaskPath, { noRecurse: true, matchBase: true })
+                .map(function (item) {
+                    return path.basename(item);
+                });
+        }
         if (!taskList.length) {
             throw new Error(`Unable to find any tasks matching pattern ${taskPattern}`);
         }

--- a/ci/courtesy-push.yml
+++ b/ci/courtesy-push.yml
@@ -10,7 +10,7 @@ steps:
     downloadPath: IndividualNugetPackagesDownloaded
   displayName: Download Artifact
 
-- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps\.nuget\externals\UnifiedDependencies.xml IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
+- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
   displayName: Update unified deps
 
 - task: NuGetAuthenticate@0
@@ -37,6 +37,7 @@ steps:
     git config --global user.email "$(username)@microsoft.com"
     git config --global user.name "$(username)"
     git add .nuget\externals\UnifiedDependencies.xml
+    git add Tfs\Service\Deploy\components\*
     git commit -m "Courtesy bump of tasks"
     git push origin $releaseBranch --force
     Write-Host "Creating Pull Request"

--- a/ci/courtesy-push/courtesy-push.js
+++ b/ci/courtesy-push/courtesy-push.js
@@ -1,14 +1,25 @@
 const fs = require('fs');
+const path = require('path');
 
-const versionReplace = (pathToUnifiedDeps, pathToNewUnifiedDeps, outputPath) => {
-    const currentDeps = fs.readFileSync(pathToUnifiedDeps, 'utf8');
-    const newDeps = fs.readFileSync(pathToNewUnifiedDeps, 'utf8');
+const azureSourceFolder = process.argv[2];
+const newDeps = process.argv[3];
+const unifiedDepsPath = path.join(azureSourceFolder, '.nuget', 'externals', 'UnifiedDependencies.xml');
+const tfsServerPath = path.join(azureSourceFolder, 'Tfs', 'Service', 'Deploy', 'components', 'TfsServer.Servicing.core.xml');
+const msPrefix = "Mseng.MS.TF.DistributedTask.Tasks.";
+const directoryTag = new RegExp('<Directory (.*)>');
 
-    const currentDepsArr = currentDeps.split('\n');
-    const newDepsArr = newDeps.split('\n');
+function formDirectoryString(nugetTaskName) {
+    const taskName = nugetTaskName.replace(msPrefix, '');
+  
+    return `  <Directory Path="[ServicingDir]Tasks\\Individual\\${taskName}\\">
+    <File Origin="nuget://Mseng.MS.TF.DistributedTask.Tasks.${taskName}/content/*" />
+  </Directory>`;
+}
+
+function formatDeps(depArr) {
     const newDepsDict = {};
 
-    newDepsArr.forEach(newDep => {
+    depArr.forEach(newDep => {
         // add to dictionary
         const depDetails = newDep.split('"');
         console.log(JSON.stringify(depDetails));
@@ -18,7 +29,24 @@ const versionReplace = (pathToUnifiedDeps, pathToNewUnifiedDeps, outputPath) => 
         newDepsDict[name] = version;
     });
 
+    return newDepsDict;
+}
+
+/* Function updating existing deps version and also add new deps with postfix 
+ * Example: Of we have dependency with name 
+ * Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2
+ * It will add Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2-Node16 */
+function updateUnifiedDeps(pathToUnifiedDeps, pathToNewUnifiedDeps, outputPath) {
+    const currentDeps = fs.readFileSync(pathToUnifiedDeps, 'utf8');
+    const newDeps = fs.readFileSync(pathToNewUnifiedDeps, 'utf8');
+
+    const currentDepsArr = currentDeps.split('\n');
+    const newDepsArr = newDeps.split('\n');
+    const newDepsDict = formatDeps(newDepsArr);
+
     const updatedDeps = [];
+    // Tasks that was updated and should be presented in TfsServer.Servicing.core.xml
+    const changedTasks = [];
 
     currentDepsArr.forEach(currentDep => {
         const depDetails = currentDep.split('"');
@@ -31,6 +59,9 @@ const versionReplace = (pathToUnifiedDeps, pathToNewUnifiedDeps, outputPath) => 
                 // update the version
                 depDetails[3] = newDepsDict[newDepsKey];
                 updatedDeps.push(depDetails.join('"'));
+
+                changedTasks.push(newDepsKey);
+                delete newDepsDict[newDepsKey];
             } else {
                 updatedDeps.push(currentDep);
                 console.log(`"${currentDep}"`);
@@ -40,12 +71,58 @@ const versionReplace = (pathToUnifiedDeps, pathToNewUnifiedDeps, outputPath) => 
         }
     });
 
+    // add the new deps from the start
+    // working only for generated deps
+
+    if (Object.keys(newDepsDict).length > 0) {
+        for (let packageName in newDepsDict) {
+            // new deps should include old packages completely
+            // Example:
+            // Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2-Node16(packageName) should include 
+            // Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2(basePackageName)
+            const depToBeInserted = newDepsArr.find(dep => dep.includes(packageName));
+            const pushingIndex = updatedDeps.findIndex(basePackage => {
+                if (!basePackage) return false;
+
+                const depDetails = basePackage.split('"');
+                const name = depDetails[1];
+                return name && name.startsWith(msPrefix) && packageName.includes(name)
+            });
+
+            if (pushingIndex !== -1) {
+                // We need to insert new package after the old one
+                updatedDeps.splice(pushingIndex + 1, 0, depToBeInserted);
+                changedTasks.push(packageName);
+            }
+        }
+    }
     // write it as a new file where currentDeps is
     fs.writeFileSync(outputPath, updatedDeps.join('\n'));
-    console.log('Done.');
+    console.log('Updating Unified Dependencies file done.');
+    return changedTasks;
 };
 
-const unifiedDeps = process.argv[2];
-const newDeps = process.argv[3];
+/* Function to insert new tasks into TfsServer.Servicing.core.xml
+ * Only if the was modified/added into UnifiedDependencies.xml and not exists in the TfsServer.Servicing.core.xml file
+ */
+function updateTfsServerDeps(pathToTfsCore, depsToUpdateArr, outputPath) {
+    const tfsCore = fs.readFileSync(pathToTfsCore, 'utf8');
+    const tfsToUpdate = tfsCore.split('\n');
+    const tfsCoreLowerCase = tfsCore.toLowerCase();
 
-versionReplace(unifiedDeps, newDeps, unifiedDeps); 
+    const insertedIndex = tfsToUpdate.findIndex(tfsString => directoryTag.test(tfsString));
+    depsToUpdateArr.forEach(dependencyName => {
+        const dependencyNameLower = dependencyName.toLowerCase();
+        if (tfsCoreLowerCase.indexOf(dependencyNameLower) === -1) {
+            const insertedString = formDirectoryString(dependencyName);
+            tfsToUpdate.splice(insertedIndex, 0, insertedString);
+            console.log(`${insertedString}`);
+        } 
+    });
+
+    fs.writeFileSync(outputPath, tfsToUpdate.join('\n'));
+    console.log('Inserting into Tfs Servicing Core file done.');
+}
+
+const changedTasks = updateUnifiedDeps(unifiedDepsPath, newDeps, unifiedDepsPath);
+updateTfsServerDeps(tfsServerPath, changedTasks, tfsServerPath);

--- a/ci/verify-source-changes.js
+++ b/ci/verify-source-changes.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var fs = require('fs');
 var process = require("process");
 var util = require('./ci-util');
 
@@ -19,6 +20,8 @@ taskList.forEach(function(taskName) {
     console.log(`====================${taskName}====================`);
 
     var taskSourcePath = path.join(util.tasksSourcePath, taskName);
+    // If task source folder doesn't exist it's generated folded and we don't need to check it
+    if (!fs.existsSync(taskSourcePath)) return
 
     var diffString = util.run(`git diff --name-only ${taskSourcePath}`);
     var diffList = diffString.split("\n").filter(Boolean);

--- a/make-util.js
+++ b/make-util.js
@@ -1327,7 +1327,16 @@ var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath
 
             // Create the full task name so we don't need to rely on the folder name.
             var fullTaskName = `Mseng.MS.TF.DistributedTask.Tasks.${taskName}V${taskJsonContents.version.Major}`;
-
+            if (taskJsonContents.hasOwnProperty('_buildConfigMapping')) { 
+                for (let i in taskJsonContents._buildConfigMapping) {
+                    if (taskJsonContents._buildConfigMapping[i] === taskVersion && i.toLocaleLowerCase() !== 'default') {
+                        // take only first part of the name
+                        var postfix = i.split('-')[0];
+                        fullTaskName = fullTaskName + `-${postfix}`;
+                        break;
+                    }
+                }
+            }
             // Create xml entry for UnifiedDependencies
             unifiedDepsContent.push(`  <package id="${fullTaskName}" version="${taskVersion}" availableAtDeployTime="true" />`);
 
@@ -1700,5 +1709,113 @@ var getTaskNodeVersion = function(buildPath, taskName) {
     return [ 10 ];
 }
 exports.getTaskNodeVersion = getTaskNodeVersion;
+
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// codegen functions
+//------------------------------------------------------------------------------
+
+/**
+ * Returns path to BuldConfigGenerator, if generator wasn't compile it will compile it
+ * @returns Path to the executed file
+ */
+var getBuildConfigGenerator = function (baseConfigToolPath) {
+    var programPath = "";
+    var configToolBuildUtility = "";
+
+    if (os.platform() === 'win32') {
+        programPath = path.join(baseConfigToolPath, 'bin', 'BuildConfigGen.exe');
+        configToolBuildUtility = path.join(baseConfigToolPath, "dev.cmd");
+    } else {
+        programPath = path.join(baseConfigToolPath, 'bin', 'BuildConfigGen');
+        configToolBuildUtility = path.join(baseConfigToolPath, "dev.sh");
+    }
+
+    if (!fs.existsSync(programPath)) {
+        console.log(`BuildConfigGen not found at ${programPath}. Starting build.`);
+        run(configToolBuildUtility, true);
+    }
+
+    return programPath;
+};
+exports.getBuildConfigGenerator = getBuildConfigGenerator;
+
+/**
+ * Function to validate generated tasks
+ * @param {String} baseConfigToolPath Path to generating programm
+ * @param {Array} taskList  Array with allowed tasks
+ * @param {Object} makeOptions Object with all tasks
+ */
+var validateGeneratedTasks = function(baseConfigToolPath, taskList, makeOptions) {
+    if (!makeOptions) fail("makeOptions is not defined");
+    const excludedMakeOptionKeys = ["tasks", "taskResources"];
+    const validatingTasks = {};
+    
+    for (const key in makeOptions) {
+        if (excludedMakeOptionKeys.indexOf(key) > -1) continue;
+
+        makeOptions[key].forEach((taskName) => {
+            if (taskList.indexOf(taskName) ===  -1) return;
+            if (validatingTasks[taskName]) {
+                validatingTasks[taskName].push(key);
+            } else {
+                validatingTasks[taskName] = [key];
+            }
+        });
+    }
+
+    for (const taskName in validatingTasks) {
+        const programPath = getBuildConfigGenerator(baseConfigToolPath);
+        const config = validatingTasks[taskName];
+        const configString = config.join("|");
+        const args = [
+            "--configs",
+            `"${configString}"`,
+            "--task",
+            taskName,
+        ];
+
+        banner('Validating: ' + taskName);
+        run(`${programPath} ${args.join(' ')}`, true);
+    }
+}
+exports.validateGeneratedTasks = validateGeneratedTasks;
+
+/**
+ * Function to generate new tasks
+ * @param {String} baseConfigToolPath Path to generating program
+ * @param {Array} taskList  Array with allowed tasks
+ * @param {String} configsString String with generation configs 
+ * @param {Object} makeOptions Object to put generated definitions
+ */
+
+var generateTasks = function(baseConfigToolPath, taskList, configsString, makeOptions) {
+    const args = `--write-updates --configs "${configsString}"`;
+    const configsArr = configsString.split("|")
+    let newMakeOptions = makeOptions;
+
+    taskList.forEach(function (taskName) {
+        const programPath = getBuildConfigGenerator(baseConfigToolPath);
+        const buildArgs = args + ` --task ${taskName}`;
+
+        banner('Generating: ' + taskName);
+        run(`${programPath} ${buildArgs}` , true);
+
+        // insert to make-options.json
+        configsArr.forEach(function (config) {
+            if (!newMakeOptions[config]) {
+                newMakeOptions[config] = [];
+            }
+            
+            if (newMakeOptions[config].indexOf(taskName) === -1) {
+                newMakeOptions[config].push(taskName);
+            }
+        });
+    });
+
+    return newMakeOptions;
+}
+exports.generateTasks = generateTasks;
 
 //------------------------------------------------------------------------------

--- a/make.js
+++ b/make.js
@@ -52,6 +52,9 @@ var binPath = path.join(__dirname, 'node_modules', '.bin');
 var makeOptionsPath = path.join(__dirname, 'make-options.json');
 var gendocsPath = path.join(__dirname, '_gendocs');
 var packagePath = path.join(__dirname, '_package');
+var baseConfigToolPath = path.join(__dirname, 'BuildConfigGen');
+var genTaskPath = path.join(__dirname, '_generated');
+var genTaskCommonPath = path.join(__dirname, '_generated', 'Common');
 
 var CLI = {};
 
@@ -78,6 +81,15 @@ if (argv.task) {
         .map(function (item) {
             return path.basename(item);
         });
+
+    // If base tasks was not found, try to find the task in the _generated tasks folder
+    if (taskList.length == 0) { 
+        taskList = matchFind(argv.task, genTaskPath, { noRecurse: true, matchBase: true })
+            .map(function (item) {
+                return path.basename(item);
+            });
+    }
+
     if (!taskList.length) {
         fail('Unable to find any tasks matching pattern ' + argv.task);
     }
@@ -91,6 +103,27 @@ if (argv.task) {
 //
 // note, currently the ts runner igores this setting and will always run.
 process.env['TASK_TEST_RUNNER'] = argv.runner || '';
+
+function getTaskList(taskList) {
+    let tasksToBuild = taskList;
+
+    if (!fs.existsSync(genTaskPath)) return tasksToBuild;
+
+    const generatedTaskFolders = fs.readdirSync(genTaskPath)
+        .filter((taskName) => {
+            return fs.statSync(path.join(genTaskPath, taskName)).isDirectory();
+        });
+
+    taskList.forEach((taskName) => {
+        generatedTaskFolders.forEach((generatedTaskName) => {
+            if (taskName !== generatedTaskName && generatedTaskName.startsWith(taskName)) {
+                tasksToBuild.push(generatedTaskName);
+            }
+        });
+    });
+
+    return tasksToBuild.sort();
+}
 
 CLI.clean = function() {
     rm('-Rf', buildPath);
@@ -147,10 +180,26 @@ CLI.build = function() {
     });
 
     const removeNodeModules = taskList.length > 1;
+    const allTasks = getTaskList(taskList);
 
-    taskList.forEach(function(taskName) {
+    // Need to validate generated tasks first
+    const makeOptions = fileToJson(makeOptionsPath);
+    util.validateGeneratedTasks(baseConfigToolPath, taskList, makeOptions);
+
+    allTasks.forEach(function(taskName) {
+        let isGeneratedTask = false;
         banner('Building: ' + taskName);
-        var taskPath = path.join(tasksPath, taskName);
+
+        // If we have the task in generated folder, prefer to build from there and add all generated tasks which starts with task name
+        var taskPath = path.join(genTaskPath, taskName);
+        if (fs.existsSync(taskPath)) {
+            // Need to add all tasks which starts with task name
+            console.log('Found generated task: ' + taskName);
+            isGeneratedTask = true;
+        } else {
+            taskPath = path.join(tasksPath, taskName);
+        }
+        
         ensureExists(taskPath);
 
         // load the task.json
@@ -199,6 +248,11 @@ CLI.build = function() {
 
                 if (!test('-d', modOutDir)) {
                     banner('Building module ' + modPath, true);
+
+                    // Ensure that Common folder exists for _generated tasks, otherwise copy it from Tasks folder
+                    if (!fs.existsSync(genTaskCommonPath) && isGeneratedTask) {
+                        cp('-Rf', path.resolve(tasksPath, "Common"), genTaskCommonPath);
+                    }
 
                     mkdir('-p', modOutDir);
 
@@ -314,6 +368,11 @@ CLI.build = function() {
         }
     });
 
+    // Remove Commons from _generated folder as it is not required
+    if (fs.existsSync(genTaskCommonPath)) {
+        rm('-Rf', genTaskCommonPath);
+    }
+
     banner('Build successful', true);
 }
 
@@ -336,7 +395,6 @@ CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */
     console.log('> copying ps test lib resources');
     mkdir('-p', path.join(buildTestsPath, 'lib'));
     matchCopy(path.join('**', '@(*.ps1|*.psm1)'), path.join(testsPath, 'lib'), path.join(buildTestsPath, 'lib'));
-
     var suiteType = argv.suite || 'L0';
     function runTaskTests(taskName) {
         banner('Testing: ' + taskName);
@@ -375,17 +433,17 @@ CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */
         });
     }
 
-    if (argv.task) {
-        runTaskTests(argv.task);
-    } else {
-        // Run tests for each task that exists
-        taskList.forEach(function(taskName) {
-            var taskPath = path.join(buildTasksPath, taskName);
-            if (fs.existsSync(taskPath)) {
-                runTaskTests(taskName);
-            }
-        });
+    // Run tests for each task that exists
+    const allTasks = getTaskList(taskList);
 
+    allTasks.forEach(function(taskName) {
+        var taskPath = path.join(buildTasksPath, taskName);
+        if (fs.existsSync(taskPath)) {
+            runTaskTests(taskName);
+        }
+    });
+
+    if (!argv.task) {
         banner('Running common library tests');
         var commonLibPattern = path.join(buildTasksPath, 'Common', '*', 'Tests', suiteType + '.js');
         var specs = [];
@@ -833,6 +891,28 @@ CLI.gensprintlyzip = function(/** @type {{ sprint: string; outputdir: string; de
     rm('-Rf', tempWorkspaceDirectory);
 
     console.log('\n# Completed creating sprintly zip.');
+}
+
+CLI.gentask = function() {
+    if (argv.rebuild) {
+        rm("-Rf", path.join(baseConfigToolPath, "bin"));
+    }
+
+    const makeOptions = fileToJson(makeOptionsPath);
+    const validate = argv.validate;
+    const configsString = argv.configs;
+
+    if (validate) {
+        util.validateGeneratedTasks(baseConfigToolPath, taskList, makeOptions);
+        return;
+    }
+    
+    if (!configsString) {
+        throw Error ('--configs is required');
+    }
+
+    const newMakeOptions = util.generateTasks(baseConfigToolPath, taskList, configsString, makeOptions);
+    fs.writeFileSync(makeOptionsPath, JSON.stringify(newMakeOptions, null, 4));
 }
 
 var command  = argv._[0];


### PR DESCRIPTION
**Description**: 
- Add the ability to run the CodeGen from our CLI tool. (node make.js gentask command)
- Include generated tasks in the build and test processes (node make.js build/test commands)
- Inject the generated task into our ci/cd process (courtesy push and hotfix processes)

**Documentation changes required:** N

**Added unit tests:**N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

The changes was tested by me and buddy-tested by @ivanduplenskikh 