### PR TITLE
Removing Node16 for DownloadPackageV0 task (#18340)

### DIFF
--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 0,
         "Minor": 221,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",
@@ -90,10 +90,6 @@
     "instanceNameFormat": "Download Package",
     "execution": {
         "Node10": {
-            "target": "download.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
             "target": "download.js",
             "argumentFormat": ""
         }

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 221,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",
@@ -90,10 +90,6 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "execution": {
     "Node10": {
-      "target": "download.js",
-      "argumentFormat": ""
-    },
-    "Node16": {
       "target": "download.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
-Removing Node16 for DownloadPackageV0 task
-Bumping version number for DownloadPackageV0 task

**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
