### PR TITLE
Execute this.appServiceUtility.getApplicationURL only if appServiceUt…

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
@@ -63,13 +63,12 @@ export class AzureRmWebAppDeploymentProvider implements IWebAppDeploymentProvide
         }
         
         if(this.appServiceUtility) {
-        let appServiceApplicationUrl: string = await this.appServiceUtility.getApplicationURL(!this.taskParams.isLinuxApp 
-            ? this.taskParams.VirtualApplication : null);
-        console.log(tl.loc('AppServiceApplicationURL', appServiceApplicationUrl));
-        tl.setVariable('AppServiceApplicationUrl', appServiceApplicationUrl);
+            let appServiceApplicationUrl: string = await this.appServiceUtility.getApplicationURL(!this.taskParams.isLinuxApp 
+                ? this.taskParams.VirtualApplication : null);
+            console.log(tl.loc('AppServiceApplicationURL', appServiceApplicationUrl));
+            tl.setVariable('AppServiceApplicationUrl', appServiceApplicationUrl);
         }
-    }
-    
+    }    
 
     protected async PostDeploymentStep() {
         if(this.taskParams.AppSettings) {

--- a/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/deploymentProvider/AzureRmWebAppDeploymentProvider.ts
@@ -62,11 +62,14 @@ export class AzureRmWebAppDeploymentProvider implements IWebAppDeploymentProvide
             tl.debug('Active DeploymentId :'+ this.activeDeploymentID);
         }
         
+        if(this.appServiceUtility) {
         let appServiceApplicationUrl: string = await this.appServiceUtility.getApplicationURL(!this.taskParams.isLinuxApp 
             ? this.taskParams.VirtualApplication : null);
         console.log(tl.loc('AppServiceApplicationURL', appServiceApplicationUrl));
         tl.setVariable('AppServiceApplicationUrl', appServiceApplicationUrl);
+        }
     }
+    
 
     protected async PostDeploymentStep() {
         if(this.taskParams.AppSettings) {

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 4,
-        "Minor": 223,
-        "Patch": 4
+        "Minor": 224,
+        "Patch": 0
     },
     "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
     "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 223,
-    "Patch": 4
+    "Minor": 224,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV4

**Description**: We execute the UpdateDeploymentStatus despite there is an exception or not so the 
this.appServiceUtility.getApplicationURL should be called only if appServiceUtility exists

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
