### PR TITLE
AndroidSigningV2: remove `typings.json` file

### DIFF
--- a/Tasks/AndroidSigningV2/task.json
+++ b/Tasks/AndroidSigningV2/task.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 225,
-    "Patch": 1
+    "Minor": 226,
+    "Patch": 0
   },
   "demands": [
     "JDK"

--- a/Tasks/AndroidSigningV2/task.loc.json
+++ b/Tasks/AndroidSigningV2/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 225,
-    "Patch": 1
+    "Minor": 226,
+    "Patch": 0
   },
   "demands": [
     "JDK"

--- a/Tasks/AndroidSigningV2/typings.json
+++ b/Tasks/AndroidSigningV2/typings.json
@@ -1,8 +1,0 @@
-{
-  "name": "vsts-androidsigning-task",
-  "dependencies": {},
-  "globalDependencies": {
-    "node": "registry:dt/node#6.0.0+20160921192128",
-    "q": "registry:dt/q#0.0.0+20160613154756"
-  }
-}


### PR DESCRIPTION
**Task name**: AndroidSigningV2

**Description**: Remove `typings.json` from AndroidSigningV2 task

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #18761 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
