### PR TITLE
Handle multi-file content better

### DIFF
--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/en-US/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Starting download of package %s to location %s",
   "loc.messages.ExtractingPackage": "Extracting package %s to directory %s",
   "loc.messages.PackageTypeNotSupported": "Only Nuget, Python, Universal, Npm, and Maven packages types can be downloaded using this task.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "Failed to extract package with error %s",
   "loc.messages.RetryingOperation": "Operation failed, waiting %sms before retrying, retries remaining: %s",
   "loc.messages.RedirectUrlError": "Unable to get redirect URL with error %.",

--- a/Tasks/DownloadPackageV1/Tests/L0.ts
+++ b/Tasks/DownloadPackageV1/Tests/L0.ts
@@ -192,7 +192,7 @@ describe("Download multi file package suite", function() {
         tl.rmRF(rootDir);
     });
 
-    it("only downloads jar and pom files from the maven archive and doesn't extract them", (done: MochaDone) => {
+    it("only downloads jar and pom files from the maven archive and doesn't extract them", (done: Mocha.Done) => {
         this.timeout(1000);
 
         let tp: string = path.join(__dirname, "L0DownloadMultiFilePackage.js");

--- a/Tasks/DownloadPackageV1/Tests/helpers/webapimock.ts
+++ b/Tasks/DownloadPackageV1/Tests/helpers/webapimock.ts
@@ -85,7 +85,8 @@ class RestMock {
                     name: "packageName.jar",
                     protocolMetadata: {
                         data: {
-                            storageId: "storageId"
+                            storageId: "storageId",
+                            content: null
                         }
                     }
                 },
@@ -102,7 +103,8 @@ class RestMock {
                     name: "packageName.xml",
                     protocolMetadata: {
                         data: {
-                            storageId: null
+                            storageId: null,
+                            content: null
                         }
                     }
                 }

--- a/Tasks/DownloadPackageV1/multifilepackage.ts
+++ b/Tasks/DownloadPackageV1/multifilepackage.ts
@@ -55,7 +55,11 @@ export class MultiFilePackage extends Package {
     }
 
     private async getPackageFileContent(fileMetadata: any, feedId: string, project: string, packageMetadata: any): Promise<PackageFileResult|null> {
-        if (fileMetadata.protocolMetadata.data.storageId) {
+        const protocolFileData = fileMetadata.protocolMetadata.data;
+
+        // sometimes the file info has PascalCase keys, sometimes camelCase
+        const storageId = protocolFileData.storageId || protocolFileData.StorageId;
+        if (storageId) {
             tl.debug(`Getting download url for file ${fileMetadata.name}.`)
             
             try {
@@ -73,14 +77,12 @@ export class MultiFilePackage extends Package {
             }
         }
 
-        if(fileMetadata.protocolMetadata.data.content)
+        const content = protocolFileData.content || protocolFileData.Content;
+        if(content)
         {
             tl.debug(`Getting literal content for file ${fileMetadata.name}.`)
 
-            return new PackageFileResult(
-                fileMetadata.name, 
-                fileMetadata.protocolMetadata.data.content, 
-                false);
+            return new PackageFileResult(fileMetadata.name, content, false);
         }
         
         tl.warning(tl.loc("SkippingFileWithNoContent", fileMetadata.name));

--- a/Tasks/DownloadPackageV1/multifilepackage.ts
+++ b/Tasks/DownloadPackageV1/multifilepackage.ts
@@ -21,87 +21,69 @@ export class MultiFilePackage extends Package {
         return new Set<string>(match(files, this.pattern));
     }
 
-    private async getPackageFileDownloadUrl(
-        feedId: string,
-        project: string,
-        packageMetadata: any,
-        fileMetadata: any
-    ): Promise<Map<string, PackageFileResult>> {
-        return new Promise<Map<string, PackageFileResult>>((resolve, reject) => {
-            this.getUrl(
-                this.pkgsConnection.vsoClient,
-                this.packageProtocolAreaName,
-                this.packageProtocolDownloadAreadId,
-                this.getRouteParams(feedId, project, packageMetadata, fileMetadata)
-            )
-                .then(downloadUrl => {
-                    var url = new Map<string, PackageFileResult>();
-                    url[fileMetadata.name] = new PackageFileResult(downloadUrl, true);
-                    return resolve(url);
-                })
-                .catch(error => {
-                    tl.debug("Getting download url for file " + fileMetadata.name + " failed with error: " + error);
-                    throw reject(error);
-                });
-        });
-    }
-
-    private async getPackageFileContent(fileMetadata: any): Promise<Map<string, PackageFileResult>> {
-        return new Promise<Map<string, PackageFileResult>>((resolve, reject) => {
-            var resultMap = new Map<string, PackageFileResult>();
-            var content = fileMetadata.protocolMetadata.data.content as string;
-
-            if(typeof content !='undefined' && content)
-            {
-                resultMap[fileMetadata.name] = new PackageFileResult(content, false);
-                return resolve(resultMap);
-            }
-
-            throw reject('Unable to download package with empty content.');
-        });
-    }
-
     async getDownloadUrls(feedId: string, project: string, packageId: string, packageVersion: string): Promise<Map<string, PackageFileResult>> {
-        return new Promise<Map<string, PackageFileResult>>((resolve, reject) => {
-            return this.getPackageMetadata(this.feedConnection, {
+        const packageMetadata = await this.getPackageMetadata(this.feedConnection, {
                 feedId: feedId,
                 project: project,
                 packageId: packageId,
                 packageVersionId: packageVersion
-            })
-                .then(packageMetadata => {
-                    var fileMetadatas: any[] = packageMetadata.files;
-                    tl.debug("Found " + fileMetadatas.length + " files in this package.");
-                    var filteredFileList: Set<string> = this.filterFilesMinimatch(fileMetadatas);
-                    tl.debug(filteredFileList.size + " files match filter criteria.");
+            });
 
-                    var pkgFileUrlPromises: Promise<Map<string, PackageFileResult>>[] = [];
+        var fileMetadatas: any[] = packageMetadata.files;
+        tl.debug("Found " + fileMetadatas.length + " files in this package.");
+        var filteredFileList: Set<string> = this.filterFilesMinimatch(fileMetadatas);
+        tl.debug(filteredFileList.size + " files match filter criteria.");
 
-                    for (let i = 0; i < fileMetadatas.length; i++) {
-                        if (filteredFileList.has(fileMetadatas[i].name)) {
-                            const fileMetadata = fileMetadatas[i];
-                            pkgFileUrlPromises.push(
-                                fileMetadata.protocolMetadata.data.storageId != null
-                                    ? this.getPackageFileDownloadUrl(feedId, project, packageMetadata, fileMetadata)
-                                    : this.getPackageFileContent(fileMetadata)
-                            );
-                        }
-                    }
-                    return Promise.all(pkgFileUrlPromises)
-                        .then(urls => {
-                            var downloadUrls = new Map<string, PackageFileResult>();
-                            urls.forEach(url => {
-                                downloadUrls = { ...downloadUrls, ...url };
-                            });
-                            return resolve(downloadUrls);
-                        })
-                        .catch(error => {
-                            throw error;
-                        });
-                })
-                .catch(error => {
-                    return reject(error);
-                });
-        });
+        const fileContentPromises: Promise<PackageFileResult>[] = [];
+        for (const fileMetadata of fileMetadatas) {
+            if (filteredFileList.has(fileMetadata.name)) {
+                fileContentPromises.push(
+                    this.getPackageFileContent(fileMetadata, feedId, project, packageMetadata));
+            }
+        }
+
+        const fileContents = await Promise.all(fileContentPromises);
+        
+        const fileContentsMap = new Map<string, PackageFileResult>();
+        for (const fileContent of fileContents) {
+            if(fileContent) {
+                fileContentsMap[fileContent.FileName] = fileContent
+            }
+        }
+
+        return fileContentsMap;
+    }
+
+    private async getPackageFileContent(fileMetadata: any, feedId: string, project: string, packageMetadata: any): Promise<PackageFileResult|null> {
+        if (fileMetadata.protocolMetadata.data.storageId) {
+            tl.debug(`Getting download url for file ${fileMetadata.name}.`)
+            
+            try {
+                const downloadUrl = await this.getUrl(
+                    this.pkgsConnection.vsoClient,
+                    this.packageProtocolAreaName,
+                    this.packageProtocolDownloadAreadId,
+                    this.getRouteParams(feedId, project, packageMetadata, fileMetadata));
+    
+                return new PackageFileResult(fileMetadata.name, downloadUrl, true);
+            }
+            catch(error) {
+                    tl.debug("Getting download url for file " + fileMetadata.name + " failed with error: " + error);
+                    throw error;
+            }
+        }
+
+        if(fileMetadata.protocolMetadata.data.content)
+        {
+            tl.debug(`Getting literal content for file ${fileMetadata.name}.`)
+
+            return new PackageFileResult(
+                fileMetadata.name, 
+                fileMetadata.protocolMetadata.data.content, 
+                false);
+        }
+        
+        tl.warning(tl.loc("SkippingFileWithNoContent", fileMetadata.name));
+        return null;
     }
 }

--- a/Tasks/DownloadPackageV1/package.ts
+++ b/Tasks/DownloadPackageV1/package.ts
@@ -11,9 +11,13 @@ import { ICoreApi } from "azure-devops-node-api/CoreApi";
 import stream = require("stream");
 
 export class PackageFileResult {
+    private fileName: string;
     private value: string;
     private isUrl: boolean;
 
+    get FileName() {
+        return this.fileName;
+    }
     get Value() {
         return this.value;
     }
@@ -21,7 +25,8 @@ export class PackageFileResult {
         return this.isUrl;
     }
 
-    constructor(value: string, isUrl: boolean) {
+    constructor(fileName: string, value: string, isUrl: boolean) {
+        this.fileName = fileName;
         this.value = value;
         this.isUrl = isUrl;
     }

--- a/Tasks/DownloadPackageV1/singlefilepackage.ts
+++ b/Tasks/DownloadPackageV1/singlefilepackage.ts
@@ -30,7 +30,8 @@ export class SingleFilePackage extends Package {
                     )
                         .then(downloadUrl => {
                             var urls = new Map<string, PackageFileResult>();
-                            urls[packageName.replace(/\//g, '_') + this.extension] = new PackageFileResult(downloadUrl, true);
+                            const fileName = packageName.replace(/\//g, '_') + this.extension;
+                            urls[fileName] = new PackageFileResult(fileName, downloadUrl, true);
                             return resolve(urls);
                         })
                         .catch(error => {

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-        "Minor": 221,
+        "Minor": 226,
         "Patch": 0
     },
     "demands": [],
@@ -182,6 +182,7 @@
         "StartingDownloadOfPackage": "Starting download of package %s to location %s",
         "ExtractingPackage": "Extracting package %s to directory %s",
         "PackageTypeNotSupported": "Only Nuget, Python, Universal, Npm, and Maven packages types can be downloaded using this task.",
+        "SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
         "ExtractionFailed": "Failed to extract package with error %s",
         "RetryingOperation": "Operation failed, waiting %sms before retrying, retries remaining: %s",
         "RedirectUrlError": "Unable to get redirect URL with error %.",

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,7 @@
     "author": "ms-vscs-rm",
     "version": {
         "Major": 1,
-        "Minor": 226,
+        "Minor": 227,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 226,
+    "Minor": 227,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 221,
+    "Minor": 226,
     "Patch": 0
   },
   "demands": [],
@@ -182,6 +182,7 @@
     "StartingDownloadOfPackage": "ms-resource:loc.messages.StartingDownloadOfPackage",
     "ExtractingPackage": "ms-resource:loc.messages.ExtractingPackage",
     "PackageTypeNotSupported": "ms-resource:loc.messages.PackageTypeNotSupported",
+    "SkippingFileWithNoContent": "ms-resource:loc.messages.SkippingFileWithNoContent",
     "ExtractionFailed": "ms-resource:loc.messages.ExtractionFailed",
     "RetryingOperation": "ms-resource:loc.messages.RetryingOperation",
     "RedirectUrlError": "ms-resource:loc.messages.RedirectUrlError",


### PR DESCRIPTION
Should fix internal ticket #2090880

**Task name**: DownloadPackageV1

**Description**: Adjusts handling of multi-file packages to avoid bugs in recognizing the available content on the server

**Documentation changes required:** N

**Added unit tests:** existing tests adjusted

**Attached related issue:** internal ticket #2090880

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
