### PR TITLE
Remove OneES_JobScannedCount variable from azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ variables:
   taskNameIsSet: ${{ not(eq(parameters.task_name, 'TaskNameVN')) }}
   isHotfix: ${{ and(eq(parameters.push_to_feed, true), eq(variables.taskNameIsSet, true)) }}
   runCodeQl: ${{ eq(parameters.enableCodeQL, true) }}
-  OneES_JobScannedCount: 1  #Skip CG scan for now
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:


### PR DESCRIPTION
Reverts https://github.com/microsoft/azure-pipelines-tasks/pull/19747

Remove OneES_JobScannedCount variable to not skip CG task
