### PR TITLE
Switch back to node 10 before running tests in pipeline builds

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -99,6 +99,12 @@ steps:
   displayName: Build Tasks Node20
   condition: and(succeeded(), ne(variables['numTasks'], 0))
 
+# Use node 10, npm 6
+- task: NodeTool@0
+  displayName: Use node 10
+  inputs:
+    versionSpec: 10.24.1
+
 - script: node ./ci/after-build-check-tasks.js
   displayName: Check that tasks has no duplicated libs
   condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'), ne(variables['numTasks'], 0))

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -57,6 +57,12 @@ steps:
 - script: node make.js serverBuild --task "$(task_pattern)" --node Node20
   displayName: Build Tasks Node20
 
+# Use node 10, npm 6
+- task: NodeTool@0
+  displayName: Use node 10
+  inputs:
+    versionSpec: 10.24.1
+
 # Check diff for task sources
 - script: node ./ci/verify-source-changes.js "$(task_pattern)"
   displayName: Verify task source changes


### PR DESCRIPTION
**Task name**: Pipeline

**Description**: Build node 20 tasks using node 20, then switch back to node 10 before running tests in pipeline builds.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
