### PR TITLE
Remove deprecated tasks from make-options to unblock courtesy build

### DIFF
--- a/make-options.json
+++ b/make-options.json
@@ -165,7 +165,6 @@
         "PublishTestResultsV1",
         "PublishTestResultsV2",
         "PublishToAzureServiceBusV1",
-        "PyPIPublisherV0",
         "PythonScriptV0",
         "QueryWorkItemsV0",
         "QuickPerfTestV1",
@@ -197,7 +196,6 @@
         "WindowsMachineFileCopyV2",
         "XamarinAndroidV1",
         "XamariniOSV2",
-        "XamarinTestCloudV1",
         "XcodeV5"
     ],
     "taskResources": [


### PR DESCRIPTION
**Task name**: PyPIPublisherV0, XamarinTestCloudV1

**Description**:
Since both tasks are deprecated now, removing them from the build.

**Documentation changes required:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
