### PR TITLE
Users/abpowell/updating nuget tasks to handle product version 0.0.0.0

### DIFF
--- a/Tasks/NuGetCommandV2/nugetrestore.ts
+++ b/Tasks/NuGetCommandV2/nugetrestore.ts
@@ -14,6 +14,7 @@ import * as telemetry from "azure-pipelines-tasks-utility-common/telemetry";
 import INuGetCommandOptions from "azure-pipelines-tasks-packaging-common/nuget/INuGetCommandOptions2";
 import { getProjectAndFeedIdFromInputParam } from "azure-pipelines-tasks-packaging-common/util";
 import { logError } from "azure-pipelines-tasks-packaging-common/util";
+import {getVersionFallback} from "azure-pipelines-tasks-packaging-common/nuget/ProductVersionHelper"
 
 class RestoreOptions implements INuGetCommandOptions {
     constructor(
@@ -178,7 +179,7 @@ export async function run(nuGetPath: string): Promise<void> {
                     isNugetOrgBehaviorWarn = true;
                 }
 
-                const nuGetSource: auth.IPackageSource = nuGetVersion.productVersion.a < 3
+                const nuGetSource: auth.IPackageSource = getVersionFallback(nuGetVersion).a < 3
                                         ? auth.NuGetOrgV2PackageSource
                                         : auth.NuGetOrgV3PackageSource;
                 sources.push(nuGetSource);

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -122,9 +122,9 @@
             }
         },
         "azure-pipelines-tasks-packaging-common": {
-            "version": "3.221.0",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.221.0.tgz",
-            "integrity": "sha512-ykgEMeQl6aGq2dFofRnhgdtnWIZVI78/FOTC2+6M+LZcR5QjisRE9nMApHNW3nelvyp2Wc363qULVzwV1jn71g==",
+            "version": "3.221.1",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.221.1.tgz",
+            "integrity": "sha512-74U71UvXlAFPBlZBd2lG1s/rFUMsBeUiF39ykb9iuGeMQEzFN1GfD7tMjVwmkx0Dz/EKOhN5LyZyR2oH0IKwSA==",
             "requires": {
                 "@types/ini": "1.3.30",
                 "@types/ltx": "2.8.0",

--- a/Tasks/NuGetCommandV2/package.json
+++ b/Tasks/NuGetCommandV2/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@types/node": "^16.11.39",
         "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tasks-packaging-common": "3.221.0",
+        "azure-pipelines-tasks-packaging-common": "3.221.1",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
         "xmlreader": "^0.2.3"
     },

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 2,
         "Minor": 221,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 221,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetV0/nuget.ts
+++ b/Tasks/NuGetV0/nuget.ts
@@ -8,6 +8,7 @@ import nuGetGetter = require("azure-pipelines-tasks-packaging-common-v3/nuget/Nu
 import peParser = require('azure-pipelines-tasks-packaging-common-v3/pe-parser/index');
 import * as pkgLocationUtils from "azure-pipelines-tasks-packaging-common-v3/locationUtilities";
 import { logError } from 'azure-pipelines-tasks-packaging-common-v3/util';
+import { getVersionFallback } from 'azure-pipelines-tasks-packaging-common/nuget/ProductVersionHelper'
 
 class NuGetExecutionOptions {
     constructor(
@@ -51,7 +52,7 @@ async function main(): Promise<void> {
     }
 
     const version = await peParser.getFileVersionInfoAsync(nuGetPath);
-    if(version.productVersion.a < 3 || (version.productVersion.a <= 3 && version.productVersion.b < 5))
+    if(getVersionFallback(version).a < 3 || (getVersionFallback(version).a <= 3 && getVersionFallback(version).b < 5))
     {
         tl.setResult(tl.TaskResult.Failed, tl.loc("Info_NuGetSupportedAfter3_5", version.strings.ProductVersion));
         return;

--- a/Tasks/NuGetV0/package-lock.json
+++ b/Tasks/NuGetV0/package-lock.json
@@ -106,6 +106,36 @@
                 "uuid": "^3.0.1"
             }
         },
+        "azure-pipelines-tasks-packaging-common": {
+            "version": "3.221.1",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.221.1.tgz",
+            "integrity": "sha512-74U71UvXlAFPBlZBd2lG1s/rFUMsBeUiF39ykb9iuGeMQEzFN1GfD7tMjVwmkx0Dz/EKOhN5LyZyR2oH0IKwSA==",
+            "requires": {
+                "@types/ini": "1.3.30",
+                "@types/ltx": "2.8.0",
+                "@types/mocha": "^5.2.6",
+                "@types/mockery": "1.4.29",
+                "@types/node": "^16.11.39",
+                "@types/q": "1.5.2",
+                "adm-zip": "^0.4.11",
+                "azure-devops-node-api": "10.2.2",
+                "azure-pipelines-task-lib": "^4.0.0-preview",
+                "azure-pipelines-tool-lib": "^2.0.0-preview",
+                "ini": "^1.3.8",
+                "ip-address": "^5.8.9",
+                "ltx": "^2.6.2",
+                "q": "^1.5.0",
+                "semver": "^5.5.0",
+                "typed-rest-client": "1.8.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "16.18.31",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+                    "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw=="
+                }
+            }
+        },
         "azure-pipelines-tasks-packaging-common-v3": {
             "version": "3.213.0",
             "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-packaging-common-v3/-/azure-pipelines-tasks-packaging-common-v3-3.213.0.tgz",

--- a/Tasks/NuGetV0/package.json
+++ b/Tasks/NuGetV0/package.json
@@ -18,7 +18,8 @@
     "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
     "dependencies": {
         "azure-pipelines-task-lib": "^4.1.0",
-        "azure-pipelines-tasks-packaging-common-v3": "^3.213.0"
+        "azure-pipelines-tasks-packaging-common-v3": "^3.213.0",
+        "azure-pipelines-tasks-packaging-common": "3.221.1"
     },
     "devDependencies": {
         "typescript": "4.0.2"

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -11,7 +11,7 @@
     "version": {
         "Major": 0,
         "Minor": 221,
-        "Patch": 0
+        "Patch": 1
     },
     "runsOn": [
         "Agent",

--- a/Tasks/NuGetV0/task.json
+++ b/Tasks/NuGetV0/task.json
@@ -10,7 +10,7 @@
     "helpMarkDown": "",
     "version": {
         "Major": 0,
-        "Minor": 219,
+        "Minor": 221,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -10,7 +10,7 @@
   "helpMarkDown": "ms-resource:loc.helpMarkDown",
   "version": {
     "Major": 0,
-    "Minor": 219,
+    "Minor": 221,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetV0/task.loc.json
+++ b/Tasks/NuGetV0/task.loc.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 221,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: NuGetCommandV2, NuGetV0

**Description**: Hotfix to use fileVersion when productVersion is 0.0.0.0

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
