### PR TITLE
fix(16789): allow whitespace in bicep deployment file paths

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/CSMwithBicep WithSpaceInPath.bicep
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/CSMwithBicep WithSpaceInPath.bicep
@@ -1,0 +1,18 @@
+param location string = 'eastasia'
+
+var storageAccountName = 'deepak2121'
+var storageAccountType = 'Premium_LRS'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
+  name: toLower(take(storageAccountName, 24))
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+}
+
+output storageAccount_Name string = storageAccount.name
+output storageAccount_Location string = storageAccount.location
+output storageAccount_SKUName string = storageAccount.sku.name
+output storageAccount_Kind string = storageAccount.kind

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/L0.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/L0.ts
@@ -206,6 +206,26 @@ describe('Azure Resource Manager Template Deployment', function () {
         }
     });
 
+    it('Successfully triggered createOrUpdate deployment using bicep file with space in path', (done) => {
+        let tp = path.join(__dirname, 'createOrUpdate.js');
+        process.env["csmFile"] = "CSMwithBicep WithSpaceInPath.bicep";
+        process.env["csmParametersFile"] = "";
+        process.env["deploymentOutputs"] = "someVar";
+        let tr = new ttm.MockTestRunner(tp);
+        tr.run();
+        try {
+            assert(tr.succeeded, "Should have succeeded");
+            assert(tr.stdout.indexOf("deployments.createOrUpdate is called") > 0, "deployments.createOrUpdate function should have been called from azure-sdk");
+            assert(tr.stdout.indexOf("##vso[task.setvariable variable=someVar;]") >= 0, "deploymentsOutput should have been updated");
+            done();
+        }
+        catch (error) {
+            console.log("STDERR", tr.stderr);
+            console.log("STDOUT", tr.stdout);
+            done(error);
+        }
+    });
+
     it('Successfully triggered createOrUpdate deployment using bicep file with unused params', (done) => {
         let tp = path.join(__dirname, 'createOrUpdate.js');
         process.env["csmFile"] = "CSMwithBicepWithWarning.bicep";

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/createOrUpdate.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/Tests/createOrUpdate.ts
@@ -33,6 +33,7 @@ process.env["ENDPOINT_AUTH_PARAMETER_AzureRM_AUTHENTICATIONTYPE"] = "key";
 
 var CSMJson = path.join(__dirname, "CSM.json");
 var CSMBicep = path.join(__dirname, "CSMwithBicep.bicep");
+var CSMBicepWithSpaceInPath = path.join(__dirname, "CSMwithBicep WithSpaceInPath.bicep");
 var CSMBicepParam = path.join(__dirname, "CSMwithBicep.bicepparam");
 var CSMBicepParamWithEnv = path.join(__dirname, "CSMwithBicep.prod.bicepparam");
 var CSMBicepWithWarning = path.join(__dirname, "CSMwithBicepWithWarning.bicep");
@@ -41,6 +42,7 @@ var CSMwithComments = path.join(__dirname, "CSMwithComments.json");
 var defaults = path.join(__dirname, "defaults.json");
 var faultyCSM = path.join(__dirname, "faultyCSM.json");
 var bicepbuildCmd = `az bicep build --file ${path.join(__dirname, "CSMwithBicep.bicep")}`;
+var bicepbuildwithspaceinpathCmd = `az bicep build --file "${path.join(__dirname, "CSMwithBicep WithSpaceInPath.bicep")}"`;
 var bicepparambuildCmd = `az bicep build-params --file ${path.join(__dirname, "CSMwithBicep.bicepparam")} --outfile ${path.join(__dirname, "CSMwithBicep.parameters.json")}`;
 var bicepparambuildwithenvironmentCmd = `az bicep build-params --file ${path.join(__dirname, "CSMwithBicep.prod.bicepparam")} --outfile ${path.join(__dirname, "CSMwithBicep.parameters.json")}`;
 var bicepbuildwithWarning = `az bicep build --file ${path.join(__dirname, "CSMwithBicepWithWarning.bicep")}`;
@@ -54,6 +56,7 @@ const successExec = {
     "stdout": "Executed Successfully"
 }
 exec[bicepbuildCmd] = successExec;
+exec[bicepbuildwithspaceinpathCmd] = successExec;
 exec[bicepparambuildCmd] = successExec;
 exec[bicepparambuildwithenvironmentCmd] = successExec;
 exec[bicepbuildwithWarning] = successExec;
@@ -72,6 +75,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "findMatch": {
         "CSM.json": [CSMJson],
         "CSMwithBicep.bicep": [CSMBicep],
+        "CSMwithBicep WithSpaceInPath.bicep": [CSMBicepWithSpaceInPath],
         "CSMwithBicep.bicepparam": [CSMBicepParam],
         "CSMwithBicep.prod.bicepparam": [CSMBicepParamWithEnv],
         "CSMwithBicepWithWarning.bicep": [CSMBicepWithWarning],

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/Utils.ts
@@ -488,7 +488,7 @@ class Utils {
         var finalPathExtension: string = ".json" 
 
         if(filePathExtension === 'bicep'){
-            const result: IExecSyncResult = tl.execSync("az", `bicep build --file ${filePath}`);
+            const result: IExecSyncResult = tl.execSync("az", `bicep build --file "${filePath}"`);
             if(result && result.code !== 0){
                 throw new Error(tl.loc("BicepBuildFailed", result.stderr));
             }
@@ -497,7 +497,7 @@ class Utils {
             finalPathExtension = ".parameters.json"
 
             //Using --outfile to avoid overwriting primary bicep file in the case bicep and param file have the the same file name.
-            const result: IExecSyncResult = tl.execSync("az", `bicep build-params --file ${filePath} --outfile ${path.join(fileDir, fileName + finalPathExtension)}`);
+            const result: IExecSyncResult = tl.execSync("az", `bicep build-params --file "${filePath}" --outfile "${path.join(fileDir, fileName + finalPathExtension)}"`);
             if(result && result.code !== 0){
                 throw new Error(tl.loc("BicepParamBuildFailed", result.stderr));
             } 

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 240,
+    "Minor": 241,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 240,
+    "Minor": 241,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: AzureResourceManagerTemplateDeploymentV3

**Description**: Allow bicep template file paths to contain spaces

**Documentation changes required:** (N)

**Added unit tests:** (Y)

**Attached related issue:** (Y) #16789 (and would supersede #19382)

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] ~~Checked that applied changes work as expected~~ I haven't been able to confirm this due to many (many) publish & test environment issues. I'm relying on the pipeline to let me know if the tests run as I've spent too long just trying to get any of them to pass from mainline