### PR TITLE
Change chmod from 777 to 755

### DIFF
--- a/Tasks/ContainerBuildV0/src/utils.ts
+++ b/Tasks/ContainerBuildV0/src/utils.ts
@@ -65,7 +65,7 @@ export async function downloadBuildctl(version: string): Promise<string> {
 
     tl.debug('Buildctl path: ' + buildctlpath);
 
-    fs.chmodSync(buildctlpath, "777");
+    fs.chmodSync(buildctlpath, "755");
     return buildctlpath;
 }
 

--- a/Tasks/ContainerBuildV0/task.json
+++ b/Tasks/ContainerBuildV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 225,
+        "Minor": 230,
         "Patch": 0
     },
     "demands": [],

--- a/Tasks/ContainerBuildV0/task.loc.json
+++ b/Tasks/ContainerBuildV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 225,
+    "Minor": 230,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 219,
+        "Minor": 230,
         "Patch": 0
     },
     "preview": true,

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 219,
+    "Minor": 230,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/ContainerStructureTestV0/testrunner.ts
+++ b/Tasks/ContainerStructureTestV0/testrunner.ts
@@ -37,7 +37,7 @@ export class TestRunner {
                     throw new Error(`Download or caching of tool(${runnerPath}) failed`);
                 }
 
-                chmodSync(runnerPath, "777");
+                chmodSync(runnerPath, "755");
                 var start = new Date().getTime();
                 const output: string = this.runContainerStructureTest(runnerPath, this.testFilePath, this.imageName);
                 var end = new Date().getTime();

--- a/Tasks/DuffleInstallerV0/src/duffleinstaller.ts
+++ b/Tasks/DuffleInstallerV0/src/duffleinstaller.ts
@@ -39,7 +39,7 @@ async function downloadDuffle(version: string): Promise<string> {
     }
 
     const dufflePath = path.join(cachedToolPath, DuffleToolName + getExecutableExtension());
-    fs.chmodSync(dufflePath, '777');
+    fs.chmodSync(dufflePath, '755');
     return dufflePath;
 }
 

--- a/Tasks/DuffleInstallerV0/task.json
+++ b/Tasks/DuffleInstallerV0/task.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 228,
+    "Minor": 230,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DuffleInstallerV0/task.loc.json
+++ b/Tasks/DuffleInstallerV0/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 228,
+    "Minor": 230,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/FuncToolsInstallerV0/src/utils.ts
+++ b/Tasks/FuncToolsInstallerV0/src/utils.ts
@@ -75,10 +75,10 @@ async function downloadFuncToolsInternal(version: string): Promise<string> {
     }
 
     const funcPath = path.join(cachedToolpath, funcToolName + getExecutableExtension());
-    fs.chmodSync(funcPath, '777');
+    fs.chmodSync(funcPath, '755');
     const gozipPath = path.join(cachedToolpath, 'gozip' + getExecutableExtension());
     if (fs.existsSync(gozipPath)) {
-        fs.chmodSync(gozipPath, '777');
+        fs.chmodSync(gozipPath, '755');
     }
     
     return funcPath;

--- a/Tasks/FuncToolsInstallerV0/task.json
+++ b/Tasks/FuncToolsInstallerV0/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 224,
+    "Minor": 230,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/FuncToolsInstallerV0/task.loc.json
+++ b/Tasks/FuncToolsInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 224,
+    "Minor": 230,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/OpenPolicyAgentInstallerV0/src/utils.ts
+++ b/Tasks/OpenPolicyAgentInstallerV0/src/utils.ts
@@ -83,11 +83,11 @@ export async function downloadOpa(version: string): Promise<string> {
     if (!cachedToolpath || !fs.existsSync(opaPath)) {
         const opaPathTmp = path.join(getTempDirectory(), opaToolName + getExecutableExtension());
         taskLib.cp(opaDownloadPath, opaPathTmp, '-f');
-        fs.chmodSync(opaPathTmp, '777');
+        fs.chmodSync(opaPathTmp, '755');
         return opaPathTmp;
     }
 
-    fs.chmodSync(opaPath, '777');
+    fs.chmodSync(opaPath, '755');
     return opaPath;
 }
 

--- a/Tasks/OpenPolicyAgentInstallerV0/task.json
+++ b/Tasks/OpenPolicyAgentInstallerV0/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 225,
+        "Minor": 230,
         "Patch": 0
     },
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/OpenPolicyAgentInstallerV0/task.loc.json
+++ b/Tasks/OpenPolicyAgentInstallerV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 225,
+    "Minor": 230,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
**Task name**: ContainerBuildV0, ContainerStructureTestV0, DuffleInstallerV0, FuncToolsInstallerV0, OpenPolicyAgentInstallerV0

**Description**:
-- Changed chmod for the tasks from 777 to 755s

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** `WI 2088490`

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
