### PR TITLE
Support FileCopyOptions for PublishBuildArtifactsV1

### DIFF
--- a/Tasks/PublishBuildArtifactsV1/Invoke-Robocopy.ps1
+++ b/Tasks/PublishBuildArtifactsV1/Invoke-Robocopy.ps1
@@ -10,6 +10,9 @@ param(
     [int]$ParallelCount,
 
     [Parameter(Mandatory = $false)]
+    [string]$FileCopyOptions),
+
+    [Parameter(Mandatory = $false)]
     [string]$File)
 
 # This script translates the output from robocopy into UTF8. Node has limited
@@ -45,10 +48,10 @@ if (!$File) {
 
 # Print the ##command. The /MT parameter is only supported on 2008 R2 and higher.
 if ($ParallelCount -gt 1) {
-    [System.Console]::WriteLine("##[command]robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 /MT:$ParallelCount `"$Source`" `"$Target`" `"$File`"")
+    [System.Console]::WriteLine("##[command]robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 /MT:$ParallelCount $FileCopyOptions `"$Source`" `"$Target`" `"$File`"")
 }
 else {
-    [System.Console]::WriteLine("##[command]robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 `"$Source`" `"$Target`" `"$File`"")
+    [System.Console]::WriteLine("##[command]robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 $FileCopyOptions `"$Source`" `"$Target`" `"$File`"")
 }
 
 # The $OutputEncoding variable instructs PowerShell how to interpret the output
@@ -75,7 +78,7 @@ $OutputEncoding = [System.Text.Encoding]::Default
 #
 # Note, the /MT parameter is only supported on 2008 R2 and higher.
 if ($ParallelCount -gt 1) {
-    & robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 /MT:$ParallelCount $Source $Target $File 2>&1 |
+    & robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 /MT:$ParallelCount $FileCopyOptions $Source $Target $File 2>&1 |
         ForEach-Object {
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             [System.Console]::WriteLine($_.Exception.Message)
@@ -86,7 +89,7 @@ if ($ParallelCount -gt 1) {
     }
 }
 else {
-    & robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 $Source $Target $File 2>&1 |
+    & robocopy.exe $CopySubFoldersOption /COPY:DA /NP /R:3 $Source $FileCopyOptions $Target $File 2>&1 |
         ForEach-Object {
         if ($_ -is [System.Management.Automation.ErrorRecord]) {
             [System.Console]::WriteLine($_.Exception.Message)

--- a/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
+++ b/Tasks/PublishBuildArtifactsV1/publishbuildartifacts.ts
@@ -146,6 +146,8 @@ async function run() {
             tl.command("artifact.upload", data, pathToUpload);
         }
         else if (artifactType === "filepath") {
+            let fileCopyOptions: string = tl.getInput('FileCopyOptions', false);
+            
             let targetPath: string = tl.getInput('TargetPath', true);
             let artifactPath: string = path.join(targetPath, artifactName);
             data['artifactlocation'] = targetPath; // artifactlocation for back compat with old xplat agent
@@ -166,11 +168,11 @@ async function run() {
 
                 // copy the files
                 let script: string = path.join(__dirname, 'Invoke-Robocopy.ps1');
-                let command: string = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(pathToUpload)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount}`
+                let command: string = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(pathToUpload)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -FileCopyOptions ${fileCopyOptions}`
                 if (tl.stats(pathToUpload).isFile()) {
                     let parentFolder = path.dirname(pathToUpload);
                     let file = path.basename(pathToUpload);
-                    command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -File '${file}'`
+                    command = `& ${pathToScriptPSString(script)} -Source ${pathToRobocopyPSString(parentFolder)} -Target ${pathToRobocopyPSString(artifactPath)} -ParallelCount ${parallelCount} -FileCopyOptions ${fileCopyOptions} -File '${file}'`
                 }
 
                 let powershell = new tr.ToolRunner('powershell.exe');

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -84,6 +84,15 @@
             "visibleRule": "ArtifactType = FilePath && Parallel = true"
         },
         {
+            "name": "FileCopyOptions",
+            "type": "string",
+            "label": "File copy options",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Passes additional options to the Robocopy command. For example, the recursive minimatch pattern **/*",
+            "visibleRule": "ArtifactType = FilePath"
+        },
+        {
             "name": "StoreAsTar",
             "type": "boolean",
             "label": "Tar the artifact before uploading",

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -12,7 +12,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 223,
+        "Minor": 224,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/PublishBuildArtifactsV1/task.json
+++ b/Tasks/PublishBuildArtifactsV1/task.json
@@ -12,8 +12,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 224,
-        "Patch": 0
+        "Minor": 223,
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "1.91.0",

--- a/Tasks/PublishBuildArtifactsV1/task.loc.json
+++ b/Tasks/PublishBuildArtifactsV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 223,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.91.0",


### PR DESCRIPTION
**Task name**: PublishBuildArtifactsV1

**Description**: Support FileCopyOptions for PublishBuildArtifactsV1

**Documentation changes required:** (Y/N) Not required. The option was documented, but never implemented

**Added unit tests:** (Y/N) Todo

**Attached related issue:** (Y/N) [PublishBuildArtifacts task - Robocopy: Additional File copy parameters are not applied](https://github.com/microsoft/azure-pipelines-tasks/issues/11451)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
