### PR TITLE
Show failed tests for all tasks instead of the first one.

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -281,7 +281,7 @@ var matchCopy = function (pattern, sourceRoot, destRoot, options) {
 }
 exports.matchCopy = matchCopy;
 
-var run = function (cl, inheritStreams, noHeader) {
+var run = function (cl, inheritStreams, noHeader, throwOnErr) {
     if (!noHeader) {
         console.log();
         console.log('> ' + cl);
@@ -300,7 +300,11 @@ var run = function (cl, inheritStreams, noHeader) {
             console.error(err.output ? err.output.toString() : err.message);
         }
 
-        process.exit(1);
+        if (throwOnErr) {
+            throw err;
+        } else {
+            process.exit(1);
+        }
     }
 
     return (output || '').toString().trim();


### PR DESCRIPTION
**Description**: 
- Added option to util.run command to throw an error instead of exiting the process.
- With a new logic the tests for the all tasks will be run and the failed tasks will be shown at the end

**Documentation changes required:** N

**Added unit tests:** N

**Checklist**:
- [x] Checked that applied changes work as expected
