### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 28695612

### DIFF
--- a/Tasks/AzureCLIV2/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/de-DE/resources.resjson
@@ -31,8 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Wenn dieser Wert FALSE ist, wird am Ende Ihres Skripts die Zeile \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\" angehängt. Dadurch wird der letzte Exitcode aus einem externen Befehl als Exitcode der PowerShell weitergegeben. Andernfalls wird die Zeile nicht an das Ende Ihres Skripts angehängt.",
   "loc.input.label.visibleAzLogin": "Ausgabesichtbarkeit der az-Anmeldung",
   "loc.input.help.visibleAzLogin": "Durch Festlegen auf „true“ wird der az-Anmeldebefehl an die Aufgabe ausgegeben. Durch Festlegen auf „false“ wird die Ausgabe der az-Anmeldung unterdrückt.",
-  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
-  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
+  "loc.input.label.keepAzSessionActive": "[Experimentell] Azure CLI-Sitzung aktiv halten",
+  "loc.input.help.keepAzSessionActive": "Wenn diese Option aktiviert ist, meldet die Aufgabe sich kontinuierlich bei Azure an, um AADSTS700024 Fehler beim Anfordern von Zugriffstoken über das IdToken-Ablaufdatum hinaus zu vermeiden. Beachten Sie, dass dieses Feature EXPERIMENTELL ist und möglicherweise nicht in allen Szenarien funktioniert und Sie es ohne jegliche Gewährleistungen verwenden. Gilt nur für Dienstverbindungen, die das Authentifizierungsschema des Workloadidentitätsverbunds verwenden.",
   "loc.messages.ScriptReturnCode": "Skript wurde mit Rückgabecode beendet: %d",
   "loc.messages.ScriptFailed": "Skriptfehler: %s",
   "loc.messages.ScriptFailedStdErr": "Das Skript weist Ausgabe in stderr auf. Dies verursacht einen Fehler, weil \"failOnStdErr\" auf TRUE festgelegt ist.",
@@ -52,7 +52,7 @@
   "loc.messages.UnacceptedScriptLocationValue": "\"%s\" ist kein gültiger Wert für die Aufgabeneingabe für den Skriptspeicherort (\"scriptLocation\" in YAML). Der Wert kann entweder \"inlineScript\"oder \"scriptPath\" lauten.",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Das Geheimnis ist abgelaufen. Aktualisieren Sie die Dienstverbindung unter %s. Weitere Informationen zur Konvertierung in Dienstverbindungen ohne Geheimnis finden Sie unter https://aka.ms/azdo-rm-workload-identity-conversion.",
   "loc.messages.ProxyConfig": "Das az-Tool ist für die Verwendung von „%s“ als Proxyserver konfiguriert.",
-  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
-  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
-  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
+  "loc.messages.FailedToRefreshAzSession": "Fehler beim Aktualisieren der AZ-CLI-Sitzung: %s",
+  "loc.messages.RefreshingAzSession": "Es wird versucht, die AZ-CLI-Sitzung zu aktualisieren...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "Die Eingabe \"keepAzSessionActive\" kann nur für die ARM-Dienstverbindung des Workloadidentitätsverbunds verwendet werden. Das Authentifizierungsschema des Dienstendpunkts, auf das verwiesen wird, war unerwartet: %s. Ändern Sie das Schema, oder entfernen Sie die Eingabe \"keepAzSessionActive\"."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -31,8 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Si es false, se anexa la línea \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\" al final del script. Esto hará que se propague el último código de salida de un comando externo como código de salida de PowerShell. De lo contrario, no se anexa la línea al final del script.",
   "loc.input.label.visibleAzLogin": "visibilidad de salida de acceso de zona de disponibilidad",
   "loc.input.help.visibleAzLogin": "Si se establece en true, el comando de acceso de zona de disponibilidad generará la salida en la tarea. Si se establece en false, se suprimirá la salida de acceso de zona de disponibilidad.",
-  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
-  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
+  "loc.input.label.keepAzSessionActive": "[Experimental] Mantener la sesión de la CLI de Azure activa",
+  "loc.input.help.keepAzSessionActive": "Cuando se habilita, esta tarea iniciará sesión continuamente en Azure para evitar errores de AADSTS700024 al solicitar tokens de acceso más allá de la fecha de expiración del IdToken. Tenga en cuenta que esta característica es EXPERIMENTAL, podría no funcionar en todos los escenarios y está usándola sin ninguna garantía. Solo es válido para las conexiones de servicio que usan el esquema de autenticación de federación de identidades de carga de trabajo.",
   "loc.messages.ScriptReturnCode": "El script finalizó con el código de retorno: %d",
   "loc.messages.ScriptFailed": "No se pudo ejecutar el script. Error: %s",
   "loc.messages.ScriptFailedStdErr": "El script tiene la salida en stderr. Se produce un error cuando failOnStdErr está establecido en true.",
@@ -52,7 +52,7 @@
   "loc.messages.UnacceptedScriptLocationValue": "%s no es un valor válido para la entrada de tarea \"Ubicación del script\" (scriptLocation en YAML). El valor puede ser \"inlineScript\" o \"scriptPath\".",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "El secreto expiró. Actualice la conexión de servicio en %s Consulte https://aka.ms/azdo-rm-workload-identity-conversion para obtener más información sobre la conversión a conexiones de servicio sin secretos.",
   "loc.messages.ProxyConfig": "la herramienta de zona de disponibilidad está configurada para usar %s como servidor proxy",
-  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
-  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
-  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
+  "loc.messages.FailedToRefreshAzSession": "Error al intentar actualizar la sesión de az-cli: %s",
+  "loc.messages.RefreshingAzSession": "Intentando actualizar la sesión de az-cli...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "La entrada \"keepAzSessionActive\" solo se puede usar para la conexión del servicio ARM de federación de identidades de carga de trabajo. No se esperaba el esquema de autenticación del punto de conexión de servicio al que se hace referencia: %s. Cambie el esquema o quite la entrada \"keepAzSessionActive\"."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -31,8 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Si cette valeur est false, la ligne 'if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }' est ajoutée à la fin de votre script. Cela entraîne la propagation du dernier code de sortie d'une commande externe en tant que code de sortie de PowerShell. Sinon, la ligne n'est pas ajoutée à la fin de votre script.",
   "loc.input.label.visibleAzLogin": "visibilité de sortie de connexion az",
   "loc.input.help.visibleAzLogin": "Si la valeur est définie sur true, la commande de connexion az est générée dans la tâche. Si la valeur est définie sur false, la sortie de connexion az est supprimée",
-  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
-  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
+  "loc.input.label.keepAzSessionActive": "[Expérimental] Maintenir une session Azure CLI active",
+  "loc.input.help.keepAzSessionActive": "Si vous activez cette option, cette tâche va se connecter continuellement à Azure pour éviter des erreurs de type AADSTS700024 lors d’une demande de jetons d’accès au-delà de la date d’expiration de IdToken. Notez que cette fonctionnalité est EXPÉRIMENTALE, risque de ne pas fonctionner dans tous les scénarios et que vous l’utilisez sans aucune garantie. Valide uniquement pour les connexions de service utilisant le schéma d’authentification de fédération des identités de charge de travail.",
   "loc.messages.ScriptReturnCode": "Arrêt du script. Code de retour : %d",
   "loc.messages.ScriptFailed": "Échec du script. Erreur : %s",
   "loc.messages.ScriptFailedStdErr": "Le script a une sortie vers stderr. Échec, car failOnStdErr a la valeur true.",
@@ -52,7 +52,7 @@
   "loc.messages.UnacceptedScriptLocationValue": "%s n'est pas une valeur valide pour l'entrée de tâche 'Script Location' (scriptLocation en YAML). La valeur peut être 'inlineScript' ou 'scriptPath'",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Secret expiré, mettez à jour la connexion de service à l’adresse %s Consultez https://aka.ms/azdo-rm-workload-identity-conversion pour en savoir plus sur la conversion en connexions de service sans secret.",
   "loc.messages.ProxyConfig": "l’outil az est configuré pour utiliser %s comme serveur proxy",
-  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
-  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
-  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
+  "loc.messages.FailedToRefreshAzSession": "L’erreur suivante s’est produite lors de la tentative d’actualisation de la session az-cli : %s",
+  "loc.messages.RefreshingAzSession": "Tentative d’actualisation de la session az-cli... Merci de patienter.",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "L’entrée « keepAzSessionActive » est susceptible d’être uniquement utilisée pour la connexion du service ARM de fédération des identités de charge de travail. Le schéma d’authentification du point de terminaison de service référencé était inattendu : %s. Modifiez le schéma ou supprimez l’entrée « keepAzSessionActive »."
 }

--- a/Tasks/AzureCLIV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureCLIV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -31,8 +31,8 @@
   "loc.input.help.powerShellIgnoreLASTEXITCODE": "Если задано значение False, в конец скрипта добавляется строка \"if ((Test-Path -LiteralPath variable:\\LASTEXITCODE)) { exit $LASTEXITCODE }\". Это приведет к тому, что последний код выхода из внешней команды будет использоваться как код выхода PowerShell. В противном случае эта строка не добавляется в конец скрипта.",
   "loc.input.label.visibleAzLogin": "Видимость вывода при az login",
   "loc.input.help.visibleAzLogin": "Если для этого параметра установлено значение ИСТИНА, команда az login выведет задачу. Установка значения ЛОЖЬ приведет к скрытию вывода az login.",
-  "loc.input.label.keepAzSessionActive": "[Experimental] Keep Azure CLI session active",
-  "loc.input.help.keepAzSessionActive": "When enabled, this task will continuously sign into Azure to avoid AADSTS700024 errors when requesting access tokens beyond the IdToken expiry date. Note that this feature is EXPERIMENTAL, may not work in all scenarios and you are using it without any guarantees. Valid only for service connections using the Workload Identity Federation authentication scheme.",
+  "loc.input.label.keepAzSessionActive": "[Экспериментальная] Сохранять сеанс Azure CLI активным",
+  "loc.input.help.keepAzSessionActive": "Если включено, эта задача будет непрерывно входить в Azure, чтобы избежать ошибок AADSTS700024 при запросе маркеров доступа после даты окончания срока действия IdToken. Обратите внимание, что эта функция является ЭКСПЕРИМЕНТАЛЬНОЙ и может работать не во всех сценариях. Вы используете ее без каких-либо гарантий. Допустимо только для подключений службы, использующих схему проверки подлинности федерации удостоверений рабочей нагрузки.",
   "loc.messages.ScriptReturnCode": "Выход из сценария с кодом возврата: %d",
   "loc.messages.ScriptFailed": "Сбой сценария с ошибкой: %s",
   "loc.messages.ScriptFailedStdErr": "Скрипт выводит выходные данные в stderr. Завершается сбоем, если failOnStdErr имеет значение true.",
@@ -52,7 +52,7 @@
   "loc.messages.UnacceptedScriptLocationValue": "%s не является допустимым значением для входных данных задачи \"Расположение скрипта\" (scriptLocation в YAML). Значение может быть равно inlineScript либо scriptPath",
   "loc.messages.ExpiredServicePrincipalMessageWithLink": "Срок действия секрета истек. Обновите подключение службы %s. Подробнее о преобразовании в подключения служб без секретов см. https://aka.ms/azdo-rm-workload-identity-conversion.",
   "loc.messages.ProxyConfig": "Инструмент az настроен на использование %s в качестве прокси-сервера",
-  "loc.messages.FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
-  "loc.messages.RefreshingAzSession": "Attempting to refresh az-cli session...",
-  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "The 'keepAzSessionActive' input might be used only for workload identity federation ARM service connection. The referenced service endpoint auth scheme was unexpected: %s. Change the scheme or remove 'keepAzSessionActive' input."
+  "loc.messages.FailedToRefreshAzSession": "При попытке обновить сеанс az-cli произошла следующая ошибка: %s",
+  "loc.messages.RefreshingAzSession": "Попытка обновить сеанс az-cli...",
+  "loc.messages.KeepingAzSessionActiveUnsupportedScheme": "Входные данные \"keepAzSessionActive\" могут использоваться только для подключения службы ARM федерации удостоверений рабочей нагрузки. Указана непредвиденная схема проверки подлинности конечной точки службы: %s. Измените схему или удалите входные данные \"keepAzSessionActive\"."
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.