### PR TITLE
[UseDotNetV2] Fix prerelease from global.json

### DIFF
--- a/Tasks/UseDotNetV2/Tests/globaljsonfetcherTest.ts
+++ b/Tasks/UseDotNetV2/Tests/globaljsonfetcherTest.ts
@@ -52,7 +52,7 @@ mockery.registerMock('fs', {
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == validSubDirGlobalJson) {
-            var globalJson = new GlobalJson(subDirVersionNumber);
+            var globalJson = new GlobalJson(subDirVersionNumber, true);
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == pathToEmptyGlobalJson) {
@@ -67,6 +67,10 @@ mockery.registerMock('./versionfetcher', {
         return {
             getVersionInfo: function (versionSpec: string, vsVersionSpec: string, packageType: string, includePreviewVersions: boolean): Promise<VersionInfo> {
                 return Promise<VersionInfo>((resolve, reject) => {
+                    if (/pre/.test(versionSpec) && !includePreviewVersions) {
+                        reject("Unable to find version");
+                    }
+
                     resolve(new VersionInfo({ version: versionSpec, files: null, "runtime-version": versionSpec, "vs-version": vsVersionSpec }, packageType));
                 });
             }

--- a/Tasks/UseDotNetV2/_buildConfigs/Node16/Tests/globaljsonfetcherTest.ts
+++ b/Tasks/UseDotNetV2/_buildConfigs/Node16/Tests/globaljsonfetcherTest.ts
@@ -52,7 +52,7 @@ mockery.registerMock('fs', {
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == validSubDirGlobalJson) {
-            var globalJson = new GlobalJson(subDirVersionNumber);
+            var globalJson = new GlobalJson(subDirVersionNumber, true);
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == pathToEmptyGlobalJson) {
@@ -67,6 +67,10 @@ mockery.registerMock('./versionfetcher', {
         return {
             getVersionInfo: function (versionSpec: string, vsVersionSpec: string, packageType: string, includePreviewVersions: boolean): Promise<VersionInfo> {
                 return Promise<VersionInfo>((resolve, reject) => {
+                    if (/pre/.test(versionSpec) && !includePreviewVersions) {
+                        reject('Unable to find version');
+                    }
+
                     resolve(new VersionInfo({ 
                         version: versionSpec, 
                         files: [{

--- a/Tasks/UseDotNetV2/_buildConfigs/Node16/globaljsonfetcher.ts
+++ b/Tasks/UseDotNetV2/_buildConfigs/Node16/globaljsonfetcher.ts
@@ -21,11 +21,11 @@ export class globalJsonFetcher {
      */
     public async GetVersions(): Promise<VersionInfo[]> {
         var versionInformation: VersionInfo[] = new Array<VersionInfo>();
-        var versionStrings = this.getVersionStrings();
-        for (let index = 0; index < versionStrings.length; index++) {
-            const version = versionStrings[index];
-            if (version != null) {
-                var versionInfo = await this.versionFetcher.getVersionInfo(version, null, "sdk", false);
+        var sdks = this.getSdks();
+        for (let index = 0; index < sdks.length; index++) {
+            const sdk = sdks[index];
+            if (sdk != null) {
+                var versionInfo = await this.versionFetcher.getVersionInfo(sdk.version, null, "sdk", sdk.allowPrerelease);
                 versionInformation.push(versionInfo);
             }
         }
@@ -33,7 +33,7 @@ export class globalJsonFetcher {
         return Array.from(new Set(versionInformation)); // this remove all not unique values.
     }
 
-    private getVersionStrings(): Array<string | null> {
+    private getSdks(): Array<sdk | null> {
         let filePathsToGlobalJson = tl.findMatch(this.workingDirectory, "**/global.json");
         if (filePathsToGlobalJson == null || filePathsToGlobalJson.length == 0) {
             throw tl.loc("FailedToFindGlobalJson", this.workingDirectory);
@@ -43,7 +43,7 @@ export class globalJsonFetcher {
             var content = this.readGlobalJson(path);
             if (content != null) {
                 tl.loc("GlobalJsonSdkVersion", content.sdk.version, path);
-                return content.sdk.version;
+                return content.sdk;
             }
 
             return null;
@@ -58,12 +58,12 @@ export class globalJsonFetcher {
             let fileContent = fileSystem.readFileSync(path);
             // Since here is a buffer, we need to check length property to determine if it is empty. 
             if (!fileContent.length) {
-            // do not throw if globa.json is empty, task need not install any version in such case.
+                // do not throw if globa.json is empty, task need not install any version in such case.
                 tl.loc("GlobalJsonIsEmpty", path);
                 return null;
             }
 
-            globalJson = (JSON.parse(fileContent.toString())) as { sdk: { version: string } };
+            globalJson = (JSON.parse(fileContent.toString())) as { sdk: { version: string, allowPrerelease: boolean } };
         } catch (error) {
             // we throw if the global.json is invalid
             throw tl.loc("FailedToReadGlobalJson", path, error); // We don't throw if a global.json is invalid.
@@ -80,10 +80,15 @@ export class globalJsonFetcher {
 }
 
 export class GlobalJson {
-    constructor(version: string | null = null) {
+    constructor(version: string | null = null, allowPrerelease: boolean | null = null) {
         if (version != null) {
             this.sdk = new sdk();
             this.sdk.version = version;
+            if (allowPrerelease !== null) {
+                this.sdk.allowPrerelease = allowPrerelease;
+            } else {
+                this.sdk.allowPrerelease = false;
+            }
         }
     }
     public sdk: sdk;
@@ -91,4 +96,5 @@ export class GlobalJson {
 
 class sdk {
     public version: string;
+    public allowPrerelease: boolean;
 }

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 228,
-    "Patch": 1
+    "Minor": 229,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 228,
-    "Patch": 1
+    "Minor": 229,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"

--- a/_generated/UseDotNetV2/Tests/globaljsonfetcherTest.ts
+++ b/_generated/UseDotNetV2/Tests/globaljsonfetcherTest.ts
@@ -52,7 +52,7 @@ mockery.registerMock('fs', {
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == validSubDirGlobalJson) {
-            var globalJson = new GlobalJson(subDirVersionNumber);
+            var globalJson = new GlobalJson(subDirVersionNumber, true);
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == pathToEmptyGlobalJson) {
@@ -67,6 +67,10 @@ mockery.registerMock('./versionfetcher', {
         return {
             getVersionInfo: function (versionSpec: string, vsVersionSpec: string, packageType: string, includePreviewVersions: boolean): Promise<VersionInfo> {
                 return Promise<VersionInfo>((resolve, reject) => {
+                    if (/pre/.test(versionSpec) && !includePreviewVersions) {
+                        reject("Unable to find version");
+                    }
+
                     resolve(new VersionInfo({ version: versionSpec, files: null, "runtime-version": versionSpec, "vs-version": vsVersionSpec }, packageType));
                 });
             }

--- a/_generated/UseDotNetV2_Node16/Tests/globaljsonfetcherTest.ts
+++ b/_generated/UseDotNetV2_Node16/Tests/globaljsonfetcherTest.ts
@@ -52,7 +52,7 @@ mockery.registerMock('fs', {
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == validSubDirGlobalJson) {
-            var globalJson = new GlobalJson(subDirVersionNumber);
+            var globalJson = new GlobalJson(subDirVersionNumber, true);
             return Buffer.from(JSON.stringify(globalJson));
         }
         if (path == pathToEmptyGlobalJson) {
@@ -67,6 +67,10 @@ mockery.registerMock('./versionfetcher', {
         return {
             getVersionInfo: function (versionSpec: string, vsVersionSpec: string, packageType: string, includePreviewVersions: boolean): Promise<VersionInfo> {
                 return Promise<VersionInfo>((resolve, reject) => {
+                    if (/pre/.test(versionSpec) && !includePreviewVersions) {
+                        reject('Unable to find version');
+                    }
+
                     resolve(new VersionInfo({ 
                         version: versionSpec, 
                         files: [{

--- a/_generated/UseDotNetV2_Node16/globaljsonfetcher.ts
+++ b/_generated/UseDotNetV2_Node16/globaljsonfetcher.ts
@@ -21,11 +21,11 @@ export class globalJsonFetcher {
      */
     public async GetVersions(): Promise<VersionInfo[]> {
         var versionInformation: VersionInfo[] = new Array<VersionInfo>();
-        var versionStrings = this.getVersionStrings();
-        for (let index = 0; index < versionStrings.length; index++) {
-            const version = versionStrings[index];
-            if (version != null) {
-                var versionInfo = await this.versionFetcher.getVersionInfo(version, null, "sdk", false);
+        var sdks = this.getSdks();
+        for (let index = 0; index < sdks.length; index++) {
+            const sdk = sdks[index];
+            if (sdk != null) {
+                var versionInfo = await this.versionFetcher.getVersionInfo(sdk.version, null, "sdk", sdk.allowPrerelease);
                 versionInformation.push(versionInfo);
             }
         }
@@ -33,7 +33,7 @@ export class globalJsonFetcher {
         return Array.from(new Set(versionInformation)); // this remove all not unique values.
     }
 
-    private getVersionStrings(): Array<string | null> {
+    private getSdks(): Array<sdk | null> {
         let filePathsToGlobalJson = tl.findMatch(this.workingDirectory, "**/global.json");
         if (filePathsToGlobalJson == null || filePathsToGlobalJson.length == 0) {
             throw tl.loc("FailedToFindGlobalJson", this.workingDirectory);
@@ -43,7 +43,7 @@ export class globalJsonFetcher {
             var content = this.readGlobalJson(path);
             if (content != null) {
                 tl.loc("GlobalJsonSdkVersion", content.sdk.version, path);
-                return content.sdk.version;
+                return content.sdk;
             }
 
             return null;
@@ -58,12 +58,12 @@ export class globalJsonFetcher {
             let fileContent = fileSystem.readFileSync(path);
             // Since here is a buffer, we need to check length property to determine if it is empty. 
             if (!fileContent.length) {
-            // do not throw if globa.json is empty, task need not install any version in such case.
+                // do not throw if globa.json is empty, task need not install any version in such case.
                 tl.loc("GlobalJsonIsEmpty", path);
                 return null;
             }
 
-            globalJson = (JSON.parse(fileContent.toString())) as { sdk: { version: string } };
+            globalJson = (JSON.parse(fileContent.toString())) as { sdk: { version: string, allowPrerelease: boolean } };
         } catch (error) {
             // we throw if the global.json is invalid
             throw tl.loc("FailedToReadGlobalJson", path, error); // We don't throw if a global.json is invalid.
@@ -80,10 +80,15 @@ export class globalJsonFetcher {
 }
 
 export class GlobalJson {
-    constructor(version: string | null = null) {
+    constructor(version: string | null = null, allowPrerelease: boolean | null = null) {
         if (version != null) {
             this.sdk = new sdk();
             this.sdk.version = version;
+            if (allowPrerelease !== null) {
+                this.sdk.allowPrerelease = allowPrerelease;
+            } else {
+                this.sdk.allowPrerelease = false;
+            }
         }
     }
     public sdk: sdk;
@@ -91,4 +96,5 @@ export class GlobalJson {
 
 class sdk {
     public version: string;
+    public allowPrerelease: boolean;
 }


### PR DESCRIPTION
**Task name**: UseDotNetV2

**Description**: When getting version information from `global.json`, `allowPrerelease` was always passed as `false`. This adjusts the behavior to read the `allowPrerelease` field from `global.json`.

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** Y #18988

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
