### PR TITLE
BuildConfig fixes compilation errors following adding preprocessor instructions to task.  Base task needs to be copied to _generated in that scenerio

### DIFF
--- a/BuildConfigGen/Preprocessor.cs
+++ b/BuildConfigGen/Preprocessor.cs
@@ -17,7 +17,7 @@ namespace BuildConfigGen
         private static partial Regex elseAndEndIfPreprocess();
 
 
-        internal static void Preprocess(string file, IEnumerable<string> lines, ISet<string> configreprocessorVariableName, string configName, out string processedOutput, out List<string> validationErrors, out bool madeChanges)
+        internal static void Preprocess(string file, IEnumerable<string> lines, ISet<string> validConfigPreprocessorVariableNames, string configName, out string processedOutput, out List<string> validationErrors, out bool madeChanges)
         {
             const string ifCommand = "if";
             const string elseIfCommand = "elseif";
@@ -67,9 +67,9 @@ namespace BuildConfigGen
                         validationErrors.Add($"Error {file}:{lineNumber}: there must be a single space after the hash");
                     }
 
-                    if (!configreprocessorVariableName.Contains(startPreprocessMatch.Groups["expression"].Value))
+                    if (!validConfigPreprocessorVariableNames.Contains(startPreprocessMatch.Groups["expression"].Value))
                     {
-                        validationErrors.Add($"Error {file}:{lineNumber}: the expression can only be {string.Join(',', configreprocessorVariableName.ToArray())}");
+                        validationErrors.Add($"Error {file}:{lineNumber}: the expression can only be {string.Join(',', validConfigPreprocessorVariableNames.ToArray())}");
                     }
 
                     command = startPreprocessMatch.Groups["command"].Value;


### PR DESCRIPTION
This only affects ADDING preprocessor instructions to existing tasks.  No current tasks are affected.

BuildConfigGen: Force generating 'base' generated task if task contains preprocessing instructions (otherwise we'll get build errors building 'base' task). ('base' generated task may be excluded if no preprocessing instructions)
BuildConfigGen: Also: Fix for detecting preprocessors in _buildconfig\* (which isn't currently supported)

**Task name**: N/A

**Description**: Splitting from !19538 

**Documentation changes required:** N/A

**Added unit tests:** N/A

**Attached related issue:** N/A

**Checklist**: 
- [N/A] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected (tested with  !19538 )
