### PR TITLE
Update input label for MysqlDeploymentOnMachineGroupV1

### DIFF
--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -76,7 +76,7 @@
         {
             "name": "SqlUsername",
             "type": "string",
-            "label": "Mysql User Name",
+            "label": "MySQL User Name",
             "required": true,
             "defaultValue": "",
             "helpMarkDown": "When you connect using MySQL Workbench, this is the same value that is used for 'Username' in 'Parameters'."


### PR DESCRIPTION
A customer [raised a PR](https://github.com/MicrosoftDocs/azure-devops-yaml-schema/pull/150) to fix this in the task docs, but since they are autogenerated, the fix needs to happen here.

**Task name**: MysqlDeploymentOnMachineGroupV1

**Description**: Fixing customer reported typo

**Documentation changes required:** (Y/N) Doc change will be automatic
N<Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
