### PR TITLE
Fix CargoAuthenticate for registries containing more than one dash

### DIFF
--- a/Tasks/CargoAuthenticateV0/cargoauthenticatemain.ts
+++ b/Tasks/CargoAuthenticateV0/cargoauthenticatemain.ts
@@ -75,7 +75,7 @@ async function main(): Promise<void> {
 
         for (let registry of Object.keys(result.registries)) {
             const registryUrl = url.parse(result.registries[registry].index);
-            let tokenName = `CARGO_REGISTRIES_${registry.toLocaleUpperCase().replace("-", "_")}_TOKEN`;
+            let tokenName = `CARGO_REGISTRIES_${registry.toLocaleUpperCase().replace(/-/g, "_")}_TOKEN`;
             if (registryUrl && registryUrl.host && collectionHosts.indexOf(registryUrl.host.toLowerCase()) >= 0) {
                 let currentRegistry : string;
                 for (let serviceConnection of externalServiceConnections) {

--- a/Tasks/CargoAuthenticateV0/task.json
+++ b/Tasks/CargoAuthenticateV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 221,
+        "Minor": 223,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/CargoAuthenticateV0/task.loc.json
+++ b/Tasks/CargoAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 221,
+    "Minor": 223,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
**Task name**: CargoAuthenticateV0

**Description**: Bug fix. The `.replace` function only replaces the first dash, and we need to replace all of them when converting the name to an environment variable.

**Documentation changes required:** N

**Added unit tests:** No unit tests existed for this task

**Attached related issue:** N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
