### PR TITLE
Run build_all_darwin on macos-14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,7 +210,7 @@ extends:
           timeoutInMinutes: 360
           pool:
             name: Azure Pipelines
-            image: macos-11
+            image: macos-14
             os: macOS
           steps:
           - template: /ci/build-all-steps.yml@self


### PR DESCRIPTION
Update pool image for Build all tasks (macOS) job to use macos-14