### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 20923108

### DIFF
--- a/Tasks/BashV3/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/de-DE/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash hat mindestens eine Zeile in den Standardfehlerstream geschrieben.",
   "loc.messages.JS_TranslatePathFailed": "Der Pfad \"%s\" kann nicht in das Linux-Dateisystem übersetzt werden.",
   "loc.messages.JS_BashEnvAlreadyDefined": "Die Umgebungsvariable „BASH_ENV“ wurde bereits auf „%s“ festgelegt. Die Aufgabe überschreibt sie mit „%s“.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Eingabeargumente wurden von Sanitizer geändert. Ausgabe von Sanitizer: %s"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/es-ES/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash escribió una o varias líneas en la secuencia de error estándar.",
   "loc.messages.JS_TranslatePathFailed": "La ruta de acceso \"%s\" no se puede traducir al sistema de archivos de Linux.",
   "loc.messages.JS_BashEnvAlreadyDefined": "La variable de entorno BASH_ENV ya se ha establecido en '%s'. La tarea la reemplazará por '%s'",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Sanitizer cambió los argumentos de entrada. Salida de Sanitizer: “%s”"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/fr-FR/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash a écrit une ou plusieurs lignes dans le flux d'erreurs standard.",
   "loc.messages.JS_TranslatePathFailed": "Impossible de traduire le chemin '%s' vers le système de fichiers Linux.",
   "loc.messages.JS_BashEnvAlreadyDefined": "La variable d’environnement BASH_ENV a déjà été définie sur un « %s », la tâche la remplacera par « %s ».",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Sanitizer a modifié les arguments d’entrée. Sortie du désinfectant : '%s'"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/it-IT/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash ha scritto una o più righe nel flusso di errore standard.",
   "loc.messages.JS_TranslatePathFailed": "Non è possibile convertire il percorso '%s' per il file system Linux.",
   "loc.messages.JS_BashEnvAlreadyDefined": "La variabile di ambiente BASH_ENV è già stata impostata su '%s'. L'attività la sostituirà con '%s'",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Gli argomenti di input sono stati modificati da Sanitizer. Output da Sanitizer: '%s'"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/ja-JP/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "bash が標準エラー ストリームに 1 行以上を書き込みました。",
   "loc.messages.JS_TranslatePathFailed": "パス '%s' は、Linux ファイル システムに変換できません。",
   "loc.messages.JS_BashEnvAlreadyDefined": "環境変数 BASH_ENV は既に '%s' に設定されていますが、このタスクはこれを '%s' で上書きします",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "サニタイザーが入力引数を変更しました。サニタイザーからの出力: '%s'"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/ko-KR/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash가 표준 오류 스트림에 하나 이상의 줄을 썼습니다.",
   "loc.messages.JS_TranslatePathFailed": "'%s' 경로를 Linux 파일 시스템으로 변환할 수 없습니다.",
   "loc.messages.JS_BashEnvAlreadyDefined": "BASH_ENV 환경 변수가 이미 '%s'(으)로 설정되어 있습니다. 작업에서 '%s'(으)로 재정의합니다.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "삭제기가 입력 인수를 변경했습니다. 삭제기의 출력: '%s'"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/ru-RU/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Оболочка Bash записала одну или несколько строк в стандартный поток ошибок.",
   "loc.messages.JS_TranslatePathFailed": "Не удалось преобразовать путь \"%s\" для файловой системы Linux.",
   "loc.messages.JS_BashEnvAlreadyDefined": "Для переменной среды BASH_ENV уже задано значение \"%s\". Задача переопределит его на \"%s\"",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Санитайзер изменил входные аргументы. Выходные данные санитайзера: \"%s\""
 }

--- a/Tasks/BashV3/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/zh-CN/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash 向标准错误流写入一个或多个行。",
   "loc.messages.JS_TranslatePathFailed": "无法将路径“%s”转换到 Linux 文件系统。",
   "loc.messages.JS_BashEnvAlreadyDefined": "已将 BASH_ENV环境变量设置为“%s”，任务将使用“%s”替代它",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "擦除系统更改了输入参数。来自擦除器的输出: “%s”"
 }

--- a/Tasks/BashV3/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/BashV3/Strings/resources.resjson/zh-TW/resources.resjson
@@ -25,5 +25,5 @@
   "loc.messages.JS_Stderr": "Bash 已將一或多行寫入標準錯誤資料流。",
   "loc.messages.JS_TranslatePathFailed": "無法將路徑 '%s' 轉譯成 Linux 檔案系統。",
   "loc.messages.JS_BashEnvAlreadyDefined": "BASH_ENV 環境變數已設定為 '%s'，工作會以 '%s' 覆寫",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "清理程式已變更輸入引數。從清理程式輸出: '%s'"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "Ungültiger Dateipfad \"%s\". Ein Pfad zu einer PS1-Datei ist erforderlich.",
   "loc.messages.JS_Stderr": "PowerShell hat mindestens eine Zeile in den Standardfehlerstream geschrieben.",
   "loc.messages.JS_InvalidTargetType": "Ungültiger Zieltyp \"%s\". Der Wert muss einem der Werte \"filepath\" oder \"inline\" entsprechen",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "Eingabeargumente wurden von Sanitizer geändert. Ausgabe von Sanitizer: %s",
   "loc.messages.PS_ExitCode": "PowerShell wurde beendet mit dem Code \"{0}\".",
   "loc.messages.PS_FormattedCommand": "Formatierter Befehl: {0}",
   "loc.messages.PS_InvalidActionPreference": "Ungültige Aktionseinstellung für {0}: „{1}“. Der Wert muss einer der folgenden Werte sein: {2}",
   "loc.messages.PS_InvalidFilePath": "Ungültiger Dateipfad \"{0}\". Ein Pfad zu einer PS1-Datei ist erforderlich.",
   "loc.messages.PS_UnableToDetermineExitCode": "Unerwartete Ausnahme. Der Exitcode von PowerShell konnte nicht bestimmt werden.",
   "loc.messages.PS_InvalidTargetType": "Ungültiger Zieltyp \"{0}\". Der Wert muss einem der Werte \"filepath\" oder \"inline\" entsprechen",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "Eingabeargumente wurden von Sanitizer geändert. Ausgabe von Sanitizer: {0}"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "La ruta de acceso de archivo \"%s\" no es válida. Se necesita una ruta de acceso a un archivo .ps1.",
   "loc.messages.JS_Stderr": "PowerShell escribió una o varias líneas en la secuencia de error estándar.",
   "loc.messages.JS_InvalidTargetType": "Tipo de destino «%s» no válido. El valor debe ser uno de los siguientes: «FilePath» o «inline»",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "Sanitizer cambió los argumentos de entrada. Salida de Sanitizer: “%s”",
   "loc.messages.PS_ExitCode": "PowerShell se cerró con el código \"{0}\".",
   "loc.messages.PS_FormattedCommand": "Comando con formato: {0}",
   "loc.messages.PS_InvalidActionPreference": "Preferencia de acción no válida para {0}: \"{1}\". El valor debe ser uno de los siguientes: {2}",
   "loc.messages.PS_InvalidFilePath": "La ruta de acceso de archivo \"{0}\" no es válida. Se necesita una ruta de acceso a un archivo .ps1.",
   "loc.messages.PS_UnableToDetermineExitCode": "Excepción inesperada. No se puede determinar el código de salida de PowerShell.",
   "loc.messages.PS_InvalidTargetType": "Tipo de destino «{0}» no válido. El valor debe ser uno de los siguientes: «FilePath» o «inline»",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "Sanitizer cambió los argumentos de entrada. Salida de Sanitizer: “{0}”"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "Chemin de fichier non valide : '%s'. Le chemin d'un fichier .ps1 est obligatoire.",
   "loc.messages.JS_Stderr": "PowerShell a écrit une ou plusieurs lignes dans le flux d'erreurs standard.",
   "loc.messages.JS_InvalidTargetType": "Type de cible « %s » non valide. La valeur doit être l’une des suivantes : 'FilePath’ou’inline'",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "Sanitizer a modifié les arguments d’entrée. Sortie du désinfectant : '%s'",
   "loc.messages.PS_ExitCode": "Arrêt de PowerShell. Code de sortie : '{0}'.",
   "loc.messages.PS_FormattedCommand": "Commande mise en forme : {0}",
   "loc.messages.PS_InvalidActionPreference": "Préférence d’action non valide pour {0}: «{1}». La valeur doit être l’une des suivantes : {2}",
   "loc.messages.PS_InvalidFilePath": "Chemin de fichier '{0}' non valide. Le chemin d'un fichier .ps1 est obligatoire.",
   "loc.messages.PS_UnableToDetermineExitCode": "Exception inattendue. Impossible de déterminer le code de sortie de PowerShell.",
   "loc.messages.PS_InvalidTargetType": "Type de cible « {0} » non valide. La valeur doit être l’une des suivantes : 'FilePath’ou’inline'",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "Le désinfectant a modifié les arguments d’entrée. Sortie du désinfectant : '{0}'"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "Il percorso file '%s' non è valido. È necessario un percorso di un file con estensione ps1.",
   "loc.messages.JS_Stderr": "PowerShell ha scritto una o più righe nel flusso di errore standard.",
   "loc.messages.JS_InvalidTargetType": "Il tipo di destinazione '%s' non è valido. Il valore deve essere uno dei seguenti: 'filepath' o 'inline'",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "Gli argomenti di input sono stati modificati da Sanitizer. Output da Sanitizer: '%s'",
   "loc.messages.PS_ExitCode": "PowerShell terminato con codice '{0}'.",
   "loc.messages.PS_FormattedCommand": "Comando formattato: {0}",
   "loc.messages.PS_InvalidActionPreference": "Preferenza di azione non valida per {0}: '{1}'. Il valore deve essere uno dei seguenti: {2}",
   "loc.messages.PS_InvalidFilePath": "Il percorso file '{0}' non è valido. È necessario un percorso di un file con estensione ps1.",
   "loc.messages.PS_UnableToDetermineExitCode": "Eccezione imprevista. Non è possibile determinare il codice di uscita da PowerShell.",
   "loc.messages.PS_InvalidTargetType": "Il tipo di destinazione '{0}' non è valido. Il valore deve essere uno dei seguenti: 'filepath' o 'inline'",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "Gli argomenti di input sono stati modificati da Sanitizer. Output da Sanitizer: '{0}'"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "ファイル パス '%s' が無効です。.ps1 ファイルへのパスが必要です。",
   "loc.messages.JS_Stderr": "PowerShell が標準エラー ストリームに 1 行以上を書き込みました。",
   "loc.messages.JS_InvalidTargetType": "無効なターゲット型 '%s' です。値は 'filepath' または 'inline' のどちらかである必要があります",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "サニタイザーが入力引数を変更しました。サニタイザーからの出力: '%s'",
   "loc.messages.PS_ExitCode": "PowerShell がコード '{0}' で終了しました。",
   "loc.messages.PS_FormattedCommand": "フォーマット後のコマンド: {0}",
   "loc.messages.PS_InvalidActionPreference": "{0} の無効なアクション設定: '{1}'。値は次のいずれかである必要があります: {2}",
   "loc.messages.PS_InvalidFilePath": "ファイル パス '{0}' が無効です。.ps1 ファイルへのパスが必要です。",
   "loc.messages.PS_UnableToDetermineExitCode": "予期しない例外が発生しました。PowerShell からの終了コードを判別できません。",
   "loc.messages.PS_InvalidTargetType": "無効なターゲット型 '{0}' です。値は 'filepath' または 'inline' のどちらかである必要があります",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "サニタイザーが入力引数を変更しました。サニタイザーからの出力: {0}"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "잘못된 파일 경로 '%s'입니다. .ps1 파일의 경로가 필요합니다.",
   "loc.messages.JS_Stderr": "PowerShell이 표준 오류 스트림에 하나 이상의 줄을 썼습니다.",
   "loc.messages.JS_InvalidTargetType": "대상 유형 '%s'이(가) 잘못되었습니다. 값은 'filepath' 또는 'inline' 중 하나여야 합니다.",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "삭제기가 입력 인수를 변경했습니다. 삭제기의 출력: '%s'",
   "loc.messages.PS_ExitCode": "PowerShell이 코드 '{0}'(으)로 종료되었습니다.",
   "loc.messages.PS_FormattedCommand": "형식이 지정된 명령: {0}",
   "loc.messages.PS_InvalidActionPreference": "{0}에 대한 잘못된 작업 기본 설정: '{1}'. 값은 다음 중 하나여야 합니다. {2}",
   "loc.messages.PS_InvalidFilePath": "잘못된 파일 경로 '{0}'입니다. .ps1 파일의 경로가 필요합니다.",
   "loc.messages.PS_UnableToDetermineExitCode": "예기치 않은 예외가 발생했습니다. PowerShell의 종료 코드를 확인할 수 없습니다.",
   "loc.messages.PS_InvalidTargetType": "잘못된 대상 유형 '{0}'. 값은 'filepath' 또는 'inline' 중 하나여야 합니다.",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "삭제기가 입력 인수를 변경했습니다. 삭제기의 출력: '{0}'"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "Недопустимый путь к файлу \"%s\". Требуется путь к файлу PS1.",
   "loc.messages.JS_Stderr": "Оболочка PowerShell записала одну или несколько строк в стандартный поток ошибок.",
   "loc.messages.JS_InvalidTargetType": "Недопустимый тип целевого объекта \"%s\". Должно использоваться одно из следующих значений: filepath или inline",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "Санитайзер изменил входные аргументы. Выходные данные санитайзера: \"%s\"",
   "loc.messages.PS_ExitCode": "Завершение работы PowerShell с кодом \"{0}\".",
   "loc.messages.PS_FormattedCommand": "Отформатирована команда: {0}",
   "loc.messages.PS_InvalidActionPreference": "Недопустимая настройка действия для {0}: \"{1}\". Должно применяться одно из следующих значений: {2}",
   "loc.messages.PS_InvalidFilePath": "Недопустимый путь к файлу \"{0}\". Требуется путь к файлу PS1.",
   "loc.messages.PS_UnableToDetermineExitCode": "Непредвиденное исключение. Не удается определить код выхода из PowerShell.",
   "loc.messages.PS_InvalidTargetType": "Недопустимый тип целевого объекта \"{0}\". Должно использоваться одно из следующих значений: filepath или inline",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "Санитайзер изменил входные аргументы. Выходные данные санитайзера: \"{0}\""
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "无效的文件路径“%s”。需要 .ps1 文件的路径。",
   "loc.messages.JS_Stderr": "PowerShell 向标准错误流写入一个或多个行。",
   "loc.messages.JS_InvalidTargetType": "目标类型“%s”无效。该值必须是以下值之一: “filepath” 或 “inline”",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "擦除系统更改了输入参数。来自擦除器的输出: “%s”",
   "loc.messages.PS_ExitCode": "PowerShell 已退出，代码为“{0}”。",
   "loc.messages.PS_FormattedCommand": "已设置格式的命令: {0}",
   "loc.messages.PS_InvalidActionPreference": "{0} 的操纵首选项无效:“{1}”。值必须为以下值之一: {2}",
   "loc.messages.PS_InvalidFilePath": "无效的文件路径“{0}”。需要 .ps1 文件的路径。",
   "loc.messages.PS_UnableToDetermineExitCode": "出现意外异常。无法确定 powershell 的退出代码。",
   "loc.messages.PS_InvalidTargetType": "目标类型“{0}”无效。该值必须是以下值之一: “filepath” 或 “inline”",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "擦除系统更改了输入参数。来自擦除器的输出: “{0}”"
 }

--- a/Tasks/PowerShellV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PowerShellV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -44,12 +44,12 @@
   "loc.messages.JS_InvalidFilePath": "檔案路徑 '%s' 無效。需要到達 .ps1 檔案的路徑。",
   "loc.messages.JS_Stderr": "PowerShell 已將一或多行寫入標準錯誤資料流。",
   "loc.messages.JS_InvalidTargetType": "無效的目標型別 '%s'。值必須是下列其中一個: 'filepath' 或 'inline'",
-  "loc.messages.JS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'",
+  "loc.messages.JS_SanitizerOutput": "清理程式已變更輸入引數。從清理程式輸出: '%s'",
   "loc.messages.PS_ExitCode": "PowerShell 已結束，代碼為 '{0}'。",
   "loc.messages.PS_FormattedCommand": "經過格式化的命令: {0}",
   "loc.messages.PS_InvalidActionPreference": "{0} 的動作喜好設定無效: ‘{1}’。值必須是以下其中之一: {2}",
   "loc.messages.PS_InvalidFilePath": "檔案路徑 '{0}' 無效。需要到達 .ps1 檔案的路徑。",
   "loc.messages.PS_UnableToDetermineExitCode": "未預期的例外狀況。無法從 PowerShell 判斷結束代碼。",
   "loc.messages.PS_InvalidTargetType": "無效的目標型別 '{0}'。值必須是下列其中一個: 'filepath' 或 'inline'",
-  "loc.messages.PS_SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '{0}'"
+  "loc.messages.PS_SanitizerOutput": "清理程式已變更輸入引數。從清理程式輸出: '{0}'"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "Es wird versucht, eine SSH-Verbindung mit \"%s@%s:%s\" einzurichten.",
   "loc.messages.SshConnectionSuccessful": "Verbindung erfolgreich hergestellt.",
   "loc.messages.UseDefaultPort": "Port 22 wird als Standardeinstellung für SSH verwendet, da kein Port angegeben wurde.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Eingabeargumente wurden von Sanitizer geändert. Ausgabe von Sanitizer: %s"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "Intentando establecer una conexión SSH con %s@%s: %s",
   "loc.messages.SshConnectionSuccessful": "Conectado correctamente.",
   "loc.messages.UseDefaultPort": "Usando el puerto 22, que es el predeterminado para SSH, porque no se especificó ningún puerto.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Sanitizer cambió los argumentos de entrada. Salida de Sanitizer: “%s”"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "Tentative d'établissement d'une connexion SSH à %s@%s:%s",
   "loc.messages.SshConnectionSuccessful": "Connexion réussie.",
   "loc.messages.UseDefaultPort": "Utilisation du port 22, qui représente la valeur par défaut pour SSH, car aucun port n'a été spécifié.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Sanitizer a modifié les arguments d’entrée. Sortie du désinfectant : '%s'"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "Tentativo di stabilire una connessione SSH a %s@%s:%s",
   "loc.messages.SshConnectionSuccessful": "La connessione è riuscita.",
   "loc.messages.UseDefaultPort": "Verrà usata la porta 22 che corrisponde a quella predefinita per SSH perché non è stata specificata alcuna porta.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Gli argomenti di input sono stati modificati da Sanitizer. Output da Sanitizer: '%s'"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "%s@%s:%s への SSH 接続を確立しようとしています",
   "loc.messages.SshConnectionSuccessful": "正常に接続しました。",
   "loc.messages.UseDefaultPort": "ポートが指定されなかったため、SSH で既定のポート 22 を使用しています。",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "サニタイザーが入力引数を変更しました。サニタイザーからの出力: '%s'"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "%s@%s:%s에 대한 SSH 연결을 설정하는 중",
   "loc.messages.SshConnectionSuccessful": "연결되었습니다.",
   "loc.messages.UseDefaultPort": "포트가 지정되지 않았으므로 SSH에 대한 기본값인 포트 22를 사용합니다.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "삭제기가 입력 인수를 변경했습니다. 삭제기의 출력: '%s'"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "Попытка установить SSH-подключение к %s@%s:%s",
   "loc.messages.SshConnectionSuccessful": "Подключение успешно установлено.",
   "loc.messages.UseDefaultPort": "Используется порт 22, который является портом по умолчанию для SSH, так как порт не указан.",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "Санитайзер изменил входные аргументы. Выходные данные санитайзера: \"%s\""
 }

--- a/Tasks/SshV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "正在尝试建立与 %s@%s:%s 的 SSH 连接",
   "loc.messages.SshConnectionSuccessful": "已成功连接。",
   "loc.messages.UseDefaultPort": "由于未指定端口，将使用SSH 的默认端口 22。",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "擦除系统更改了输入参数。来自擦除器的输出: “%s”"
 }

--- a/Tasks/SshV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/SshV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -35,5 +35,5 @@
   "loc.messages.SettingUpSshConnection": "正在嘗試對 %s@%s:%s 建立 SSH 連線",
   "loc.messages.SshConnectionSuccessful": "連線成功。",
   "loc.messages.UseDefaultPort": "因為未指定任何連接埠，所以將使用 SSH 的預設連接埠 22。",
-  "loc.messages.SanitizerOutput": "Sanitizer changed input arguments. Output from sanitizer: '%s'"
+  "loc.messages.SanitizerOutput": "清理程式已變更輸入引數。從清理程式輸出: '%s'"
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.