### PR TITLE
Fixes UseDotNet@2 always downloads SDK, even when it is already installed

### DIFF
--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 232,
+    "Minor": 233,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 232,
+    "Minor": 233,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/UseDotNetV2/versioninstaller.ts
+++ b/Tasks/UseDotNetV2/versioninstaller.ts
@@ -98,11 +98,19 @@ export class VersionInstaller {
         }
 
         var isInstalled: boolean = false;
-        if (this.packageType == utils.Constants.sdk) {
-            isInstalled = tl.exist(path.join(this.installationPath, utils.Constants.relativeSdkPath, version)) && tl.exist(path.join(this.installationPath, utils.Constants.relativeSdkPath, `${version}.complete`));
-        }
-        else {
-            isInstalled = tl.exist(path.join(this.installationPath, utils.Constants.relativeRuntimePath, version)) && tl.exist(path.join(this.installationPath, utils.Constants.relativeRuntimePath, `${version}.complete`));
+
+        const folderPath = path.join(this.installationPath, this.packageType == utils.Constants.sdk ? utils.Constants.relativeSdkPath : utils.Constants.relativeRuntimePath);
+        const versionFolderPath = path.join(folderPath, version);
+        
+        //this file is created by this task
+        const fileToCheck = path.join(folderPath, `${version}.complete`); 
+        
+        //this file should be present if SDK/runtime is installed on hosted agent
+        const alternativeFileToCheck = path.join(versionFolderPath, this.packageType == utils.Constants.sdk ? '.version' : 'LICENSE.txt'); 
+
+        if (tl.exist(versionFolderPath)) {
+            isInstalled = tl.exist(fileToCheck)
+                || tl.exist(alternativeFileToCheck); //workaround for hosted build agent where SDK is preinstalled but missing `${version}.complete`
         }
 
         isInstalled ? console.log(tl.loc("VersionFoundInCache", version)) : console.log(tl.loc("VersionNotFoundInCache", version));


### PR DESCRIPTION
…lled #15020

**Task name**: UseDotnet@2

**Description**: Fixed [BUG] UseDotNet@2 always downloads SDK, even when it is already installed by checking also for
'.version' file, resp 'LICENSE.txt' (depending on SDK / runtime folder)

**Documentation changes required: N

**Added unit tests:** N

**Attached related issue:** Y

**Checklist**:
- [x] Task version was bumped
- [x] Checked that applied changes work as expected


## Steps to check that applied changes work as expected
- create new pipeline and run it on hosted build agent:

```yaml
pool:
  vmImage: windows-latest

steps:
- task: UseDotNet@2 
  displayName: 'Install .NET SDK'
  inputs:
    version: 8.0.100
    installationPath: C:\Program Files\dotnet
```

check logs for Version 8.0.100 was found in cache.