### PR TITLE
AzureWebAppContainerV1: Add multiline support

### DIFF
--- a/Tasks/AzureWebAppContainerV1/task.json
+++ b/Tasks/AzureWebAppContainerV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 230,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppContainerV1/task.loc.json
+++ b/Tasks/AzureWebAppContainerV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 230,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppContainerV1/taskparameters.ts
+++ b/Tasks/AzureWebAppContainerV1/taskparameters.ts
@@ -29,6 +29,11 @@ export class TaskParametersUtility {
         taskParameters.azureEndpoint = await new AzureRMEndpoint(taskParameters.connectedServiceName).getEndpoint();
         console.log(tl.loc('GotconnectiondetailsforazureRMWebApp0', taskParameters.WebAppName));
 
+        if(taskParameters.AppSettings && taskParameters.AppSettings !== null)
+        {
+            taskParameters.AppSettings = taskParameters.AppSettings.replace('\n',' ');
+        }
+        
         let appDetails = await this.getWebAppKind(taskParameters);
         taskParameters.ResourceGroupName = appDetails["resourceGroupName"];
         taskParameters.OSType = appDetails["osType"];


### PR DESCRIPTION
**Task name**: AzureWebAppContainerV1

**Description**: support \n caracter for multiline
As some other Task (example : AzureFunctionAppV1) use appsettings parameter : Add multiline support.
I suggest to use \n as space (mandatory). It's better for readibility. A space is not visible and easy to forget it.
It's also more consistent with other tasks.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related PR:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/pull/19022

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
