### PR TITLE
Arm-rest-v2: Add telemetry logs for Kudu auth method

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
@@ -108,17 +108,25 @@ export class AzureAppServiceUtility {
     private async getKuduAuthHeader(publishingCredentials: any): Promise<string> {
         const scmPolicyCheck = await this.isSitePublishingCredentialsEnabled(); 
 
+        let method = "";
+        let token = "";
+
         if(scmPolicyCheck === false) {
-            tl.debug('Kudu: Getting Bearer token');
-            const accessToken = await this._appService._client.getCredentials().getToken();
-            return "Bearer " + accessToken;
+            token = await this._appService._client.getCredentials().getToken();
+            method = "Bearer";
         } else {
             tl.setVariable(`AZURE_APP_SERVICE_KUDU_${this._appService.getSlot()}_PASSWORD`, publishingCredentials.properties["publishingPassword"], true);
-            var accessToken = (new Buffer(publishingCredentials.properties["publishingUserName"] + ':' + publishingCredentials.properties["publishingPassword"]).toString('base64'));
-            tl.debug("Kudu: using basic auth.");
+            token = (new Buffer(publishingCredentials.properties["publishingUserName"] + ':' + publishingCredentials.properties["publishingPassword"]).toString('base64'));
 
-            return "Basic " + accessToken;
+            method = "Basic";
         }
+
+        const authMethodtelemetry = {
+            authMethod: method
+        };
+        console.log("##vso[telemetry.publish area=TaskDeploymentMethod;feature=AzureAppServiceDeployment]" + JSON.stringify(authMethodtelemetry));
+
+        return `${method} ${token}`;
     }
 
     public async updateAndMonitorAppSettings(addProperties?: any, deleteProperties?: any, formatJSON?: boolean): Promise<boolean> {

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.221.0",
+  "version": "3.221.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.221.1",
+  "version": "3.221.2",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-pipelines-tasks-azure-arm-rest-v2

**Description**: Add additional telemetry for Kudu authentication method

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://eng.ms/docs/cloud-ai-platform/devdiv/serverless-paas-balam/serverless-paas-benbyrd/app-service-web-apps/antares-trouble-shooting-guides-tsg/partnertsgs/basicauth

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
