### PR TITLE
WebRequestOption - New flag is added for resetstream

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.223.4",
+  "version": "3.223.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.223.4",
+  "version": "3.223.5",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",

--- a/common-npm-packages/azure-arm-rest-v2/webClient.d.ts
+++ b/common-npm-packages/azure-arm-rest-v2/webClient.d.ts
@@ -17,7 +17,6 @@ export declare class WebRequestOptions {
     retryIntervalInSeconds: number;
     retriableStatusCodes: number[];
     retryRequestTimedout: boolean;
-    shouldResetStreamOnReadableOrNot?: boolean;
 }
 export declare function sendRequest(request: WebRequest, options?: WebRequestOptions): Promise<WebResponse>;
 export declare function sleepFor(sleepDurationInSeconds: any): Promise<any>;

--- a/common-npm-packages/azure-arm-rest-v2/webClient.d.ts
+++ b/common-npm-packages/azure-arm-rest-v2/webClient.d.ts
@@ -17,6 +17,7 @@ export declare class WebRequestOptions {
     retryIntervalInSeconds: number;
     retriableStatusCodes: number[];
     retryRequestTimedout: boolean;
+    shouldResetStreamOnReadableOrNot?: boolean;
 }
 export declare function sendRequest(request: WebRequest, options?: WebRequestOptions): Promise<WebResponse>;
 export declare function sleepFor(sleepDurationInSeconds: any): Promise<any>;

--- a/common-npm-packages/azure-arm-rest-v2/webClient.ts
+++ b/common-npm-packages/azure-arm-rest-v2/webClient.ts
@@ -42,6 +42,7 @@ export class WebRequestOptions {
     public retryIntervalInSeconds: number;
     public retriableStatusCodes: number[];
     public retryRequestTimedout: boolean;
+    public shouldResetStreamOnReadableOrNot?: boolean;
 }
 
 export async function sendRequest(request: WebRequest, options?: WebRequestOptions): Promise<WebResponse> {
@@ -50,10 +51,11 @@ export async function sendRequest(request: WebRequest, options?: WebRequestOptio
     let retryIntervalInSeconds = options && options.retryIntervalInSeconds ? options.retryIntervalInSeconds : 2;
     let retriableErrorCodes = options && options.retriableErrorCodes ? options.retriableErrorCodes : ["ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "ESOCKETTIMEDOUT", "ECONNREFUSED", "EHOSTUNREACH", "EPIPE", "EA_AGAIN"];
     let retriableStatusCodes = options && options.retriableStatusCodes ? options.retriableStatusCodes : [408, 409, 500, 502, 503, 504];
+    let shouldResetStreamOnReadableOrNot = options && options.shouldResetStreamOnReadableOrNot ? options.shouldResetStreamOnReadableOrNot : false;
     let timeToWait: number = retryIntervalInSeconds;
     while (true) {
         try {
-            if (request.body && typeof(request.body) !== 'string' && !request.body["readable"]) {
+            if (request.body && typeof(request.body) !== 'string' && (shouldResetStreamOnReadableOrNot || !request.body["readable"])) {
                 request.body = fs.createReadStream(request.body["path"]);
             }
             


### PR DESCRIPTION
**Task name**: azure-arm-rest-v2

**Description**: A new flag is added to give option to reset stream when it is readable or not on retry.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y
#18376 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
