### PR TITLE
item name should start from task, not include it

### DIFF
--- a/ci/ci-test-tasks/test-and-verify-v2.js
+++ b/ci/ci-test-tasks/test-and-verify-v2.js
@@ -46,6 +46,7 @@ async function start(taskName) {
     console.log(`Detected buildconfigs ${JSON.stringify(configs)}`);
     const promises = [];
     for (const config of configs) {
+      console.log(`Running tests for ${taskName} with config ${config} for pipeline ${pipeline.name}`)
       const pipelineBuild = await runTestPipeline(pipeline, config);
       const promise = new Promise((resolve, reject) => verifyBuildStatus(taskName, pipelineBuild, resolve, reject))
       promises.push(promise);
@@ -69,7 +70,7 @@ function getBuildConfigs(task) {
       const itemPath = path.join('_generated', item);
       const stats = fs.statSync(itemPath);
 
-      if (stats.isDirectory() && item.indexOf(task) !== -1) {
+      if (stats.isDirectory() && item.startsWith(task)) {
         tasksToTest.push(item);
       }
     }


### PR DESCRIPTION
**Description**: The problem is if we have similar-named tasks the line returns>-1.
As an example: "AzureFunctionOnKubernetesV1_Node16".indexOf("KubernetesV1") returns true in the condition

**Checklist**:
- [x] Checked that applied changes work as expected
