### PR TITLE
Remove token usage from downgrading check CI/CD

### DIFF
--- a/ci/check-downgrading.js
+++ b/ci/check-downgrading.js
@@ -247,7 +247,11 @@ async function main({ task, sprint, week }) {
     }
 
     console.log('\nor you might have an outdated branch, try to merge/rebase your branch from master');
-    process.exit(1);
+
+    // If only we have errors, we should fail the build
+    if (messages.some(x => x.type === 'error')) {
+      process.exit(1);
+    }
   }
 }
 

--- a/ci/check-downgrading.js
+++ b/ci/check-downgrading.js
@@ -15,10 +15,8 @@ if (!packageEndpoint) {
   process.exit(1);
 }
 
-const packageToken = process.env['PACKAGE_TOKEN'];
 const { RestClient } = require('typed-rest-client/RestClient');
-const { PersonalAccessTokenCredentialHandler } = require('typed-rest-client/Handlers');
-const client = new RestClient('azure-pipelines-tasks-ci', '', [new PersonalAccessTokenCredentialHandler(packageToken)]);
+const client = new RestClient('azure-pipelines-tasks-ci', '');
 
 const argv = require('minimist')(process.argv.slice(2));
 


### PR DESCRIPTION
**Description**: We [can not use](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#contributions-from-forks) a secret token variable when we try to merge branches from forks to origin repo so I removed token usage from downgrading check CI/CD and checks were passed successfully.

**Checklist**:
- [x] Checked that applied changes work as expected
