### PR TITLE
[GruntV0] Sample PR for upgrading to new version of task-lib (mockery to sinon replacement)

### DIFF
--- a/Tasks/GruntV0/Tests/L0.ts
+++ b/Tasks/GruntV0/Tests/L0.ts
@@ -152,7 +152,7 @@ describe('GruntV0 Suite', function () {
 
         tr.run();
 
-        assert(tr.stdOutContained('Input required: cwd'), 'Should have printed: Input required: cwd');
+        assert(tr.stdOutContained('loc_mock_LIB_InputRequired cwd'), 'Should have printed: loc_mock_LIB_InputRequired cwd');
         assert(tr.invokedToolCount == 0, 'should exit before running Grunt');
         assert(tr.failed, 'should have failed');
 
@@ -165,7 +165,7 @@ describe('GruntV0 Suite', function () {
 
         tr.run();
 
-        assert(tr.stdOutContained('Input required: gruntFile'), 'Should have printed: Input required: gruntFile');
+        assert(tr.stdOutContained('loc_mock_LIB_InputRequired gruntFile'), 'Should have printed: loc_mock_LIB_InputRequired gruntFile');
         assert(tr.invokedToolCount == 0, 'should exit before running Grunt');
         assert(tr.failed, 'should have failed');
 
@@ -178,7 +178,7 @@ describe('GruntV0 Suite', function () {
 
         tr.run();
 
-        assert(tr.stdOutContained('Input required: gruntCli'), 'Should have printed: Input required: gruntCli');
+        assert(tr.stdOutContained('loc_mock_LIB_InputRequired gruntCli'), 'Should have printed: loc_mock_LIB_InputRequired gruntCli');
         assert(tr.invokedToolCount == 0, 'should exit before running Grunt');
         assert(tr.failed, 'should have failed');
 
@@ -193,7 +193,7 @@ describe('GruntV0 Suite', function () {
 
         assert(tr.invokedToolCount == 0, 'should exit before running gulp');
         assert(tr.failed, 'task should have failed');
-        assert(tr.stdOutContained('Input required: testResultsFiles'), 'Should have printed: Input required: testResultsFiles');
+        assert(tr.stdOutContained('loc_mock_LIB_InputRequired testResultsFiles'), 'Should have printed: loc_mock_LIB_InputRequired testResultsFiles');
 
         done();
     });
@@ -222,7 +222,7 @@ describe('GruntV0 Suite', function () {
         tr.run();
 
         assert(tr.invokedToolCount == 0, 'should exit before running grunt');
-        assert(tr.stdOutContained('Input required: testFiles'), 'Should have printed: Input required: testFiles');
+        assert(tr.stdOutContained('loc_mock_LIB_InputRequired testFiles'), 'Should have printed: loc_mock_LIB_InputRequired testFiles');
         assert(tr.failed, 'task should have failed');
 
         done();

--- a/Tasks/GruntV0/Tests/L0GruntGlobalGood.ts
+++ b/Tasks/GruntV0/Tests/L0GruntGlobalGood.ts
@@ -60,6 +60,11 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "**/TEST-*.xml": ["/user/build/fun/test-123.xml"],
         "**/*.js": ["/test/test.js"],
     },
+    "find": {
+        "/user/build": [
+            "/user/build/test-results/TEST-FILES.xml"
+        ]
+    }
 };
 tr.setAnswers(a);
 


### PR DESCRIPTION
**Task name**: GruntV0

**Description**: 

- Localization Changes: If a localized error message was used, it will now go through a mocked loc function and hence, get a mocked localization, not the real one.
- Related to a migration to a new version of task-lib - Absent TaskLibAnswers

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
