### PR TITLE
[KubernetesManifestV1] Add input param that allows usage of the cluster admin credentials

### DIFF
--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Wählen Sie eine Azure-Ressourcengruppe aus.",
   "loc.input.label.kubernetesCluster": "Kubernetes-Cluster",
   "loc.input.help.kubernetesCluster": "Wählen Sie einen verwalteten Azure-Cluster aus.",
+  "loc.input.label.useClusterAdmin": "Anmeldeinformationen für Clusteradministrator verwenden",
+  "loc.input.help.useClusterAdmin": "Verwenden Sie anstelle der standardmäßigen Anmeldeinformationen für Clusterbenutzer Anmeldeinformationen für Clusteradministratoren.",
   "loc.input.label.namespace": "Namespace",
   "loc.input.help.namespace": "Legen Sie den Namespace für die Befehle fest, indem Sie das Flag „–namespace“ verwenden. Wenn kein Namespace angegeben wird, werden die Befehle im Standardnamespace ausgeführt.",
   "loc.input.label.strategy": "Strategie",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Select an Azure resource group.",
   "loc.input.label.kubernetesCluster": "Kubernetes cluster",
   "loc.input.help.kubernetesCluster": "Select an Azure managed cluster.",
+  "loc.input.label.useClusterAdmin": "Use cluster admin credentials",
+  "loc.input.help.useClusterAdmin": "Use cluster administrator credentials instead of default cluster user credentials.",  
   "loc.input.label.namespace": "Namespace",
   "loc.input.help.namespace": "Sets the namespace for the commands by using the –namespace flag. If the namespace is not provided, the commands will run in the default namespace.",
   "loc.input.label.strategy": "Strategy",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Seleccione un grupo de recursos de Azure.",
   "loc.input.label.kubernetesCluster": "Clúster de Kubernetes",
   "loc.input.help.kubernetesCluster": "Seleccione un clúster de Azure administrado.",
+  "loc.input.label.useClusterAdmin": "Usar credenciales de administrador del clúster",
+  "loc.input.help.useClusterAdmin": "Use las credenciales de administrador del clúster en lugar de las credenciales predeterminadas de usuario de clúster.",  
   "loc.input.label.namespace": "Nombres",
   "loc.input.help.namespace": "Establece el espacio de nombres para los comandos con la marca –namespace. Si no se proporciona el espacio de nombres, los comandos se ejecutan en el predeterminado.",
   "loc.input.label.strategy": "Estrategia",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Sélectionnez un groupe de ressources Azure.",
   "loc.input.label.kubernetesCluster": "Cluster Kubernetes",
   "loc.input.help.kubernetesCluster": "Sélectionnez un cluster managé Azure.",
+  "loc.input.label.useClusterAdmin": "Utiliser les informations d'identification de l'administrateur de cluster",
+  "loc.input.help.useClusterAdmin": "Utilisez les informations d'identification de l'administrateur de cluster à la place des informations d'identification de l'utilisateur de cluster par défaut.",  
   "loc.input.label.namespace": "Espace de noms",
   "loc.input.help.namespace": "Définit l’espace de noms des commandes à l’aide de l’indicateur –namespace. Si vous n’indiquez pas l’espace de noms, les commandes sont exécutées dans l’espace de noms par défaut.",
   "loc.input.label.strategy": "Stratégie",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Consente di selezionare un gruppo di risorse di Azure.",
   "loc.input.label.kubernetesCluster": "Cluster Kubernetes",
   "loc.input.help.kubernetesCluster": "Selezionare un cluster gestito di Azure.",
+  "loc.input.label.useClusterAdmin": "Usa credenziali dell'amministratore del cluster",
+  "loc.input.help.useClusterAdmin": "Consente di usare le credenziali dell'amministratore del cluster invece delle credenziali utente del cluster predefinite.",  
   "loc.input.label.namespace": "Spazio dei nomi",
   "loc.input.help.namespace": "Consente di impostare lo spazio dei nomi per i comandi usando il flag –namespace. Se lo spazio dei nomi non viene specificato, i comandi verranno eseguiti nello spazio dei nomi predefinito.",
   "loc.input.label.strategy": "Strategia",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Azure リソース グループを選択します。",
   "loc.input.label.kubernetesCluster": "Kubernetes クラスター",
   "loc.input.help.kubernetesCluster": "Azure 管理対象クラスターを選択します。",
+  "loc.input.label.useClusterAdmin": "クラスター管理者の資格情報を使用する",
+  "loc.input.help.useClusterAdmin": "既定のクラスター ユーザーの資格情報ではなく、クラスター管理者の資格情報をご使用ください。",
   "loc.input.label.namespace": "名前空間",
   "loc.input.help.namespace": "コマンドの名前空間を設定するには、–namespace フラグを使用します。名前空間が指定されていない場合、コマンドは既定の名前空間で実行されます。",
   "loc.input.label.strategy": "戦略",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Azure 리소스 그룹을 선택합니다.",
   "loc.input.label.kubernetesCluster": "Kubernetes 클러스터",
   "loc.input.help.kubernetesCluster": "Azure 관리 클러스터를 선택합니다.",
+  "loc.input.label.useClusterAdmin": "클러스터 관리자 자격 증명 사용",
+  "loc.input.help.useClusterAdmin": "기본 클러스터 사용자 자격 증명 대신 클러스터 관리자 자격 증명을 사용합니다.",
   "loc.input.label.namespace": "네임스페이스",
   "loc.input.help.namespace": "–namespace 플래그를 사용하여 명령의 네임스페이스를 설정합니다. 네임스페이스를 지정하지 않으면 기본 네임스페이스에서 명령이 실행됩니다.",
   "loc.input.label.strategy": "전략",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "Выберите группу ресурсов Azure.",
   "loc.input.label.kubernetesCluster": "Кластер Kubernetes",
   "loc.input.help.kubernetesCluster": "Выберите управляемый кластер Azure.",
+  "loc.input.label.useClusterAdmin": "Использовать учетные данные администратора кластера",
+  "loc.input.help.useClusterAdmin": "Используйте учетные данные администратора кластера вместо учетных данных пользователя кластера по умолчанию.",
   "loc.input.label.namespace": "Пространство имен",
   "loc.input.help.namespace": "Задает пространство имен для команд с помощью флага –namespace. Если пространство имен не указано, команды будут выполняться в пространстве имен по умолчанию.",
   "loc.input.label.strategy": "Стратегия",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "选择 Azure 资源组。",
   "loc.input.label.kubernetesCluster": "Kubernetes 群集",
   "loc.input.help.kubernetesCluster": "选择 Azure 托管的群集。",
+  "loc.input.label.useClusterAdmin": "使用群集管理员凭据",
+  "loc.input.help.useClusterAdmin": "使用群集管理员凭据而不是默认的群集用户凭据。",
   "loc.input.label.namespace": "命名空间",
   "loc.input.help.namespace": "使用 -namespace 标志设置命令的命名空间。如果未提供命名空间，则命令将在默认命名空间中运行。",
   "loc.input.label.strategy": "策略",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.azureResourceGroup": "請選取 Azure 資源群組。",
   "loc.input.label.kubernetesCluster": "Kubernetes 叢集",
   "loc.input.help.kubernetesCluster": "選取 Azure 受控叢集。",
+  "loc.input.label.useClusterAdmin": "使用叢集系統管理員認證",
+  "loc.input.help.useClusterAdmin": "使用叢集系統管理員認證而非預設叢集使用者認證。",
   "loc.input.label.namespace": "命名空間",
   "loc.input.help.namespace": "使用 –namespace 旗標為命令設定命名空間。若未提供命名空間，這些命令會在預設命名空間中執行。",
   "loc.input.label.strategy": "策略",

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 221,
+        "Minor": 222,
         "Patch": 0
     },
     "demands": [],
@@ -96,6 +96,14 @@
             "properties": {
                 "EditableOptions": "True"
             }
+        },
+        {
+            "name": "useClusterAdmin",
+            "type": "boolean",
+            "label": "Use cluster admin credentials",
+            "defaultValue": "false",
+            "visibleRule": "connectionType = azureResourceManager",
+            "helpMarkDown": "Use cluster administrator credentials instead of default cluster user credentials."
         },
         {
             "name": "namespace",

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 221,
+    "Minor": 222,
     "Patch": 0
   },
   "demands": [],
@@ -96,6 +96,14 @@
       "properties": {
         "EditableOptions": "True"
       }
+    },
+    {
+      "name": "useClusterAdmin",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.useClusterAdmin",
+      "defaultValue": "false",
+      "visibleRule": "connectionType = azureResourceManager",
+      "helpMarkDown": "ms-resource:loc.input.help.useClusterAdmin"
     },
     {
       "name": "namespace",


### PR DESCRIPTION
**Task name**: KubernetesManifestV1

**Description**: Add input param that allows usage of the cluster admin credentials

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) [#18253](https://github.com/microsoft/azure-pipelines-tasks/issues/18253)

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
