### PR TITLE
Move Courtesy Push pipeline from PipelineTools to ADO

### DIFF
--- a/.gdn/.gdnbaselines
+++ b/.gdn/.gdnbaselines
@@ -373,9 +373,6 @@
       "createdDate": "2024-03-20 10:25:39Z",
       "justification": "PSAvoidUsingConvertToSecureStringWithPlainText"
     },
-
-
-
     "a2a4017726eb18c7612da6ab3828cfdfd1218160fbd5d373c715476df1847499": {
       "signature": "a2a4017726eb18c7612da6ab3828cfdfd1218160fbd5d373c715476df1847499",
       "alternativeSignatures": [
@@ -1645,6 +1642,636 @@
       ],
       "justification": "Unit tests data",
       "createdDate": "2024-04-05 11:19:32Z"
+    },
+    "7cc4f9cdd65c36c2e0305618544638ab4af8491b5620601e92f208066a61b468": {
+      "signature": "7cc4f9cdd65c36c2e0305618544638ab4af8491b5620601e92f208066a61b468",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-04 00:19:32Z"
+    },
+    "5eb54a59b8413305fb1cdaa7f38d253f19f9762a955de75d0b93a2cfa719384e": {
+      "signature": "5eb54a59b8413305fb1cdaa7f38d253f19f9762a955de75d0b93a2cfa719384e",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-04 00:19:32Z"
+    },
+    "0cd237641b18cd597c96d58d41fe54274d79018df8c8357f0dfb6be29a8c6326": {
+      "signature": "0cd237641b18cd597c96d58d41fe54274d79018df8c8357f0dfb6be29a8c6326",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-04 00:19:32Z"
+    },
+    "3356860080fba9b740b7b0b8124d71a5f1294acfe07c27b1f7e8d56d5e5dcfa2": {
+      "signature": "3356860080fba9b740b7b0b8124d71a5f1294acfe07c27b1f7e8d56d5e5dcfa2",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-04 00:19:32Z"
+    },
+    "70e0454e0947ee7548aef02cd2688b556fb635619e1fa431ae183a0a4fa41d92": {
+      "signature": "70e0454e0947ee7548aef02cd2688b556fb635619e1fa431ae183a0a4fa41d92",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-04 00:19:32Z"
+    },
+    "c4284989cdcef9398b8ec9330d80d4485987131759dfcb7e99d09ba38995d031": {
+      "signature": "c4284989cdcef9398b8ec9330d80d4485987131759dfcb7e99d09ba38995d031",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "9e399b76e2b34e9054f53afdd8760044105109f88d0790ac2bb3e9048782b508": {
+      "signature": "9e399b76e2b34e9054f53afdd8760044105109f88d0790ac2bb3e9048782b508",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "7a53e4642945373ffb008d29e479fa52e51109fc194f1c2dfebcbd825fa2515a": {
+      "signature": "7a53e4642945373ffb008d29e479fa52e51109fc194f1c2dfebcbd825fa2515a",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "3b16b0643bbe5eb8e5addc631b9a88cb8f6e7be324a9dd7df2aa9a29e23da85e": {
+      "signature": "3b16b0643bbe5eb8e5addc631b9a88cb8f6e7be324a9dd7df2aa9a29e23da85e",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "c7467bdd2dfc148fe0ffec2b1d54e8e29aa6b44f2ac47e70f0943d70acc8b9f6": {
+      "signature": "c7467bdd2dfc148fe0ffec2b1d54e8e29aa6b44f2ac47e70f0943d70acc8b9f6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "e78ecee8ff636bd1995da1035d086d2692117a13e29b0fd1602bfc21f1650b90": {
+      "signature": "e78ecee8ff636bd1995da1035d086d2692117a13e29b0fd1602bfc21f1650b90",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "2345a08971d84b89f3ecd82156a93dcc46b75d5279c36648cc6f60105b195ff7": {
+      "signature": "2345a08971d84b89f3ecd82156a93dcc46b75d5279c36648cc6f60105b195ff7",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "270732bcc3b3bda387cc48bc66c12095c34e685c9e81024bc2f8d9d1270044af": {
+      "signature": "270732bcc3b3bda387cc48bc66c12095c34e685c9e81024bc2f8d9d1270044af",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "9d83d1be36d1686f176d3208e693e42ca325b6fa196d922a9747e528e14480b5": {
+      "signature": "9d83d1be36d1686f176d3208e693e42ca325b6fa196d922a9747e528e14480b5",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "c61aba0f5f8a597a6b51c0d90d5e8ed05f70ec79b17239023ab51cc3282f04e6": {
+      "signature": "c61aba0f5f8a597a6b51c0d90d5e8ed05f70ec79b17239023ab51cc3282f04e6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "2031cd00cb076e7f3f810dedc1f1743bc09abc65f15131dcc13e27ffc07edb03": {
+      "signature": "2031cd00cb076e7f3f810dedc1f1743bc09abc65f15131dcc13e27ffc07edb03",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "3b5c2d027d1d14feea3fbb03385fdc088f4ac9b067bb65e3514d70e600522be2": {
+      "signature": "3b5c2d027d1d14feea3fbb03385fdc088f4ac9b067bb65e3514d70e600522be2",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "d2099fa10f96a92c573d3abf6acacf51a5f23bd4e7e5a8f2f96191285a145597": {
+      "signature": "d2099fa10f96a92c573d3abf6acacf51a5f23bd4e7e5a8f2f96191285a145597",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "cbefc778166f4aa3204494a7f3d43cd93e8c5673cd4c2ed7ad786bdc1cb6e9b9": {
+      "signature": "cbefc778166f4aa3204494a7f3d43cd93e8c5673cd4c2ed7ad786bdc1cb6e9b9",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "1679d1aa43537bbfca749817e85e2239684543b6c5f614be30acab7e86a0edc5": {
+      "signature": "1679d1aa43537bbfca749817e85e2239684543b6c5f614be30acab7e86a0edc5",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "8597a071ac214f454f541dc1ed6758d2420e7fc90df31433c58aedbc22669d4f": {
+      "signature": "8597a071ac214f454f541dc1ed6758d2420e7fc90df31433c58aedbc22669d4f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "eb0d5d9142dfbd5c77645ed0e040e52d4e67c1ed71402528f6b5bef896853f57": {
+      "signature": "eb0d5d9142dfbd5c77645ed0e040e52d4e67c1ed71402528f6b5bef896853f57",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "85ad19afaf3b332f31f19a6a7c93cc76a5ddfd49b31314f24b73d9e18cbad298": {
+      "signature": "85ad19afaf3b332f31f19a6a7c93cc76a5ddfd49b31314f24b73d9e18cbad298",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "8df6cba3d65fb0374620e94e28d6dda122daece0c8da0e7ab42cea08dcc83c1b": {
+      "signature": "8df6cba3d65fb0374620e94e28d6dda122daece0c8da0e7ab42cea08dcc83c1b",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "0ceadf145e3a24ab95ba31fa6f1549998f66c927735a5de67d40b11ef03b63c3": {
+      "signature": "0ceadf145e3a24ab95ba31fa6f1549998f66c927735a5de67d40b11ef03b63c3",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "97ac1b4a5eb9fc3eca9ae8511e6c3fa3c71d8a0f69a58e7917748e8ecc7b9a04": {
+      "signature": "97ac1b4a5eb9fc3eca9ae8511e6c3fa3c71d8a0f69a58e7917748e8ecc7b9a04",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "9b0d1f053557cc42e5d6e3304440468f99d5d1be76e1ad958455e97e70e33684": {
+      "signature": "9b0d1f053557cc42e5d6e3304440468f99d5d1be76e1ad958455e97e70e33684",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "bddebe90aacf7fa07dd67230b9df3d5dcfa8e2711d284a304f56f6f23b237774": {
+      "signature": "bddebe90aacf7fa07dd67230b9df3d5dcfa8e2711d284a304f56f6f23b237774",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "cbc318d0ea4f0ae3e87cc76aed28d2bc35b2d87ca93377aa84a527d02e37e504": {
+      "signature": "cbc318d0ea4f0ae3e87cc76aed28d2bc35b2d87ca93377aa84a527d02e37e504",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "509d657d6750b3c3cccbec635df086fb8cf8715067188ef55570398c1dda4d89": {
+      "signature": "509d657d6750b3c3cccbec635df086fb8cf8715067188ef55570398c1dda4d89",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "993d798d3613424f0d295d38d664861f8e05c2dc030da8faabb20aca4def27fe": {
+      "signature": "993d798d3613424f0d295d38d664861f8e05c2dc030da8faabb20aca4def27fe",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "324ec7ade0805153a8bad6d216e6ae203469d5da2a91fd592e204cb54e55150f": {
+      "signature": "324ec7ade0805153a8bad6d216e6ae203469d5da2a91fd592e204cb54e55150f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "2cdabc7f5cfd27eebcec3d6f8c6a52c9b31d5d8c40f6b976909699ceeddfabdb": {
+      "signature": "2cdabc7f5cfd27eebcec3d6f8c6a52c9b31d5d8c40f6b976909699ceeddfabdb",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "96cb7a600322c48add17a186c78f9c9a3e69f34d702e8ff0781c7a8ad6cfa4b2": {
+      "signature": "96cb7a600322c48add17a186c78f9c9a3e69f34d702e8ff0781c7a8ad6cfa4b2",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "53f3fc1bc5ca32844726b072cc7c0e416322cc0f4a4cc1a7ed8688a441054423": {
+      "signature": "53f3fc1bc5ca32844726b072cc7c0e416322cc0f4a4cc1a7ed8688a441054423",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14: 35Z"
+    },
+    "e61261f28f8f27b1919b8c9cce6f36447b36839cb58f4039ea9b1fb149d25079": {
+      "signature": "e61261f28f8f27b1919b8c9cce6f36447b36839cb58f4039ea9b1fb149d25079",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "7a2ff5fd952f5a131de0a380172b30b633071ce8646edae0064ab1097689769e": {
+      "signature": "7a2ff5fd952f5a131de0a380172b30b633071ce8646edae0064ab1097689769e",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "4efc6f506287e555e06c548bc9832e4a9835fa2701011bf2945f9d5bca01e211": {
+      "signature": "4efc6f506287e555e06c548bc9832e4a9835fa2701011bf2945f9d5bca01e211",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "4ad696d2e996458116960e18a1f9101b3e3418449e0ea45160e82874e171fb32": {
+      "signature": "4ad696d2e996458116960e18a1f9101b3e3418449e0ea45160e82874e171fb32",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "9be44bdc682cf236a3ebbedd95dae4cdb94feea7b7e434c26b8d02262da6537f": {
+      "signature": "9be44bdc682cf236a3ebbedd95dae4cdb94feea7b7e434c26b8d02262da6537f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "f213f4863d3ba4bba936bb68892b8520fb09141eae80b7aaeac15dc4fd69769f": {
+      "signature": "f213f4863d3ba4bba936bb68892b8520fb09141eae80b7aaeac15dc4fd69769f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "5f5a2aaba2d8f25f0aed47cede32d7d8ebec9e14d80e740587845f1b935c6456": {
+      "signature": "5f5a2aaba2d8f25f0aed47cede32d7d8ebec9e14d80e740587845f1b935c6456",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "1a9ae7df28234993754952f3c8628f03e155b38d403875df5489395f63f3ba9e": {
+      "signature": "1a9ae7df28234993754952f3c8628f03e155b38d403875df5489395f63f3ba9e",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "60e3dda8663498bd8b17ca2d376581378e42388a840613ea03d03a8d3a8eafac": {
+      "signature": "60e3dda8663498bd8b17ca2d376581378e42388a840613ea03d03a8d3a8eafac",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "bdf8226e663d9b4e4506377758f278aa80b9513354013e613f946f34633cac82": {
+      "signature": "bdf8226e663d9b4e4506377758f278aa80b9513354013e613f946f34633cac82",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "d5904255fc1e559d1d3a2b55b00cd8b25c279de6f025d92b6b3f6cac113d4483": {
+      "signature": "d5904255fc1e559d1d3a2b55b00cd8b25c279de6f025d92b6b3f6cac113d4483",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "6785803fd937e35d7db1cc08f7606160004f91de93314906d8c260813ad996ff": {
+      "signature": "6785803fd937e35d7db1cc08f7606160004f91de93314906d8c260813ad996ff",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "b1c395cdce67835489ba8fad70f6110bc407fa9adc0a346287fd63156a0a5ae6": {
+      "signature": "b1c395cdce67835489ba8fad70f6110bc407fa9adc0a346287fd63156a0a5ae6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "295e082abca3f4ec29e76cdc0a89d6577a121cfde5283edfe75ab1e779313c33": {
+      "signature": "295e082abca3f4ec29e76cdc0a89d6577a121cfde5283edfe75ab1e779313c33",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "5ccf01d5f9a63661f70874faf8dc50b4dae51d4e4f9d0d081165f4c55fb1a96f": {
+      "signature": "5ccf01d5f9a63661f70874faf8dc50b4dae51d4e4f9d0d081165f4c55fb1a96f",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "a8a07e8b44cc2993fc2a826f3e7dc239cfc9462f9ccb9b9a55f": {
+      "signature": "a8a07e8b44cc2993fc2a826f3e7dc239cfc9462f9ccb9b9a55fda8ea308c6aaf",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "116e84e69906365be35403dd94483c724ef85375a59610e7ee951b63c72d4099": {
+      "signature": "116e84e69906365be35403dd94483c724ef85375a59610e7ee951b63c72d4099",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "767b9a029a87c8fe7b65caa4aeec1d1c5821eef2376913a49b7c163fe17e086d": {
+      "signature": "767b9a029a87c8fe7b65caa4aeec1d1c5821eef2376913a49b7c163fe17e086d",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "f0bd53aff705ed298de0e95d0f2ab5a8b629323daa846fd5899e548f0a8c0535": {
+      "signature": "f0bd53aff705ed298de0e95d0f2ab5a8b629323daa846fd5899e548f0a8c0535",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "54a1d1576372943cecbe14cc47864c31f89dde4513c369fa5a496cb72992ccf6": {
+      "signature": "54a1d1576372943cecbe14cc47864c31f89dde4513c369fa5a496cb72992ccf6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "4d445934d7465256db801d4d77a9a5a1f27bd23ae47db45952652004aa5de8fa": {
+      "signature": "4d445934d7465256db801d4d77a9a5a1f27bd23ae47db45952652004aa5de8fa",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "aaa7da3dd16b2c578aa7b89e6cee1887b9e3a024c25fa3abb6c3a2c81bc36f52": {
+      "signature": "aaa7da3dd16b2c578aa7b89e6cee1887b9e3a024c25fa3abb6c3a2c81bc36f52",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "f608e3f8b7aa764ed2b5105e800203ccbd0adb7dae2ff5fa5d9031bcafed14e0": {
+      "signature": "f608e3f8b7aa764ed2b5105e800203ccbd0adb7dae2ff5fa5d9031bcafed14e0",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "f893563950a31bab4bb8bdc692d362acc37a1d269dadc9887797cdcb50efe5f1": {
+      "signature": "f893563950a31bab4bb8bdc692d362acc37a1d269dadc9887797cdcb50efe5f1",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "9f7fa9d5849279e1f85cff39eef916c669f2109f79c64032ef42d87f2eec358d": {
+      "signature": "9f7fa9d5849279e1f85cff39eef916c669f2109f79c64032ef42d87f2eec358d",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "71dbaa8da1136709f2a750606f876ca612b1cba4709582211f3ff3b39742ac2a": {
+      "signature": "71dbaa8da1136709f2a750606f876ca612b1cba4709582211f3ff3b39742ac2a",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "8122f3168cd9ec0afa3283e9b76f0d26605fb48b2c8f4cb326caf15a90f482eb": {
+      "signature": "8122f3168cd9ec0afa3283e9b76f0d26605fb48b2c8f4cb326caf15a90f482eb",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "64caf19c5cb7deafbbfac65c7ba589df83b759ec877e2c747982576ee8f0cffe": {
+      "signature": "64caf19c5cb7deafbbfac65c7ba589df83b759ec877e2c747982576ee8f0cffe",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "206db152b4bd29f6e949e880a301dee9e484125f8e09112fa7141827c6456773": {
+      "signature": "206db152b4bd29f6e949e880a301dee9e484125f8e09112fa7141827c6456773",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "c307fac63c3f6b0c5a32bf4bd5dab9d92353160bc2eb15cfd12fa0af2f819642": {
+      "signature": "c307fac63c3f6b0c5a32bf4bd5dab9d92353160bc2eb15cfd12fa0af2f819642",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "66ceb191bad5ce2cd0de55201647c4b83fa98e09d0fb5e62650fa724887ca090": {
+      "signature": "66ceb191bad5ce2cd0de55201647c4b83fa98e09d0fb5e62650fa724887ca090",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "07a4868c698680d9d305bf8911a7080064b6bb4d0db2187bc82a75d3f9450ff6": {
+      "signature": "07a4868c698680d9d305bf8911a7080064b6bb4d0db2187bc82a75d3f9450ff6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "312768faea2b900d6d7db7ebe21b0b51dc5ee6ebc4a2ea312dae7bd673ddef84": {
+      "signature": "312768faea2b900d6d7db7ebe21b0b51dc5ee6ebc4a2ea312dae7bd673ddef84",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "eb190a151189f142181c913f2a15187e91a52635fa88e0e91528fb76c6b05a14": {
+      "signature": "eb190a151189f142181c913f2a15187e91a52635fa88e0e91528fb76c6b05a14",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
+    },
+    "a8a07e8b44cc2993fc2a826f3e7dc239cfc9462f9ccb9b9a55fda8ea308c6aaf": {
+      "signature": "a8a07e8b44cc2993fc2a826f3e7dc239cfc9462f9ccb9b9a55fda8ea308c6aaf",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "justification": "Unit tests data",
+      "createdDate": "2024-06-05 17:14:35Z"
     }
   }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,10 @@ resources:
   repositories:
   - repository: AzureDevOps
     type: git
-    endpoint: AzureDevOpsRepos
     name: AzureDevOps/AzureDevOps
 
   - repository: ConfigChange
     type: git
-    endpoint: AzureDevOpsRepos
     name: AzureDevOps/AzureDevOps.ConfigChange
 
   - repository: 1ESPipelineTemplates
@@ -89,6 +87,7 @@ extends:
             task_name: ${{ parameters.task_name }}
             push_to_feed: ${{ parameters.push_to_feed }}
             generate_prs: ${{ parameters.generate_prs }}
+            enableCodeQL: ${{ parameters.enableCodeQL }}
 
       - ${{ if not(parameters.build_single_task) }}:
 
@@ -158,6 +157,15 @@ extends:
                 )
               )
             )
+          templateContext:
+            outputs:
+            - output: nuget
+              packagesToPush:  '$(Build.SourcesDirectory)/IndividualNugetPackages/*/*.nupkg'
+              packageParentPath: '$(Build.SourcesDirectory)'
+              publishVstsFeed: 'c86767d8-af79-4303-a7e6-21da0ba435e2/e10d0795-57cd-4d7f-904e-5f39703cb096'
+              nuGetFeedType: internal
+              displayName: Push Nuget package
+              allowPackageConflicts: $(COURTESY_PUSH)
           steps:
           - checkout: AzureDevOps
             fetchDepth: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,7 +160,7 @@ extends:
           templateContext:
             outputs:
             - output: nuget
-              packagesToPush:  '$(Build.SourcesDirectory)/IndividualNugetPackages/*/*.nupkg'
+              packagesToPush:  '$(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded/IndividualNugetPackages/*/*.nupkg'
               packageParentPath: '$(Build.SourcesDirectory)'
               publishVstsFeed: 'c86767d8-af79-4303-a7e6-21da0ba435e2/e10d0795-57cd-4d7f-904e-5f39703cb096'
               nuGetFeedType: internal

--- a/ci/build-single-ado-pr-steps.yml
+++ b/ci/build-single-ado-pr-steps.yml
@@ -45,7 +45,7 @@ steps:
     node open-hotfix-pr.js
   displayName: Create PR
   env:
-    TOKEN: $(Package.Token)
+    TOKEN: $(System.AccessToken)
     TASK_NAME: ${{ parameters.task_name }}
     REPOSITORY: AzureDevOps
     BRANCH: $(branchName)

--- a/ci/build-single-ado-pr-steps.yml
+++ b/ci/build-single-ado-pr-steps.yml
@@ -27,10 +27,10 @@ steps:
 - task: DownloadBuildArtifacts@0
   inputs:
     artifactName: IndividualNugetPackages
-    downloadPath: IndividualNugetPackagesDownloaded
+    downloadPath: $(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded
   displayName: Download Artifact
 
-- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
+- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps $(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
   displayName: Update unified deps
 
 - powershell: ./azure-pipelines-tasks/ci/set-sprint-variables.ps1

--- a/ci/build-single-cc-pr-steps.yml
+++ b/ci/build-single-cc-pr-steps.yml
@@ -46,7 +46,7 @@ steps:
     node open-hotfix-pr.js
   displayName: Open PR in ConfigChange
   env:
-    TOKEN: $(Package.Token)
+    TOKEN: $(System.AccessToken)
     TASK_NAME: ${{ parameters.task_name }}
     REPOSITORY: AzureDevOps.ConfigChange
     BRANCH: '$(branchName)'
@@ -56,4 +56,4 @@ steps:
     node create-hotfix-release.js $(hotfixFolderPath) "${{ parameters.task_name }}"
   displayName: Create Release in AzureDevOps.ConfigChange
   env:
-    TOKEN: $(Package.Token)
+    TOKEN: $(System.AccessToken)

--- a/ci/build-single-jobs.yml
+++ b/ci/build-single-jobs.yml
@@ -5,6 +5,10 @@ parameters:
   type: boolean
 - name: generate_prs
   type: boolean
+- name: enableCodeQL
+  displayName: Enable CodeQL for run
+  type: boolean
+  default: false
 
 jobs:
 # Build Single Task and stage hotfix
@@ -25,6 +29,13 @@ jobs:
         displayName: 'Publish per task NuGet package artifact'
         PathtoPublish: nuget-packages
         ArtifactName: IndividualNuGetPackages
+      - output: nuget
+        packagesToPush:  '$(Build.SourcesDirectory)/nuget-packages/*/*.nupkg'
+        packageParentPath: '$(Build.SourcesDirectory)'
+        publishVstsFeed: 'c86767d8-af79-4303-a7e6-21da0ba435e2/e10d0795-57cd-4d7f-904e-5f39703cb096'
+        nuGetFeedType: internal
+        displayName: Push Nuget package
+        allowPackageConflicts: $(COURTESY_PUSH)
 
   steps:
   - template: /ci/build-single-steps.yml@self

--- a/ci/build-single-steps.yml
+++ b/ci/build-single-steps.yml
@@ -127,16 +127,6 @@ steps:
   - script: npm run package
     displayName: npm run package
 
-  # Authenticate 
-  - task: NuGetAuthenticate@1
-    displayName: Authenticate with nuget
-
-  # Push to feed
-  - script: |
-      cd $(Build.SourcesDirectory)\_package\nuget-packages
-      push.cmd
-    displayName: Push Nuget package
-
   - powershell: |
       mv _package/nuget-packages nuget-packages
     displayName: Move _package/nuget-packages to nuget-packages

--- a/ci/ci-util.js
+++ b/ci/ci-util.js
@@ -27,7 +27,6 @@ var aggregatePackSourceContentsZipPath = path.join(packagePath, 'aggregate-pack-
 var aggregatePackageName = 'Mseng.MS.TF.Build.Tasks';
 var aggregateNuspecPath = path.join(packagePath, 'Mseng.MS.TF.Build.Tasks.nuspec');
 var publishLayoutPath = path.join(packagePath, 'publish-layout');
-var publishPushCmdPath = path.join(packagePath, 'publish-layout', 'push.cmd');
 var genTaskPath = path.join(__dirname, '..', '_generated');
 var makeOptionPath = path.join(__dirname, '..', 'make-options.json');
 
@@ -49,7 +48,6 @@ exports.aggregatePackSourceContentsZipPath = aggregatePackSourceContentsZipPath;
 exports.aggregatePackageName = aggregatePackageName;
 exports.aggregateNuspecPath = aggregateNuspecPath;
 exports.publishLayoutPath = publishLayoutPath;
-exports.publishPushCmdPath = publishPushCmdPath;
 exports.genTaskPath = genTaskPath;
 exports.makeOptionPath = makeOptionPath;
 

--- a/ci/courtesy-push.yml
+++ b/ci/courtesy-push.yml
@@ -18,10 +18,10 @@ steps:
 - task: DownloadBuildArtifacts@0
   inputs:
     artifactName: IndividualNugetPackages
-    downloadPath: IndividualNugetPackagesDownloaded
+    downloadPath: $(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded
   displayName: Download Artifact
 
-- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
+- script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps $(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
   displayName: Update unified deps
 
 - powershell: ./azure-pipelines-tasks/ci/set-sprint-variables.ps1
@@ -57,9 +57,4 @@ steps:
   condition: eq(variables['build.reason'], 'Schedule')
   env:
     TEAMS_WEBHOOK: $(MSTeamsUri)
-    
-- task: DownloadBuildArtifacts@0
-  inputs:
-    artifactName: IndividualNugetPackages
-    downloadPath: $(Build.SourcesDirectory)
-  displayName: Download Artifact
+  

--- a/ci/courtesy-push.yml
+++ b/ci/courtesy-push.yml
@@ -5,6 +5,12 @@ steps:
   displayName: Install nuget
 
 - powershell: |
+    $sourcePath = "$(Build.SourcesDirectory)/azure-pipelines-tasks/.gdn"
+    $destinationPath = "$(Build.SourcesDirectory)/"
+    Copy-Item -Path $sourcePath -Destination $destinationPath -Recurse
+  displayName: Copy baseline files to root
+
+- powershell: |
     cd azure-pipelines-tasks/ci/courtesy-push
     npm install
   displayName: npm install
@@ -17,18 +23,6 @@ steps:
 
 - script: node azure-pipelines-tasks\ci\courtesy-push\courtesy-push.js AzureDevOps IndividualNugetPackagesDownloaded\IndividualNugetPackages\unified_deps.xml
   displayName: Update unified deps
-
-- task: NuGetAuthenticate@1
-  displayName: Authenticate with nuget
-
-# Everything until this point is idempotent (other than pushing tasks release branch which will get overwritten if we re-do this anyways).
-# Note: Pushing the tasks release branch has to happen in the first job in case commits are pushed between now and then.
-
-- script: |
-    cd IndividualNugetPackagesDownloaded
-    cd IndividualNugetPackages
-    push.cmd
-  displayName: Push Nuget packages
 
 - powershell: ./azure-pipelines-tasks/ci/set-sprint-variables.ps1
   displayName: Set currentSprint variables
@@ -56,10 +50,16 @@ steps:
     Start-Sleep -Seconds 30
   displayName: Create PR in Azure DevOps
   env:
-    TOKEN: $(Package.Token)
+    TOKEN: $(System.AccessToken)
 
 - powershell: .\azure-pipelines-tasks\ci\courtesy-push\send-notification.ps1
   displayName: Send MS Teams notification
   condition: eq(variables['build.reason'], 'Schedule')
   env:
     TEAMS_WEBHOOK: $(MSTeamsUri)
+    
+- task: DownloadBuildArtifacts@0
+  inputs:
+    artifactName: IndividualNugetPackages
+    downloadPath: $(Build.SourcesDirectory)
+  displayName: Download Artifact

--- a/make-util.js
+++ b/make-util.js
@@ -1286,11 +1286,8 @@ exports.createNonAggregatedZip = createNonAggregatedZip;
  * /artifacts
  *  /AndroidSigningV2
  *      /Mseng.MS.TF.DistributedTask.Tasks.AndroidSigningV2.2.135.0.nupkg
- *      /push.cmd
  *  /AnotherTask
  *      /Mseng.MS.TF.DistributedTask.Tasks.AnotherTaskV1.1.0.0.nupkg
- *      /push.cmd
- *  /push.cmd * Root push.cmd that runs all nested push.cmd's.
  *  /servicing.xml * Convenience file. Generates all XML to update servicing configuration for tasks.
  *  /unified_deps.xml * Convenience file. Generates all XML to update unified dependencies file.
  *
@@ -1376,15 +1373,12 @@ var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath
             // Write layout version file. This will help us if we change the structure of the individual NuGet packages in the future.
             fs.writeFileSync(path.join(nugetContentPath, 'layout-version.txt'), '3');
 
-            // Create the nuspec file, nupkg, and push.cmd
+            // Create the nuspec file and nupkg
             var taskNuspecPath = createNuspecFile(taskZipPath, fullTaskName, taskVersion);
-            var taskPublishFolder = createNuGetPackage(nugetPackagesPath, taskFolderName, taskNuspecPath, taskZipPath);
-            createPushCmd(taskPublishFolder, fullTaskName, taskVersion);
+            createNuGetPackage(nugetPackagesPath, taskFolderName, taskNuspecPath, taskZipPath);
         });
 
     console.log();
-    console.log('> Creating root push.cmd at ' + nugetPackagesPath);
-    createRootPushCmd(nugetPackagesPath);
 
     // Write file that has XML for unified dependencies, makes it easier to setup that file.
     console.log('> Generating XML dependencies for UnifiedDependencies');
@@ -1398,25 +1392,6 @@ var createNugetPackagePerTask = function (packagePath, /*nonAggregatedLayoutPath
 }
 exports.createNugetPackagePerTask = createNugetPackagePerTask;
 
-/**
- * Create push.cmd at root of the nuget packages path.
- *
- * This makes it easier to run all the nested push.cmds within the task folders.
- * @param {*} nugetPackagesPath
- */
-var createRootPushCmd = function (nugetPackagesPath) {
-    var contents = 'for /D %%s in (.\\*) do ( ' + os.EOL;
-    contents +=     'pushd %%s' + os.EOL;
-    contents +=     'if exist push.cmd (' + os.EOL;
-    contents +=     'push.cmd' + os.EOL;
-    contents +=     ') else (' + os.EOL;
-    contents +=     'echo "file not exist"' + os.EOL;
-    contents +=     ')' + os.EOL;
-    contents +=     'popd' + os.EOL;
-    contents += ')';
-    var rootPushCmdPath = path.join(nugetPackagesPath, 'push.cmd');
-    fs.writeFileSync(rootPushCmdPath, contents);
-}
 
 /**
  * Create xml content for servicing.
@@ -1493,29 +1468,6 @@ var createNuGetPackage = function (publishPath, taskFolderName, taskNuspecPath, 
     return taskPublishFolder;
 }
 
-/**
- * Create push.cmd for the task.
- * @param {*} taskPublishFolder Folder for a specific task within the publish folder.
- * @param {*} fullTaskName Full name of the task. e.g - Mseng.MS.TF.Build.Tasks.AzureCLIV1
- * @param {*} taskVersion Version of the task. e.g - 1.132.0
- */
-var createPushCmd = function (taskPublishFolder, fullTaskName, taskVersion) {
-    console.log('> Creating push.cmd for task ' + fullTaskName);
-
-    var taskPushCmdPath = path.join(taskPublishFolder, 'push.cmd');
-    var nupkgName = `${fullTaskName}.${taskVersion}.nupkg`;
-
-    var taskFeedUrl = process.env.AGGREGATE_TASKS_FEED_URL;
-    var apiKey = 'Skyrise';
-
-    var pushCmd = `nuget.exe push ${nupkgName} -source "${taskFeedUrl}" -apikey ${apiKey}`;
-
-    if (process.env['COURTESY_PUSH']) {
-        pushCmd += ' -skipDuplicate'
-    }
-
-    fs.writeFileSync(taskPushCmdPath, pushCmd);
-}
 
 // Rename task folders that are created from the aggregate. Allows NuGet generation from aggregate using same process as normal.
 // [stfrance]: remove this once we have fully migrated to nuget package per task.


### PR DESCRIPTION
Fixed dependency on some tasks

**Task name**: Move courtesy-push pipeline into ADO

**Description**:  Courtesy push is run on PipelineTools project, we need to move it to ADO project and rid of PATs

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N 

**Attached related issue:** (Y/N) N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

[AB#2174750](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2174750)

