### PR TITLE
Fix link in warning for PublishCodeCoverageResultsV1

### DIFF
--- a/Tasks/PublishCodeCoverageResultsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PublishCodeCoverageResultsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -23,5 +23,5 @@
   "loc.messages.IgnoringReportDirectory": "Ignoring coverage report directory with Html content as we are auto-generating Html content",
   "loc.messages.UpgradeAgentMessage": "Please upgrade your agent version. https://github.com/Microsoft/vsts-agent/releases",
   "loc.messages.GeneratedHtmlReport": "Generated code coverage html report: %s",
-  "loc.messages.V1TaskDeprecationNotice": "New V2 version of task publishing code coverage results is available to all our customers now. We highly recommend to stop using the V1 version and migrate to V2 version (https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2). For more details, see - https://devblogs.microsoft.com/devops/new-pccr-task."
+  "loc.messages.V1TaskDeprecationNotice": "New V2 version of task publishing code coverage results is available to all our customers now. We highly recommend to stop using the V1 version and migrate to V2 version https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/publish-code-coverage-results-v2. For more details, see - https://devblogs.microsoft.com/devops/new-pccr-task."
 }

--- a/Tasks/PublishCodeCoverageResultsV1/task.json
+++ b/Tasks/PublishCodeCoverageResultsV1/task.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 238,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/PublishCodeCoverageResultsV1/task.loc.json
+++ b/Tasks/PublishCodeCoverageResultsV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 238,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",


### PR DESCRIPTION
**Task name**: PublishCodeCoverageResultsV1

**Description**: Update link so incorrect URL isn't created

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** #19713 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
