### PR TITLE
Set Cargo credential-provider setting alongside auth setting

### DIFF
--- a/Tasks/CargoAuthenticateV0/task.json
+++ b/Tasks/CargoAuthenticateV0/task.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 227,
+    "Minor": 229,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/CargoAuthenticateV0/task.loc.json
+++ b/Tasks/CargoAuthenticateV0/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 227,
+    "Minor": 229,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
**Task name**: CargoAuthenticateV0

**Description**: Inline with the final changes to Cargo to support authenticated registries, set up the `cargo:token` credential provider when setting a token

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N/A

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
