### PR TITLE
Replace PAT with AAD in canary tests

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -24,7 +24,7 @@ jobs:
       azureSubscription: 'ci-test-tasks'
       scriptType: 'pscore'
       scriptLocation: 'inlineScript'
-      inlineScript: 'Write-Host "##vso[task.setvariable variable=ADOToken;isOutput=true;issecret=true]$(az account get-access-token)"'
+      inlineScript: 'Write-Host "##vso[task.setvariable variable=ADOTOKEN;isOutput=true;issecret=true]$(az account get-access-token)"'
 
 - job: run_main_test_pipeline
   displayName: Run main test pipeline
@@ -33,8 +33,8 @@ jobs:
   variables:
       - name: tasks
         value: $[dependencies.detect_changes.outputs['detect.TASKS']]
-      - name: ADOToken
-        value: $[dependencies.get_ado_token.outputs['get_ado_token.ADOToken']]
+      - name: adoToken
+        value: $[dependencies.get_ado_token.outputs['get_ado_token.ADOTOKEN']]
   pool:
     vmImage: ubuntu-20.04
   steps:
@@ -43,6 +43,6 @@ jobs:
     displayName: npm i axios
   - script: |
       echo $(tasks)
-      node ./ci/ci-test-tasks/test-and-verify-v2.js $(ADOToken) $(ADOUrl) $(System.TeamProject) $(tasks)
+      node ./ci/ci-test-tasks/test-and-verify-v2.js $(adoToken) $(ADOUrl) $(System.TeamProject) $(tasks)
     displayName: 'Run test pipelines and verify results'
     failOnStderr: true

--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -13,14 +13,28 @@ jobs:
       echo "##vso[task.setvariable variable=TASKS;isoutput=true]$(node ./ci/ci-test-tasks/detect-changed-tasks.js $(git diff --name-only origin/master))"
     displayName: 'Detect changed tasks'
     name: detect
- 
+
+- job: get_ado_token
+  displayName: Get ADO Token
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'ci-test-tasks'
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: 'Write-Host "##vso[task.setvariable variable=ADOToken;isOutput=true;issecret=true]$(az account get-access-token)"'
+
 - job: run_main_test_pipeline
   displayName: Run main test pipeline
   condition: and(succeeded(),gt(length(dependencies.detect_changes.outputs['detect.TASKS']), 0))
-  dependsOn: detect_changes
+  dependsOn: detect_changes, get_ado_token
   variables:
       - name: tasks
         value: $[dependencies.detect_changes.outputs['detect.TASKS']]
+      - name: ADOToken
+        value: $[dependencies.get_ado_token.outputs['get_ado_token.ADOToken']]
   pool:
     vmImage: ubuntu-20.04
   steps:


### PR DESCRIPTION
**Description**: Replace PAT Token in the ci-test-tasks pipeline with Managed Identity

**Checklist**:
- [ ] Checked that applied changes work as expected
