### PR TITLE
Bump CI node to 10.x

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -15,14 +15,11 @@ steps:
     displayName: Start collect diagnostics
     condition: and(succeeded(), eq(variables.collect_diagnostics, 'true'))
 
-# Use node 8, npm 5
+# Use node 10, npm 6
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
-
-- script: npm i -g npm@6.9.0 --force
-  displayName: Use npm version 6.9.0
+    versionSpec: 10.x
 
 # npm install
 - script: npm install

--- a/ci/build-all-tasks.yml
+++ b/ci/build-all-tasks.yml
@@ -6,14 +6,11 @@ steps:
 - checkout: self
   clean: true
 
-# Use node 8, npm 5
+# Use node 10, npm 6
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
-
-- script: npm i -g npm@6.9.0 --force
-  displayName: Use npm version 6.9.0
+    versionSpec: 10.x
 
 # npm install
 - script: npm install

--- a/ci/build-common-npm.yml
+++ b/ci/build-common-npm.yml
@@ -5,12 +5,9 @@ steps:
   clean: true
 
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
-
-- script: npm i -g npm@6.9.0 --force
-  displayName: Use npm version 6.9.0
+    versionSpec: 10.x
 
 # Build typescript in ./Test and ./Test/lib
 - bash: |

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -14,11 +14,11 @@ steps:
 - powershell: ./ci/start-collect-diagnostics.ps1
   displayName: Start collect diagnostics
 
-# Use node 8, npm 5
+# Use node 10, npm 6
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
+    versionSpec: 10.x
 
 # npm install
 - script: npm install

--- a/ci/ci-test-tasks/build-init.yml
+++ b/ci/ci-test-tasks/build-init.yml
@@ -10,11 +10,11 @@ steps:
     git checkout --progress --force refs/remotes/origin/${{ parameters.BuildSourceVersion }}
   displayName: Checkout ${{ parameters.BuildSourceVersion }}
 
-# Use node 8, npm 5
+# Use node 10, npm 6
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
+    versionSpec: 10.x
 
 # npm install
 - script: npm install

--- a/ci/publish-steps.yml
+++ b/ci/publish-steps.yml
@@ -4,11 +4,11 @@ steps:
 - checkout: self
   clean: true
 
-# Use node 8, npm 5
+# Use node 10, npm 6
 - task: NodeTool@0
-  displayName: Use node 8
+  displayName: Use node 10
   inputs:
-    versionSpec: 8.x
+    versionSpec: 10.x
 
 # Use NuGet 4
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
**Description**: Bumped nodejs version in CI for tasks and common packages.
This will allow us to use `engine-strict=true` to auto validate task's dependencies.

Note: Node.js will be 10.24.1 as latest and npm 6.14.12

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
