### PR TITLE
Version Bump Fix for AzureFileCopyV4 and AzureFileCopyV5

### DIFF
--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 224,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 224,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 224,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 224,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
**Task name**: AzureFileCopyV4, AzureFileCopyV5

**Description**: 

PR #18494 is updated tasks 4.224.0 and 5.224.0

But previously merged PR also have same bump #18475 

So; I'm bumping versions for #18494 to correct values

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
