### PR TITLE
Use args correctly for coveragepublisher

### DIFF
--- a/Tasks/Common/coveragepublisher/coveragepublisher.ts
+++ b/Tasks/Common/coveragepublisher/coveragepublisher.ts
@@ -36,11 +36,15 @@ async function publishCoverage(inputFiles: string[], reportDirectory: string, pa
         dotnet.arg(path.join(__dirname, "CoveragePublisher", 'CoveragePublisher.Console.dll'));
     }
 
-    dotnet.arg('"' + inputFiles.join('" "') + '"');
-    dotnet.arg('--reportDirectory ' + reportDirectory);
+    for (const inputFile of inputFiles) {
+        dotnet.arg('"' + inputFile + '"');
+    }
+    dotnet.arg('--reportDirectory');
+    dotnet.arg(reportDirectory);
 
     if(!isNullOrWhitespace(pathToSources)) {
-        dotnet.arg('--sourceDirectory ' + pathToSources);
+        dotnet.arg('--sourceDirectory');
+        dotnet.arg(pathToSources);
     }
 
     try {


### PR DESCRIPTION
**Task name**: Related to `PublishCodeCoverageResults@2`

**Description**:
This is using one item in the args array for each argument. When Node.js spawn's the new process it will work as expected.
See:
https://github.com/microsoft/azure-pipelines-task-lib/blob/4086d6bef172fe1329d3006ccacc324e05baac1e/node/toolrunner.ts#L269

**Documentation changes required:** (N)

**Added unit tests:** (N - There were none)

**Attached related issue:** (Y) #17756

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
