### PR TITLE
ARM-rest-v2: Add mask hint for msdeploy when basic auth is disabled

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
@@ -114,6 +114,15 @@ export class AzureAppServiceUtility {
         if(scmPolicyCheck === false) {
             token = await this._appService._client.getCredentials().getToken();
             method = "Bearer";
+            // Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY. 
+            // This needs to be cleaned up once MSDEPLOY suppport is reomve. Safe handle the exception setting up mask hint as we dont want to fail here.
+            try {      
+                tl.setVariable(`AZURE_APP_MSDEPLOY_${this._appService.getSlot()}_PASSWORD`, publishingCredentials.properties["publishingPassword"], true);
+            }
+            catch (error){
+                // safe handle the exception setting up mask hint
+                tl.debug(`Setting mask hint for publish profile password failed with error: ${error}`);
+            }
         } else {
             tl.setVariable(`AZURE_APP_SERVICE_KUDU_${this._appService.getSlot()}_PASSWORD`, publishingCredentials.properties["publishingPassword"], true);
             const buffer = new Buffer(publishingCredentials.properties["publishingUserName"] + ':' + publishingCredentials.properties["publishingPassword"]);

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.221.2",
+  "version": "3.221.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.221.2",
+  "version": "3.221.3",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Though bearer AuthN is used, lets try to set publish profile password for mask hints to maintain compat with old behavior for MSDEPLOY on best effort basis.
 This needs to be cleaned up once MSDEPLOY suppport is reomve. Safe handle the exception setting up mask hint as we dont want to fail here.

Cherry picked from https://github.com/microsoft/azure-pipelines-tasks/pull/18183

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
