### PR TITLE
[BuildConfigGen] Allow typescript 4.8.4 for node 20 migration

### DIFF
--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -206,6 +206,7 @@ namespace BuildConfigGen
                 if (config.isNode)
                 {
                     WriteNodePackageJson(taskOutput, config.nodePackageVersion);
+                    WriteDevDependencyPackageJson(taskOutput, config.nodePackageVersion);
                 }
             }
         }
@@ -374,6 +375,20 @@ namespace BuildConfigGen
             string nodePackageContent = outputNodePackagePathJsonNode.ToJsonString(jso) + Environment.NewLine;
             ensureUpdateModeVerifier!.WriteAllText(outputNodePackagePath, nodePackageContent, suppressValidationErrorIfTargetPathDoesntExist: false);
         }
+
+        private static void WriteDevDependencyPackageJson(string taskOutputNode, string nodeVersion)
+        {
+            string outputNodePackagePath = Path.Combine(taskOutputNode, "package.json");
+            JsonNode outputNodePackagePathJsonNode = JsonNode.Parse(ensureUpdateModeVerifier!.FileReadAllText(outputNodePackagePath))!;
+            
+            // Upgrade typescript version for Node 20
+            if (nodeVersion == "^20.3.1") {
+                outputNodePackagePathJsonNode["devDependencies"]!["typescript"] = "4.8.4";
+            }
+            string nodePackageContent = outputNodePackagePathJsonNode.ToJsonString(jso) + Environment.NewLine;
+            ensureUpdateModeVerifier!.WriteAllText(outputNodePackagePath, nodePackageContent, suppressValidationErrorIfTargetPathDoesntExist: false);
+        }
+
 
         private static bool HasNodeHandler(JsonNode taskHandlerContents)
         {

--- a/make-util.js
+++ b/make-util.js
@@ -16,7 +16,7 @@ var downloadPath = path.join(__dirname, '_download');
 // list of .NET culture names
 var cultureNames = ['cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'tr', 'zh-Hans', 'zh-Hant'];
 
-var allowedTypescriptVersions = ['4.8.4'];
+var allowedTypescriptVersions = ['4.8.4', '4.0.2'];
 
 //------------------------------------------------------------------------------
 // shell functions

--- a/make-util.js
+++ b/make-util.js
@@ -16,7 +16,7 @@ var downloadPath = path.join(__dirname, '_download');
 // list of .NET culture names
 var cultureNames = ['cs', 'de', 'es', 'fr', 'it', 'ja', 'ko', 'pl', 'pt-BR', 'ru', 'tr', 'zh-Hans', 'zh-Hant'];
 
-var allowedTypescriptVersions = ['4.0.2'];
+var allowedTypescriptVersions = ['4.8.4'];
 
 //------------------------------------------------------------------------------
 // shell functions

--- a/make.js
+++ b/make.js
@@ -191,7 +191,7 @@ CLI.build = function()
 CLI.serverBuild = function() {
     ensureBuildTasksAndRemoveTestPath();
 
-    ensureTool('tsc', '--version', 'Version 4.0.2');
+    ensureTool('tsc', '--version', 'Version 4.8.4');
     ensureTool('npm', '--version', function (output) {
         if (semver.lt(output, '5.6.0')) {
             fail('Expected 5.6.0 or higher. To fix, run: npm install -g npm');
@@ -410,7 +410,7 @@ CLI.serverBuild = function() {
 //
 CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */ argv) {
     var minIstanbulVersion = '10';
-    ensureTool('tsc', '--version', 'Version 4.0.2');
+    ensureTool('tsc', '--version', 'Version 4.8.4');
     ensureTool('mocha', '--version', '6.2.3');
 
     // build the general tests and ps test infra
@@ -529,7 +529,7 @@ CLI.test = function(/** @type {{ suite: string; node: string; task: string }} */
 //
 
 CLI.testLegacy = function(/** @type {{ suite: string; node: string; task: string }} */ argv) {
-    ensureTool('tsc', '--version', 'Version 4.0.2');
+    ensureTool('tsc', '--version', 'Version 4.8.4');
     ensureTool('mocha', '--version', '6.2.3');
 
     if (argv.suite) {


### PR DESCRIPTION
**Task name**: BuildConfigGen

**Description**: Allow typescript 4.8.4, automate upgrade its version in package.json file.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
