### PR TITLE
Remove preview tag from AzureContainerApps@1

### DIFF
--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -21,7 +21,6 @@
         "Minor": 222,
         "Patch": 0
     },
-    "preview": true,
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy",
     "showEnvironmentVariables": false,

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -21,7 +21,6 @@
     "Minor": 222,
     "Patch": 0
   },
-  "preview": true,
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "showEnvironmentVariables": false,


### PR DESCRIPTION
**Task name**: AzureContainerAppsV1

**Description**: Removing the `preview: true` field from the `task.json` to ensure that when selecting the V1 version of the task, the UI doesn't display "_(preview)_" as a suffix.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
~- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it~
~- [ ] Checked that applied changes work as expected~
