### PR TITLE
Add ability to use specific node version in canary tests

### DIFF
--- a/ci/ci-test-tasks/test-and-verify-v2.js
+++ b/ci/ci-test-tasks/test-and-verify-v2.js
@@ -96,7 +96,7 @@ function fetchPipelines() {
 
 function runTestPipeline(pipeline, config = '') {
   console.log(`Run ${pipeline.name} pipeline, pipelineId: ${pipeline.id}`);
-  const {BUILD_SOURCEVERSION: CANARY_TEST_BRANCH } = process.env;
+  const {BUILD_SOURCEVERSION: CANARY_TEST_BRANCH, CANARY_TEST_NODE_VERSION } = process.env;
   return axios
     .post(`${apiUrl}/${pipeline.id}/runs?${apiVersion}`, 
     {
@@ -112,7 +112,11 @@ function runTestPipeline(pipeline, config = '') {
         CANARY_TEST_CONFIG: {
           "isSecret": false,
           "value": config 
-        }
+        },
+        CANARY_TEST_NODE_VERSION: {
+          "isSecret": false,
+          "value": CANARY_TEST_NODE_VERSION
+        },
       },
     }, { auth })
     .then(res =>  res.data)


### PR DESCRIPTION
**Task name**: N/A

**Description**: This PR is adding an extra variable to use a specific node version to build tasks in the canary test extension

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
