### PR TITLE
Allow not to change versions which should be bumped due to changes in common

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -43,11 +43,12 @@ steps:
   env:
     PACKAGE_ENDPOINT: $(Package.Endpoint)
     PACKAGE_TOKEN: $(Package.Token)
+    SKIP_BUMPING_VERSIONS_DUE_TO_CHANGES_IN_COMMON: $(skipBumpingVersionsDueToChangesInCommon)
 
 # Build
 - script: node make.js build --task "$(task_pattern)"
   displayName: Build
-  condition: ne(variables['numTasks'], 0)
+  condition: and(succeeded(), ne(variables['numTasks'], 0))
 
 - script: node ./ci/check-tasks.js
   displayName: Check that tasks has no duplicated libs
@@ -94,10 +95,10 @@ steps:
 # Test
 - script: node make.js test
   displayName: Run tests
-  condition: ne(variables['numTasks'], 0)
+  condition: and(succeeded(), ne(variables['numTasks'], 0))
 - script: node make.js testLegacy --task "$(task_pattern)"
   displayName: Legacy tests with node 6
-  condition: ne(variables['numTasks'], 0)
+  condition: and(succeeded(), ne(variables['numTasks'], 0))
 
 # Publish code coverage result
 - task: PublishCodeCoverageResults@1


### PR DESCRIPTION
**Description:** This PR adds the ability to manually skip the check in the CI which verifies that task versions have been bumped up if a common package on which these tasks depend has been updated, by setting the `skipBumpingVersionsDueToChangesInCommon` pipeline variable to `true`.

**Documentation changes required:** No

**Added unit tests:** No

**Checklist:**
- [ ] Checked that applied changes work as expected — see [test pull request](https://github.com/microsoft/azure-pipelines-tasks/pull/18454)
