### PR TITLE
Fix remote repo name for canary tests

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -10,7 +10,7 @@ jobs:
   - script: |
       git fetch origin master
       git diff --name-only origin/master
-      echo "##vso[task.setvariable variable=TASKS;isoutput=true]$(node ./ci/ci-test-tasks/detect-changed-tasks.js $(git diff --name-only ms/master))"
+      echo "##vso[task.setvariable variable=TASKS;isoutput=true]$(node ./ci/ci-test-tasks/detect-changed-tasks.js $(git diff --name-only origin/master))"
     displayName: 'Detect changed tasks'
     name: detect
  


### PR DESCRIPTION
**Task name**: N/A

**Description**: Fixes remote repo name for canary tests

**Documentation changes required:** (Y/N) N
**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
