### PR TITLE
AppCenterDistributeV1 and AppCenterDistributeV2: use public npm registry

### DIFF
--- a/Tasks/AppCenterDistributeV1/package-lock.json
+++ b/Tasks/AppCenterDistributeV1/package-lock.json
@@ -227,7 +227,7 @@
     },
     "abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org//abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
       "requires": {
         "event-target-shim": "^5.0.0"
@@ -335,7 +335,7 @@
     },
     "event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k="
     },
     "events": {

--- a/Tasks/AppCenterDistributeV1/task.json
+++ b/Tasks/AppCenterDistributeV1/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 225,
+        "Minor": 226,
         "Patch": 0
     },
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/AppCenterDistributeV1/task.loc.json
+++ b/Tasks/AppCenterDistributeV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 225,
+    "Minor": 226,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/AppCenterDistributeV2/package-lock.json
+++ b/Tasks/AppCenterDistributeV2/package-lock.json
@@ -227,7 +227,7 @@
     },
     "abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
       "requires": {
         "event-target-shim": "^5.0.0"
@@ -335,7 +335,7 @@
     },
     "event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/msmobilecenter/_packaging/AppCenter/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k="
     },
     "events": {

--- a/Tasks/AppCenterDistributeV2/task.json
+++ b/Tasks/AppCenterDistributeV2/task.json
@@ -14,7 +14,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 214,
+        "Minor": 226,
         "Patch": 0
     },
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/AppCenterDistributeV2/task.loc.json
+++ b/Tasks/AppCenterDistributeV2/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 214,
+    "Minor": 226,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**: `AppCenterDistributeV1` and `AppCenterDistributeV2`

**Description**: Use public `registry.npmjs.org` instead of private `pkgs.dev.azure.com`. This prevented `npm install` from working.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
