### PR TITLE
Un deprecate PA older version tasks

### DIFF
--- a/Tasks/DownloadPipelineArtifactV0/task.json
+++ b/Tasks/DownloadPipelineArtifactV0/task.json
@@ -9,15 +9,13 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 229,
-        "Patch": 1
+        "Minor": 230,
+        "Patch": 0
     },
     "groups": [],
     "demands": [],
     "minimumAgentVersion": "2.155.1",
     "preview": false,
-    "deprecated": true,
-    "removalDate": "2024-04-22",
     "inputs": [
         {
             "name": "pipelineId",

--- a/Tasks/DownloadPipelineArtifactV0/task.loc.json
+++ b/Tasks/DownloadPipelineArtifactV0/task.loc.json
@@ -9,15 +9,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 229,
-    "Patch": 1
+    "Minor": 230,
+    "Patch": 0
   },
   "groups": [],
   "demands": [],
   "minimumAgentVersion": "2.155.1",
   "preview": false,
-  "deprecated": true,
-  "removalDate": "2024-04-22",
   "inputs": [
     {
       "name": "pipelineId",

--- a/Tasks/DownloadPipelineArtifactV1/task.json
+++ b/Tasks/DownloadPipelineArtifactV1/task.json
@@ -9,15 +9,13 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 229,
+        "Minor": 230,
         "Patch": 0
     },
     "groups": [],
     "demands": [],
     "minimumAgentVersion": "2.155.1",
     "preview": false,
-    "deprecated": true,
-    "removalDate": "2024-04-22",
     "inputs": [
         {
             "name": "buildType",

--- a/Tasks/DownloadPipelineArtifactV1/task.loc.json
+++ b/Tasks/DownloadPipelineArtifactV1/task.loc.json
@@ -9,15 +9,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 229,
+    "Minor": 230,
     "Patch": 0
   },
   "groups": [],
   "demands": [],
   "minimumAgentVersion": "2.155.1",
   "preview": false,
-  "deprecated": true,
-  "removalDate": "2024-04-22",
   "inputs": [
     {
       "name": "buildType",

--- a/Tasks/PublishPipelineArtifactV0/task.json
+++ b/Tasks/PublishPipelineArtifactV0/task.json
@@ -9,15 +9,13 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 229,
+        "Minor": 230,
         "Patch": 0
     },
     "groups": [],
     "demands": [],
     "minimumAgentVersion": "2.199.0",
     "preview": false,
-    "deprecated": true,
-    "removalDate": "2024-04-22",
     "inputs": [
         {
             "name": "artifactName",

--- a/Tasks/PublishPipelineArtifactV0/task.loc.json
+++ b/Tasks/PublishPipelineArtifactV0/task.loc.json
@@ -9,15 +9,13 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 229,
+    "Minor": 230,
     "Patch": 0
   },
   "groups": [],
   "demands": [],
   "minimumAgentVersion": "2.199.0",
   "preview": false,
-  "deprecated": true,
-  "removalDate": "2024-04-22",
   "inputs": [
     {
       "name": "artifactName",


### PR DESCRIPTION
**Task name**: Pipeline Artifact - publish and download

**Description**: As a team, we have decided to not deprecate older versions of PA tasks

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:**N 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
