### PR TITLE
Remove endpoint parameter in repository resources

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ resources:
   repositories:
   - repository: AzureDevOps
     type: git
-    endpoint: AzureDevOps
+    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps
 
   - repository: ConfigChange
     type: git
-    endpoint: AzureDevOps
+    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps.ConfigChange
 
   - repository: 1ESPipelineTemplates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ resources:
   repositories:
   - repository: AzureDevOps
     type: git
-    endpoint: AzureDevOps_TEST
+    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps
 
   - repository: ConfigChange
     type: git
-    endpoint: AzureDevOps_TEST
+    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps.ConfigChange
 
   - repository: 1ESPipelineTemplates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,10 @@ resources:
   repositories:
   - repository: AzureDevOps
     type: git
-    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps
 
   - repository: ConfigChange
     type: git
-    endpoint: AzureDevOps_TasksCI
     name: AzureDevOps/AzureDevOps.ConfigChange
 
   - repository: 1ESPipelineTemplates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ resources:
   repositories:
   - repository: AzureDevOps
     type: git
-    endpoint: AzureDevOps_TasksCI
+    endpoint: AzureDevOps_TEST
     name: AzureDevOps/AzureDevOps
 
   - repository: ConfigChange
     type: git
-    endpoint: AzureDevOps_TasksCI
+    endpoint: AzureDevOps_TEST
     name: AzureDevOps/AzureDevOps.ConfigChange
 
   - repository: 1ESPipelineTemplates


### PR DESCRIPTION
Currently pipelines can't start due to the following issue:

The pipeline is not valid. The repository AzureDevOps in project ********* could not be retrieved. Verify the name and credentials being used. The repository AzureDevOps.ConfigChange in project *********** could not be retrieved. Verify the name and credentials being used.

Remove endpoint parameter to unblock PR checks.

We will still need to fix the permissions to automatically create PRs.
