### PR TITLE
ARM Deployment Task-Error for Bicep File Paths(#16789)

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
@@ -463,7 +463,7 @@ class Utils {
     }
 
     private static async execBicepBuild(filePath): Promise<void> {
-        const result: IExecSyncResult = tl.execSync("az", `bicep build --file ${filePath}`);
+        const result: IExecSyncResult = tl.execSync("az", `bicep build --file "${filePath}"`);
         if(result && result.code !== 0){
             throw new Error(tl.loc("BicepBuildFailed", result.stderr));
         }


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeploymentV3

**Description**: To fix ARM Template deployment Task fails for bicep files when the path includes spaces
**Documentation changes required:** (N) 
**Added unit tests:** (N)

**Attached related issue:** (Y) [https://github.com/microsoft/azure-pipelines-tasks/issues/16789]

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
