### PR TITLE
[AzureContainerAppsV1] Hide output from select 'az containerapp' commands

### DIFF
--- a/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Learn more about this task](http://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureContainerAppsV1/README.md)",
   "loc.description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
   "loc.instanceNameFormat": "Azure Container Apps Deploy",
-  "loc.releaseNotes": "Released version 1.x.x of AzureContainerApps task for building and deploying Azure Container Apps.",
+  "loc.releaseNotes": "Hide output from select 'az containerapp' command calls.",
   "loc.input.label.cwd": "Working Directory",
   "loc.input.help.cwd": "Current working directory where the script is run.  Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)",
   "loc.input.label.appSourcePath": "Application source path",

--- a/Tasks/AzureContainerAppsV1/src/ContainerAppHelper.ts
+++ b/Tasks/AzureContainerAppsV1/src/ContainerAppHelper.ts
@@ -32,7 +32,7 @@ export class ContainerAppHelper {
         optionalCmdArgs: string[]) {
             tl.debug(`Attempting to create Container App with name "${containerAppName}" in resource group "${resourceGroup}" based from image "${imageToDeploy}"`);
             try {
-                let command = `containerapp create -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy} --environment ${environment}`;
+                let command = `containerapp create -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy} --environment ${environment} --output none`;
                 optionalCmdArgs.forEach(function (val: string) {
                     command += ` ${val}`;
                 });
@@ -59,7 +59,7 @@ export class ContainerAppHelper {
         yamlConfigPath: string) {
             tl.debug(`Attempting to create Container App with name "${containerAppName}" in resource group "${resourceGroup}" from provided YAML "${yamlConfigPath}"`);
             try {
-                let command = `containerapp create -n ${containerAppName} -g ${resourceGroup} --yaml ${yamlConfigPath}`;
+                let command = `containerapp create -n ${containerAppName} -g ${resourceGroup} --yaml ${yamlConfigPath} --output none`;
 
                 new Utility().throwIfError(
                     tl.execSync('az', command),
@@ -85,7 +85,7 @@ export class ContainerAppHelper {
         optionalCmdArgs: string[]) {
             tl.debug(`Attempting to update Container App with name "${containerAppName}" in resource group "${resourceGroup}" based from image "${imageToDeploy}"`);
             try {
-                let command = `containerapp update -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy}`;
+                let command = `containerapp update -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy} --output none`;
                 optionalCmdArgs.forEach(function (val: string) {
                     command += ` ${val}`;
                 });
@@ -119,7 +119,7 @@ export class ContainerAppHelper {
             tl.debug(`Attempting to update Container App with name "${containerAppName}" in resource group "${resourceGroup}" based from image "${imageToDeploy}"`);
             const util = new Utility();
             try {
-                let command = `containerapp up -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy}`;
+                let command = `containerapp up -n ${containerAppName} -g ${resourceGroup} -i ${imageToDeploy} --output none`;
                 optionalCmdArgs.forEach(function (val: string) {
                     command += ` ${val}`;
                 });
@@ -154,7 +154,7 @@ export class ContainerAppHelper {
         yamlConfigPath: string) {
             tl.debug(`Attempting to update Container App with name "${containerAppName}" in resource group "${resourceGroup}" from provided YAML "${yamlConfigPath}"`);
             try {
-                let command = `containerapp update -n ${containerAppName} -g ${resourceGroup} --yaml ${yamlConfigPath}`;
+                let command = `containerapp update -n ${containerAppName} -g ${resourceGroup} --yaml ${yamlConfigPath} --output none`;
 
                 new Utility().throwIfError(
                     tl.execSync('az', command),
@@ -175,7 +175,7 @@ export class ContainerAppHelper {
     public doesContainerAppExist(containerAppName: string, resourceGroup: string): boolean {
         tl.debug(`Attempting to determine if Container App with name "${containerAppName}" exists in resource group "${resourceGroup}"`);
         try {
-            const command = `containerapp show -n ${containerAppName} -g ${resourceGroup} -o none`;
+            const command = `containerapp show -n ${containerAppName} -g ${resourceGroup} --output none`;
             const result = tl.execSync('az', command);
             return result.code == 0;
         } catch (err) {
@@ -193,7 +193,7 @@ export class ContainerAppHelper {
     public doesContainerAppEnvironmentExist(containerAppEnvironment: string, resourceGroup: string): boolean {
         tl.debug(`Attempting to determine if Container App Environment with name "${containerAppEnvironment}" exists in resource group "${resourceGroup}"`);
         try {
-            const command = `containerapp env show -n ${containerAppEnvironment} -g ${resourceGroup} -o none`;
+            const command = `containerapp env show -n ${containerAppEnvironment} -g ${resourceGroup} --output none`;
             const result = tl.execSync('az', command);
             return result.code == 0;
         } catch (err) {
@@ -210,7 +210,7 @@ export class ContainerAppHelper {
     public doesResourceGroupExist(resourceGroup: string): boolean {
         tl.debug(`Attempting to determine if resource group "${resourceGroup}" exists`);
         try {
-            const command = `group show -n ${resourceGroup} -o none`;
+            const command = `group show -n ${resourceGroup} --output none`;
             const result = tl.execSync('az', command);
             return result.code == 0;
         } catch (err) {

--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -6,7 +6,7 @@
     "description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
     "author": "Microsoft Corporation",
     "helpMarkDown": "[Learn more about this task](http://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureContainerAppsV1/README.md)",
-    "releaseNotes": "Released version 1.x.x of AzureContainerApps task for building and deploying Azure Container Apps.",
+    "releaseNotes": "Hide output from select 'az containerapp' command calls.",
     "category": "Deploy",
     "visibility": [
         "Build",
@@ -18,7 +18,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 225,
+        "Minor": 229,
         "Patch": 1
     },
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 225,
+    "Minor": 229,
     "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**: AzureContainerAppsV1

**Description**: Hiding the output from select `az containerapp` commands executed during the task

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
