### PR TITLE
Allows to choose the version of Static App Client

### DIFF
--- a/Tasks/AzureStaticWebAppV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureStaticWebAppV0/Strings/resources.resjson/en-US/resources.resjson
@@ -36,5 +36,7 @@
   "loc.input.label.production_branch": "Production Branch",
   "loc.input.help.production_branch": "Production branch. When specified and Deployment Environment is empty, deployments from other branches will be preview environments",
   "loc.input.label.data_api_location": "Data api location",
-  "loc.input.help.data_api_location": "Directory location of the Data API source files relative to working directory"
+  "loc.input.help.data_api_location": "Directory location of the Data API source files relative to working directory",
+  "loc.input.label.static_app_client_label": "Label of Static App Client",
+  "loc.input.help.static_app_client_label": "Label of the Static App Client"
 }

--- a/Tasks/AzureStaticWebAppV0/index.ts
+++ b/Tasks/AzureStaticWebAppV0/index.ts
@@ -15,6 +15,7 @@ const apiTokenInputName = 'azure_static_web_apps_api_token';
 const deploymentEnvironmentInputName = 'deployment_environment';
 const productionBranchInputName = 'production_branch';
 const dataApiLocationInputName = 'data_api_location';
+const staticAppClientLabelInputName  = 'static_app_client_label';
 
 async function run() {
     const envVarFilePath: string = path.join(__dirname, 'env.list');
@@ -82,6 +83,7 @@ async function createDockerEnvVarFile(envVarFilePath: string) {
     const deploymentEnvironment: string = tl.getInput(deploymentEnvironmentInputName, false) || "";
     const productionBranch: string = tl.getInput(productionBranchInputName, false) || "";
     const dataApiLocation: string = tl.getInput(dataApiLocationInputName, false) || "";
+    const staticAppClientLabel: string = tl.getInput(staticAppClientLabelInputName, false) || "stable";
 
     const skipAppBuild: boolean = tl.getBoolInput('skip_app_build', false);
     const skipApiBuild: boolean = tl.getBoolInput('skip_api_build', false);
@@ -93,7 +95,7 @@ async function createDockerEnvVarFile(envVarFilePath: string) {
 
     const verbose = inputVerbose === true ? true : (inputVerbose === false ? false : systemVerbose === true);
 
-    const deploymentClient = "mcr.microsoft.com/appsvc/staticappsclient:stable";
+    const deploymentClient = "mcr.microsoft.com/appsvc/staticappsclient:";
     const containerWorkingDir = "/working_dir";
 
     addInputStringToString("APP_LOCATION", appLocation, appLocationInputName);
@@ -115,7 +117,7 @@ async function createDockerEnvVarFile(envVarFilePath: string) {
 
     addInputStringToString("DEPLOYMENT_TOKEN", apiToken, apiTokenInputName);
 
-    process.env['SWA_DEPLOYMENT_CLIENT'] = deploymentClient;
+    process.env['SWA_DEPLOYMENT_CLIENT'] = deploymentClient + staticAppClientLabel;
     process.env['SWA_WORKING_DIR'] = workingDirectory;
     process.env['SWA_WORKSPACE_DIR'] = containerWorkingDir;
 

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -14,7 +14,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 220,
+    "Minor": 222,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/AzureStaticWebAppV0/task.json
+++ b/Tasks/AzureStaticWebAppV0/task.json
@@ -160,6 +160,19 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Directory location of the Data API source files relative to working directory"
+    },
+    {
+      "name": "static_app_client_label",
+      "type": "string",
+      "label": "Label of Static App Client",
+      "defaultValue": "stable",
+      "required": false,
+      "options": {
+        "stable": "Stable",
+        "latest": "Latest",
+        "prev": "Previous"
+      },
+      "helpMarkDown": "Label of the Static App Client"
     }
   ],
   "execution": {

--- a/Tasks/AzureStaticWebAppV0/task.loc.json
+++ b/Tasks/AzureStaticWebAppV0/task.loc.json
@@ -160,6 +160,19 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.data_api_location"
+    },
+    {
+      "name": "static_app_client_label",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.static_app_client_label",
+      "defaultValue": "stable",
+      "required": false,
+      "options": {
+        "stable": "Stable",
+        "latest": "Latest",
+        "prev": "Previous"
+      },
+      "helpMarkDown": "ms-resource:loc.input.help.static_app_client_label"
     }
   ],
   "execution": {


### PR DESCRIPTION
**Task name**: AzureStaticWebAppV0

**Description**: Adds a new parameter to choose the version of the Static App Client that will be used. If not specified keeps the current behaviour

**Documentation changes required:** Y

**Added unit tests:** N - Could not find any existing test to include the new parameter

**Attached related issue:** Y #18255 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
