### PR TITLE
Allow powershell check only on windows-based os

### DIFF
--- a/ci/after-build-check-tasks.js
+++ b/ci/after-build-check-tasks.js
@@ -119,6 +119,11 @@ function findNonUniqueTaskLib() {
 
 function analyzePowershellTasks() {
     let output = '';
+    if (process.platform !== 'win32') {
+        console.log('The powershell check is only supported on Windows. Skipping...');
+        return;
+    }
+
     try {
         const pwshScriptPath = path.join(__dirname, 'check-powershell-syntax.ps1');
         output = util.run(`powershell -NoLogo -Sta -NoProfile -NonInteractive -ExecutionPolicy Unrestricted ${pwshScriptPath} ${buildTasksPath}`, true);


### PR DESCRIPTION
**Description**: 
Run checks for PowerShell only on windows-based os, because the Linux based has only PowerShell core

**Checklist**:
- [x] Checked that applied changes work as expected
