### PR TITLE
Exposed MaxContextPopulation parameter to AZ PS task inputs.

### DIFF
--- a/Tasks/AzurePowerShellV5/azurepowershell.ts
+++ b/Tasks/AzurePowerShellV5/azurepowershell.ts
@@ -36,6 +36,7 @@ async function run() {
         let serviceName = tl.getInput('ConnectedServiceNameARM',/*required*/true);
         let endpointObject= await new AzureRMEndpoint(serviceName).getEndpoint();
         let input_workingDirectory = tl.getPathInput('workingDirectory', /*required*/ true, /*check*/ true);
+        let maxContextPopulation: string = convertToNullIfUndefined(tl.getInput('maxContextPopulation', /*required*/ false));
         let isDebugEnabled = (process.env['SYSTEM_DEBUG'] || "").toLowerCase() === "true";
 
         // string constants
@@ -78,6 +79,9 @@ async function run() {
         let initAzCommand = `${azFilePath} -endpoint '${endpoint}'`
         if (targetAzurePs != "") {
             initAzCommand += ` -targetAzurePs  ${targetAzurePs}`;
+        }
+        if (maxContextPopulation != "") {
+            initAzCommand += ` -MaxContextPopulation '${maxContextPopulation}'`;
         }
         if (endpointObject.scheme === 'WorkloadIdentityFederation') {
             const oidc_token = await endpointObject.applicationTokenCredentials.getFederatedToken();

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 230,
+    "Minor": 231,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -173,6 +173,15 @@
       "defaultValue": "",
       "helpMarkDown": "Working directory where the script is run.",
       "groupName": "advanced"
+    },
+    {
+      "name": "maxContextPopulation",
+      "type": "string",
+      "label": "Max Context Population",
+      "required": false,
+      "defaultValue": "25",
+      "helpMarkDown": "Max subscription number to populate contexts after login. Default is 25. To populate all subscriptions to contexts, set to -1.",
+      "groupName": "advanced"
     }
   ],
   "instanceNameFormat": "Azure PowerShell script: $(ScriptType)",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 230,
+    "Minor": 231,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: AzurePowerShell

**Description**: Exposed MaxContextPopulation parameter for Connect-AzAccount to task inputs.

**Documentation changes required:** Yes

**Added unit tests:** No

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/19189

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
