### PR TITLE
This PR fixes scope parameter for Connect-AzAccount that was removed when retries were added

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -112,6 +112,8 @@ function Initialize-AzSubscription {
                     ApplicationId=$Endpoint.Auth.Parameters.ServicePrincipalId;
                     Environment=$environmentName;
                     ServicePrincipal=$true;
+                    Scope='Process';
+                    WarningAction='SilentlyContinue';
                 }
             }
             else {
@@ -125,6 +127,8 @@ function Initialize-AzSubscription {
                     Credential=$psCredential;
                     Environment=$environmentName;
                     ServicePrincipal=$true;
+                    Scope='Process';
+                    WarningAction='SilentlyContinue';
                 }
             }
 
@@ -149,6 +153,7 @@ function Initialize-AzSubscription {
         @{
             Environment=$environmentName;
             Identity=$true;
+            Scope='Process';
         }
 
         if ($scopeLevel -ne "ManagementGroup") {
@@ -169,6 +174,7 @@ function Initialize-AzSubscription {
             ApplicationId=$Endpoint.Auth.Parameters.ServicePrincipalId;
             FederatedToken=$clientAssertionJwt;
             Environment=$environmentName;
+            Scope='Process';
         }
 
         if ($scopeLevel -ne "ManagementGroup") {

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 223,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 223,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
**Task name**: 
- AzureCloudPowerShellDeploymentV1
- AzureCloudPowerShellDeploymentV2
- AzureFileCopyV2
- AzureFileCopyV3
- AzureFileCopyV4
- AzureFileCopyV5
- AzurePowerShellV2
- AzurePowerShellV3
- AzurePowerShellV4
- AzurePowerShellV5
- SqlAzureDacpacDeploymentV1

To ensure successful CI checks related tasks versions were also bumped:

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
