### PR TITLE
Added a fix for loading of different Newtonsoft dll version

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -17,17 +17,19 @@ function Initialize-AzModule {
     try {
         Write-Verbose "Env:PSModulePath: '$env:PSMODULEPATH'"
 
-        Write-Verbose "Initializing Az Module."
-        Import-AzModule -azVersion $azVersion
+        Write-Verbose "Importing Az Module."
+        $azAccountsVersion = Import-AzAccountsModule -azVersion $azVersion
 
+        Write-Verbose "Initializing Az Subscription."
         $encryptedToken = ConvertTo-SecureString $vstsAccessToken -AsPlainText -Force
-        Initialize-AzSubscription -Endpoint $Endpoint -connectedServiceNameARM $connectedServiceNameARM -vstsAccessToken $encryptedToken
+        Initialize-AzSubscription -Endpoint $Endpoint -connectedServiceNameARM $connectedServiceNameARM -vstsAccessToken $encryptedToken `
+            -azAccountsModuleVersion $azAccountsVersion
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation
     }
 }
 
-function Import-AzModule {
+function Import-AzAccountsModule {
     [CmdletBinding()]
     param([string] $azVersion)
 
@@ -38,10 +40,10 @@ function Import-AzModule {
         # Attempt to resolve the module.
         Write-Verbose "Attempting to find the module '$moduleName' from the module path."
 
-        if($azVersion -eq ""){
+        if ($azVersion -eq "") {
             $module = Get-Module -Name $moduleName -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
         }
-        else{
+        else {
             $modules = Get-Module -Name $moduleName -ListAvailable
             foreach ($moduleVal in $modules) {
                 # $moduleVal.Path will have value like C:\Program Files\WindowsPowerShell\Modules\Az.Accounts\1.2.1\Az.Accounts.psd1
@@ -64,6 +66,7 @@ function Import-AzModule {
         Write-Host "##[command]Import-Module -Name $($module.Path) -Global"
         $module = Import-Module -Name $module.Path -Global -PassThru -Force
         Write-Verbose "Imported module version: $($module.Version)"
+        return $module.Version
     } finally {
         Trace-VstsLeavingInvocation $MyInvocation
     }
@@ -77,7 +80,9 @@ function Initialize-AzSubscription {
         [Parameter(Mandatory=$false)]
         [string] $connectedServiceNameARM,
         [Parameter(Mandatory=$false)]
-        [Security.SecureString]$vstsAccessToken)
+        [Security.SecureString]$vstsAccessToken,
+        [Parameter(Mandatory=$false)]
+        [Version]$azAccountsModuleVersion)
 
     #Set UserAgent for Azure Calls
     Set-UserAgent
@@ -160,7 +165,8 @@ function Initialize-AzSubscription {
             Set-CurrentAzSubscription -SubscriptionId $Endpoint.Data.SubscriptionId -TenantId $Endpoint.Auth.Parameters.TenantId
         }
     } elseif ($Endpoint.Auth.Scheme -eq 'WorkloadIdentityFederation') {
-        $clientAssertionJwt = Get-VstsFederatedToken -serviceConnectionId $connectedServiceNameARM -vstsAccessToken $vstsAccessToken
+        $clientAssertionJwt = Get-VstsFederatedToken -serviceConnectionId $connectedServiceNameARM -vstsAccessToken $vstsAccessToken `
+            -azAccountsModuleVersion $azAccountsModuleVersion
 
         Write-Host "##[command]Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue"
         $null = Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue

--- a/Tasks/Common/VstsAzureHelpers_/make.json
+++ b/Tasks/Common/VstsAzureHelpers_/make.json
@@ -7,7 +7,19 @@
                 "repository": "https://www.nuget.org/api/v2/",
                 "cp": [
                     {
-                        "source": "lib/net45/Newtonsoft.Json.dll"
+                        "source": "lib/net45/Newtonsoft.Json.dll",
+                        "dest": "Newtonsoft.Json.10/"
+                    }
+                ]
+            },
+            {
+                "name": "Newtonsoft.Json",
+                "version": "13.0.3",
+                "repository": "https://www.nuget.org/api/v2/",
+                "cp": [
+                    {
+                        "source": "lib/net45/Newtonsoft.Json.dll",
+                        "dest": "Newtonsoft.Json.13/"
                     }
                 ]
             },
@@ -23,14 +35,14 @@
             },
             {
                 "name": "Microsoft.TeamFoundationServer.Client",
-                "version": "16.170.0",
+                "version": "19.216.0-preview",
                 "repository": "https://www.nuget.org/api/v2/",
                 "cp": [
                     {
-                        "source": "lib/net462/Microsoft.TeamFoundation.Core.WebApi.dll"
+                        "source": "lib/net472/Microsoft.TeamFoundation.Core.WebApi.dll"
                     },
                     {
-                        "source": "lib/net462/<CULTURE_NAME>/Microsoft.TeamFoundation.Core.WebApi.resources.dll",
+                        "source": "lib/net472/<CULTURE_NAME>/Microsoft.TeamFoundation.Core.WebApi.resources.dll",
                         "dest": "<CULTURE_NAME>/"
                     }
                 ]

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 223,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 223,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
**Description**: Added a fix for loading of different Newtonsoft dll version depending on az accounts module version

To ensure successful CI checks related tasks versions were also bumped:

- AzureCloudPowerShellDeploymentV1
- AzureCloudPowerShellDeploymentV2
- AzureFileCopyV2
- AzureFileCopyV3
- AzureFileCopyV4
- AzureFileCopyV5
- AzurePowerShellV2
- AzurePowerShellV3
- AzurePowerShellV4
- AzurePowerShellV5
- SqlAzureDacpacDeploymentV1

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
