### PR TITLE
Dependency fix - KubernetesV1

### DIFF
--- a/Tasks/KubernetesV1/make.json
+++ b/Tasks/KubernetesV1/make.json
@@ -6,7 +6,8 @@
                 "node_modules/azure-pipelines-tasks-docker-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-kubernetes-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib",
+                "node_modules/https-proxy-agent/node_modules/agent-base"
             ],
             "options": "-Rf"
         }

--- a/Tasks/KubernetesV1/npm-shrinkwrap.json
+++ b/Tasks/KubernetesV1/npm-shrinkwrap.json
@@ -115,9 +115,12 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "agent-base": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -833,6 +836,13 @@
       "requires": {
         "agent-base": "5",
         "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+        }
       }
     },
     "inflight": {

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -6,6 +6,7 @@
     "@types/node": "^16.11.39",
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
+    "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.0.1-preview",
     "azure-pipelines-tasks-azure-arm-rest-v2": "^3.223.4",
     "azure-pipelines-tasks-docker-common": "2.0.1-preview.0",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 225,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: KubernetesV1

**Description**: "agent-base" dependency has incompatibility issue for later versions than Node10 for proxy usage.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) 
#18607 
#18621 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
