### PR TITLE
AzureAppServiceUtility: Add feature parameter

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azureAppServiceUtility.ts
@@ -6,9 +6,13 @@ import { Kudu } from './azure-arm-app-service-kudu';
 import webClient = require('./webClient');
 
 export class AzureAppServiceUtility {
-    private _appService: AzureAppService;
-    constructor(appService: AzureAppService) {
+
+    private readonly _appService: AzureAppService;
+    private readonly _telemetryFeature: string;
+
+    constructor(appService: AzureAppService, telemetryFeature?: string) {
         this._appService = appService;
+        this._telemetryFeature = telemetryFeature || "AzureAppServiceDeployment"; //TODO modify telemetry.publish command so that agent automatically pass task name and version to the server then remove this parameter
     }
 
     public async getWebDeployPublishingProfile(): Promise<any> {
@@ -137,7 +141,7 @@ export class AzureAppServiceUtility {
             authMethod: method
         };
         tl.debug(`Using ${method} authentication method for Kudu service.`);
-        console.log("##vso[telemetry.publish area=TaskDeploymentMethod;feature=AzureAppServiceDeployment]" + JSON.stringify(authMethodtelemetry));
+        console.log(`##vso[telemetry.publish area=TaskDeploymentMethod;feature=${this._telemetryFeature}]${JSON.stringify(authMethodtelemetry)}`);
 
         return method + " " + token;
     }

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.222.0",
+  "version": "3.222.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.222.0",
+  "version": "3.222.1",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To be able to distinguish task name in telemetry records we are adding optional parameter to `AzureAppServiceUtility` constructor. This PR should fulfill Finbar's comments in #18270.