### PR TITLE
Update triggers for canary-tests-v2

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -1,5 +1,6 @@
-pr:
+trigger:
   - master
+  - releases/*
 
 jobs:
 - job: detect_changes


### PR DESCRIPTION
Override the YAML pull request trigger in the pipeline definition (like in other PR checks for this repo)

https://dev.azure.com/canarytest/PipelineTasks/_apps/hub/ms.vss-ciworkflow.build-ci-hub?_a=edit-build-definition&id=117&view=Tab_Triggers