### PR TITLE
-Removing Node16 for DownloadPackageV0 task

### DIFF
--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 221,
+        "Minor": 222,
         "Patch": 0
     },
     "demands": [],
@@ -90,10 +90,6 @@
     "instanceNameFormat": "Download Package",
     "execution": {
         "Node10": {
-            "target": "download.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
             "target": "download.js",
             "argumentFormat": ""
         }

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 221,
+    "Minor": 222,
     "Patch": 0
   },
   "demands": [],
@@ -90,10 +90,6 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
-      "target": "download.js",
-      "argumentFormat": ""
-    },
-    "Node16": {
       "target": "download.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
-Bumping version number for DownloadPackageV0 task

**Task name**: DownloadPackageV0 

**Description**: Removed Node16 Changes for the specified Task

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N/A

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
