### PR TITLE
[PublishTestResultsV2] Add option to fail task if no test result files are found

### DIFF
--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/en-US/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "A test run is created for each results file. Check this option to merge results into a single test run. To optimize for better performance, results will be merged into a single run if there are more than 100 result files, irrespective of this option.",
   "loc.input.label.failTaskOnFailedTests": "Fail if there are test failures",
   "loc.input.help.failTaskOnFailedTests": "Fail the task if there are any test failures. Check this option to fail the task if test failures are detected in the result files.",
+  "loc.input.label.failTaskOnMissingResultsFile": "ms-resource:loc.input.label.failTaskOnMissingResultsFile",
+  "loc.input.help.failTaskOnMissingResultsFile": "ms-resource:loc.input.help.failTaskOnMissingResultsFile",
   "loc.input.label.testRunTitle": "Test run title",
   "loc.input.help.testRunTitle": "Provide a name for the Test Run.",
   "loc.input.label.platform": "Build Platform",

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -72,6 +72,7 @@ async function run() {
         const testRunTitle = tl.getInput('testRunTitle');
         const publishRunAttachments = tl.getInput('publishRunAttachments');
         const failTaskOnFailedTests = tl.getInput('failTaskOnFailedTests');
+		const failTaskOnMissingResultsFile: boolean = tl.getBoolInput('failTaskOnMissingResultsFile');
         let searchFolder = tl.getInput('searchFolder');
 
         tl.debug('testRunner: ' + testRunner);
@@ -82,6 +83,7 @@ async function run() {
         tl.debug('testRunTitle: ' + testRunTitle);
         tl.debug('publishRunAttachments: ' + publishRunAttachments);
         tl.debug('failTaskOnFailedTests: ' + failTaskOnFailedTests);
+		tl.debug('failTaskOnMissingResultsFile: ' + failTaskOnMissingResultsFile);
 
         if (isNullOrWhitespace(searchFolder)) {
             searchFolder = tl.getVariable('System.DefaultWorkingDirectory');
@@ -111,6 +113,7 @@ async function run() {
         ci.addToConsolidatedCi('config', config);
         ci.addToConsolidatedCi('platform', platform);
         ci.addToConsolidatedCi('testResultsFilesCount', testResultsFilesCount);
+		ci.addToConsolidatedCi('failTaskOnMissingResultsFile', failTaskOnMissingResultsFile);
 
         const dotnetVersion = getDotNetVersion();
         ci.addToConsolidatedCi('dotnetVersion', dotnetVersion);
@@ -121,7 +124,11 @@ async function run() {
         }
 
         if (testResultsFilesCount === 0) {
-            tl.warning('No test result files matching ' + testResultsFiles + ' were found.');
+              if (failTaskOnMissingResultsFile) {
+                tl.setResult(tl.TaskResult.Failed, tl.loc('NoMatchingFilesFound', testResultsFiles));
+            } else {
+                tl.warning(tl.loc('NoMatchingFilesFound', testResultsFiles));
+            }
             ci.addToConsolidatedCi('noResultsFileFound', true);
         } else {
             const osType = tl.osType();

--- a/Tasks/PublishTestResultsV2/publishtestresults.ts
+++ b/Tasks/PublishTestResultsV2/publishtestresults.ts
@@ -72,7 +72,7 @@ async function run() {
         const testRunTitle = tl.getInput('testRunTitle');
         const publishRunAttachments = tl.getInput('publishRunAttachments');
         const failTaskOnFailedTests = tl.getInput('failTaskOnFailedTests');
-		const failTaskOnMissingResultsFile: boolean = tl.getBoolInput('failTaskOnMissingResultsFile');
+	const failTaskOnMissingResultsFile: boolean = tl.getBoolInput('failTaskOnMissingResultsFile');
         let searchFolder = tl.getInput('searchFolder');
 
         tl.debug('testRunner: ' + testRunner);
@@ -83,7 +83,7 @@ async function run() {
         tl.debug('testRunTitle: ' + testRunTitle);
         tl.debug('publishRunAttachments: ' + publishRunAttachments);
         tl.debug('failTaskOnFailedTests: ' + failTaskOnFailedTests);
-		tl.debug('failTaskOnMissingResultsFile: ' + failTaskOnMissingResultsFile);
+	tl.debug('failTaskOnMissingResultsFile: ' + failTaskOnMissingResultsFile);
 
         if (isNullOrWhitespace(searchFolder)) {
             searchFolder = tl.getVariable('System.DefaultWorkingDirectory');
@@ -113,7 +113,7 @@ async function run() {
         ci.addToConsolidatedCi('config', config);
         ci.addToConsolidatedCi('platform', platform);
         ci.addToConsolidatedCi('testResultsFilesCount', testResultsFilesCount);
-		ci.addToConsolidatedCi('failTaskOnMissingResultsFile', failTaskOnMissingResultsFile);
+	ci.addToConsolidatedCi('failTaskOnMissingResultsFile', failTaskOnMissingResultsFile);
 
         const dotnetVersion = getDotNetVersion();
         ci.addToConsolidatedCi('dotnetVersion', dotnetVersion);

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -81,14 +81,14 @@
             "required": false,
             "helpMarkDown": "Fail the task if there are any test failures. Check this option to fail the task if test failures are detected in the result files."
         },
-		{
-			"name": "failTaskOnMissingResultsFile",
-			"type": "boolean",
-			"label": "ms-resource:loc.input.label.failTaskOnMissingResultsFile",
-			"defaultValue": false,
-			"required": false,
-			"helpMarkDown": "ms-resource:loc.input.help.failTaskOnMissingResultsFile"
-		},
+	{
+	    "name": "failTaskOnMissingResultsFile",
+	    "type": "boolean",
+	    "label": "ms-resource:loc.input.label.failTaskOnMissingResultsFile",
+	    "defaultValue": false,
+	    "required": false,
+	    "helpMarkDown": "ms-resource:loc.input.help.failTaskOnMissingResultsFile"
+	},
         {
             "name": "testRunTitle",
             "type": "string",

--- a/Tasks/PublishTestResultsV2/task.json
+++ b/Tasks/PublishTestResultsV2/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 216,
-        "Patch": 2
+        "Minor": 228,
+        "Patch": 0
     },
     "demands": [],
     "releaseNotes": "<ul><li>NUnit3 support</li><li>Support for Minimatch files pattern</li></ul>",
@@ -81,6 +81,14 @@
             "required": false,
             "helpMarkDown": "Fail the task if there are any test failures. Check this option to fail the task if test failures are detected in the result files."
         },
+		{
+			"name": "failTaskOnMissingResultsFile",
+			"type": "boolean",
+			"label": "ms-resource:loc.input.label.failTaskOnMissingResultsFile",
+			"defaultValue": false,
+			"required": false,
+			"helpMarkDown": "ms-resource:loc.input.help.failTaskOnMissingResultsFile"
+		},
         {
             "name": "testRunTitle",
             "type": "string",

--- a/Tasks/PublishTestResultsV2/task.loc.json
+++ b/Tasks/PublishTestResultsV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 216,
-    "Patch": 2
+    "Minor": 228,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -80,6 +80,14 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.failTaskOnFailedTests"
+    },
+    {
+      "name": "failTaskOnMissingResultsFile",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.failTaskOnMissingResultsFile",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.failTaskOnMissingResultsFile"
     },
     {
       "name": "testRunTitle",


### PR DESCRIPTION
Task name: PublishTestResultsV2

Description:
Adds an option that lets the user configure the task to fail in case no
test result files have been found. This serves as a safeguard to make
sure that the test-run task and this task has been configured properly
to find the test result files.

We are defaulting to not failing the task on missing files, to keep current behavior.

Documentation changes required: Y

Added unit tests: N
Not sure how this should be tested, as the "Warning" functionality doesn't seem to be tested either?

Attached related issue: Y
Solves https://github.com/microsoft/azure-pipelines-tasks/issues/13275

Checklist:

 Task version was bumped - Yes

Testing done: Pushed the task to my test org, working fine as expected

![image](https://github.com/microsoft/azure-pipelines-tasks/assets/92331194/83931517-bf8f-402e-9295-6c654d4cc9c0)


Copied from: https://github.com/microsoft/azure-pipelines-tasks/pull/14868