### PR TITLE
Replace azure-arm-rest-v2 with azure-arm-rest. Part 2

### DIFF
--- a/Tasks/AzureFileCopyV2/PreJobExecutionAzureFileCopy.ts
+++ b/Tasks/AzureFileCopyV2/PreJobExecutionAzureFileCopy.ts
@@ -1,10 +1,10 @@
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import fs = require('fs')
-import armStorage = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-storage');
-import msRestAzure = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common');
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
-import { AzureEndpoint, StorageAccount } from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
+import armStorage = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-storage');
+import msRestAzure = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-common');
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
+import { AzureEndpoint, StorageAccount } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 
 function isNonEmpty(str: string): boolean {
     return (!!str && !!str.trim());

--- a/Tasks/AzureFileCopyV2/package-lock.json
+++ b/Tasks/AzureFileCopyV2/package-lock.json
@@ -106,10 +106,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV2/package.json
+++ b/Tasks/AzureFileCopyV2/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 2,
         "Minor": 225,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 225,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/PreJobExecutionAzureFileCopy.ts
+++ b/Tasks/AzureFileCopyV3/PreJobExecutionAzureFileCopy.ts
@@ -1,10 +1,10 @@
 import tl = require('azure-pipelines-task-lib/task');
 import path = require('path');
 import fs = require('fs')
-import armStorage = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-storage');
-import msRestAzure = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common');
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
-import { AzureEndpoint, StorageAccount } from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
+import armStorage = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-storage');
+import msRestAzure = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-common');
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
+import { AzureEndpoint, StorageAccount } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 
 function isNonEmpty(str: string): boolean {
     return (!!str && !!str.trim());

--- a/Tasks/AzureFileCopyV3/package-lock.json
+++ b/Tasks/AzureFileCopyV3/package-lock.json
@@ -106,10 +106,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV3/package.json
+++ b/Tasks/AzureFileCopyV3/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 3,
         "Minor": 225,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 225,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/package-lock.json
+++ b/Tasks/AzureFileCopyV4/package-lock.json
@@ -106,10 +106,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV4/package.json
+++ b/Tasks/AzureFileCopyV4/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 4,
         "Minor": 225,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 225,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/package-lock.json
+++ b/Tasks/AzureFileCopyV5/package-lock.json
@@ -106,10 +106,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV5/package.json
+++ b/Tasks/AzureFileCopyV5/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^10.17.0",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "^3.1.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 5,
         "Minor": 225,
-        "Patch": 1
+        "Patch": 2
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 225,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV4/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV4/azurepowershell.ts
@@ -5,7 +5,7 @@ import tl = require('azure-pipelines-task-lib/task');
 import tr = require('azure-pipelines-task-lib/toolrunner');
 import * as telemetry from 'azure-pipelines-tasks-utility-common/telemetry';
 
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
 var uuidV4 = require('uuid/v4');
 
 function convertToNullIfUndefined<T>(arg: T): T|null {

--- a/Tasks/AzurePowerShellV4/make.json
+++ b/Tasks/AzurePowerShellV4/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib"
             ],

--- a/Tasks/AzurePowerShellV4/package-lock.json
+++ b/Tasks/AzurePowerShellV4/package-lock.json
@@ -124,10 +124,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzurePowerShellV4/package.json
+++ b/Tasks/AzurePowerShellV4/package.json
@@ -8,7 +8,7 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.0.7",
         "azure-pipelines-task-lib": "3.1.10",
-        "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+        "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
         "azure-pipelines-tasks-utility-common": "^3.0.3"
     },
     "devDependencies": {

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 4,
         "Minor": 225,
-        "Patch": 1
+        "Patch": 2
     },
     "releaseNotes": "Added support for Az Module and cross platform agents.",
     "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 225,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/ContainerBuildV0/make.json
+++ b/Tasks/ContainerBuildV0/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib",
                 "node_modules/buildctl-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-docker-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib"

--- a/Tasks/ContainerBuildV0/package-lock.json
+++ b/Tasks/ContainerBuildV0/package-lock.json
@@ -113,10 +113,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "2.208.0",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-2.208.0.tgz",
-      "integrity": "sha512-pNs84s8A+Us/nd8MyE6zyiwREFJjZR/rI5JIVri2pxXkiJVOw5+bRHYR1CfIAlxq451PuTEgykH0m5tWcBWhOQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-2.208.0.tgz",
+      "integrity": "sha512-dK/+2pVnRIfcm0+L7nJThP9ai2g//u34+eYvxgeO8RnSZGFsUG2vuUPspcxBCHUkfHWwAGQ7aNEB03b0ympq6Q==",
       "requires": {
         "@types/jsonwebtoken": "^8.5.8",
         "@types/mocha": "^5.2.7",

--- a/Tasks/ContainerBuildV0/package.json
+++ b/Tasks/ContainerBuildV0/package.json
@@ -4,7 +4,7 @@
     "@types/node": "^16.11.39",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^2.208.0",
+    "azure-pipelines-tasks-azure-arm-rest": "2.208.0",
     "azure-pipelines-tasks-docker-common": "2.0.1-preview.0",
     "azure-pipelines-tool-lib": "2.0.0-preview",
     "consistent-hashing": "0.3.0"

--- a/Tasks/ContainerBuildV0/src/utils.ts
+++ b/Tasks/ContainerBuildV0/src/utils.ts
@@ -6,7 +6,7 @@ import * as tr from "azure-pipelines-task-lib/toolrunner";
 import * as crypto from "crypto";
 import * as path from 'path';
 import fs = require('fs');
-import webclient = require("azure-pipelines-tasks-azure-arm-rest-v2/webClient");
+import webclient = require("azure-pipelines-tasks-azure-arm-rest/webClient");
 import * as os from "os";
 import * as util from "util";
 import ConsistentHashing = require("consistent-hashing");

--- a/Tasks/ContainerBuildV0/task.json
+++ b/Tasks/ContainerBuildV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 219,
+        "Minor": 225,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/ContainerBuildV0/task.loc.json
+++ b/Tasks/ContainerBuildV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 219,
+    "Minor": 225,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/PackerBuildV0/Tests/L0Windows.ts
+++ b/Tasks/PackerBuildV0/Tests/L0Windows.ts
@@ -128,5 +128,5 @@ tr.registerMock('../utilities', utMock);
 
 tr.setAnswers(a);
 
-tr.registerMock('azure-pipelines-tasks-azure-arm-rest-v2/azure-graph', require('./mock_node_modules/azure-graph'));
+tr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-graph', require('./mock_node_modules/azure-graph'));
 tr.run();

--- a/Tasks/PackerBuildV0/make.json
+++ b/Tasks/PackerBuildV0/make.json
@@ -2,7 +2,7 @@
     "rm": [
         {
             "items": [
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib"
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"
         }

--- a/Tasks/PackerBuildV0/package-lock.json
+++ b/Tasks/PackerBuildV0/package-lock.json
@@ -111,10 +111,10 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.217.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.217.1.tgz",
-      "integrity": "sha512-kozIoKwH8T85PaTyCoRBAGgw6UONPE3mswyoPGd9pN6hqH/dwpuuazG4QdW7DIePuivKg9UYNZn9qwJzdhTUtQ==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.217.1.tgz",
+      "integrity": "sha512-OjO/G+/bQhtW769xQ/U0c+4DeEBPEa6ya+wyTS+ntge/EaMgha7IN+7TR7aMdlgs741Bn1AB/n5DmOqIJXXxSw==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/PackerBuildV0/package.json
+++ b/Tasks/PackerBuildV0/package.json
@@ -6,7 +6,7 @@
     "@types/node": "^16.11.39",
     "@types/q": "^1.0.7",
     "azure-pipelines-task-lib": "^4.3.1",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.217.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.217.1",
     "decompress-zip": "^0.3.3",
     "moment": "^2.29.4"
   },

--- a/Tasks/PackerBuildV0/src/azureSpnTemplateVariablesProvider.ts
+++ b/Tasks/PackerBuildV0/src/azureSpnTemplateVariablesProvider.ts
@@ -1,7 +1,7 @@
 "use strict";
 
-import azureGraph = require('azure-pipelines-tasks-azure-arm-rest-v2/azure-graph');
-import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common");
+import azureGraph = require('azure-pipelines-tasks-azure-arm-rest/azure-graph');
+import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest/azure-arm-common");
 
 import * as tl from "azure-pipelines-task-lib/task";
 import * as constants from "./constants";

--- a/Tasks/PackerBuildV0/src/taskParameters.ts
+++ b/Tasks/PackerBuildV0/src/taskParameters.ts
@@ -4,8 +4,8 @@ import * as path from "path";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as constants from "./constants";
 import * as utils from "./utilities";
-import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-common");
-import AzureRMEndpoint = require("azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint");
+import msRestAzure = require("azure-pipelines-tasks-azure-arm-rest/azure-arm-common");
+import AzureRMEndpoint = require("azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint");
 
 export default class TaskParameters {
     public templateType: string;

--- a/Tasks/PackerBuildV0/task.json
+++ b/Tasks/PackerBuildV0/task.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 224,
-    "Patch": 2
+    "Minor": 225,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/PackerBuildV0/task.loc.json
+++ b/Tasks/PackerBuildV0/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 224,
-    "Patch": 2
+    "Minor": 225,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
The source code of the `azure-arm-rest` is now located in a new common [repository](https://github.com/microsoft/azure-pipelines-tasks-common-packages/tree/main/common-npm-packages), so `azure-arm-rest-v2` will be deprecated. We are going to [migrate](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/MIGRATION_OF_COMMON_PACKAGES.md) all common npm packages to this repo.

During migration, we get rid of redundant -v2/-v3 folders.

Replaced `azure-arm-rest-v2` with `azure-arm-rest` in task dependencies:

- AzureFileCopyV2
- AzureFileCopyV3
- AzureFileCopyV4
- AzureFileCopyV5
- AzurePowerShellV4
- PackerBuildV0
- ContainerBuildV0

azure-arm-rest-v2@2.208.0 was replaced by azure-arm-rest@2.208.0
azure-arm-rest-v2@3.217.1 was replaced by azure-arm-rest@3.217.1

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
