### PR TITLE
Revert "Add dotnet 7 for signle task build (#19283)"

### DIFF
--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -39,13 +39,6 @@ steps:
     Write-Host "##vso[task.setVariable variable=task_pattern]$taskPattern"
   displayName: Set task_pattern
 
-
-# Use .NET SDK 7
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 7.x'
-  inputs:
-    version: 7.x
-
 # Clean
 - script: node make.js clean
   displayName: Clean tasks


### PR DESCRIPTION
This reverts commit ab93ab3e4e5e65021621a563341e1d86158113ea.

Revert "Add dotnet 7 for signle task build (#19283)" which was a temporary solution