### PR TITLE
Replace the pool fpr create_hotfix job

### DIFF
--- a/ci/build-single-jobs.yml
+++ b/ci/build-single-jobs.yml
@@ -24,7 +24,7 @@ jobs:
     displayName: Create HotFix PR
     dependsOn: build_single_task
     pool:
-      vmImage: windows-2022
+      name: 1ES-Shared-Hosted-Pool_Windows-Server-2022
     steps: 
     - template: build-single-cc-pr-steps.yml
       parameters:


### PR DESCRIPTION
Replace the pool to resolve the low disk space issue in create_hotfix job

``` % git add tfs/m227/tasksHotFix-20230815-0839
fatal: Unable to create 'D:/a/1/s/AzureDevOps.ConfigChange/.git/index.lock': No space left on device
child_process.js:669
    throw err;
```
