### PR TITLE
Fix nyc command

### DIFF
--- a/make.js
+++ b/make.js
@@ -384,6 +384,7 @@ CLI.build = function() {
 // node make.js test --task ShellScript --suite L0
 //
 CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */ argv) {
+    var minIstanbulVersion = '10';
     ensureTool('tsc', '--version', 'Version 2.3.4');
     ensureTool('mocha', '--version', '6.2.3');
 
@@ -472,6 +473,9 @@ CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */
     }
 
     try {
+        // Installing node version 10 to run code coverage report, since common library tests run under node 6,
+        // which is incompatible with nyc 
+        util.installNode(minIstanbulVersion);
         util.rm(path.join(coverageTasksPath, '*coverage-summary.json'));
         util.run(`nyc merge ${coverageTasksPath} ${path.join(coverageTasksPath, 'mergedcoverage.json')}`, true);
         util.rm(path.join(coverageTasksPath, '*-coverage.json'));


### PR DESCRIPTION
**Description**: 
since common tests run with node version 6, which is not supported by nyc, we need to run nyc with node at least 8 version. Because installNode function supports only 10, Installing 10 then

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Checked that applied changes work as expected
