### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 22572925

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "Wenn diese Option aktiviert ist, wird durch diesen Buildvorgang geprüft, ob alle Dateien vollständig heruntergeladen wurden.",
   "loc.input.label.retryDownloadCount": "Anzahl der Wiederholungen",
   "loc.input.help.retryDownloadCount": "Optionale Anzahl von Wiederholungsversuchen zum Herunterladen eines Buildartefakts, wenn der Download nicht erfolgreich ist.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Alle Dateien extrahieren, die in Tar-Archiven gespeichert sind",
   "loc.input.help.extractTars": "Aktivieren Sie diese Option, um alle heruntergeladenen Dateien mit der Erweiterung \".tar\" zu extrahieren. Dies ist hilfreich, da Sie Ihre Artefaktdateien in Tar packen müssen, wenn Sie die Zugriffsberechtigungen beibehalten möchten. Durch Aktivieren der Option \"StoreAsTar\" in der Aufgabe \"PublishBuildArtartefakte\" werden Artefakte automatisch als Tar-Dateien gespeichert.",
   "loc.messages.DownloadArtifacts": "Artefakt \"%s\" wird von %s heruntergeladen.",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Die Tar-Extraktion wird unter Windows nicht unterstützt",
   "loc.messages.NoTarsFound": "Es wurden keine Tar-Archive zum Extrahieren gefunden.",
   "loc.messages.CleaningDestinationFolder": "Der Zielordner wird bereinigt: %s",
-  "loc.messages.NoFolderToClean": "Der angegebene Reinigungsordner wurde nicht gefunden. Keine zu bereinigenden Elemente"
+  "loc.messages.NoFolderToClean": "Der angegebene Reinigungsordner wurde nicht gefunden. Keine zu bereinigenden Elemente",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "Si se activa, esta tarea de compilación comprobará que todos los archivos están completamente descargados.",
   "loc.input.label.retryDownloadCount": "Número de reintentos",
   "loc.input.help.retryDownloadCount": "Número opcional de veces para reintentar la descarga de un artefacto de compilación si la descarga falla.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Extraer todos los archivos almacenados en archivos tar",
   "loc.input.help.extractTars": "Habilite esta opción para extraer todos los archivos descargados que tengan la extensión. tar. Esto es útil porque necesita empaquetar los archivos de artefacto en tar si quiere conservar los permisos de archivo de Unix. Al habilitar la opción \"StoreAsTar\" en la tarea PublishBuildArtifacts los artefactos se almacenarán como archivos .tar automáticamente.",
   "loc.messages.DownloadArtifacts": "Descargando el artefacto %s desde: %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "La extracción de tar no es compatible con Windows",
   "loc.messages.NoTarsFound": "No se encontraron archivos tar para extraer",
   "loc.messages.CleaningDestinationFolder": "Limpiando carpeta de destino: %s",
-  "loc.messages.NoFolderToClean": "No se ha encontrado la carpeta de limpieza especificada. No hay nada que limpiar"
+  "loc.messages.NoFolderToClean": "No se ha encontrado la carpeta de limpieza especificada. No hay nada que limpiar",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "Si cette vérification est vérifiée, cette tâche de build vérifie que tous les fichiers sont entièrement téléchargés.",
   "loc.input.label.retryDownloadCount": "Nombre de nouvelles tentatives",
   "loc.input.help.retryDownloadCount": "Nombre facultatif de fois pour réessayer de télécharger un artefacts de build en cas d’échec du téléchargement.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Extraire tous les fichiers stockés dans des archives archivées",
   "loc.input.help.extractTars": "Activez cette option pour extraire tous les fichiers téléchargés dont l’extension est .extension. Cela est utile, car vous devez packer vos fichiers d’artefacts dans une collection si vous voulez conserver les autorisations de fichier Unix. L’activation de l’option « StoreAsTar » dans la tâche PublishBuildArtifacts stocke automatiquement les artefacts en tant que fichiers .body.",
   "loc.messages.DownloadArtifacts": "Téléchargement de l'artefact %s à partir de %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "L’extraction par extraction d’extraction n’est pas prise en charge sur Windows",
   "loc.messages.NoTarsFound": "Aucune archive archivée n’a été trouvée pour extraire",
   "loc.messages.CleaningDestinationFolder": "Nettoyage du dossier de destination : %s",
-  "loc.messages.NoFolderToClean": "Le dossier de nettoyage spécifié est introuvable. Rien à nettoyer"
+  "loc.messages.NoFolderToClean": "Le dossier de nettoyage spécifié est introuvable. Rien à nettoyer",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "Se questa opzione è selezionata, questa attività di compilazione controllerà che tutti i file siano completamente scaricati.",
   "loc.input.label.retryDownloadCount": "Numero di tentativi",
   "loc.input.help.retryDownloadCount": "Numero facoltativo di tentativi di download di un artefatto della compilazione se il download non riesce.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Estrai tutti i file archiviati all'interno di archivi tar",
   "loc.input.help.extractTars": "Abilitare questa opzione per estrarre tutti i file scaricati con estensione .tar. Ciò è consigliabile perché è necessario comprimere gli artefatti con estensione .tar per mantenere le autorizzazioni file UNIX. Se si abilita l'opzione 'StoreAsTar' nell'attività PublishBuildArtifacts, gli artefatti verranno archiviati automaticamente come file tar.",
   "loc.messages.DownloadArtifacts": "Download dell'artefatto %s da %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "L'estrazione di tar non è supportata in Windows",
   "loc.messages.NoTarsFound": "Non sono stati trovati archivi tar da estrarre",
   "loc.messages.CleaningDestinationFolder": "Pulizia della cartella di destinazione in corso: %s",
-  "loc.messages.NoFolderToClean": "La cartella di pulizia specificata non è stata trovata. Nulla da pulire"
+  "loc.messages.NoFolderToClean": "La cartella di pulizia specificata non è stata trovata. Nulla da pulire",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "チェックを入れた場合、このビルドタスクはすべてのファイルが完全にダウンロードされていることを確認します。",
   "loc.input.label.retryDownloadCount": "再試行回数",
   "loc.input.help.retryDownloadCount": "ダウンロードが失敗した場合に、ビルド成果物のダウンロードを再試行する回数。",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Tar アーカイブ内に保存されているすべてのファイルを抽出します",
   "loc.input.help.extractTars": "このオプションを有効にすると、拡張子が .tar のダウンロード済みファイルをすべて抽出します。Unix ファイルのアクセス許可を保持するには、成果物ファイルを tar にパックする必要があるので、このオプションは便利です。PublishBuildArtifacts ティファクトタスクで 'StoreAsTar' オプションを有効にすると、成果物が .tar ファイルとして自動的に保存されます。",
   "loc.messages.DownloadArtifacts": "成果物 %s を %s からダウンロードしています",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Tar 抽出は Windows でサポートされていません",
   "loc.messages.NoTarsFound": "抽出する tar アーカイブが見つかりませんでした",
   "loc.messages.CleaningDestinationFolder": "コピー先フォルダー: %s をクリーンアップしています",
-  "loc.messages.NoFolderToClean": "指定されたクリーンアップ対象フォルダーが見つかりませんでした。クリーンアップするものがありません"
+  "loc.messages.NoFolderToClean": "指定されたクリーンアップ対象フォルダーが見つかりませんでした。クリーンアップするものがありません",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "선택한 경우, 이 빌드 작업은 모든 파일이 완전히 다운로드되었는지 확인합니다.",
   "loc.input.label.retryDownloadCount": "재시도 횟수",
   "loc.input.help.retryDownloadCount": "다운로드가 실패할 경우 빌드 아티팩트 다운로드를 재시도하는 선택적 횟수입니다.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "tar 보관함에 저장된 모든 파일 압축 풀기",
   "loc.input.help.extractTars": "이 옵션을 사용하여 확장명이 .tar인 다운로드된 모든 파일의 압축을 푸세요. 이 옵션은 Unix 파일 사용 권한을 유지하려는 경우 아티팩트 파일을 tar로 압축해야 하기 때문에 유용합니다. PublishBuildArtifacts 작업에서 `StoreAsTar` 옵션을 사용하면 아티팩트가 .tar 파일로 자동으로 저장됩니다.",
   "loc.messages.DownloadArtifacts": "%s 아티팩트를 %s에서 다운로드 중",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows에서는 tar 압축 풀기가 지원되지 않습니다",
   "loc.messages.NoTarsFound": "압축을 풀 tar 보관함이 없습니다",
   "loc.messages.CleaningDestinationFolder": "대상 폴더 정리 중: %s",
-  "loc.messages.NoFolderToClean": "지정한 정리 폴더를 찾을 수 없습니다. 정리할 항목 없음"
+  "loc.messages.NoFolderToClean": "지정한 정리 폴더를 찾을 수 없습니다. 정리할 항목 없음",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "Если этот флажок установлен, задача сборки проверит, чтобы все файлы были полностью загружены.",
   "loc.input.label.retryDownloadCount": "Число повторных попыток",
   "loc.input.help.retryDownloadCount": "Необязательное число повторных попыток загрузки артефактов сборки в случае сбоя загрузки.",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "Извлечь все файлы, хранящихся в TAR-архивах",
   "loc.input.help.extractTars": "Включите этот параметр, чтобы извлечь все загруженные файлы с расширением .tar. Это удобно, так как файлы артефактов необходимо упаковать в TAR-архив, чтобы сохранить разрешения для UNIX-файлов. При включении параметра \"StoreAsTar\" в задаче PublishBuildArtifacts артефакты будут автоматически сохранены как TAR-файлы.",
   "loc.messages.DownloadArtifacts": "Скачивается артефакт %s из: %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Извлечение из TAR-архива не поддерживается в Windows",
   "loc.messages.NoTarsFound": "TAR-архивы для извлечения не найдены",
   "loc.messages.CleaningDestinationFolder": "Очистка конечной папки: %s",
-  "loc.messages.NoFolderToClean": "Указанная папка очистки не найдена. Нет элементов для очистки"
+  "loc.messages.NoFolderToClean": "Указанная папка очистки не найдена. Нет элементов для очистки",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "如果已选中，此内部版本任务将检查是否完全下载所有文件。",
   "loc.input.label.retryDownloadCount": "重试计数",
   "loc.input.help.retryDownloadCount": "下载失败时，重试下载内部版本项目可选次数。",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "提取存储在存档内的所有文件",
   "loc.input.help.extractTars": "启用此选项以提取所有具有 .tar 扩展名的下载文件。此操作很有帮助，因为如果要保留 Unix 文件权限，则需要将项目文件打包成存档中。在 PublishBuildArtifacts 任务中启用 `StoreAsTar` 选项，项目将自动存储为 .tar 文件。",
   "loc.messages.DownloadArtifacts": "正在从后列位置下载项目 %s: %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支持存档提取",
   "loc.messages.NoTarsFound": "没有找到要提取的任何存档",
   "loc.messages.CleaningDestinationFolder": "正在清理目标文件夹: %s",
-  "loc.messages.NoFolderToClean": "未找到指定的清理文件夹。没有要清理的文件"
+  "loc.messages.NoFolderToClean": "未找到指定的清理文件夹。没有要清理的文件",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DownloadBuildArtifactsV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -37,6 +37,8 @@
   "loc.input.help.checkDownloadedFiles": "如選取，此組建工作將會檢查是否已完整下載所有檔案。",
   "loc.input.label.retryDownloadCount": "重試次數",
   "loc.input.help.retryDownloadCount": "如果下載失敗，重試下載組建成品的可選次數。",
+  "loc.input.label.retryRedirectDownloadCount": "Retry count for redirect download",
+  "loc.input.help.retryRedirectDownloadCount": "Optional number of times to retry downloading a build artifact if the download based on redirect fails. If your network does not allow following the redirect, you can set this to -1 to always download streamed response from Azure DevOps instead.",
   "loc.input.label.extractTars": "解壓縮所有儲存在 tar 封存內的檔案",
   "loc.input.help.extractTars": "啟用此選項以解壓縮所有具有 tar 副檔名的下載檔案。這個功能很實用，因為若要保留 Unix 檔案權限，您必須將成品檔封裝到 tar 中。在 PublishBuildArtifacts 工作中啟用 `StoreAsTar` 選項，系統會自動將成品儲存為 tar 檔案。",
   "loc.messages.DownloadArtifacts": "正在從 %s 下載成品 %s",
@@ -67,5 +69,7 @@
   "loc.messages.TarExtractionNotSupportedInWindows": "Windows 不支援 tar 解壓縮",
   "loc.messages.NoTarsFound": "找不到要解壓縮的 tar 封存",
   "loc.messages.CleaningDestinationFolder": "正在清除目的地資料夾: %s",
-  "loc.messages.NoFolderToClean": "找不到指定的清除資料夾。沒有可清除的項目"
+  "loc.messages.NoFolderToClean": "找不到指定的清除資料夾。沒有可清除的項目",
+  "loc.messages.PreferRedirect": "Prefer downloading files through redirect to the content stitcher: %s",
+  "loc.messages.FollowingDownloadRedirectFailed": "Could not download the files by following a redirect: %s. Falling back to consuming streamed content from Azure DevOps."
 }

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Der Download des Pakets \"%s\" an den Speicherort \"%s\" wird gestartet.",
   "loc.messages.ExtractingPackage": "Das Paket \"%s\" wird in das Verzeichnis \"%s\" extrahiert.",
   "loc.messages.PackageTypeNotSupported": "Mithilfe dieser Aufgabe können nur Nuget-, Python-, Universal-, NPM- und Maven-Pakettypen heruntergeladen werden.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "Fehler beim Extrahieren des Pakets: %s.",
   "loc.messages.RetryingOperation": "Fehler bei Vorgang. Es wird in %s ms ein neuer Versuch durchgeführt. Verbleibende Wiederholungsversuche: %s",
   "loc.messages.RedirectUrlError": "Die Umleitungs-URL kann nicht abgerufen werden. Fehler: %.",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Iniciando la descarga del paquete %s en la ubicación %s",
   "loc.messages.ExtractingPackage": "Extrayendo el paquete %s en el directorio %s.",
   "loc.messages.PackageTypeNotSupported": "Con esta tarea solo se pueden descargar los tipos de paquetes NuGet, Python, universal, npm y Maven.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "No se pudo extraer el paquete con el error %s.",
   "loc.messages.RetryingOperation": "Error de la operación. Se espera %s ms antes de reintentar. Reintentos restantes: %s",
   "loc.messages.RedirectUrlError": "No se puede obtener la URL de redireccionamiento con el error %.",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Début du téléchargement du package %s vers l'emplacement %s",
   "loc.messages.ExtractingPackage": "Extraction du package %s dans le répertoire %s",
   "loc.messages.PackageTypeNotSupported": "Seuls les types de package NuGet, Python, Universal, Npm et Maven peuvent être téléchargés à l'aide de cette tâche.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "Échec de l'extraction du package avec l'erreur %s",
   "loc.messages.RetryingOperation": "Échec de l'opération. Attente de %sms avant une nouvelle tentative. Nouvelles tentatives restantes : %s",
   "loc.messages.RedirectUrlError": "Impossible d'obtenir l'URL de redirection. Erreur : %.",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Avvio del download del pacchetto %s nel percorso %s",
   "loc.messages.ExtractingPackage": "Estrazione del pacchetto %s nella directory %s",
   "loc.messages.PackageTypeNotSupported": "Con questa attività è possibile scaricare solo i tipi di pacchetto NuGet, Python, Universal, npm e Maven.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "Non è stato possibile estrarre il pacchetto. Errore: %s",
   "loc.messages.RetryingOperation": "L'operazione non è riuscita. Si attenderanno %s ms prima di effettuare un nuovo tentativo. Tentativi rimanenti: %s",
   "loc.messages.RedirectUrlError": "Non è possibile recuperare l'URL di reindirizzamento. Errore: %.",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "パッケージ %s を場所 %s にダウンロードする処理を開始しています",
   "loc.messages.ExtractingPackage": "パッケージ %s をディレクトリ %s に抽出しています",
   "loc.messages.PackageTypeNotSupported": "このタスクを使用すると、Nuget、Python、Universal、Npm、および Maven のパッケージの種類のみをダウンロードできます。",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "次のエラーが発生したため、パッケージを抽出できませんでした: %s",
   "loc.messages.RetryingOperation": "操作に失敗しました。再試行する前に %s ミリ秒待機します。残り試行回数: %s",
   "loc.messages.RedirectUrlError": "エラー % により、リダイレクト URL を取得できません。",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "%s 패키지를 %s 위치로 다운로드하기 시작하는 중",
   "loc.messages.ExtractingPackage": "%s 패키지를 %s 디렉터리로 추출하는 중",
   "loc.messages.PackageTypeNotSupported": "이 작업을 사용하면 Nuget, Python, Universal, Npm 및 Maven 패키지 형식만 다운로드할 수 있습니다.",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "%s 오류로 인해 패키지를 추출하지 못했습니다.",
   "loc.messages.RetryingOperation": "작업이 실패했습니다. 다시 시도하기 전에 %sms 동안 대기합니다. 남은 다시 시도 횟수: %s회",
   "loc.messages.RedirectUrlError": "리디렉션 URL을 가져올 수 없습니다. 오류: %",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "Начинается скачивание пакета %s в расположение %s",
   "loc.messages.ExtractingPackage": "Извлечение пакета %s в каталог %s",
   "loc.messages.PackageTypeNotSupported": "С помощью этой задачи можно скачать только пакеты типа Nuget, Python, Universal, Npm и Maven ",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "Не удалось распаковать пакет. Ошибка: %s",
   "loc.messages.RetryingOperation": "Сбой операции, ожидание %s мс перед повторной попыткой, осталось повторных попыток: %s",
   "loc.messages.RedirectUrlError": "Не удалось получить URL-адрес перенаправления с ошибкой %.",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "开始将包 %s 下载到位置 %s",
   "loc.messages.ExtractingPackage": "将包 %s 提取至目录 %s",
   "loc.messages.PackageTypeNotSupported": "使用此任务只能下载 Nuget、Python、Universal、Npm 和 Maven 包类型。",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "未能提取包，出现错误: %s",
   "loc.messages.RetryingOperation": "操作失败，请在重试之前等待 %sms，剩余重试次数: %s",
   "loc.messages.RedirectUrlError": "无法获取重定向 URL，出现错误 %。",

--- a/Tasks/DownloadPackageV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DownloadPackageV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -26,6 +26,7 @@
   "loc.messages.StartingDownloadOfPackage": "開始將套件 %s 下載到位置 %s",
   "loc.messages.ExtractingPackage": "正在將套件 %s 解壓縮到目錄 %s",
   "loc.messages.PackageTypeNotSupported": "只有 Nuget、Python、Universal、Npm 和 Maven 套件類型可以使用這項工作下載。",
+  "loc.messages.SkippingFileWithNoContent": "Skipping file %s as no supported content could be found",
   "loc.messages.ExtractionFailed": "無法解壓縮套件，錯誤為 %s",
   "loc.messages.RetryingOperation": "作業失敗，請等候 %sms 後再重試，重試機會剩餘 %s 次",
   "loc.messages.RedirectUrlError": "無法取得重新導向 URL。錯誤: %。",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "Server-URL",
   "loc.input.label.username": "Benutzername",
   "loc.input.label.password": "Kennwort",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "Stammordner",
   "loc.input.help.rootFolder": "Der Quellordner, aus dem Dateien hochgeladen werden sollen.",
   "loc.input.label.filePatterns": "Dateimuster",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "Dirección URL del servidor",
   "loc.input.label.username": "Nombre de usuario",
   "loc.input.label.password": "Contraseña",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "Carpeta raíz",
   "loc.input.help.rootFolder": "Carpeta de origen de donde se cargan los archivos.",
   "loc.input.label.filePatterns": "Patrones de archivo",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "URL du serveur",
   "loc.input.label.username": "Nom d'utilisateur",
   "loc.input.label.password": "Mot de passe",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "Dossier racine",
   "loc.input.help.rootFolder": "Dossier source du chargement des fichiers.",
   "loc.input.label.filePatterns": "Modèles de fichiers",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "URL del server",
   "loc.input.label.username": "Nome utente",
   "loc.input.label.password": "Password",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "Cartella radice",
   "loc.input.help.rootFolder": "Cartella di origine da cui caricare i file.",
   "loc.input.label.filePatterns": "Criteri dei file",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "サーバーの URL",
   "loc.input.label.username": "ユーザー名",
   "loc.input.label.password": "パスワード",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "ルート フォルダー",
   "loc.input.help.rootFolder": "ファイルのアップロード元のソース フォルダー。",
   "loc.input.label.filePatterns": "ファイル パターン",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "서버 URL",
   "loc.input.label.username": "사용자 이름",
   "loc.input.label.password": "암호",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "루트 폴더",
   "loc.input.help.rootFolder": "파일을 업로드할 소스 폴더입니다.",
   "loc.input.label.filePatterns": "파일 패턴",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "URL-адрес сервера",
   "loc.input.label.username": "Имя пользователя",
   "loc.input.label.password": "Пароль",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "Корневая папка",
   "loc.input.help.rootFolder": "Исходная папка, из которой выполняется отправка файлов.",
   "loc.input.label.filePatterns": "Шаблоны файлов",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "服务器 URL",
   "loc.input.label.username": "用户名",
   "loc.input.label.password": "密码",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "根文件夹",
   "loc.input.help.rootFolder": "要上传其中文件的源文件夹。",
   "loc.input.label.filePatterns": "文件模式",

--- a/Tasks/FtpUploadV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/FtpUploadV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -11,6 +11,7 @@
   "loc.input.label.serverUrl": "伺服器 URL",
   "loc.input.label.username": "使用者名稱",
   "loc.input.label.password": "密碼",
+  "loc.input.label.implicitFTPS": "Use implicit FTPS",
   "loc.input.label.rootFolder": "根資料夾",
   "loc.input.help.rootFolder": "要上傳之檔案所在的來源資料夾。",
   "loc.input.label.filePatterns": "檔案模式",

--- a/Tasks/GoToolV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "Ein benutzerdefinierter Wert für die GOPATH-Umgebungsvariable.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "Ein benutzerdefinierter Wert für die GOBIN-Umgebungsvariable.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "Fehler beim Herunterladen der Go-Version %s. Überprüfen Sie, ob die Version gültig ist, und beheben Sie eventuelle andere Probleme. Fehler: %s",
   "loc.messages.TempDirNotSet": "Es wurde erwartet, dass die Umgebungsvariable \"Agent.TempDirectory\" festgelegt ist."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "Un valor personalizado para la variable de entorno GOPATH.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "Un valor personalizado para la variable de entorno GOBIN.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "No se pudo descargar la versión de Go %s. Compruebe que la versión es válida y resuelva los otros problemas. Error: %s",
   "loc.messages.TempDirNotSet": "Se esperaba que la variable de entorno \"Agent.TempDirectory\" estuviera configurada."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "Valeur personnalisée de la variable d'environnement GOPATH.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "Valeur personnalisée de la variable d'environnement GOBIN.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "Échec du téléchargement de Go version %s. Vérifiez que la version est valide et résolvez les autres problèmes. Erreur : %s",
   "loc.messages.TempDirNotSet": "La variable d'environnement 'Agent.TempDirectory' doit être définie."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "Valore personalizzato della variabile di ambiente GOPATH.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "Valore personalizzato della variabile di ambiente GOBIN.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "Non è stato possibile scaricare la versione %s di Go. Verificare che la versione sia valida e risolvere eventuali altri problemi. Errore: %s",
   "loc.messages.TempDirNotSet": "La variabile di ambiente 'Agent.TempDirectory' deve essere impostata."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "GOPATH 環境変数のカスタム値です。",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "GOBIN 環境変数のカスタム値です。",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "バージョン %s の Go をダウンロードできませんでした。このバージョンが有効であることを確認し、その他の問題を解決します。エラー: %s",
   "loc.messages.TempDirNotSet": "'Agent.TempDirectory' 環境変数を設定することが必要です。"
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "GOPATH 환경 변수에 대한 사용자 지정 값입니다.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "GOBIN 환경 변수에 대한 사용자 지정 값입니다.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "Go 버전 %s을(를) 다운로드하지 못했습니다. 버전이 유효한지 확인하고 다른 문제를 모두 해결하세요. 오류: %s",
   "loc.messages.TempDirNotSet": "'Agent.TempDirectory' 환경 변수를 설정해야 합니다."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "Пользовательское значение переменной среды GOPATH.",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "Пользовательское значение переменной среды GOBIN.",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "Не удалось скачать версию Go %s. Проверьте правильность версии и устраните другие ошибки. Ошибка: %s",
   "loc.messages.TempDirNotSet": "Переменная среды Agent.TempDirectory должна была быть задана."
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "GOPATH 环境变量的自定义值。",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "GOBIN 环境变量的自定义值。",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "无法下载 Go 版本 %s。请验证该版本是否有效并解决发生的任何其他问题。错误: %s",
   "loc.messages.TempDirNotSet": "应设置 \"Agent.TempDirectory\" 环境变量。"
 }

--- a/Tasks/GoToolV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -10,6 +10,8 @@
   "loc.input.help.goPath": "GOPATH 環境變數的自訂值。",
   "loc.input.label.goBin": "GOBIN",
   "loc.input.help.goBin": "GOBIN 環境變數的自訂值。",
+  "loc.input.label.goSource": "Go source",
+  "loc.input.help.goSource": "Go distribution to install",
   "loc.messages.FailedToDownload": "無法下載 Go %s 版。請驗證版本有效，並解決其他任何問題。錯誤: %s",
   "loc.messages.TempDirNotSet": "應設定 'Agent.TempDirectory' 環境變數。"
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "Fehler beim Festlegen der partition_id-ACL für den privaten Schlüssel. Überprüfen Sie, ob \"Kennwort für Schlüsselbund\" richtig ist, oder verwenden Sie stattdessen \"Temporärer Schlüsselbund\".",
   "loc.messages.InstallRequiresMac": "Für die Installation eines Apple-Zertifikats wird ein macOS-Agent benötigt. Das Installieren von Apple-Zertifikaten auf Linux oder Windows wird von Apple nicht unterstützt.",
   "loc.messages.CertNotValidYetError": "Das Zertifikat \"%s\" (Fingerabdruck: \"%s\") ist erst ab dem %s gültig.",
-  "loc.messages.CertExpiredError": "Das Zertifikat \"%s\" (Fingerabdruck: \"%s\") ist am %s abgelaufen."
+  "loc.messages.CertExpiredError": "Das Zertifikat \"%s\" (Fingerabdruck: \"%s\") ist am %s abgelaufen.",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "Error al establecer la lista ACL partition_id para la clave privada. Compruebe que la \"Contraseña de cadena de claves\" es correcta o use un valor de \"Temporary Keychain\" en su lugar.",
   "loc.messages.InstallRequiresMac": "Para instalar un certificado de Apple, se requiere un agente de macOS. Apple no admite la instalación de certificados de Apple en Linux o Windows.",
   "loc.messages.CertNotValidYetError": "El certificado \"%s\" (huella digital %s) no es válido hasta el %s.",
-  "loc.messages.CertExpiredError": "El certificado \"%s\" (huella digital %s) expiró el %s."
+  "loc.messages.CertExpiredError": "El certificado \"%s\" (huella digital %s) expiró el %s.",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "Erreur durant la définition de l'ACL de partition_id pour la clé privée. Vérifiez que le 'Mot de passe du trousseau' est correct, ou utilisez un 'Trousseau temporaire' à la place.",
   "loc.messages.InstallRequiresMac": "L'installation du certificat Apple nécessite un agent macOS. L'installation de certificats Apple sur Linux ou Windows n'est pas prise en charge par Apple.",
   "loc.messages.CertNotValidYetError": "Le certificat \"%s\" (empreinte digitale : %s) est non valide avant %s",
-  "loc.messages.CertExpiredError": "Le certificat \"%s\" (empreinte digitale : %s) est arrivé à expiration le %s"
+  "loc.messages.CertExpiredError": "Le certificat \"%s\" (empreinte digitale : %s) est arrivé à expiration le %s",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "Si è verificato un errore durante l'impostazione dell'ACL partition_id per la chiave privata. Verificare che il valore di `Password keychain` sia corretto oppure usare `Keychain temporaneo` instead.",
   "loc.messages.InstallRequiresMac": "Per installare un certificato Apple, è richiesto un agente macOS. L'installazione di certificati Apple in Linux o Windows non è supportata da Apple.",
   "loc.messages.CertNotValidYetError": "Il certificato \"%s\" (impronta digitale: %s) non è valido fino al giorno %s",
-  "loc.messages.CertExpiredError": "Il certificato \"%s\" (impronta digitale: %s) è scaduto il giorno %s"
+  "loc.messages.CertExpiredError": "Il certificato \"%s\" (impronta digitale: %s) è scaduto il giorno %s",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "秘密キーへの partition_id ACL の設定でエラーが発生しました。`Keychain password` が正しいことを確認するか、代わりに `Temporary Keychain` を使用します。",
   "loc.messages.InstallRequiresMac": "Apple の証明書のインストールには、macOS エージェントが必要です。Apple は、Linux または Windows での Apple の証明書のインストールをサポートしていません。",
   "loc.messages.CertNotValidYetError": "証明書 \"%s\" (フィンガープリント: %s) は %s まで有効ではありません",
-  "loc.messages.CertExpiredError": "証明書 \"%s\" (フィンガープリント: %s) の有効期限が %s に切れました"
+  "loc.messages.CertExpiredError": "証明書 \"%s\" (フィンガープリント: %s) の有効期限が %s に切れました",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "프라이빗 키의 partition_id ACL을 설정하는 중 오류가 발생했습니다. '키 집합 암호'가 올바른지 확인하거나, '임시 키 집합'을 대신 사용하세요.",
   "loc.messages.InstallRequiresMac": "Apple 인증서를 설치하려면 macOS 에이전트가 필요합니다. Linux 또는 Windows에는 Apple 인증서를 설치할 수 없습니다.",
   "loc.messages.CertNotValidYetError": "\"%s\" 인증서(지문: %s)는 %s까지 유효하지 않습니다.",
-  "loc.messages.CertExpiredError": "\"%s\" 인증서(지문: %s)가 %s에 만료되었습니다."
+  "loc.messages.CertExpiredError": "\"%s\" 인증서(지문: %s)가 %s에 만료되었습니다.",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "Ошибка при установке ACL partition_id для закрытого ключа. Проверьте правильность пароля цепочки ключей или используйте временную цепочку ключей.",
   "loc.messages.InstallRequiresMac": "Для установки сертификата Apple требуется агент macOS. Установка сертификатов Apple в Linux или Windows не поддерживается Apple.",
   "loc.messages.CertNotValidYetError": "Сертификат \"%s\" (отпечаток: %s) является недействительным до %s",
-  "loc.messages.CertExpiredError": "Срок действия сертификата \"%s\" (отпечаток: %s) истек %s"
+  "loc.messages.CertExpiredError": "Срок действия сертификата \"%s\" (отпечаток: %s) истек %s",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "设置私钥的 partition_id ACL 时出错。验证“密钥链密码”是否正确，或改用“临时密钥链”。",
   "loc.messages.InstallRequiresMac": "安装 Apple 证书需要 macOS 代理。Apple 不支持在 Linux 或 Windows 上安装 Apple 证书。",
   "loc.messages.CertNotValidYetError": "证书“%s”(指纹: %s)在 %s之前无效",
-  "loc.messages.CertExpiredError": "证书“%s”(指纹: %s)已在 %s过期"
+  "loc.messages.CertExpiredError": "证书“%s”(指纹: %s)已在 %s过期",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/InstallAppleCertificateV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.SetKeyPartitionListCommandFailed": "設定私密金鑰的 partition_id ACL 時發生錯誤。請驗證 [金鑰鏈密碼] 正確，或改用 [臨時金鑰鏈]。",
   "loc.messages.InstallRequiresMac": "必須有 macOS 代理程式才能安裝 Apple Certificate。Apple 不支援在 Linux 或 Windows 上安裝 Apple Certificate。",
   "loc.messages.CertNotValidYetError": "憑證 \"%s\" (指紋: %s) 於 %s 後才會生效",
-  "loc.messages.CertExpiredError": "憑證 \"%s\" (指紋: %s) 於 %s 過期"
+  "loc.messages.CertExpiredError": "憑證 \"%s\" (指紋: %s) 於 %s 過期",
+  "loc.messages.OpenSSLError": "Error parsing certificate. This might be caused by an unsupported algorithm. If you're using old certificate with a new OpenSSL version try to set -legacy flag in opensslPkcsArgs input."
 }

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "Für jede Ergebnisdatei wird ein Testlauf erstellt. Aktivieren Sie diese Option, um die Ergebnisse in einem einzigen Testlauf zusammenzuführen. Zur Leistungsoptimierung werden die Ergebnisse unabhängig von dieser Option in einem einzigen Lauf zusammengeführt, wenn mehr als 100 Ergebnisdateien vorliegen.",
   "loc.input.label.failTaskOnFailedTests": "Bei Testfehlern als fehlerhaft markieren",
   "loc.input.help.failTaskOnFailedTests": "Aufgabe bei Testfehlern als fehlerhaft markieren. Aktivieren Sie diese Option, um die Aufgabe als fehlerhaft zu markieren, wenn in den Ergebnisdateien Fehler ermittelt werden.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "Testlauftitel",
   "loc.input.help.testRunTitle": "Geben Sie einen Namen für den Testlauf an.",
   "loc.input.label.platform": "Buildplattform",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "Se crea una serie de pruebas para cada archivo de resultados. Active esta opción para fusionar los resultados en una sola serie de pruebas. Para optimizar el rendimiento, los resultados se fusionarán en una sola serie si hay más de 100 archivos de resultados, independientemente de esta opción.",
   "loc.input.label.failTaskOnFailedTests": "Interrumpir si hay errores en las pruebas",
   "loc.input.help.failTaskOnFailedTests": "Interrumpa la tarea si hay errores en las pruebas. Seleccione esta opción para interrumpir la tarea si se detectan errores de las pruebas en los archivos de resultados.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "Título de la serie de pruebas",
   "loc.input.help.testRunTitle": "Proporcione un nombre para la serie de pruebas.",
   "loc.input.label.platform": "Plataforma de compilación",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "Une série de tests est créée pour chaque fichier de résultats. Cochez cette option pour fusionner les résultats dans une seule série de tests. Pour optimiser le niveau de performance, les résultats sont fusionnés en une seule série de tests, s'il existe plus de 100 fichiers de résultats, indépendamment de cette option.",
   "loc.input.label.failTaskOnFailedTests": "Cesser toute exécution en cas d'échecs de tests",
   "loc.input.help.failTaskOnFailedTests": "Faire cesser la tâche en cas d'échecs liés à des tests. Cochez cette option pour faire cesser la tâche si des échecs de tests sont détectés dans les fichiers de résultats.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "Titre de la série de tests",
   "loc.input.help.testRunTitle": "Indiquez le nom de la série de tests.",
   "loc.input.label.platform": "Plateforme de build",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "Viene creata un'esecuzione dei test per ogni file di risultati. Selezionare questa opzione per unire i risultati in un'unica esecuzione dei test. Per ottimizzare l'operazione e garantire migliori prestazioni, i risultati verranno uniti in un'unica esecuzione se sono presenti più di 100 file di risultati, indipendentemente da questa opzione.",
   "loc.input.label.failTaskOnFailedTests": "Non eseguire in caso di errori di test",
   "loc.input.help.failTaskOnFailedTests": "Non esegue l'attività in caso di errori di test. Selezionare questa opzione per non eseguire l'attività se vengono rilevati errori di test nei file di risultati.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "Titolo dell'esecuzione dei test",
   "loc.input.help.testRunTitle": "Consente di specificare un nome per l'esecuzione dei test.",
   "loc.input.label.platform": "Piattaforma di compilazione",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "結果ファイルごとにテストの実行が作成されます。結果を 1 つのテストの実行にマージする場合、このオプションを有効にします。最適化してパフォーマンスを向上させるため、結果ファイルが 100 個を超えたら、このオプションに関係なく、結果は 1 つの実行にマージされます。",
   "loc.input.label.failTaskOnFailedTests": "テスト エラーがある場合に失敗する",
   "loc.input.help.failTaskOnFailedTests": "テストが失敗した場合にタスクを失敗させます。結果ファイルでテスト エラーが検出された場合にタスクを中止するには、このオプションをオンにします。",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "テストの実行のタイトル",
   "loc.input.help.testRunTitle": "テスト実行の名前を指定します。",
   "loc.input.label.platform": "ビルド プラットフォーム",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "각 결과 파일에 대해 테스트 실행이 생성됩니다. 결과를 단일 테스트 실행에 병합하려면 이 옵션을 선택하세요. 성능 향상에 최적화하기 위해, 이 옵션에 관계없이 결과 파일이 100개를 넘을 경우 결과가 단일 실행에 병합됩니다.",
   "loc.input.label.failTaskOnFailedTests": "테스트 오류가 있을 경우 실패",
   "loc.input.help.failTaskOnFailedTests": "테스트 오류가 있을 경우 작업에 실패합니다. 결과 파일에서 테스트 오류가 검색될 경우 작업에 실패하도록 하려면 이 옵션을 선택합니다.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "테스트 실행 제목",
   "loc.input.help.testRunTitle": "테스트 실행의 이름을 제공하세요.",
   "loc.input.label.platform": "빌드 플랫폼",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "Тестовый запуск создается для каждого файла результатов. Установите этот флажок, чтобы объединить результаты в один тестовый запуск. Для повышения производительности при наличии более 100 файлов результатов они будут объединены в один тестовый запуск независимо от значения этого параметра.",
   "loc.input.label.failTaskOnFailedTests": "Ошибка при наличии сбоев тестов",
   "loc.input.help.failTaskOnFailedTests": "Ошибка выполнения задачи при наличии любых сбоев тестов. Установите этот флажок, чтобы задача завершилась ошибкой при обнаружении сбоев тестов в файлах результатов.",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "Название тестового запуска",
   "loc.input.help.testRunTitle": "Укажите имя для тестового запуска.",
   "loc.input.label.platform": "Платформа сборки",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "为每个结果文件创建测试运行。选中此选项可将结果合并到单个测试运行中。为了进行优化以提高性能，如果存在超过 100 个结果文件，结果将合并到单个运行中，而不无论此选项如何。",
   "loc.input.label.failTaskOnFailedTests": "如果存在测试问题，则会失败",
   "loc.input.help.failTaskOnFailedTests": "如果存在任何测试问题，任务将失败。如果在结果文件中检测到测试问题，请选中此选项以使任务失败。",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "测试运行标题",
   "loc.input.help.testRunTitle": "提供测试运行的名称。",
   "loc.input.label.platform": "生成平台",

--- a/Tasks/PublishTestResultsV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/PublishTestResultsV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -15,6 +15,8 @@
   "loc.input.help.mergeTestResults": "為每個結果檔案建立一個測試回合。請檢查此選項，以將結果合併成單一測試回合。若結果檔案超過 100 個，為盡可能達到最佳效能，則不論此選項設定為何，都會將結果合併成單一回合。",
   "loc.input.label.failTaskOnFailedTests": "如果有測試失敗，即失敗",
   "loc.input.help.failTaskOnFailedTests": "如果沒有任何測試失敗，就使工作失敗。請於在結果檔案中偵測到測試失敗時，選取此選項來讓工作失敗。",
+  "loc.input.label.failTaskOnMissingResultsFile": "Fail if no result files are found",
+  "loc.input.help.failTaskOnMissingResultsFile": "Fail the task if no result files are found.",
   "loc.input.label.testRunTitle": "測試回合標題",
   "loc.input.help.testRunTitle": "提供測試回合的名稱。",
   "loc.input.label.platform": "組建平台",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "Pakete wurden erfolgreich veröffentlicht.",
   "loc.messages.PackagesFailedToPublish": "Fehler beim Veröffentlichen der Pakete.",
   "loc.messages.UnknownFeedType": "Unbekannter Feedtyp \"%s\".",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "Für die Veröffentlichung wurde keine externe Quelle angegeben.",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "Für den Download wurde keine externe Quelle angegeben.",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "Unerwarteter Fehler beim Versuch, das Paket mithilfe von Push zu übertragen. Exitcode (%s) und Fehler (%s).",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "Los paquetes se publicaron correctamente.",
   "loc.messages.PackagesFailedToPublish": "Error al publicar los paquetes.",
   "loc.messages.UnknownFeedType": "Tipo de fuente '%s' desconocido.",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "No se ha especificado ningún origen externo para la publicación.",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "No se ha especificado ningún origen externo para la descarga.",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "Error inesperado al intentar insertar el paquete. Código de salida: (%s). Error: (%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "Les packages ont été publiés correctement",
   "loc.messages.PackagesFailedToPublish": "Échec de la publication des packages",
   "loc.messages.UnknownFeedType": "Type de flux inconnu '%s'",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "Aucune source externe spécifiée pour la publication",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "Aucune source externe spécifiée pour le téléchargement",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "Une erreur inattendue s'est produite durant l'envoi (push) du package. Code de sortie (%s) et erreur (%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "I pacchetti sono stati pubblicati",
   "loc.messages.PackagesFailedToPublish": "La pubblicazione dei pacchetti non è riuscita",
   "loc.messages.UnknownFeedType": "Tipo di feed '%s' sconosciuto",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "Non è stata specificata alcuna origine esterna per la pubblicazione",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "Non è stata specificata alcuna origine esterna per il download",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "Si è verificato un errore imprevisto durante il tentativo di eseguire il push del pacchetto. Codice di uscita: %s. Errore:%s",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "パッケージが正常に発行されました",
   "loc.messages.PackagesFailedToPublish": "パッケージを発行できませんでした",
   "loc.messages.UnknownFeedType": "フィードの種類 '%s' が不明です",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "公開する外部ソースが指定されていませんでした",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "ダウンロードする外部ソースが指定されていませんでした",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "パッケージをプッシュしようとして予期しないエラーが発生しました。終了コード (%s) とエラー (%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "패키지가 게시되었습니다.",
   "loc.messages.PackagesFailedToPublish": "패키지를 게시하지 못했습니다.",
   "loc.messages.UnknownFeedType": "알 수 없는 피드 유형 '%s'",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "게시할 외부 소스를 지정하지 않았습니다.",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "다운로드할 외부 소스를 지정하지 않았습니다.",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "패키지를 푸시하는 중 예기치 않은 오류가 발생했습니다. 종료 코드(%s) 및 오류(%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "Пакеты успешно опубликованы",
   "loc.messages.PackagesFailedToPublish": "Не удалось опубликовать пакеты",
   "loc.messages.UnknownFeedType": "Неизвестный тип канала (\"%s\")",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "Не указан внешний источник для публикации",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "Не указан внешний источник для скачивания",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "Непредвиденная ошибка при попытке отправить пакет. Код завершения (%s) и ошибка (%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "已成功发布包",
   "loc.messages.PackagesFailedToPublish": "包发布失败",
   "loc.messages.UnknownFeedType": "未知的源类型“%s”",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "未指定用于发布的外部源",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "未指定用于下载的外部源",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "尝试推送包时出现意外错误。退出代码(%s)和错误(%s)",

--- a/Tasks/UniversalPackagesV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/UniversalPackagesV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -59,6 +59,7 @@
   "loc.messages.PackagesPublishedSuccessfully": "已成功發行套件",
   "loc.messages.PackagesFailedToPublish": "無法發行套件",
   "loc.messages.UnknownFeedType": "未知的摘要類型 '%s'",
+  "loc.messages.Error_NoVersionOptionSpecifiedForPublish": "Invalid versionOption/versionPublishSelector provided. Must be set to 'major', 'minor', 'patch', or 'custom'",
   "loc.messages.Error_NoSourceSpecifiedForPublish": "未指定發佈的外部來源",
   "loc.messages.Error_NoSourceSpecifiedForDownload": "未指定下載的外部來源",
   "loc.messages.Error_UnexpectedErrorArtifactTool": "嘗試推送套件時發生未預期的錯誤。結束代碼(%s) 與錯誤(%s)",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.