### PR TITLE
DTS Task 2023781: DTS [Pipelines Agents Tasks UI]: The api-version '2…

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-management-group.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-management-group.ts
@@ -13,7 +13,7 @@ export class ManagementGroupManagementClient extends azureServiceClientBase.Azur
     constructor(credentials: msRestAzure.ApplicationTokenCredentials, managementGroupId: string, options?: any) {
         super(credentials);
         this.validateInputs(managementGroupId);
-        this.apiVersion = (credentials.isAzureStackEnvironment) ? '2016-06-01' : '2021-04-01';
+        this.apiVersion = (credentials.isAzureStackEnvironment) ? '2019-10-01' : '2021-04-01';
         this.acceptLanguage = 'en-US';
         this.generateClientRequestId = true;
         if (!!options && !!options.longRunningOperationRetryTimeout) {

--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-subscription.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-subscription.ts
@@ -13,7 +13,7 @@ export class SubscriptionManagementClient extends azureServiceClientBase.AzureSe
     constructor(credentials: msRestAzure.ApplicationTokenCredentials, subscriptionId: string, options?: any) {
         super(credentials);
         this.validateInputs(subscriptionId);
-        this.apiVersion = (credentials.isAzureStackEnvironment) ? '2016-06-01' : '2021-04-01';
+        this.apiVersion = (credentials.isAzureStackEnvironment) ? '2019-10-01' : '2021-04-01';
         this.acceptLanguage = 'en-US';
         this.generateClientRequestId = true;
         if (!!options && !!options.longRunningOperationRetryTimeout) {

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.222.2",
+  "version": "3.223.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.222.2",
+  "version": "3.223.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
…021-04-01' is invalid on Azure Stack Hub

**Task name**: azure-pipelines-tasks-azure-arm-rest-v2

**Description**: Changed the Api version of azure stack hub

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
