### PR TITLE
ServiceFabricUpdateManifestV2 add option to filter on branch name for…

### DIFF
--- a/Tasks/ServiceFabricUpdateManifestsV2/task.json
+++ b/Tasks/ServiceFabricUpdateManifestsV2/task.json
@@ -19,7 +19,7 @@
     ],
     "version": {
         "Major": 2,
-        "Minor": 198,
+        "Minor": 222,
         "Patch": 0
     },
     "minimumAgentVersion": "1.95.0",
@@ -104,7 +104,8 @@
             "helpMarkDown": "The build for comparison.",
             "options": {
                 "LastSuccessful": "Last Successful Build",
-                "Specific": "Specific Build"
+                "Specific": "Specific Build",
+                "LatestFromBranch": "Last Successful Build from a specific Branch",
             },
             "visibleRule": "updateType = Manifest versions && updateOnlyChanged = true"
         },
@@ -116,6 +117,15 @@
             "required": false,
             "helpMarkDown": "The build number for comparison.",
             "visibleRule": "updateType = Manifest versions && compareType = Specific"
+        },
+        {
+            "name": "branchName",
+            "type": "string",
+            "label": "Branch Name",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The branch name to get the build for comparison.",
+            "visibleRule": "updateType = Manifest versions && compareType = LatestFromBranch"
         },
         {
             "name": "overwriteExistingPkgArtifact",


### PR DESCRIPTION


Enables getting the Latest, Succeeded Build from a the given Branch name, when using 'Update only if changed' option in the task. 

I've added a third option called 'Last Successful Build from a specific Branch' . 
![image](https://user-images.githubusercontent.com/3382443/234270147-cc77f1e2-dc28-4261-98b5-553acb084e0d.png)

**Task name**:  ServiceFabricUpdateManifestV2

**Description**:  Updating manifest is done by comparing build outputs. I've added a build filter `LatestFromBranch` to be able to select the Latest, Succeeded Build from a Branch.

**Documentation changes required:** (Y/N) **Unsure**

**Added unit tests:**  No,  I've found no tests in this area, as it just leverages the Azure DevOps API.

**Attached related issue:** No, I did not make an issue, I wanted to check functionality and noticed this is a minor change.

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected **(note: I need help with this)**
