### PR TITLE
[BashV3] Sample PR for upgrading to new version of task-lib (mockery to sinon replacement)

### DIFF
--- a/Tasks/BashV3/Tests/L0Args.ts
+++ b/Tasks/BashV3/Tests/L0Args.ts
@@ -68,8 +68,8 @@ fsClone.writeFileSync = function(filePath, contents, options) {
 tmr.registerMock('fs', fsClone);
 
 // Mock uuidv4
-tmr.registerMock('uuid/v4', function () {
+tmr.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 tmr.run();

--- a/Tasks/BashV3/Tests/L0External.ts
+++ b/Tasks/BashV3/Tests/L0External.ts
@@ -67,8 +67,8 @@ fsClone.writeFileSync = function(filePath, contents, options) {
 tmr.registerMock('fs', fsClone);
 
 // Mock uuidv4
-tmr.registerMock('uuid/v4', function () {
+tmr.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 tmr.run();

--- a/Tasks/BashV3/Tests/L0FailOnExitCodeNull.ts
+++ b/Tasks/BashV3/Tests/L0FailOnExitCodeNull.ts
@@ -57,8 +57,8 @@ fsClone.writeFileSync = function(filePath, contents, options) {
 tmr.registerMock('fs', fsClone);
 
 // Mock uuidv4
-tmr.registerMock('uuid/v4', function () {
+tmr.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 tmr.run();

--- a/Tasks/BashV3/Tests/L0Inline.ts
+++ b/Tasks/BashV3/Tests/L0Inline.ts
@@ -58,8 +58,8 @@ fsClone.writeFileSync = function(filePath, contents, options) {
 tmr.registerMock('fs', fsClone);
 
 // Mock uuidv4
-tmr.registerMock('uuid/v4', function () {
+tmr.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 tmr.run();

--- a/Tasks/BashV3/Tests/L0SetBashEnv.ts
+++ b/Tasks/BashV3/Tests/L0SetBashEnv.ts
@@ -69,8 +69,8 @@ fsClone.writeFileSync = function (filePath, contents, options) {
 taskRunner.registerMock('fs', fsClone);
 
 // Mock uuidv4
-taskRunner.registerMock('uuid/v4', function () {
+taskRunner.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 taskRunner.run();

--- a/Tasks/BashV3/Tests/L0StdErr.ts
+++ b/Tasks/BashV3/Tests/L0StdErr.ts
@@ -68,8 +68,8 @@ fsClone.writeFileSync = function(filePath, contents, options) {
 tmr.registerMock('fs', fsClone);
 
 // Mock uuidv4
-tmr.registerMock('uuid/v4', function () {
+tmr.registerMock('uuid', {v4: function () {
     return 'fileName';
-});
+}});
 
 tmr.run();

--- a/Tasks/BashV3/bash.ts
+++ b/Tasks/BashV3/bash.ts
@@ -2,7 +2,7 @@ import fs = require('fs');
 import path = require('path');
 import tl = require('azure-pipelines-task-lib/task');
 import tr = require('azure-pipelines-task-lib/toolrunner');
-var uuidV4 = require('uuid/v4');
+var uuid = require('uuid');
 import { sanitizeArgs } from 'azure-pipelines-tasks-utility-common/argsSanitizer';
 import { emitTelemetry } from "azure-pipelines-tasks-utility-common/telemetry";
 
@@ -171,7 +171,7 @@ async function run() {
         tl.assertAgent('2.115.0');
         let tempDirectory = tl.getVariable('agent.tempDirectory');
         tl.checkPath(tempDirectory, `${tempDirectory} (agent.tempDirectory)`);
-        let fileName = uuidV4() + '.sh';
+        let fileName = uuid.v4() + '.sh';
         let filePath = path.join(tempDirectory, fileName);
 
         fs.writeFileSync(


### PR DESCRIPTION
**Task name**: BashV3

**Description**: 

- Import Aliasing: If import aliasing was used in the task implementation, and it is being mocked in unit tests, changes are needed.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
