### PR TITLE
Add version map downgrade check

### DIFF
--- a/ci/check-downgrading.js
+++ b/ci/check-downgrading.js
@@ -1,4 +1,4 @@
-const { join, posix, sep } = require('path');
+const { join, posix, sep, basename } = require('path');
 const {
   readFileSync,
   existsSync
@@ -57,7 +57,7 @@ function compareVersionMapFilesToDefaultBranch() {
 
   modifiedVersionMapFiles.forEach(filePath => {
     //get task name from a string like _generated/TaskNameVN.versionmap.txt
-    const taskName = filePath.slice(11, -15);
+    const taskName = basename(filePath, '.versionmap.txt');
 
     defaultBranchVersionMap = parseVersionMap(getVersionMapContent(filePath, defaultBranch));
     sourceBranchVersionMap = parseVersionMap(getVersionMapContent(filePath, sourceBranch));
@@ -114,8 +114,7 @@ function getVersionMapContent(versionMapFilePath, branchName) {
 }
 
 function parseVersionMap(fileContent) {
-  //TODO: make regex more accurate
-  const simpleVersionMapRegex = /(?<configName>.*)\|(?<version>.*)$/;
+  const simpleVersionMapRegex = /(?<configName>.+)\|(?<version>\d.\d{1,3}.\d+)$/;
   const versionMap = {};
   fileContent.split('\n').forEach(line => {
     if (simpleVersionMapRegex.test(line)) {


### PR DESCRIPTION
**Description**: Add version map downgrade check

We need to avoid such updates to versionmap.txt where the task version is not correctly updated. New versions of the task should be greater than the previous max version.

![image](https://github.com/microsoft/azure-pipelines-tasks/assets/16704239/c4f12807-46c0-4d6c-87e9-5ca72b70fa72)

Updated our downgrading checks:
Example: [pipeline run](https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=27828177&view=logs&j=2e88ae7a-d74a-5f0f-dea9-35d1d1ac5e70&t=91355482-3c90-55e7-6847-2892d048f808)

Error message:
> ##[error]Task Name: NuGetRestoreV1. Please check _generated/NuGetRestoreV1.versionmap.txt. New versions of the task should be greater than the previous max version. Default|1.238.1 should be greater than 1.238.1


**Attached related issue:** [AB#2157402](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2157402)

**Checklist**:
- [x] Checked that applied changes work as expected
