### PR TITLE
Replace azure-arm-rest-v2 with azure-arm-rest. Part 1

### DIFF
--- a/Tasks/AzureSpringCloudV0/Tests/AzureSpringAppsUnitTests.ts
+++ b/Tasks/AzureSpringCloudV0/Tests/AzureSpringAppsUnitTests.ts
@@ -1,6 +1,6 @@
 
-import { AzureEndpoint } from "azure-pipelines-tasks-azure-arm-rest-v2/azureModels";
-import { getMockEndpoint, nock } from 'azure-pipelines-tasks-azure-arm-rest-v2/Tests/mock_utils';
+import { AzureEndpoint } from "azure-pipelines-tasks-azure-arm-rest/azureModels";
+import { getMockEndpoint, nock } from 'azure-pipelines-tasks-azure-arm-rest/Tests/mock_utils';
 import { MOCK_RESOURCE_GROUP_NAME, API_VERSION } from "./mock_utils";
 import assert = require('assert');
 

--- a/Tasks/AzureSpringCloudV0/azurespringappsdeployment.ts
+++ b/Tasks/AzureSpringCloudV0/azurespringappsdeployment.ts
@@ -10,7 +10,7 @@ export async function main() {
 
     console.log('Starting deployment task execution');
     tl.setResourcePath(path.join(__dirname, 'task.json'));
-    tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-azure-arm-rest-v2/module.json'));
+    tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-azure-arm-rest/module.json'));
     tl.setResourcePath(path.join(__dirname, 'node_modules/azure-pipelines-tasks-webdeployment-common/module.json'));
     var taskParams: TaskParameters = TaskParametersUtility.getParameters();
     var deploymentProvider = new AzureSpringAppsDeploymentProvider(taskParams);

--- a/Tasks/AzureSpringCloudV0/deploymentProvider/AzureSpringAppsDeploymentProvider.ts
+++ b/Tasks/AzureSpringCloudV0/deploymentProvider/AzureSpringAppsDeploymentProvider.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Package, PackageType } from 'azure-pipelines-tasks-webdeployment-common/packageUtility';
 import { Actions, DeploymentType, TaskParameters } from '../operations/taskparameters';
 import { SourceType, AzureSpringApps } from './azure-arm-spring-apps';
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
 import tl = require('azure-pipelines-task-lib/task');
 import tar = require('tar');
 import { AzureResourceFilterUtility } from '../operations/AzureResourceFilterUtility';

--- a/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-apps.ts
+++ b/Tasks/AzureSpringCloudV0/deploymentProvider/azure-arm-spring-apps.ts
@@ -1,9 +1,9 @@
 import tl = require('azure-pipelines-task-lib/task');
 import jsonPath = require('JSONPath');
-import webClient = require('azure-pipelines-tasks-azure-arm-rest-v2/webClient');
-import { AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
-import { ServiceClient } from 'azure-pipelines-tasks-azure-arm-rest-v2/AzureServiceClient';
-import { ToError } from 'azure-pipelines-tasks-azure-arm-rest-v2/AzureServiceClientBase';
+import webClient = require('azure-pipelines-tasks-azure-arm-rest/webClient');
+import { AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
+import { ServiceClient } from 'azure-pipelines-tasks-azure-arm-rest/AzureServiceClient';
+import { ToError } from 'azure-pipelines-tasks-azure-arm-rest/AzureServiceClientBase';
 import { uploadFileToSasUrl } from './azure-storage';
 import https = require('https');
 import { parse } from 'azure-pipelines-tasks-webdeployment-common/ParameterParserUtility';

--- a/Tasks/AzureSpringCloudV0/operations/AzureResourceFilterUtility.ts
+++ b/Tasks/AzureSpringCloudV0/operations/AzureResourceFilterUtility.ts
@@ -1,6 +1,6 @@
 import tl = require('azure-pipelines-task-lib/task');
-import { AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
-import { Resources } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-resource';
+import { AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
+import { Resources } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-resource';
 
 export class AzureResourceFilterUtility {
     public static async getAzureSpringAppsResourceId(endpoint: AzureEndpoint, resourceName: string): Promise<string> {

--- a/Tasks/AzureSpringCloudV0/package-lock.json
+++ b/Tasks/AzureSpringCloudV0/package-lock.json
@@ -417,10 +417,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.221.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.221.1.tgz",
-      "integrity": "sha512-ku1bb4n9+udPPUQj+xRCmEiVsq4ZY96KH99gPJE36WPtjWsUH38ZwPbby2juKN2H6SLuPfCMtIby7WEjGsNRDQ==",
+    "azure-pipelines-tasks-azure-arm-rest": {
+      "version": "3.221.11",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.221.11.tgz",
+      "integrity": "sha512-7L5/optXO4LKWNzJw3+X4s+C/MkO024PNOXCVHvlpkIVGRRAbT3gD8C7bjNa45nDKiHaKIiSkztA1aS+0Y6ZuA==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureSpringCloudV0/package.json
+++ b/Tasks/AzureSpringCloudV0/package.json
@@ -27,7 +27,7 @@
     "@types/q": "1.0.7",
     "@xmldom/xmldom": "^0.8.7",
     "JSONPath": "^0.11.2",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.221.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.221.11",
     "azure-pipelines-tasks-webdeployment-common": "^4.222.0",
     "moment": "^2.29.4",
     "nock": "9.0.11",

--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "2.104.1",
     "groups": [

--- a/Tasks/AzureSpringCloudV0/task.loc.json
+++ b/Tasks/AzureSpringCloudV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 225,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureVmssDeploymentV0/Tests/updateImageOnLinuxAgent.ts
+++ b/Tasks/AzureVmssDeploymentV0/Tests/updateImageOnLinuxAgent.ts
@@ -56,8 +56,8 @@ Date.now = function (): number {
 }
 
 tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-storage', require('./mock_node_modules/azure-arm-storage'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-storage', require('./mock_node_modules/azure-arm-storage'));
 tr.registerMock('azp-tasks-az-blobstorage-provider/blobservice', require('./mock_node_modules/blobservice'));
 tr.registerMock('azure-pipelines-tasks-utility-common/compressutility', require('./mock_node_modules/compressutility'));
 

--- a/Tasks/AzureVmssDeploymentV0/Tests/updateImageOnWindowsAgent.ts
+++ b/Tasks/AzureVmssDeploymentV0/Tests/updateImageOnWindowsAgent.ts
@@ -57,8 +57,8 @@ Date.now = function (): number {
 }
 
 tr.registerMock('azure-pipelines-task-lib/toolrunner', require('azure-pipelines-task-lib/mock-toolrunner'));
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-storage', require('./mock_node_modules/azure-arm-storage'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-compute', require('./mock_node_modules/azure-arm-compute'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-storage', require('./mock_node_modules/azure-arm-storage'));
 tr.registerMock('azp-tasks-az-blobstorage-provider/blobservice', require('./mock_node_modules/blobservice'));
 tr.registerMock('azure-pipelines-tasks-utility-common/compressutility', require('./mock_node_modules/compressutility'));
 

--- a/Tasks/AzureVmssDeploymentV0/make.json
+++ b/Tasks/AzureVmssDeploymentV0/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/artifact-engine/node_modules/azure-pipelines-task-lib",
                 "node_modules/azp-tasks-az-blobstorage-provider/node_modules/azure-pipelines-task-lib"

--- a/Tasks/AzureVmssDeploymentV0/models/AzureVmssTaskParameters.ts
+++ b/Tasks/AzureVmssDeploymentV0/models/AzureVmssTaskParameters.ts
@@ -1,6 +1,6 @@
 import tl = require("azure-pipelines-task-lib/task");
-import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common");
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
+import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest/azure-arm-common");
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
 
 export default class AzureVmssTaskParameters {
 

--- a/Tasks/AzureVmssDeploymentV0/operations/VirtualMachineScaleSet.ts
+++ b/Tasks/AzureVmssDeploymentV0/operations/VirtualMachineScaleSet.ts
@@ -3,9 +3,9 @@ import os = require('os');
 import util = require('util');
 import tl = require("azure-pipelines-task-lib/task");
 
-import armCompute = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-compute');
-import armStorage = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-storage');
-import azureModel = require('azure-pipelines-tasks-azure-arm-rest-v2/azureModels');
+import armCompute = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-compute');
+import armStorage = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-storage');
+import azureModel = require('azure-pipelines-tasks-azure-arm-rest/azureModels');
 import BlobService = require('azp-tasks-az-blobstorage-provider/blobservice');
 import compress = require('azure-pipelines-tasks-utility-common/compressutility');
 import AzureVmssTaskParameters from "../models/AzureVmssTaskParameters";

--- a/Tasks/AzureVmssDeploymentV0/package-lock.json
+++ b/Tasks/AzureVmssDeploymentV0/package-lock.json
@@ -2663,10 +2663,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.221.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.221.1.tgz",
-      "integrity": "sha512-ku1bb4n9+udPPUQj+xRCmEiVsq4ZY96KH99gPJE36WPtjWsUH38ZwPbby2juKN2H6SLuPfCMtIby7WEjGsNRDQ==",
+    "azure-pipelines-tasks-azure-arm-rest": {
+      "version": "3.221.11",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.221.11.tgz",
+      "integrity": "sha512-7L5/optXO4LKWNzJw3+X4s+C/MkO024PNOXCVHvlpkIVGRRAbT3gD8C7bjNa45nDKiHaKIiSkztA1aS+0Y6ZuA==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureVmssDeploymentV0/package.json
+++ b/Tasks/AzureVmssDeploymentV0/package.json
@@ -8,7 +8,7 @@
     "artifact-engine": "^1.2.0",
     "azp-tasks-az-blobstorage-provider": "^2.219.1",
     "azure-pipelines-task-lib": "^3.4.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.221.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.221.11",
     "azure-pipelines-tasks-utility-common": "^3.0.0-preview.0",
     "moment": "^2.29.4"
   },

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -15,7 +15,7 @@
     "version": {
         "Major": 0,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureVmssDeploymentV0/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 225,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/Tests/L0Windows.ts
+++ b/Tasks/PackerBuildV1/Tests/L0Windows.ts
@@ -123,5 +123,5 @@ tr.registerMock('../utilities', utMock);
 
 tr.setAnswers(a);
 
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-graph', require('./mock_node_modules/azure-graph'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-graph', require('./mock_node_modules/azure-graph'));
 tr.run();

--- a/Tasks/PackerBuildV1/Tests/L0WindowsManaged.ts
+++ b/Tasks/PackerBuildV1/Tests/L0WindowsManaged.ts
@@ -125,5 +125,5 @@ tr.registerMock('../utilities', utMock);
 
 tr.setAnswers(a);
 
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-graph', require('./mock_node_modules/azure-graph'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-graph', require('./mock_node_modules/azure-graph'));
 tr.run();

--- a/Tasks/PackerBuildV1/make.json
+++ b/Tasks/PackerBuildV1/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/PackerBuildV1/package-lock.json
+++ b/Tasks/PackerBuildV1/package-lock.json
@@ -120,10 +120,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
-      "version": "3.220.2",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.220.2.tgz",
-      "integrity": "sha512-E5xVhAn5cFp39eBqHbxi88rdjluVbSFXZzQc2QuFpmB/lErwJLR95VGi8AORnBtpsPGOTQctxAfWun64m73E0A==",
+    "azure-pipelines-tasks-azure-arm-rest": {
+      "version": "3.221.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.221.2.tgz",
+      "integrity": "sha512-A8MT2ggii43DjMQhmiLiiU/dxIwGbu08dMZqIq4zZLQPU6Cd7PPUVPQ8BE203X54lYRUKSwCGRsx65eMWbkqmw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/PackerBuildV1/package.json
+++ b/Tasks/PackerBuildV1/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^16.11.39",
     "@types/q": "^1.0.7",
     "azure-pipelines-task-lib": "^4.3.1",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.220.2",
+    "azure-pipelines-tasks-azure-arm-rest": "3.221.2",
     "decompress-zip": "^0.3.3"
   },
   "devDependencies": {

--- a/Tasks/PackerBuildV1/src/taskParameters.ts
+++ b/Tasks/PackerBuildV1/src/taskParameters.ts
@@ -4,8 +4,8 @@ import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as constants from "./constants";
 import * as utils from "./utilities";
-import { AzureRMEndpoint } from "azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint";
-import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common");
+import { AzureRMEndpoint } from "azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint";
+import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest/azure-arm-common");
 
 export default class TaskParameters {
     public templateType: string;

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 224,
-    "Patch": 2
+    "Minor": 225,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 224,
-    "Patch": 2
+    "Minor": 225,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
The source code of the `azure-arm-rest` is now located in a new common [repository](https://github.com/microsoft/azure-pipelines-tasks-common-packages/tree/main/common-npm-packages), so `azure-arm-rest-v2` will be deprecated. We are going to [migrate](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/MIGRATION_OF_COMMON_PACKAGES.md) all common npm packages to this repo.

During migration, we get rid of redundant -v2/-v3 folders.

Replaced `azure-arm-rest-v2` with `azure-arm-rest` in task dependencies:

- AzureSpringCloudV0
- AzureVmssDeploymentV0
- PackerBuildV1


azure-arm-rest-v2@3.220.2 was replaced by azure-arm-rest@3.221.2
azure-arm-rest-v2@3.221.1 was replaced by azure-arm-rest@3.221.11
See details: https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/181

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
