### PR TITLE
Make azure-arm-rest-v2 compatible with Centauri

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-app-service.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-app-service.ts
@@ -618,7 +618,7 @@ export class AzureAppService {
             }, null, '2018-02-01');
 
             var response = await this._client.beginRequest(httpRequest);
-            if (response.statusCode != 200) {
+            if (response.statusCode != 200 && response.statusCode != 202) {
                 throw ToError(response);
             }
 

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.221.3",
+  "version": "3.221.4",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-arm-rest-v2

**Description**: Function apps on Centauri return 202 response (not 200) for PATCH /config/web

**Documentation changes required:** (Y/N) NO

**Added unit tests:** (Y/N) NO

**Attached related issue:** (Y/N) NO

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
