### PR TITLE
Updated VsTestV2 task to version 2.229.0

### DIFF
--- a/Tasks/VsTestV2/make.json
+++ b/Tasks/VsTestV2/make.json
@@ -6,7 +6,7 @@
                 "dest": "./"
             },
             {
-                "url": "https://testexecution.blob.core.windows.net/testexecution/22451088/TestAgent.zip",
+                "url": "https://testexecution.blob.core.windows.net/testexecution/22799172/TestAgent.zip",
                 "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV2/task.json
+++ b/Tasks/VsTestV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 228,
+        "Minor": 229,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/VsTestV2/task.loc.json
+++ b/Tasks/VsTestV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 228,
+    "Minor": 229,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
**Task name**: VstestV2

**Description**:  Bumping up the vstest version from 2.228.0 to 2.229.0 to pick the latest changes in sprint 229.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2099515

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
