### PR TITLE
[InstallAppleCertificateV2] - Add new input to pass arguments for openssl extracting

### DIFF
--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/en-US/resources.resjson
@@ -23,6 +23,8 @@
   "loc.input.help.signingIdentity": "The Common Name of the subject in the signing certificate.  Will attempt to parse the Common Name if this is left empty.",
   "loc.input.label.setUpPartitionIdACLForPrivateKey": "Set up partition_id ACL for the imported private key",
   "loc.input.help.setUpPartitionIdACLForPrivateKey": "If true - sets the partition_id ACL for the imported private key, so codesign won't prompt to use the key for signing. This isn't necessary for temporary keychains, at least on MacOS High Sierra. See the [link](http://www.openradar.me/28524119) for more details.",
+  "loc.input.label.opensslPkcsArgs": "OpenSSL arguments for PKCS12",
+  "loc.input.help.opensslPkcsArgs": "Arguments for extraction certificate information using openssl.",
   "loc.messages.INVALID_P12": "Unable to find the certificate SHA1 hash and common name (CN). Verify that the certificate is a valid P12.",
   "loc.messages.NoP12PwdWarning": "No P12 password was supplied. If the P12 file requires a password, the best practice is to supply it as pipeline variable and mark it secret by enabling the lock icon.",
   "loc.messages.P12PrivateKeyNameNotFound": "Failed to identify the private key name: %s",

--- a/Tasks/InstallAppleCertificateV2/Tests/L0.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0.ts
@@ -72,6 +72,22 @@ describe('InstallAppleCertificate Suite', function () {
         done();
     });
 
+    it('Defaults: install certificate in default keychain before build with openssl args', (done: Mocha.Done) => {
+        let tp: string = path.join(__dirname, 'L0InstallDefaultKeychainWithArgs.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+
+        assert(tr.ran('/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain'),
+            'certificate should have been installed in the default keychain');
+        assert(!tr.ran('/usr/bin/security create-keychain -p mykeychainPwd /usr/lib/login.keychain'), 'login keychain should not be created')
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+
+        done();
+    });
+
+
     it('Defaults: delete certificate from default keychain after build', (done: Mocha.Done) => {
         let tp: string = path.join(__dirname, 'L0DeleteCertDefaultKeychain.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychainWithArgs.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0InstallDefaultKeychainWithArgs.ts
@@ -1,0 +1,84 @@
+import * as ma from 'azure-pipelines-task-lib/mock-answer';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import path = require('path');
+import fs = require('fs');
+import os = require('os');
+
+let taskPath = path.join(__dirname, '..', 'preinstallcert.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('certSecureFile', 'mySecureFileId');
+tr.setInput('certPwd', 'mycertPwd');
+tr.setInput('keychain', 'default');
+tr.setInput('keychainPassword', 'mykeychainPwd');
+tr.setInput('opensslPkcsArgs', '-legacy');
+
+let secureFileHelperMock = require('azure-pipelines-tasks-securefiles-common/securefiles-common-mock');
+tr.registerMock('azure-pipelines-tasks-securefiles-common/securefiles-common', secureFileHelperMock);
+
+tr.registerMock('fs', {
+    ...fs,
+    writeFileSync: function (filePath, contents) {
+    }
+});
+
+process.env['AGENT_VERSION'] = '2.116.0';
+process.env['AGENT_TEMPDIRECTORY'] = '/build/temp';
+process.env['HOME'] = '/users/test';
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "which": {
+        "openssl": "/usr/bin/openssl",
+        "security": "/usr/bin/security",
+        "grep": "/usr/bin/grep"
+    },
+    "checkPath": {
+        "/usr/bin/openssl": true,
+        "/usr/bin/security": true,
+        "/usr/bin/grep": true
+    },
+    "exist": {
+        "/build/temp/mySecureFileId.filename": true,
+        "/usr/lib/login.keychain": true
+    },
+    "exec": {
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nokeys -passin pass:mycertPwd -legacy | /usr/bin/openssl x509 -sha1 -noout -fingerprint -subject -dates -nameopt utf8,sep_semi_plus_space": {
+            "code": 0,
+            "stdout": "MAC verified OK\nSHA1 Fingerprint=BB:26:83:C6:AA:88:35:DE:36:94:F2:CF:37:0A:D4:60:BB:AE:87:0C\nsubject=UID=ZD34QB2EFN; CN=iPhone Developer: Madhuri Gummalla (HE432Y3E2Q); OU=A9M46DL4GH; O=Madhuri Gummalla; C=US\nnotBefore=Nov 13 03:37:42 2018 GMT\nnotAfter=Nov 13 03:37:42 2099 GMT\n"
+        },
+        "/usr/bin/openssl pkcs12 -in /build/temp/mySecureFileId.filename -nocerts -passin pass:mycertPwd -passout pass:mycertPwd -legacy | /usr/bin/grep friendlyName": {
+            "code": 0,
+            "stdout": "MAC verified OK\n    friendlyName: iOS Developer: Madhuri Gummalla (Madhuri Gummalla)"
+        },
+        "/usr/bin/security default-keychain": {
+            "code": 0,
+            "stdout": "/usr/lib/login.keychain"
+        },
+        "/usr/bin/security unlock-keychain -p mykeychainPwd /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "keychain unlocked"
+        },
+        "/usr/bin/security import /build/temp/mySecureFileId.filename -P mycertPwd -A -t cert -f pkcs12 -k /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "cert installed"
+        },
+        "/usr/bin/security set-key-partition-list -S apple-tool:,apple: -s -l iOS Developer: Madhuri Gummalla (Madhuri Gummalla) -k mykeychainPwd /usr/lib/login.keychain": {
+            "code": 0,
+            "stdout": "private key dump"
+        },
+        "/usr/bin/security list-keychain -d user": {
+            "code": 0,
+            "stdout": "/usr/lib/login.keychain"
+        }
+    }
+};
+tr.setAnswers(a);
+
+os.platform = () => {
+    return 'darwin';
+}
+tr.registerMock('os', os);
+
+tr.run();
+

--- a/Tasks/InstallAppleCertificateV2/preinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/preinstallcert.ts
@@ -20,6 +20,7 @@ async function run() {
 
         // download decrypted contents
         secureFileId = tl.getInput('certSecureFile', true);
+        const opensslArgs = tl.getInput('opensslPkcsArgs', false);
         
         secureFileHelpers = new secureFilesCommon.SecureFileHelpers(retryCount);
         let certPath: string = await secureFileHelpers.downloadSecureFile(secureFileId);
@@ -27,7 +28,7 @@ async function run() {
         let certPwd: string = tl.getInput('certPwd');
 
         // get the P12 details - SHA1 hash, common name (CN) and expiration.
-        const p12Properties = await sign.getP12Properties(certPath, certPwd);
+        const p12Properties = await sign.getP12Properties(certPath, certPwd, opensslArgs);
         let commonName: string = p12Properties.commonName;
         const fingerprint: string = p12Properties.fingerprint,
             notBefore: Date = p12Properties.notBefore,
@@ -77,7 +78,7 @@ async function run() {
 
         const setUpPartitionIdACLForPrivateKey: boolean = tl.getBoolInput('setUpPartitionIdACLForPrivateKey', false);
         const useKeychainIfExists: boolean = true;
-        await sign.installCertInTemporaryKeychain(keychainPath, keychainPwd, certPath, certPwd, useKeychainIfExists, setUpPartitionIdACLForPrivateKey);
+        await sign.installCertInTemporaryKeychain(keychainPath, keychainPwd, certPath, certPwd, useKeychainIfExists, setUpPartitionIdACLForPrivateKey, opensslArgs);
 
         // set the keychain output variable.
         tl.setVariable('keychainPath', keychainPath);

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 220,
+        "Minor": 225,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",
@@ -113,6 +113,15 @@
             "label": "Set up partition_id ACL for the imported private key",
             "required": false,
             "helpMarkDown": "If true - sets the partition_id ACL for the imported private key, so codesign won't prompt to use the key for signing. This isn't necessary for temporary keychains, at least on MacOS High Sierra. See the [link](http://www.openradar.me/28524119) for more details.",
+            "groupName": "advanced"
+        },
+        {
+            "name": "opensslPkcsArgs",
+            "type": "string",
+            "defaultValue": "",
+            "label": "OpenSSL arguments for PKCS12",
+            "required": false,
+            "helpMarkDown": "Arguments for extraction certificate information using openssl.",
             "groupName": "advanced"
         }
     ],

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 220,
+    "Minor": 225,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -113,6 +113,15 @@
       "label": "ms-resource:loc.input.label.setUpPartitionIdACLForPrivateKey",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.setUpPartitionIdACLForPrivateKey",
+      "groupName": "advanced"
+    },
+    {
+      "name": "opensslPkcsArgs",
+      "type": "string",
+      "defaultValue": "",
+      "label": "ms-resource:loc.input.label.opensslPkcsArgs",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.opensslPkcsArgs",
       "groupName": "advanced"
     }
   ],


### PR DESCRIPTION
**Task name**: InstallAppleCertificateV2

**Description**: 
- Added new inputs to pass arguments for openssl extracting
- Added unit tests for the new logic

**Documentation changes required:** Y

**Added unit tests:** Y

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

The PR is in draft for now until https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/183 won't merged
