### PR TITLE
Updating to explicit library version

### DIFF
--- a/Tasks/DotNetCoreCLIV2/package.json
+++ b/Tasks/DotNetCoreCLIV2/package.json
@@ -22,7 +22,7 @@
         "archiver": "1.2.0",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.1.0",
-        "azure-pipelines-tasks-packaging-common": "^3.214.0",
+        "azure-pipelines-tasks-packaging-common": "3.x",
         "azure-pipelines-tasks-utility-common": "^3.212.0",
         "uuid": "3.2.1"
     },

--- a/Tasks/DownloadGitHubNpmPackageV1/package.json
+++ b/Tasks/DownloadGitHubNpmPackageV1/package.json
@@ -23,7 +23,7 @@
     "azure-pipelines-task-lib": "^4.1.0",
     "ini": "^1.3.4",
     "mockery": "^1.7.0",
-    "azure-pipelines-tasks-packaging-common": "^2.198.1",
+    "azure-pipelines-tasks-packaging-common": "2.x",
     "azure-pipelines-tasks-utility-common": "^3.198.1"
   },
   "devDependencies": {

--- a/Tasks/DownloadPackageV0/package.json
+++ b/Tasks/DownloadPackageV0/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^16.11.39",
     "azure-devops-node-api": "^11.2.0",
     "azure-pipelines-task-lib": "^4.1.0",
-    "azure-pipelines-tasks-packaging-common": "^3.206.0",
+    "azure-pipelines-tasks-packaging-common": "3.x",
     "azure-pipelines-tasks-utility-common": "^3.210.0",
     "decompress-zip": "0.3.3"
   },

--- a/Tasks/MavenV4/package.json
+++ b/Tasks/MavenV4/package.json
@@ -15,7 +15,7 @@
     "azure-pipelines-tasks-codeanalysis-common": "2.223.0",
     "azure-pipelines-tasks-codecoverage-tools": "3.214.0",
     "azure-pipelines-tasks-java-common": "2.198.1",
-    "azure-pipelines-tasks-packaging-common": "^3.200.1",
+    "azure-pipelines-tasks-packaging-common": "3.x",
     "base-64": "^0.1.0",
     "fs-extra": "^0.30.0",
     "jsdom": "^16.7.0",

--- a/Tasks/NuGetRestoreV1/package.json
+++ b/Tasks/NuGetRestoreV1/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^16.11.39",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.3.1",
-    "azure-pipelines-tasks-packaging-common": "^3.220.0",
+    "azure-pipelines-tasks-packaging-common": "3.x",
     "azure-pipelines-tasks-utility-common": "3.198.1",
     "xmlreader": "^0.2.3"
   },

--- a/Tasks/NuGetToolInstallerV0/package.json
+++ b/Tasks/NuGetToolInstallerV0/package.json
@@ -26,7 +26,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^16.11.39",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-tasks-packaging-common": "^3.221.0",
+        "azure-pipelines-tasks-packaging-common": "3.x",
         "azure-pipelines-tasks-utility-common": "^3.210.0"
     },
     "devDependencies": {

--- a/Tasks/UniversalPackagesV0/package.json
+++ b/Tasks/UniversalPackagesV0/package.json
@@ -21,7 +21,7 @@
         "@types/node": "^16.11.39",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.1.0",
-        "azure-pipelines-tasks-packaging-common": "^3.214.0",
+        "azure-pipelines-tasks-packaging-common": "3.x",
         "azure-pipelines-tasks-utility-common": "^3.212.0"
     },
     "devDependencies": {

--- a/Tasks/UseDotNetV2/package.json
+++ b/Tasks/UseDotNetV2/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^10.17.0",
     "@types/semver": "6.0.0",
     "azure-pipelines-task-lib": "^3.0.0-preview",
-    "azure-pipelines-tasks-packaging-common": "^2.198.1",
+    "azure-pipelines-tasks-packaging-common": "2.x",
     "azure-pipelines-tasks-utility-common": "^3.198.1",
     "azure-pipelines-tool-lib": "^1.0.1",
     "semver": "6.3.0",

--- a/_generated/UseDotNetV2/package.json
+++ b/_generated/UseDotNetV2/package.json
@@ -28,7 +28,7 @@
     "@types/node": "^10.17.0",
     "@types/semver": "6.0.0",
     "azure-pipelines-task-lib": "^3.0.0-preview",
-    "azure-pipelines-tasks-packaging-common": "^2.198.1",
+    "azure-pipelines-tasks-packaging-common": "2.x",
     "azure-pipelines-tasks-utility-common": "^3.198.1",
     "azure-pipelines-tool-lib": "^1.0.1",
     "semver": "6.3.0",


### PR DESCRIPTION
**Task name**: MavenV4, DownloadPackageV0, NuGetToolInstallerV0, DownloadGitHubNpmPackageV1, UniversalPackagesV0, DotNetCoreCLIV2, UseDotNetV2, NuGetRestoreV1

**Description**:  Explicitly setting the package version for dependencies on azure-pipelines-tasks-packaging-common

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) Y Work item #2074002

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
