### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 20061169

### DIFF
--- a/Tasks/AzureFunctionAppContainerV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/AzureFunctionAppContainerV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -71,7 +71,7 @@
   "loc.messages.RequestedURLforkuduphysicalpath": "Kudu 실제 경로의 요청된 URL: %s",
   "loc.messages.Physicalpathalreadyexists": "실제 경로 '%s'이(가) 이미 있습니다.",
   "loc.messages.KuduPhysicalpathCreatedSuccessfully": "Kudu 실제 경로를 만들었습니다. %s",
-  "loc.messages.KuduStackTraceURL": "추가로 디버깅하려면 Kudu 스택 추적 URL %s을(를) 확인하세요.",
+  "loc.messages.KuduStackTraceURL": "추가로 디버깅하려면 Kudu 스택 추적 URL(%s)을 확인하세요.",
   "loc.messages.FailedtocreateKuduPhysicalPath": "Kudu 실제 경로를 만들지 못했습니다. 오류: %s",
   "loc.messages.FailedtocheckphysicalPath": "Kudu 실제 경로를 확인하지 못했습니다. 오류 코드: %s",
   "loc.messages.VirtualApplicationDoesNotExist": "가상 응용 프로그램이 없습니다. %s",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -16,7 +16,7 @@
   "loc.input.label.kubernetesCluster": "Clúster de Kubernetes",
   "loc.input.help.kubernetesCluster": "Seleccione un clúster de Azure administrado.",
   "loc.input.label.useClusterAdmin": "Usar credenciales de administrador del clúster",
-  "loc.input.help.useClusterAdmin": "Use las credenciales de administrador del clúster en lugar de las credenciales predeterminadas de usuario de clúster.",  
+  "loc.input.help.useClusterAdmin": "Use las credenciales de administrador del clúster en lugar de las credenciales predeterminadas de usuario de clúster.",
   "loc.input.label.namespace": "Nombres",
   "loc.input.help.namespace": "Establece el espacio de nombres para los comandos con la marca –namespace. Si no se proporciona el espacio de nombres, los comandos se ejecutan en el predeterminado.",
   "loc.input.label.strategy": "Estrategia",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -16,7 +16,7 @@
   "loc.input.label.kubernetesCluster": "Cluster Kubernetes",
   "loc.input.help.kubernetesCluster": "Sélectionnez un cluster managé Azure.",
   "loc.input.label.useClusterAdmin": "Utiliser les informations d'identification de l'administrateur de cluster",
-  "loc.input.help.useClusterAdmin": "Utilisez les informations d'identification de l'administrateur de cluster à la place des informations d'identification de l'utilisateur de cluster par défaut.",  
+  "loc.input.help.useClusterAdmin": "Utilisez les informations d’identification de l’administrateur de cluster à la place des informations d’identification de l’utilisateur de cluster par défaut.",
   "loc.input.label.namespace": "Espace de noms",
   "loc.input.help.namespace": "Définit l’espace de noms des commandes à l’aide de l’indicateur –namespace. Si vous n’indiquez pas l’espace de noms, les commandes sont exécutées dans l’espace de noms par défaut.",
   "loc.input.label.strategy": "Stratégie",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -16,7 +16,7 @@
   "loc.input.label.kubernetesCluster": "Cluster Kubernetes",
   "loc.input.help.kubernetesCluster": "Selezionare un cluster gestito di Azure.",
   "loc.input.label.useClusterAdmin": "Usa credenziali dell'amministratore del cluster",
-  "loc.input.help.useClusterAdmin": "Consente di usare le credenziali dell'amministratore del cluster invece delle credenziali utente del cluster predefinite.",  
+  "loc.input.help.useClusterAdmin": "Consente di usare le credenziali dell'amministratore del cluster invece delle credenziali utente del cluster predefinite.",
   "loc.input.label.namespace": "Spazio dei nomi",
   "loc.input.help.namespace": "Consente di impostare lo spazio dei nomi per i comandi usando il flag –namespace. Se lo spazio dei nomi non viene specificato, i comandi verranno eseguiti nello spazio dei nomi predefinito.",
   "loc.input.label.strategy": "Strategia",

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "Der Name des Artefakts, das am Speicherort für die Veröffentlichung erstellt werden soll.",
   "loc.input.label.ArtifactType": "Veröffentlichungsort für Artefakte",
   "loc.input.help.ArtifactType": "Wählen Sie aus, ob Sie das Artefakt in Azure Pipelines speichern oder in eine Dateifreigabe kopieren möchten, die vom Build-Agent aus zugänglich sein muss.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "Dateifreigabepfad",
   "loc.input.help.TargetPath": "Die Dateifreigabe, in die die Artefaktdateien kopiert werden. Diese kann Variablen umfassen. Beispiel: \\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). Das Veröffentlichen von Artefakten über einen Linux- oder macOS-Agent in einer Dateifreigabe wird nicht unterstützt.",
   "loc.input.label.Parallel": "Paralleles Kopieren",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "Diese Aufgabe muss in einem Build ausgeführt werden, um Artefakte in Azure Pipelines zu veröffentlichen.",
   "loc.messages.PublishBuildArtifactsFailed": "Fehler beim Veröffentlichen von Buildartefakten: %s",
   "loc.messages.UnexpectedParallelCount": "Nicht unterstützte parallele Anzahl \"%s\". Geben Sie eine Zahl zwischen 1 und 128 ein.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Die Tar-Extraktion wird unter Windows nicht unterstützt"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Die Tar-Extraktion wird unter Windows nicht unterstützt",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "El nombre del artefacto que se va a crear en la ubicación de publicación.",
   "loc.input.label.ArtifactType": "Ubicación de publicación de artefactos",
   "loc.input.help.ArtifactType": "Elija si el artefacto se va a almacenar en Azure Pipelines o se va a copiar en un recurso compartido de archivos al que se pueda acceder desde el agente de compilación.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "Ruta de acceso del recurso compartido de archivos",
   "loc.input.help.TargetPath": "El recurso compartido de archivos en el que se copiarán los archivos de artefacto. Puede incluir variables. Ejemplo: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). No se admite la publicación de artefactos de un agente de Linux o macOS en un recurso compartido de archivos.",
   "loc.input.label.Parallel": "Copia en paralelo",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "Esta tarea debe ejecutarse en una compilación para publicar artefactos en Azure Pipelines.",
   "loc.messages.PublishBuildArtifactsFailed": "Error al publicar artefactos de compilación: %s",
   "loc.messages.UnexpectedParallelCount": "Recuento de elementos \"%s\" en paralelo no admitido. Especifique un número entre 1 y 128.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "La extracción de tar no es compatible con Windows"
+  "loc.messages.TarExtractionNotSupportedInWindows": "La extracción de tar no es compatible con Windows",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "Nom de l'artefact à créer dans l'emplacement de publication.",
   "loc.input.label.ArtifactType": "Emplacement de publication des artefacts",
   "loc.input.help.ArtifactType": "Choisissez entre le stockage de l'artefact dans Azure Pipelines, ou sa copie sur un partage de fichiers qui doit être accessible à l'agent de build.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "Chemin du partage de fichiers",
   "loc.input.help.TargetPath": "Partage de fichiers où sont copiés les fichiers d'artefacts. Il peut inclure des variables. Exemple : \\\\\\\\mon\\\\partage\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). La publication d'artefacts d'un agent Linux ou macOS vers un partage de fichiers n'est pas prise en charge.",
   "loc.input.label.Parallel": "Copie parallèle",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "Cette tâche doit s'exécuter dans une build pour permettre la publication d'artefacts sur Azure Pipelines.",
   "loc.messages.PublishBuildArtifactsFailed": "Échec de la publication des artefacts de build. Erreur : %s",
   "loc.messages.UnexpectedParallelCount": "Nombre parallèle '%s' non pris en charge. Entrez un nombre compris entre 1 et 128.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "L’extraction par extraction d’extraction n’est pas prise en charge sur Windows"
+  "loc.messages.TarExtractionNotSupportedInWindows": "L’extraction par extraction d’extraction n’est pas prise en charge sur Windows",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "Nome dell'artefatto da creare nel percorso di pubblicazione.",
   "loc.input.label.ArtifactType": "Percorso di pubblicazione degli artefatti",
   "loc.input.help.ArtifactType": "Consente di scegliere se archiviare l'artefatto in Azure Pipelines oppure copiarlo in una condivisione file accessibile dall'agente di compilazione.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "Percorso condivisione file",
   "loc.input.help.TargetPath": "Condivisione file in cui verranno copiati i file di artefatto. Può includere variabili. Esempio: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). La pubblicazione di artefatti da un agente Linux o macOS in una condivisione file non è supportata.",
   "loc.input.label.Parallel": "Copia parallela",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "Per pubblicare gli artefatti in Azure Pipelines, questa attività deve essere eseguita in una compilazione.",
   "loc.messages.PublishBuildArtifactsFailed": "La pubblicazione degli artefatti di compilazione non è riuscita. Errore: %s",
   "loc.messages.UnexpectedParallelCount": "Conteggio parallelo '%s' non supportato. Immettere un numero compreso tra 1 e 128.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "L'estrazione di tar non è supportata in Windows"
+  "loc.messages.TarExtractionNotSupportedInWindows": "L'estrazione di tar non è supportata in Windows",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "公開場所に作成する成果物の名前。",
   "loc.input.label.ArtifactType": "成果物の発行場所",
   "loc.input.help.ArtifactType": "成果物を Azure Pipelines に保存するか、またはビルド エージェントからアクセスできるファイル共有にコピーするかを選択します。",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "ファイル共有パス",
   "loc.input.help.TargetPath": "成果物ファイルのコピー先であるファイル共有です。これには変数を含めることができます。例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。Linux または macOS エージェントから成果物をファイル共有に公開することはサポートされていません。",
   "loc.input.label.Parallel": "並列コピー",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "成果物を Azure Pipelines に公開するには、ビルドでこのタスクを実行する必要があります。",
   "loc.messages.PublishBuildArtifactsFailed": "ビルド成果物の発行が失敗し、次のエラーが発生しました: %s",
   "loc.messages.UnexpectedParallelCount": "並列数 '%s' はサポートされていません。1 以上 128 以下の数を入力してください。",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Tar 抽出は Windows でサポートされていません"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Tar 抽出は Windows でサポートされていません",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "게시 위치에 만들 아티팩트의 이름입니다.",
   "loc.input.label.ArtifactType": "아티팩트 게시 위치",
   "loc.input.help.ArtifactType": "아티팩트를 Azure Pipelines에 저장할지 또는 빌드 에이전트에서 액세스할 수 있어야 하는 파일 공유에 복사할지를 선택합니다.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "파일 공유 경로",
   "loc.input.help.TargetPath": "아티팩트 파일을 복사할 파일 공유입니다. 변수를 포함할 수 있습니다(예: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)). Linux 또는 macOS 에이전트의 아티팩트를 파일 공유에 게시할 수는 없습니다.",
   "loc.input.label.Parallel": "병렬 복사",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "아티팩트를 Azure Pipelines에 게시하려면 빌드에서 이 작업을 실행해야 합니다.",
   "loc.messages.PublishBuildArtifactsFailed": "오류가 발생하여 빌드 아티팩트를 게시하지 못함: %s",
   "loc.messages.UnexpectedParallelCount": "지원되지 않는 병렬 개수 '%s'입니다. 1에서 128 사이의 숫자를 입력하세요.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Windows에서는 tar 압축 풀기가 지원되지 않습니다"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Windows에서는 tar 압축 풀기가 지원되지 않습니다",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "Имя артефакта, который будет создан в расположении публикации.",
   "loc.input.label.ArtifactType": "Расположение публикации артефакта",
   "loc.input.help.ArtifactType": "Выберите, нужно ли сохранить артефакт в Azure Pipelines либо скопировать его в общую папку, которая должна быть доступна из агента сборки.",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "Путь к общей папке",
   "loc.input.help.TargetPath": "Общая папка, в которую будут скопированы файлы артефактов. Может включать в себя переменные. Пример: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). Публикация артефактов из агента Linux или macOS в общей папке не поддерживается.",
   "loc.input.label.Parallel": "Параллельное копирование",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "Эта задача должна выполняться в сборке для публикации артефактов в Azure Pipelines.",
   "loc.messages.PublishBuildArtifactsFailed": "Сбой публикации артефактов сборки с ошибкой: %s",
   "loc.messages.UnexpectedParallelCount": "Неподдерживаемое значение счетчика параллелизма \"%s\". Введите число от 1 до 128.",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Извлечение из TAR-архива не поддерживается в Windows"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Извлечение из TAR-архива не поддерживается в Windows",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "要在发布位置中创建的项目的名称。",
   "loc.input.label.ArtifactType": "项目发布位置",
   "loc.input.help.ArtifactType": "选择是否在 Azure Pipelines 中存储项目，或者是否将其复制到必须可从生成代理访问的文件共享中。",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "文件共享路径",
   "loc.input.help.TargetPath": "项目文件将复制到的文件共享。这可包括变量。示例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。不支持将项目从 Linux 或 macOS 代理发布到文件共享。",
   "loc.input.label.Parallel": "并行复制",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "此任务必须在生成中运行，以将项目发布到 Azure Pipelines。",
   "loc.messages.PublishBuildArtifactsFailed": "发布生成项目失败，出现错误: %s",
   "loc.messages.UnexpectedParallelCount": "并行计数“%s”不受支持。输入介于 1 到 128 之间的数字。",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支持存档提取"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支持存档提取",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.ArtifactName": "要在發佈位置建立的成品名稱。",
   "loc.input.label.ArtifactType": "成品發佈位置",
   "loc.input.help.ArtifactType": "選擇要在 Azure Pipelines 中儲存成品，還是將成品複製到必須可透過組建代理程式存取的檔案共用。",
+  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
+  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
   "loc.input.label.TargetPath": "檔案共用路徑",
   "loc.input.help.TargetPath": "成品檔案所要複製到的檔案共用。此項目可包含變數。範例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。不支援從 Linux 或 macOS 代理程式將成品發佈至檔案共用。",
   "loc.input.label.Parallel": "平行複製",
@@ -22,5 +24,6 @@
   "loc.messages.ErrorHostTypeNotSupported": "此工作必須在組建中執行才能將成品發佈至 Azure Pipelines。",
   "loc.messages.PublishBuildArtifactsFailed": "發行組建成品失敗，錯誤: %s",
   "loc.messages.UnexpectedParallelCount": "不支援的平行計數 '%s'。請輸入介於 1 到 128 之間的數字。",
-  "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支援 tar 解壓縮"
+  "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支援 tar 解壓縮",
+  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.