### PR TITLE
[MavenV4] Sample PR for upgrading to new version of task-lib (mockery to sinon replacement)

### DIFF
--- a/Tasks/MavenV4/Tests/L0DefaultsWithHomeSet.ts
+++ b/Tasks/MavenV4/Tests/L0DefaultsWithHomeSet.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -35,6 +32,9 @@ setInputs(taskRunner, inputs);
 const mavenHome = "/anotherHome/";
 const mavenBin =  path.join(mavenHome, "bin", "mvn");
 process.env["M2_HOME"] = mavenHome;
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0DefaultsWithNoHomeSet.ts
+++ b/Tasks/MavenV4/Tests/L0DefaultsWithNoHomeSet.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0InvalidMavenVersionSelection.ts
+++ b/Tasks/MavenV4/Tests/L0InvalidMavenVersionSelection.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "garbage",
@@ -29,6 +26,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenPathInvalid.ts
+++ b/Tasks/MavenV4/Tests/L0MavenPathInvalid.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const mavenPath = "/not/a/valid/maven/path/";
 const mavenBin =  path.join(mavenPath, "bin", "mvn");
 
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenPathMissing.ts
+++ b/Tasks/MavenV4/Tests/L0MavenPathMissing.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const mavenPath = "/home/bin/maven2/";
 const mavenBin =  path.join(mavenPath, "bin", "mvn");
 
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenVersionSelectionSetToPath.ts
+++ b/Tasks/MavenV4/Tests/L0MavenVersionSelectionSetToPath.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const mavenPath = "/home/bin/maven2/";
 const mavenBin =  path.join(mavenPath, "bin", "mvn");
 
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenWithFeed.ts
+++ b/Tasks/MavenV4/Tests/L0MavenWithFeed.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenWithFeedSettings.ts
+++ b/Tasks/MavenV4/Tests/L0MavenWithFeedSettings.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const options = "/o -s settings.xml /p /t";
 const optionsWithoutSettings = "/o /p /t";
 // Set Inputs
@@ -35,6 +32,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenWithFeedSettingsAndSpaces.ts
+++ b/Tasks/MavenV4/Tests/L0MavenWithFeedSettingsAndSpaces.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const optionsWithEscaping = `-DoptWithEscaping="{\\\"serverUri\\\": \\\"http://elasticsearch:9200\\\",\\\"username\\\": \\\"elastic\\\", \\\"password\\\": \\\"changeme\\\", \\\"connectionTimeout\\\": 30000}"`;
 const optionsWithoutEscaping = `-DoptWithEscaping={\"serverUri\": \"http://elasticsearch:9200\",\"username\": \"elastic\", \"password\": \"changeme\", \"connectionTimeout\": 30000}`;
 // Set Inputs
@@ -35,6 +32,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenWithoutFeed.ts
+++ b/Tasks/MavenV4/Tests/L0MavenWithoutFeed.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -29,6 +26,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MavenWithoutFeedSkipEffectivePom.ts
+++ b/Tasks/MavenV4/Tests/L0MavenWithoutFeedSkipEffectivePom.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -30,6 +27,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MissingGoals.ts
+++ b/Tasks/MavenV4/Tests/L0MissingGoals.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MissingJavaHomeSelection.ts
+++ b/Tasks/MavenV4/Tests/L0MissingJavaHomeSelection.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MissingMavenFeedAuthenticate.ts
+++ b/Tasks/MavenV4/Tests/L0MissingMavenFeedAuthenticate.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -24,6 +21,9 @@ const inputs: MavenTaskInputs = {
     testResultsFiles: "**/TEST-*.xml"
 };
 setInputs(taskRunner, inputs);
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MissingMavenVersionSelection.ts
+++ b/Tasks/MavenV4/Tests/L0MissingMavenVersionSelection.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     // mavenVersionSelection not specified
@@ -25,6 +22,9 @@ const inputs: MavenTaskInputs = {
     mavenFeedAuthenticate: true
 };
 setInputs(taskRunner, inputs);
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0MissingTestResultsFiles.ts
+++ b/Tasks/MavenV4/Tests/L0MissingTestResultsFiles.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0PublishJUnitTestResults.ts
+++ b/Tasks/MavenV4/Tests/L0PublishJUnitTestResults.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: "Default",
@@ -33,6 +30,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0RestoreOriginalPomXml.ts
+++ b/Tasks/MavenV4/Tests/L0RestoreOriginalPomXml.ts
@@ -10,9 +10,6 @@ const taskPath = path.join(__dirname, '..', 'maventask.js');
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: 'Default',
@@ -36,6 +33,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env.M2_HOME; // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {
@@ -104,6 +104,7 @@ taskRunner.registerMock('azure-pipelines-tasks-codecoverage-tools/codecoveragefa
 const originalPomXmlContents = 'original pom.xml contents';
 
 const fsClone = Object.assign({}, fs);
+const fsClone2 = Object.assign({}, fs);
 Object.assign(fsClone, {
     readFileSync(filename: string, encoding: BufferEncoding ): string {
         if (filename === 'pom.xml' && encoding === 'utf8') {
@@ -111,7 +112,7 @@ Object.assign(fsClone, {
             return originalPomXmlContents;
         }
 
-        return fs.readFileSync(filename, encoding);
+        return fsClone2.readFileSync(filename, encoding);
     },
     writeFileSync(filename: string, data: any): void {
         if (filename === 'pom.xml') {
@@ -123,7 +124,7 @@ Object.assign(fsClone, {
             throw new Error(`Trying to write unknown data into pom.xml; data=${data}`);
         }
 
-        fs.writeFileSync(filename, data);
+        fsClone2.writeFileSync(filename, data);
     }
 });
 taskRunner.registerMock('fs', fsClone);

--- a/Tasks/MavenV4/Tests/L0SetM2Home.ts
+++ b/Tasks/MavenV4/Tests/L0SetM2Home.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const mavenPath = "/home/bin/maven2/";
 const mavenBin =  path.join(mavenPath, "bin", "mvn");
 
@@ -34,6 +31,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0SetM2HomeInvalid.ts
+++ b/Tasks/MavenV4/Tests/L0SetM2HomeInvalid.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, "..", "maventask.js");
 
 const taskRunner = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(taskRunner);
-
 const mavenPath = "/home/bin/maven2/";
 const mavenBin =  path.join(mavenPath, "bin", "mvn");
 
@@ -34,6 +31,9 @@ setInputs(taskRunner, inputs);
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env['M2_HOME'] // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(taskRunner);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {

--- a/Tasks/MavenV4/Tests/L0SpotbugsPlugin.ts
+++ b/Tasks/MavenV4/Tests/L0SpotbugsPlugin.ts
@@ -8,9 +8,6 @@ const taskPath = path.join(__dirname, '..', 'maventask.js');
 
 const tmr = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(tmr);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: 'Default',
@@ -39,6 +36,9 @@ const mavenBin = path.join(mavenHome, 'bin', 'mvn');
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env.M2_HOME; // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(tmr);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {
@@ -107,7 +107,10 @@ const fileUtilsMock = {
     }
 };
 
-tmr.registerMock('./fileUtils', fileUtilsMock);
+let curpath = __dirname;
+let relativePath = './fileUtils';
+let fullPath = path.join(curpath, relativePath);
+tmr.registerMock(fullPath, fileUtilsMock);
 
 // Run task
 tmr.run();

--- a/Tasks/MavenV4/Tests/L0SpotbugsWithResultPublishing.ts
+++ b/Tasks/MavenV4/Tests/L0SpotbugsWithResultPublishing.ts
@@ -9,9 +9,6 @@ const taskPath = path.join(__dirname, '..', 'maventask.js');
 
 const tmr = new TaskMockRunner(taskPath);
 
-// Common initial setup
-initializeTest(tmr);
-
 // Set Inputs
 const inputs: MavenTaskInputs = {
     mavenVersionSelection: 'Default',
@@ -40,6 +37,9 @@ const mavenBin = path.join(mavenHome, 'bin', 'mvn');
 // Set up environment variables (task-lib does not support mocking getVariable)
 // Env vars in the mock framework must replace '.' with '_'
 delete process.env.M2_HOME; // Remove in case process running this test has it already set
+
+// Common initial setup
+initializeTest(tmr);
 
 // Provide answers for task mock
 const answers: TaskLibAnswers = {
@@ -108,7 +108,10 @@ const fileUtilsMock = {
     }
 };
 
-tmr.registerMock('./fileUtils', fileUtilsMock);
+let curpath = __dirname;
+let relativePath = './fileUtils';
+let fullPath = path.join(curpath, relativePath);
+tmr.registerMock(fullPath, fileUtilsMock);
 
 const spotbugsPublishMock = {
     PublishSpotbugsReport: function (mavenPOMFile: string, buildOutput: BuildOutput): void {
@@ -116,7 +119,10 @@ const spotbugsPublishMock = {
     }
 };
 
-tmr.registerMock('./publishSpotbugsReport', spotbugsPublishMock);
+let curpath = __dirname;
+let relativePath = './publishSpotbugsReport';
+let fullPath = path.join(curpath, relativePath);
+tmr.registerMock(fullPath, spotbugsPublishMock);
 
 // Run task
 tmr.run();

--- a/Tasks/MavenV4/package.json
+++ b/Tasks/MavenV4/package.json
@@ -11,7 +11,7 @@
     "@types/jsdom": "^16.2.14",
     "@types/mocha": "^5.2.7",
     "@types/node": "^16.11.39",
-    "azure-pipelines-task-lib": "^4.0.0-preview",
+    "azure-pipelines-task-lib": "^5.0.0",
     "azure-pipelines-tasks-codeanalysis-common": "2.223.0",
     "azure-pipelines-tasks-codecoverage-tools": "3.214.0",
     "azure-pipelines-tasks-java-common": "2.198.1",


### PR DESCRIPTION
**Task name**: MavenV4

**Description**: 

- Relative Path: Changes required because a relative path for local module was used when mocking
- Initialization Order: Changes occur because the sequence in which you initialize the task-lib and set inputs in tests is important. Setting inputs should go before initialization of task-lib.
- Module Clone and Recursive Calls: To maintain the original behavior within a mocked function in Sinon, you need to add module's clone, otherwise it may lead to recursive calls.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
