### PR TITLE
Exposed fething federated token from ADO as public method of ApplicationTokenCredentials

### DIFF
--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-common.d.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-common.d.ts
@@ -19,6 +19,7 @@ export declare class ApplicationTokenCredentials {
     getToken(force?: boolean): Q.Promise<string>;
     getDomain(): string;
     getClientId(): string;
+    getFederatedToken(): Promise<string>;
     public static getMSIAuthorizationToken(retyCount, timeToWait, baseUrl, msiClientId?);
     private _getSPNAuthorizationToken();
     private _getSPNAuthorizationTokenFromCertificate();

--- a/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
+++ b/common-npm-packages/azure-arm-rest-v2/azure-arm-common.ts
@@ -441,9 +441,7 @@ export class ApplicationTokenCredentials {
         return msalInstance;
     }
 
-    private async configureMSALWithOIDC(msalConfig: msal.Configuration): Promise<msal.ConfidentialClientApplication> {
-        tl.debug("MSAL - FederatedAccess - OIDC is used.");
-
+    public async getFederatedToken(): Promise<string> {
         const projectId: string = tl.getVariable("System.TeamProjectId");
         const hub: string = tl.getVariable("System.HostType");
         const planId: string = tl.getVariable('System.PlanId');
@@ -466,7 +464,13 @@ export class ApplicationTokenCredentials {
             0,
             2000);
 
-        msalConfig.auth.clientAssertion = oidc_token;
+        return oidc_token;
+    }
+
+    private async configureMSALWithOIDC(msalConfig: msal.Configuration): Promise<msal.ConfidentialClientApplication> {
+        tl.debug("MSAL - FederatedAccess - OIDC is used.");
+
+        msalConfig.auth.clientAssertion = await this.getFederatedToken();
 
         let msalInstance = new msal.ConfidentialClientApplication(msalConfig);
         return msalInstance;

--- a/common-npm-packages/azure-arm-rest-v2/package-lock.json
+++ b/common-npm-packages/azure-arm-rest-v2/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.223.6",
+  "version": "3.224.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/common-npm-packages/azure-arm-rest-v2/package.json
+++ b/common-npm-packages/azure-arm-rest-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-pipelines-tasks-azure-arm-rest-v2",
-  "version": "3.223.6",
+  "version": "3.224.0",
   "description": "Common Lib for Azure ARM REST apis",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Task name**: azure-arm-rest-v2

**Description**: Exposed fething federated token from ADO as public method of ApplicationTokenCredentials

**Documentation changes required:** N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
