### PR TITLE
Temporarily disable Check for downgrading tasks

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -81,6 +81,7 @@ steps:
       )
   env:
     PACKAGE_TOKEN: $(Package.Token)
+  enabled: false
 
 # Build BuildConfigGen
 - task: DotNetCoreCLI@2


### PR DESCRIPTION
Temporarily disable Check for downgrading tasks to unblock PRs adding new tasks to the repo

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
