### PR TITLE
Set condition if target branch is only master

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -56,8 +56,7 @@ steps:
         ne(variables['numTasks'], 0),
         ne(variables['COURTESY_PUSH'], 'true'),
         eq(variables['build.reason'], 'PullRequest'),
-        ne(variables['Build.SourceBranch'], 'refs/heads/master'),
-        not(startsWith(variables['Build.SourceBranch'], 'releases/'))
+        eq(variables['Build.TargetBranch'], 'refs/heads/master')
       )
   env:
     PACKAGE_TOKEN: $(Package.Token)


### PR DESCRIPTION
**Description**: Fixed condition for executing downgrading check if target branch is master

For example, we want to patch some tasks and merge them to `releases` branch