### PR TITLE
Added deprecation flag for DownloadPackageV0, NuGetRestoreV1, NuGetIn…

### DIFF
--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -14,6 +14,7 @@
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",
+    "deprecated": true,
     "inputs": [
         {
             "name": "feed",

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 225,
+        "Minor": 222,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 0,
-        "Minor": 222,
+        "Minor": 225,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -14,6 +14,7 @@
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",
+  "deprecated": true,
   "inputs": [
     {
       "name": "feed",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 222,
+    "Minor": 225,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 225,
+    "Minor": 222,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/NuGetInstallerV0/make.json
+++ b/Tasks/NuGetInstallerV0/make.json
@@ -3,7 +3,8 @@
         {
             "items": [
                 "node_modules/azure-pipelines-tasks-packaging-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -17,6 +17,7 @@
         "DeploymentGroup"
     ],
     "minimumAgentVersion": "2.115.0",
+    "deprecated": true,
     "groups": [
         {
             "name": "advanced",

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 225,
+        "Minor": 215,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 215,
+        "Minor": 225,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 225,
+    "Minor": 215,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 215,
+    "Minor": 225,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -17,6 +17,7 @@
     "DeploymentGroup"
   ],
   "minimumAgentVersion": "2.115.0",
+  "deprecated": true,
   "groups": [
     {
       "name": "advanced",

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 223,
+        "Minor": 225,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -9,7 +9,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 225,
+        "Minor": 223,
         "Patch": 0
     },
     "runsOn": [

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -17,6 +17,7 @@
         "DeploymentGroup"
     ],
     "minimumAgentVersion": "2.144.0",
+    "deprecated": true,
     "groups": [
         {
             "name": "advanced",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -17,6 +17,7 @@
     "DeploymentGroup"
   ],
   "minimumAgentVersion": "2.144.0",
+  "deprecated": true,
   "groups": [
     {
       "name": "advanced",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 225,
+    "Minor": 223,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 223,
+    "Minor": 225,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
…stallerV0

**Task name**: DownloadPackageV0, NuGetRestoreV1, NuGetInstallerV0

**Description**: Added deprecated flag

**Documentation changes required:** Y - Add that these tasks are being deprecated

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) User stories 1662927 and 2075334

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
