### PR TITLE
Bump ssh2 dependency in SshV0. Fixes #16598

### DIFF
--- a/Tasks/SshV0/package-lock.json
+++ b/Tasks/SshV0/package-lock.json
@@ -158,9 +158,9 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buildcheck": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
-      "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
+      "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
       "optional": true
     },
     "call-bind": {
@@ -207,13 +207,13 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cpu-features": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
-      "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.9.tgz",
+      "integrity": "sha512-AKjgn2rP2yJyfbepsmLfiYcmtNn/2eUvocUyM/09yB0YDiz39HteK/5/T4Onf0pmdYDMgkBoGvRLvEguzyL7wQ==",
       "optional": true,
       "requires": {
-        "buildcheck": "0.0.3",
-        "nan": "^2.15.0"
+        "buildcheck": "~0.0.6",
+        "nan": "^2.17.0"
       }
     },
     "delayed-stream": {
@@ -553,14 +553,14 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "ssh2": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
-      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.14.0.tgz",
+      "integrity": "sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==",
       "requires": {
-        "asn1": "^0.2.4",
+        "asn1": "^0.2.6",
         "bcrypt-pbkdf": "^1.0.2",
-        "cpu-features": "~0.0.4",
-        "nan": "^2.16.0"
+        "cpu-features": "~0.0.8",
+        "nan": "^2.17.0"
       }
     },
     "ssh2-sftp-client": {

--- a/Tasks/SshV0/package.json
+++ b/Tasks/SshV0/package.json
@@ -11,7 +11,7 @@
     "@types/ssh2-sftp-client": "^5.2.0",
     "azure-pipelines-task-lib": "^4.4.0",
     "azure-pipelines-tasks-utility-common": "^3.225.1",
-    "ssh2": "^1.10.0",
+    "ssh2": "^1.14.0",
     "ssh2-sftp-client": "^8.1.0",
     "uuid": "^3.2.1"
   },

--- a/Tasks/SshV0/task.json
+++ b/Tasks/SshV0/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 226,
-        "Patch": 2
+        "Minor": 228,
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/SshV0/task.loc.json
+++ b/Tasks/SshV0/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 226,
-    "Patch": 2
+    "Minor": 228,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**: SshV0

**Description**: Bumped `ssh2` dependency to last version, which fixes the issue.

**Documentation changes required:** No

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/16598

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
