### PR TITLE
Added a fix for missing 'Clear-AzConfig' command

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 2,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 2,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 224,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 224,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 224,
-        "Patch": 4
+        "Patch": 5
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 224,
-    "Patch": 4
+    "Patch": 5
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 2,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 3,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 5,
         "Minor": 224,
-        "Patch": 3
+        "Patch": 4
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 224,
-    "Patch": 3
+    "Patch": 4
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -110,8 +110,10 @@ function Initialize-AzSubscription {
             $null = Clear-AzContext -Scope CurrentUser -Force -ErrorAction SilentlyContinue
             Write-Host "##[command]Clear-AzContext -Scope Process"
             $null = Clear-AzContext -Scope Process
-            Write-Host "##[command]Clear-AzConfig -DefaultSubscriptionForLogin"
-            $null = Clear-AzConfig -DefaultSubscriptionForLogin
+            if (Get-Command 'Clear-AzConfig' -errorAction SilentlyContinue) {
+                Write-Host "##[command]Clear-AzConfig -DefaultSubscriptionForLogin"
+                $null = Clear-AzConfig -DefaultSubscriptionForLogin
+            }
 
             if ($Endpoint.Auth.Parameters.AuthenticationType -eq 'SPNCertificate') {
                 $servicePrincipalCertificate = Add-CertificateForAz -Endpoint $Endpoint

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 224,
-        "Patch": 2
+        "Patch": 3
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 224,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
***Tasks list:***
* AzureCloudPowerShellDeploymentV1
* AzureCloudPowerShellDeploymentV2
* AzureFileCopyV2
* AzureFileCopyV3
* AzureFileCopyV4
* AzureFileCopyV5
* AzurePowerShellV2
* AzurePowerShellV3
* AzurePowerShellV4
* AzurePowerShellV5
* SqlAzureDacpacDeploymentV1

**Description**: Added a fix for missing 'Clear-AzConfig' command

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
