### PR TITLE
Make azure-pipelines-tasks-azurermdeploycommon compatible with Centauri

### DIFF
--- a/Tasks/Common/AzureRmDeploy-common/azure-arm-rest/azure-arm-app-service.ts
+++ b/Tasks/Common/AzureRmDeploy-common/azure-arm-rest/azure-arm-app-service.ts
@@ -371,7 +371,7 @@ export class AzureAppService {
             }, null, '2018-02-01');
             
             var response = await this._client.beginRequest(httpRequest);
-            if(response.statusCode != 200) {
+            if(response.statusCode != 200 && response.statusCode != 202) {
                 throw ToError(response);
             }
 

--- a/Tasks/Common/AzureRmDeploy-common/operations/ContainerBasedDeploymentUtility.ts
+++ b/Tasks/Common/AzureRmDeploy-common/operations/ContainerBasedDeploymentUtility.ts
@@ -23,7 +23,7 @@ export class ContainerBasedDeploymentUtility {
         this._appServiceUtility = new AzureAppServiceUtility(appService);
     }
 
-    public async deployWebAppImage(properties: any): Promise<void> {
+    public async deployWebAppImage(properties: any, restart:boolean=true): Promise<void> {
         let imageName: string = properties["ImageName"];
         let multicontainerConfigFile: string = properties["MulticontainerConfigFile"];
         let isMultiContainer: boolean = properties["isMultiContainer"];
@@ -46,8 +46,10 @@ export class ContainerBasedDeploymentUtility {
         tl.debug("Updating the webapp configuration.");
         await this._updateConfigurationDetails(properties["ConfigurationSettings"], properties["StartupCommand"], isLinuxApp, imageName, isMultiContainer, updatedMulticontainerConfigFile);
 
-        tl.debug('making a restart request to app service');
-        await this._appService.restart();
+        if (restart){
+            tl.debug('making a restart request to app service');
+            await this._appService.restart();
+        }
     }
 
     private async _updateConfigurationDetails(configSettings: any, startupCommand: string, isLinuxApp: boolean, imageName?: string, isMultiContainer?: boolean, multicontainerConfigFile?: string): Promise<void> {


### PR DESCRIPTION
**Task name**: Common/AzureRmDeploy-common

**Description**: 
1. Function apps on Centauri return 202 response (not 200) for PATCH /config/web.
2. Skip app restart steps with restart parameter is false.

**Documentation changes required:** (Y/N) NO

**Added unit tests:** (Y/N) NO

**Attached related issue:** (Y/N) NO

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
