### PR TITLE
WebAppV1 - Only attempt to update startupcommand and runtimestack if appServiceUtility is available.

### DIFF
--- a/Tasks/AzureWebAppV1/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
+++ b/Tasks/AzureWebAppV1/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts
@@ -51,9 +51,9 @@ export class BuiltInLinuxWebAppDeploymentProvider extends AzureRmWebAppDeploymen
             default:
                 throw new Error(tl.loc('Invalidwebapppackageorfolderpathprovided', this.taskParams.Package.getPath()));
         }
-
-        await this.appServiceUtility.updateStartupCommandAndRuntimeStack(this.taskParams.RuntimeStack, this.taskParams.StartupCommand);
-
+        if (this.appServiceUtility) {
+            await this.appServiceUtility.updateStartupCommandAndRuntimeStack(this.taskParams.RuntimeStack, this.taskParams.StartupCommand);
+        }
         await this.PostDeploymentStep();
     }
 


### PR DESCRIPTION
**Task name**: WebAppV1

**Description**: 
If the publication scheme is  "PublicationProfile", then the task does not get `appService` or `appServiceUtility` assigned.
[See here for codepath](https://github.com/microsoft/azure-pipelines-tasks/blob/30c99c8/Tasks/AzureWebAppV1/deploymentProvider/AzureRmWebAppDeploymentProvider.ts#L36-L52)

This causes an error to be thrown [here](https://github.com/microsoft/azure-pipelines-tasks/blob/30c99c8/Tasks/AzureWebAppV1/deploymentProvider/BuiltInLinuxWebAppDeploymentProvider.ts#L59).
```
##[error]TypeError: Cannot read property 'updateStartupCommandAndRuntimeStack' of undefined
```
(See issue #17988)

This change simply checks if `appServiceUtilty` is not null or undefined before executing  `updateStartupCommandAndRuntimeStack`.

**Documentation changes required:** No

**Added unit tests:** NA

**Attached related issue:** Fixes #17988

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

Not sure if this requires a task version bump, or how that procedure works.
