### PR TITLE
Update help text of SymbolsArtifactName of PublishSymbolsV2

### DIFF
--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -173,7 +173,7 @@
             "label": "Artifact name",
             "defaultValue": "Symbols_$(BuildConfiguration)",
             "required": false,
-            "helpMarkDown": "Specify the artifact name to use for the Symbols artifact.  The default is Symbols_$(BuildConfiguration)",
+            "helpMarkDown": "Specify the artifact name to use for the Symbols artifact. This should only be used with the FileShare symbol server type.  The default is Symbols_$(BuildConfiguration)",
             "groupName": "advanced"
         }
     ],


### PR DESCRIPTION
Update help text of SymbolsArtifactName of PublishSymbolsV2 to say that the parameter should only be used with the FileShare symbol server type

**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
