### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 20130642

### DIFF
--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "Der Name des Artefakts, das am Speicherort für die Veröffentlichung erstellt werden soll.",
   "loc.input.label.ArtifactType": "Veröffentlichungsort für Artefakte",
   "loc.input.help.ArtifactType": "Wählen Sie aus, ob Sie das Artefakt in Azure Pipelines speichern oder in eine Dateifreigabe kopieren möchten, die vom Build-Agent aus zugänglich sein muss.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "Maximale Artefaktgröße",
+  "loc.input.help.MaxArtifactSize": "Maximales Limit für die Größe von Artefakten, die in Bytes veröffentlicht werden sollen. Legen Sie \"0\" fest, wenn Sie kein Limit festlegen möchten.",
   "loc.input.label.TargetPath": "Dateifreigabepfad",
   "loc.input.help.TargetPath": "Die Dateifreigabe, in die die Artefaktdateien kopiert werden. Diese kann Variablen umfassen. Beispiel: \\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). Das Veröffentlichen von Artefakten über einen Linux- oder macOS-Agent in einer Dateifreigabe wird nicht unterstützt.",
   "loc.input.label.Parallel": "Paralleles Kopieren",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "Fehler beim Veröffentlichen von Buildartefakten: %s",
   "loc.messages.UnexpectedParallelCount": "Nicht unterstützte parallele Anzahl \"%s\". Geben Sie eine Zahl zwischen 1 und 128 ein.",
   "loc.messages.TarExtractionNotSupportedInWindows": "Die Tar-Extraktion wird unter Windows nicht unterstützt",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "Die Größe der zu veröffentlichenden Artefakte beträgt %s Bytes und überschreitet damit den maximalen Grenzwert von %s Bytes, der für die veröffentlichte Größe von Artefakten festgelegt ist."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "El nombre del artefacto que se va a crear en la ubicación de publicación.",
   "loc.input.label.ArtifactType": "Ubicación de publicación de artefactos",
   "loc.input.help.ArtifactType": "Elija si el artefacto se va a almacenar en Azure Pipelines o se va a copiar en un recurso compartido de archivos al que se pueda acceder desde el agente de compilación.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "Tamaño máximo del artefacto",
+  "loc.input.help.MaxArtifactSize": "Límite máximo del tamaño de los artefactos que se van a publicar en bytes. Escriba 0 si no desea establecer ningún límite.",
   "loc.input.label.TargetPath": "Ruta de acceso del recurso compartido de archivos",
   "loc.input.help.TargetPath": "El recurso compartido de archivos en el que se copiarán los archivos de artefacto. Puede incluir variables. Ejemplo: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). No se admite la publicación de artefactos de un agente de Linux o macOS en un recurso compartido de archivos.",
   "loc.input.label.Parallel": "Copia en paralelo",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "Error al publicar artefactos de compilación: %s",
   "loc.messages.UnexpectedParallelCount": "Recuento de elementos \"%s\" en paralelo no admitido. Especifique un número entre 1 y 128.",
   "loc.messages.TarExtractionNotSupportedInWindows": "La extracción de tar no es compatible con Windows",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "El tamaño de los artefactos que se van a publicar es de %s bytes, que supera el límite máximo de %s bytes establecido para el tamaño publicado de los artefactos."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "Nom de l'artefact à créer dans l'emplacement de publication.",
   "loc.input.label.ArtifactType": "Emplacement de publication des artefacts",
   "loc.input.help.ArtifactType": "Choisissez entre le stockage de l'artefact dans Azure Pipelines, ou sa copie sur un partage de fichiers qui doit être accessible à l'agent de build.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "Taille maximale de l’artefact",
+  "loc.input.help.MaxArtifactSize": "Limite maximale de la taille des artefacts à publier en octets. Mettez 0 si vous ne souhaitez pas définir de limite.",
   "loc.input.label.TargetPath": "Chemin du partage de fichiers",
   "loc.input.help.TargetPath": "Partage de fichiers où sont copiés les fichiers d'artefacts. Il peut inclure des variables. Exemple : \\\\\\\\mon\\\\partage\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). La publication d'artefacts d'un agent Linux ou macOS vers un partage de fichiers n'est pas prise en charge.",
   "loc.input.label.Parallel": "Copie parallèle",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "Échec de la publication des artefacts de build. Erreur : %s",
   "loc.messages.UnexpectedParallelCount": "Nombre parallèle '%s' non pris en charge. Entrez un nombre compris entre 1 et 128.",
   "loc.messages.TarExtractionNotSupportedInWindows": "L’extraction par extraction d’extraction n’est pas prise en charge sur Windows",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "La taille des artefacts en cours de publication est de %s octets, ce qui est supérieur à la limite maximale de %s octets définie pour la taille publiée des artefacts."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "Nome dell'artefatto da creare nel percorso di pubblicazione.",
   "loc.input.label.ArtifactType": "Percorso di pubblicazione degli artefatti",
   "loc.input.help.ArtifactType": "Consente di scegliere se archiviare l'artefatto in Azure Pipelines oppure copiarlo in una condivisione file accessibile dall'agente di compilazione.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "Dimensioni massime artefatto",
+  "loc.input.help.MaxArtifactSize": "Limite massimo per le dimensioni degli artefatti da pubblicare in byte. Inserire 0 se non si vuole impostare alcun limite.",
   "loc.input.label.TargetPath": "Percorso condivisione file",
   "loc.input.help.TargetPath": "Condivisione file in cui verranno copiati i file di artefatto. Può includere variabili. Esempio: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). La pubblicazione di artefatti da un agente Linux o macOS in una condivisione file non è supportata.",
   "loc.input.label.Parallel": "Copia parallela",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "La pubblicazione degli artefatti di compilazione non è riuscita. Errore: %s",
   "loc.messages.UnexpectedParallelCount": "Conteggio parallelo '%s' non supportato. Immettere un numero compreso tra 1 e 128.",
   "loc.messages.TarExtractionNotSupportedInWindows": "L'estrazione di tar non è supportata in Windows",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "Le dimensioni degli artefatti pubblicati sono %s byte, che superano il limite massimo di %s byte impostato per le dimensioni pubblicate degli artefatti."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "公開場所に作成する成果物の名前。",
   "loc.input.label.ArtifactType": "成果物の発行場所",
   "loc.input.help.ArtifactType": "成果物を Azure Pipelines に保存するか、またはビルド エージェントからアクセスできるファイル共有にコピーするかを選択します。",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "成果物の最大サイズ",
+  "loc.input.help.MaxArtifactSize": "公開する成果物のサイズの上限 (バイト単位)。制限を設定しない場合は 0 を指定します。",
   "loc.input.label.TargetPath": "ファイル共有パス",
   "loc.input.help.TargetPath": "成果物ファイルのコピー先であるファイル共有です。これには変数を含めることができます。例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。Linux または macOS エージェントから成果物をファイル共有に公開することはサポートされていません。",
   "loc.input.label.Parallel": "並列コピー",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "ビルド成果物の発行が失敗し、次のエラーが発生しました: %s",
   "loc.messages.UnexpectedParallelCount": "並列数 '%s' はサポートされていません。1 以上 128 以下の数を入力してください。",
   "loc.messages.TarExtractionNotSupportedInWindows": "Tar 抽出は Windows でサポートされていません",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "公開中の成果物のサイズが %s バイトです。これは、成果物の公開サイズに設定されている上限 %s バイトを超えています。"
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "게시 위치에 만들 아티팩트의 이름입니다.",
   "loc.input.label.ArtifactType": "아티팩트 게시 위치",
   "loc.input.help.ArtifactType": "아티팩트를 Azure Pipelines에 저장할지 또는 빌드 에이전트에서 액세스할 수 있어야 하는 파일 공유에 복사할지를 선택합니다.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "최대 아티팩트 크기",
+  "loc.input.help.MaxArtifactSize": "게시할 아티팩트 크기에 대한 최대 제한(바이트)입니다. 제한을 설정하지 않으려면 0을 입력합니다.",
   "loc.input.label.TargetPath": "파일 공유 경로",
   "loc.input.help.TargetPath": "아티팩트 파일을 복사할 파일 공유입니다. 변수를 포함할 수 있습니다(예: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)). Linux 또는 macOS 에이전트의 아티팩트를 파일 공유에 게시할 수는 없습니다.",
   "loc.input.label.Parallel": "병렬 복사",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "오류가 발생하여 빌드 아티팩트를 게시하지 못함: %s",
   "loc.messages.UnexpectedParallelCount": "지원되지 않는 병렬 개수 '%s'입니다. 1에서 128 사이의 숫자를 입력하세요.",
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows에서는 tar 압축 풀기가 지원되지 않습니다",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "게시 중인 아티팩트의 크기가 게시되는 아티팩트 크기에 대해 설정된 최대 제한 %s바이트보다 큰 %s바이트입니다."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "Имя артефакта, который будет создан в расположении публикации.",
   "loc.input.label.ArtifactType": "Расположение публикации артефакта",
   "loc.input.help.ArtifactType": "Выберите, нужно ли сохранить артефакт в Azure Pipelines либо скопировать его в общую папку, которая должна быть доступна из агента сборки.",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "Максимальный размер артефакта",
+  "loc.input.help.MaxArtifactSize": "Максимальный размер публикуемых артефактов в байтах. Если вы не хотите устанавливать какие-либо ограничения, укажите значение 0.",
   "loc.input.label.TargetPath": "Путь к общей папке",
   "loc.input.help.TargetPath": "Общая папка, в которую будут скопированы файлы артефактов. Может включать в себя переменные. Пример: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber). Публикация артефактов из агента Linux или macOS в общей папке не поддерживается.",
   "loc.input.label.Parallel": "Параллельное копирование",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "Сбой публикации артефактов сборки с ошибкой: %s",
   "loc.messages.UnexpectedParallelCount": "Неподдерживаемое значение счетчика параллелизма \"%s\". Введите число от 1 до 128.",
   "loc.messages.TarExtractionNotSupportedInWindows": "Извлечение из TAR-архива не поддерживается в Windows",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "Размер публикуемых артефактов составляет %s байт, что превышает максимальное ограничение %s байт, заданное для опубликованного размера артефактов."
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "要在发布位置中创建的项目的名称。",
   "loc.input.label.ArtifactType": "项目发布位置",
   "loc.input.help.ArtifactType": "选择是否在 Azure Pipelines 中存储项目，或者是否将其复制到必须可从生成代理访问的文件共享中。",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "最大项目大小",
+  "loc.input.help.MaxArtifactSize": "要发布的项目大小的最大限制(以字节为单位)。如果不想设置任何限制，请输入 0。",
   "loc.input.label.TargetPath": "文件共享路径",
   "loc.input.help.TargetPath": "项目文件将复制到的文件共享。这可包括变量。示例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。不支持将项目从 Linux 或 macOS 代理发布到文件共享。",
   "loc.input.label.Parallel": "并行复制",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "发布生成项目失败，出现错误: %s",
   "loc.messages.UnexpectedParallelCount": "并行计数“%s”不受支持。输入介于 1 到 128 之间的数字。",
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支持存档提取",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "正在发布的项目大小为 %s 字节，大于为项目发布的大小设置的最大限制 %s 字节。"
 }

--- a/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PublishBuildArtifactsV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -10,8 +10,8 @@
   "loc.input.help.ArtifactName": "要在發佈位置建立的成品名稱。",
   "loc.input.label.ArtifactType": "成品發佈位置",
   "loc.input.help.ArtifactType": "選擇要在 Azure Pipelines 中儲存成品，還是將成品複製到必須可透過組建代理程式存取的檔案共用。",
-  "loc.input.label.MaxArtifactSize": "Max Artifact Size",
-  "loc.input.help.MaxArtifactSize": "Maximum limit on the size of artifacts to be published in bytes. Put 0 if you don't want to set any limit.",
+  "loc.input.label.MaxArtifactSize": "成品大小上限",
+  "loc.input.help.MaxArtifactSize": "成品的發佈大小上限，以位元組為單位。如果您不想設定任何限制，請放 0。",
   "loc.input.label.TargetPath": "檔案共用路徑",
   "loc.input.help.TargetPath": "成品檔案所要複製到的檔案共用。此項目可包含變數。範例: \\\\\\\\my\\\\share\\\\$(Build.DefinitionName)\\\\$(Build.BuildNumber)。不支援從 Linux 或 macOS 代理程式將成品發佈至檔案共用。",
   "loc.input.label.Parallel": "平行複製",
@@ -25,5 +25,5 @@
   "loc.messages.PublishBuildArtifactsFailed": "發行組建成品失敗，錯誤: %s",
   "loc.messages.UnexpectedParallelCount": "不支援的平行計數 '%s'。請輸入介於 1 到 128 之間的數字。",
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支援 tar 解壓縮",
-  "loc.messages.ArtifactSizeExceeded": "The size of artifacts being published is %s bytes which is larger than the maximum limit %s bytes set for the published size of artifacts."
+  "loc.messages.ArtifactSizeExceeded": "要發佈的成品大小為 %s 位元組，這已超過成品發佈大小所設定的 %s 位元組上限。"
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.