### PR TITLE
Fix variable name in canary tests

### DIFF
--- a/ci/ci-test-tasks/test-and-verify-v2.js
+++ b/ci/ci-test-tasks/test-and-verify-v2.js
@@ -101,7 +101,7 @@ function runTestPipeline(pipeline, config = '') {
     .post(`${apiUrl}/${pipeline.id}/runs?${apiVersion}`, 
     {
       variables: {
-        CANARY_TEST_TASKNAMES: { 
+        CANARY_TEST_TASKNAME: { 
           "isSercret": false,
           "value": pipeline.name,
         },


### PR DESCRIPTION
**Task name**: N/A

**Description**: This variable was refactored in the canary extension, to be more precicise in naming (since this variable excect to contain only 1 task name to test).

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
