### PR TITLE
fix Initialize-AzSubscription

### DIFF
--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 219,
-        "Patch": 1
+        "Minor": 222,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 219,
-    "Patch": 1
+    "Minor": 222,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -76,6 +76,8 @@ function Initialize-AzSubscription {
     $null = Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue
     Write-Host "##[command]Clear-AzContext -Scope Process"
     $null = Clear-AzContext -Scope Process
+    Write-Host "##[command]Clear-AzConfig -DefaultSubscriptionForLogin"
+    $null = Clear-AzConfig -DefaultSubscriptionForLogin
 
     $environmentName = "AzureCloud"
     if($Endpoint.Data.Environment) {


### PR DESCRIPTION
**Task name:** AzureFileCopyV3

**Description:** Added clearing default subscription for login in the `Initialize-AzSubscription` function, used in the `Initialize-AzModule` function, used in the `AzureFIleCopy` task, in order to always use the subscription specified in the related `azureSubscription` (`connectedServiceName`) task input.

**Documentation changes required:** No

**Added unit tests:** No

**Checklist:**
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
