### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 28618795

### DIFF
--- a/Tasks/AzureCLIV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Wenn dieser Wert FALSE ist, wird am Ende Ihres Skripts die Zeile \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\" angehängt. Dadurch wird der letzte Exitcode aus einem externen Befehl als Exitcode der PowerShell weitergegeben. Andernfalls wird die Zeile nicht an das Ende Ihres Skripts angehängt.",
   "loc.input.label.visibleAzLogin": "Ausgabesichtbarkeit der az-Anmeldung",
   "loc.input.help.visibleAzLogin": "Durch Festlegen auf „true“ wird der az-Anmeldebefehl an die Aufgabe ausgegeben. Durch Festlegen auf „false“ wird die Ausgabe der az-Anmeldung unterdrückt.",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "Skript wurde mit Rückgabecode beendet: %d",
   "loc.messages.ScriptFailed": "Skriptfehler: %s",
   "loc.messages.ScriptFailedStdErr": "Das Skript weist Ausgabe in stderr auf. Dies verursacht einen Fehler, weil \"failOnStdErr\" auf TRUE festgelegt ist.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "Für Agent-Versionen vor 2.115.0 kann nur die globale Azure CLI-Konfiguration verwendet werden.",
   "loc.messages.UnacceptedScriptLocationValue": "\"%s\" ist kein gültiger Wert für die Aufgabeneingabe für den Skriptspeicherort (\"scriptLocation\" in YAML). Der Wert kann entweder \"inlineScript\"oder \"scriptPath\" lauten.",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Das Geheimnis ist abgelaufen. Aktualisieren Sie die Dienstverbindung unter %s. Weitere Informationen zur Konvertierung in Dienstverbindungen ohne Geheimnis finden Sie unter https://aka.ms/azdo-rm-workload-identity-conversion.",
-  "loc.messages.ProxyConfig": "Das az-Tool ist für die Verwendung von „%s“ als Proxyserver konfiguriert."
+  "loc.messages.ProxyConfig": "Das az-Tool ist für die Verwendung von „%s“ als Proxyserver konfiguriert.",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Si es false, se anexa la línea \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\" al final del script. Esto hará que se propague el último código de salida de un comando externo como código de salida de PowerShell. De lo contrario, no se anexa la línea al final del script.",
   "loc.input.label.visibleAzLogin": "visibilidad de salida de acceso de zona de disponibilidad",
   "loc.input.help.visibleAzLogin": "Si se establece en true, el comando de acceso de zona de disponibilidad generará la salida en la tarea. Si se establece en false, se suprimirá la salida de acceso de zona de disponibilidad.",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "El script finalizó con el código de retorno: %d",
   "loc.messages.ScriptFailed": "No se pudo ejecutar el script. Error: %s",
   "loc.messages.ScriptFailedStdErr": "El script tiene la salida en stderr. Se produce un error cuando failOnStdErr está establecido en true.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "Para la versión del agente < 2.115.0, solo se puede usar la configuración global de la CLI de Azure.",
   "loc.messages.UnacceptedScriptLocationValue": "%s no es un valor válido para la entrada de tarea \"Ubicación del script\" (scriptLocation en YAML). El valor puede ser \"inlineScript\" o \"scriptPath\".",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "El secreto expiró. Actualice la conexión de servicio en %s Consulte https://aka.ms/azdo-rm-workload-identity-conversion para obtener más información sobre la conversión a conexiones de servicio sin secretos.",
-  "loc.messages.ProxyConfig": "la herramienta de zona de disponibilidad está configurada para usar %s como servidor proxy"
+  "loc.messages.ProxyConfig": "la herramienta de zona de disponibilidad está configurada para usar %s como servidor proxy",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Si cette valeur est false, la ligne 'if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }' est ajoutée à la fin de votre script. Cela entraîne la propagation du dernier code de sortie d'une commande externe en tant que code de sortie de PowerShell. Sinon, la ligne n'est pas ajoutée à la fin de votre script.",
   "loc.input.label.visibleAzLogin": "visibilité de sortie de connexion az",
   "loc.input.help.visibleAzLogin": "Si la valeur est définie sur true, la commande de connexion az est générée dans la tâche. Si la valeur est définie sur false, la sortie de connexion az est supprimée",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "Arrêt du script. Code de retour : %d",
   "loc.messages.ScriptFailed": "Échec du script. Erreur : %s",
   "loc.messages.ScriptFailedStdErr": "Le script a une sortie vers stderr. Échec, car failOnStdErr a la valeur true.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "Pour une version d'agent < 2.115.0, seule la configuration Azure CLI globale peut être utilisée",
   "loc.messages.UnacceptedScriptLocationValue": "%s n'est pas une valeur valide pour l'entrée de tâche 'Script Location' (scriptLocation en YAML). La valeur peut être 'inlineScript' ou 'scriptPath'",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Secret expiré, mettez à jour la connexion de service à l’adresse %s Consultez https://aka.ms/azdo-rm-workload-identity-conversion pour en savoir plus sur la conversion en connexions de service sans secret.",
-  "loc.messages.ProxyConfig": "l’outil az est configuré pour utiliser %s comme serveur proxy"
+  "loc.messages.ProxyConfig": "l’outil az est configuré pour utiliser %s comme serveur proxy",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Se è false, la riga 'if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }' viene aggiunta alla fine dello script. In questo modo l'ultimo codice di uscita da un comando esterno verrà propagato come codice di uscita di PowerShell. In caso contrario, la riga non viene aggiunta alla fine dello script.",
   "loc.input.label.visibleAzLogin": "visibilità dell'output dell'account di accesso az",
   "loc.input.help.visibleAzLogin": "Se questa opzione è impostata su true, l'output del comando az login verrà restituito all'attività. Se si imposta su false, l'output dell'account di accesso az verrà eliminato",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "Lo script è stato terminato. Codice restituito: %d",
   "loc.messages.ScriptFailed": "Lo script non è riuscito. Errore: %s",
   "loc.messages.ScriptFailedStdErr": "L'output dello script viene inviato a STDERR. Verrà restituito un errore perché failOnStdErr è impostato su true.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "Se la versione dell'agente è inferiore a quella 2.115.0, è possibile usare solo la configurazione globale dell'interfaccia della riga di comando di Azure",
   "loc.messages.UnacceptedScriptLocationValue": "%s non è un valore valido per il valore di input attività 'Percorso script' (scriptLocation in YAML). Il valore può essere 'inlineScript' o 'scriptPath'",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Segreto scaduto. Aggiornare la connessione al servizio in %s Per altre informazioni sulla conversione a connessioni al servizio senza segreto, vedere https://aka.ms/azdo-rm-workload-identity-conversion.",
-  "loc.messages.ProxyConfig": "lo strumento az è configurato per l'utilizzo di %s come server proxy"
+  "loc.messages.ProxyConfig": "lo strumento az è configurato per l'utilizzo di %s come server proxy",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "これが false の場合、行 `if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }` がスクリプトの末尾に追加されます。この行があると、外部コマンドからの最後の終了コードが PowerShell の終了コードとして伝達されます。それ以外の場合、スクリプトの末尾にこの行が追加されることはありません。",
   "loc.input.label.visibleAzLogin": "az ログイン出力の可視性",
   "loc.input.help.visibleAzLogin": "これが true に設定されている場合、az login コマンドはタスクに出力します。false に設定すると、az ログイン出力は表示されません",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "スクリプトが次のリターン コードで終了しました: %d",
   "loc.messages.ScriptFailed": "スクリプトがエラーで失敗しました: %s",
   "loc.messages.ScriptFailedStdErr": "スクリプトに stderr への出力があります。failOnStdErr が true に設定されているため、失敗しています。",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "エージェント バージョンが 2.115.0 より前の場合、グローバルの Azure CLI 構成のみ使用できます",
   "loc.messages.UnacceptedScriptLocationValue": "%s はタスク入力 'スクリプトの場所' (YAML での scriptLocation) の有効な値ではありません。値には 'inlineScript' または 'scriptPath' のいずれかを指定できます",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "シークレットの有効期限が切れました。%s でサービスの接続を更新してください。秘密度の低いサービスの接続への変換については、https://aka.ms/azdo-rm-workload-identity-conversion を参照してください。",
-  "loc.messages.ProxyConfig": "az ツールは、%s をプロキシ サーバーとして使用するように構成されています"
+  "loc.messages.ProxyConfig": "az ツールは、%s をプロキシ サーバーとして使用するように構成されています",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "false이면 스크립트의 끝에 `if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }` 줄이 추가됩니다. 이 줄로 인해 외부 명령의 마지막 종료 코드가 PowerShell의 종료 코드로 전파됩니다. true이면 줄이 스크립트의 끝에 추가되지 않습니다.",
   "loc.input.label.visibleAzLogin": "az 로그인 출력 표시 여부",
   "loc.input.help.visibleAzLogin": "true로 설정하면 az 로그인 명령이 작업에 출력됩니다. false로 설정하면 az 로그인 출력이 표시되지 않습니다.",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "다음 반환 코드로 스크립트가 종료됨: %d",
   "loc.messages.ScriptFailed": "다음 오류가 발생하여 스크립트 실패: %s",
   "loc.messages.ScriptFailedStdErr": "스크립트가 STDERR에 출력되었습니다. failOnStdErr이 true로 설정되어 있으므로 실패합니다.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "2.115.0 이전의 에이전트 버전에서는 전역 Azure CLI 구성만 사용할 수 있습니다.",
   "loc.messages.UnacceptedScriptLocationValue": "%s은(는) '스크립트 위치'(YAML의 scriptLocation) 작업 입력에 유효한 값이 아닙니다. 값은 be'inlineScript' 또는 'scriptPath' 중 하나일 수 있습니다.",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "비밀이 만료되었습니다. %s에서 서비스 연결을 업데이트하세요. 비밀 없는 서비스 연결로의 변환에 대한 자세한 정보는 https://aka.ms/azdo-rm-workload-identity-conversion을 참고하세요.",
-  "loc.messages.ProxyConfig": "az 도구가 %s을(를) 프록시 서버로 사용하도록 구성되어 있습니다."
+  "loc.messages.ProxyConfig": "az 도구가 %s을(를) 프록시 서버로 사용하도록 구성되어 있습니다.",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Если задано значение False, в конец скрипта добавляется строка \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\". Это приведет к тому, что последний код выхода из внешней команды будет использоваться как код выхода PowerShell. В противном случае эта строка не добавляется в конец скрипта.",
   "loc.input.label.visibleAzLogin": "Видимость вывода при az login",
   "loc.input.help.visibleAzLogin": "Если для этого параметра установлено значение ИСТИНА, команда az login выведет задачу. Установка значения ЛОЖЬ приведет к скрытию вывода az login.",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "Выход из сценария с кодом возврата: %d",
   "loc.messages.ScriptFailed": "Сбой сценария с ошибкой: %s",
   "loc.messages.ScriptFailedStdErr": "Скрипт выводит выходные данные в stderr. Завершается сбоем, если failOnStdErr имеет значение true.",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "Для агента версии ниже 2.115.0 можно использовать только глобальную конфигурацию Azure CLI",
   "loc.messages.UnacceptedScriptLocationValue": "%s не является допустимым значением для входных данных задачи \"Расположение скрипта\" (scriptLocation в YAML). Значение может быть равно inlineScript либо scriptPath",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Срок действия секрета истек. Обновите подключение службы %s. Подробнее о преобразовании в подключения служб без секретов см. https://aka.ms/azdo-rm-workload-identity-conversion.",
-  "loc.messages.ProxyConfig": "Инструмент az настроен на использование %s в качестве прокси-сервера"
+  "loc.messages.ProxyConfig": "Инструмент az настроен на использование %s в качестве прокси-сервера",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "如果为 false，行 \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\" 将追加到脚本的末尾。这将导致外部命令中的最后一个退出代码传播为 powershell 的退出代码。否则，行将不会追加到脚本的末尾。",
   "loc.input.label.visibleAzLogin": "Az 登录输出可见性",
   "loc.input.help.visibleAzLogin": "如果此项设置为 true，则 Az 登录命令将输出到任务。将其设置为 false 将禁止 Az 登录输出",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "脚本已退出，返回代码: %d",
   "loc.messages.ScriptFailed": "脚本失败，出现错误: %s",
   "loc.messages.ScriptFailedStdErr": "脚本具有到 stderr 的输出。失败，因为 failOnStdErr 设置为 true。",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "对于低于 2.115.0 的代理版本，只能使用全局 Azure CLI 配置",
   "loc.messages.UnacceptedScriptLocationValue": "%s 不是任务输入“脚本位置”(YAML 中为 scriptLocation)的有效值。值可以是 \"inlineScript\" 或 \"scriptPath\"",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "机密已过期，请在 %s 更新服务连接。若要详细了解如何转换到无机密服务连接，请参阅 https://aka.ms/azdo-rm-workload-identity-conversion。",
-  "loc.messages.ProxyConfig": "Az 工具配置为将 %s 用作代理服务器"
+  "loc.messages.ProxyConfig": "Az 工具配置为将 %s 用作代理服务器",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -31,6 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "若此為 false，則會將 `if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }` 附加至您指令碼的結尾。如此會讓來自外部命令中的最後一個結束代碼，以 PowerShell 的結束代碼散佈。否則，不會將此行附加至您的指令碼結尾。",
   "loc.input.label.visibleAzLogin": "az 登入輸出可見度",
   "loc.input.help.visibleAzLogin": "如果設定為 True，az 登入命令將會輸出到工作。設定為 False 將會隱藏 az 登入輸出",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
+  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
   "loc.messages.ScriptReturnCode": "指令碼已結束。傳回碼: %d",
   "loc.messages.ScriptFailed": "指令碼失敗。錯誤: %s",
   "loc.messages.ScriptFailedStdErr": "指令碼有到 stderr 的輸出。因為 failOnStdErr 設為 true 而失敗。",
@@ -49,5 +51,8 @@
   "loc.messages.GlobalCliConfigAgentVersionWarning": "2.115.0 以下的代理程式版本只能使用全域 Azure CLI 設定",
   "loc.messages.UnacceptedScriptLocationValue": "%s 不是工作輸入 'Script Location' (在 YAML 中為 scriptLocation) 的有效值。值可以是 'inlineScript' 或 'scriptPath'",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "秘密已過期，請在 %s 更新服務連線，參閱 https://aka.ms/azdo-rm-workload-identity-conversion 以深入了解如何轉換為無秘密服務連線。",
-  "loc.messages.ProxyConfig": "az 工具已設定為使用 %s 做為 Proxy 伺服器"
+  "loc.messages.ProxyConfig": "az 工具已設定為使用 %s 做為 Proxy 伺服器",
+  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
+  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.