### PR TITLE
Replace azure-arm-rest-v2 with azure-arm-rest. Part 6

### DIFF
--- a/Tasks/HelmDeployV0/make.json
+++ b/Tasks/HelmDeployV0/make.json
@@ -3,7 +3,7 @@
         {
             "items": [
                 "node_modules/azure-pipelines-tasks-kubernetes-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-securefiles-common/node_modules/azure-pipelines-task-lib"

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -173,10 +173,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.223.4",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.223.4.tgz",
-      "integrity": "sha512-t7sfkbwSvL6oWTFxCWeC6OBY29tv+eJrT060I1+O4Xpwm0T5sTTAihMjZAi2AdB0ygFfXuOMYZEAornIqWBDKA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.223.4.tgz",
+      "integrity": "sha512-3RPwQfTk38HYGOCTmG2+UVM2JClaUV76YVqYrR/AhShMMFkg1wQIbpQZ7PLUh0YPbyWqFhmdaZla0JTRL9MWkg==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -5,7 +5,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.3.1",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.223.4",
+    "azure-pipelines-tasks-azure-arm-rest": "3.223.4",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-securefiles-common": "^2.207.0",
     "azure-pipelines-tasks-utility-common": "^3.210.0",

--- a/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
+++ b/Tasks/HelmDeployV0/src/clusters/armkubernetescluster.ts
@@ -1,9 +1,9 @@
 "use strict";
 
 import tl = require('azure-pipelines-task-lib/task');
-import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
-import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
+import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
+import { AzureEndpoint, AKSCluster, AKSClusterAccessProfile} from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 
 // get kubeconfig file content
 async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceGroup: string, clusterName: string, useClusterAdmin?: boolean) : Promise<string> {

--- a/Tasks/HelmDeployV0/src/helm.ts
+++ b/Tasks/HelmDeployV0/src/helm.ts
@@ -6,12 +6,12 @@ import path = require('path');
 import * as commonCommandOptions from "./commoncommandoption";
 import * as helmutil from "./utils"
 
-import { AKSCluster, AKSClusterAccessProfile, AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
+import { AKSCluster, AKSClusterAccessProfile, AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 import { WebRequest, WebResponse, sendRequest } from 'azure-pipelines-tasks-utility-common/restutilities';
 import { extractManifestsFromHelmOutput, getDeploymentMetadata, getManifestFileUrlsFromHelmOutput, getPublishDeploymentRequestUrl, isDeploymentEntity } from 'azure-pipelines-tasks-kubernetes-common/image-metadata-helper';
 
-import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
+import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
 import { Kubelogin } from 'azure-pipelines-tasks-kubernetes-common/kubelogin';
 import helmcli from "./helmcli";
 import kubernetescli from "./kubernetescli"
@@ -22,7 +22,7 @@ import { fail } from 'assert';
 const environmentVariableMaximumSize = 32766;
 
 tl.setResourcePath(path.join(__dirname, '..', 'task.json'));
-tl.setResourcePath(path.join(__dirname, '../node_modules/azure-pipelines-tasks-azure-arm-rest-v2/module.json'));
+tl.setResourcePath(path.join(__dirname, '../node_modules/azure-pipelines-tasks-azure-arm-rest/module.json'));
 
 function getKubeConfigFilePath(): string {
     var userdir = helmutil.getTaskTempDir();

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 0,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 225,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/KubernetesManifestV1/make.json
+++ b/Tasks/KubernetesManifestV1/make.json
@@ -4,7 +4,7 @@
             "items": [
                 "node_modules/azure-pipelines-tasks-kubernetes-common/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-docker-common/node_modules/azure-pipelines-task-lib",
-                "node_modules/azure-pipelines-tasks-azure-arm-rest-v2/node_modules/azure-pipelines-task-lib",
+                "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib",
                 "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib"
             ],
             "options": "-Rf"

--- a/Tasks/KubernetesManifestV1/package-lock.json
+++ b/Tasks/KubernetesManifestV1/package-lock.json
@@ -221,10 +221,10 @@
         }
       }
     },
-    "azure-pipelines-tasks-azure-arm-rest-v2": {
+    "azure-pipelines-tasks-azure-arm-rest": {
       "version": "3.223.4",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest-v2/-/azure-pipelines-tasks-azure-arm-rest-v2-3.223.4.tgz",
-      "integrity": "sha512-t7sfkbwSvL6oWTFxCWeC6OBY29tv+eJrT060I1+O4Xpwm0T5sTTAihMjZAi2AdB0ygFfXuOMYZEAornIqWBDKA==",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.223.4.tgz",
+      "integrity": "sha512-3RPwQfTk38HYGOCTmG2+UVM2JClaUV76YVqYrR/AhShMMFkg1wQIbpQZ7PLUh0YPbyWqFhmdaZla0JTRL9MWkg==",
       "requires": {
         "@azure/msal-node": "1.14.5",
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/KubernetesManifestV1/package.json
+++ b/Tasks/KubernetesManifestV1/package.json
@@ -7,7 +7,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^3.0.6-preview.0",
-    "azure-pipelines-tasks-azure-arm-rest-v2": "^3.223.4",
+    "azure-pipelines-tasks-azure-arm-rest": "3.223.4",
     "azure-pipelines-tasks-docker-common": "2.0.1-preview.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-utility-common": "^3.210.0",

--- a/Tasks/KubernetesManifestV1/src/clusters/armkubernetescluster.ts
+++ b/Tasks/KubernetesManifestV1/src/clusters/armkubernetescluster.ts
@@ -1,9 +1,9 @@
 "use strict";
 
 import tl = require('azure-pipelines-task-lib/task');
-import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-aks-service';
-import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest-v2/azure-arm-endpoint';
-import { AzureEndpoint, AKSClusterAccessProfile} from 'azure-pipelines-tasks-azure-arm-rest-v2/azureModels';
+import { AzureAksService } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-aks-service';
+import { AzureRMEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint';
+import { AzureEndpoint, AKSClusterAccessProfile} from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 
 // get kubeconfig file content
 async function getKubeConfigFromAKS(azureSubscriptionEndpoint: string, resourceGroup: string, clusterName: string, useClusterAdmin?: boolean) : Promise<string> {

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -14,7 +14,7 @@
     "version": {
         "Major": 1,
         "Minor": 225,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [],
     "groups": [],

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 225,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
The source code of the `azure-arm-rest` is now located in a new common [repository](https://github.com/microsoft/azure-pipelines-tasks-common-packages/tree/main/common-npm-packages), so `azure-arm-rest-v2` will be deprecated. We are going to [migrate](https://github.com/microsoft/azure-pipelines-tasks/blob/master/common-npm-packages/MIGRATION_OF_COMMON_PACKAGES.md) all common npm packages to this repo.

During migration, we get rid of redundant -v2/-v3 folders.

Replaced `azure-arm-rest-v2` with `azure-arm-rest` in task dependencies:

- KubernetesManifestV1
- HelmDeployV0

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
