### PR TITLE
Increase timeout for run_main_test_pipeline job in ci-tests-tasks-v2

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -18,6 +18,7 @@ jobs:
   displayName: Run main test pipeline
   condition: and(succeeded(),gt(length(dependencies.detect_changes.outputs['detect.TASKS']), 0))
   dependsOn: detect_changes
+  timeoutInMinutes: 180
   variables:
       - name: tasks
         value: $[dependencies.detect_changes.outputs['detect.TASKS']]


### PR DESCRIPTION
Set `timeoutInMinutes: 180` for "Run main test pipeline" job
