### PR TITLE
Add alias to Azure Spring Apps task

### DIFF
--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -18,7 +18,7 @@
   "preview": true,
   "version": {
     "Major": 0,
-    "Minor": 227,
+    "Minor": 228,
     "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
@@ -56,6 +56,9 @@
     },
     {
       "name": "AzureSpringCloud",
+      "aliases": [
+        "AzureSpringApps"
+      ],
       "type": "pickList",
       "label": "Azure Spring Apps Name",
       "required": true,


### PR DESCRIPTION
**Task name**: AzureSpringCloud@0

**Description**: Add an alias to the AzureSpringCloud task input to rename it to AzureSpringApps while preserving compatibility with the old input name in YAML. More about aliases: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/?view=azure-pipelines#what-are-task-input-aliases

**Documentation changes required:** (Y/N) N/A the doc changes will be automatic

**Added unit tests:** (Y/N) No

**Attached related issue:** (Y/N) None

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
