### PR TITLE
fix: DockerCompose@0 now normalises project name

### DIFF
--- a/Tasks/DockerComposeV0/dockercomposeconnection.ts
+++ b/Tasks/DockerComposeV0/dockercomposeconnection.ts
@@ -32,7 +32,8 @@ export default class DockerComposeConnection extends ContainerConnection {
         this.dockerComposeVersion = "2";
         this.additionalDockerComposeFiles = tl.getDelimitedInput("additionalDockerComposeFiles", "\n");
         this.requireAdditionalDockerComposeFiles = tl.getBoolInput("requireAdditionalDockerComposeFiles");
-        this.projectName = tl.getInput("projectName");
+        // docker-compose project name must be lowercase and only contain [a-z_-]
+        this.projectName = tl.getInput("projectName").toLowerCase().replace(/\\/g, "_");
     }
 
     public open(hostEndpoint?: string, authenticationToken?: AuthenticationToken): any {


### PR DESCRIPTION
`docker compose` has started enforcing validation on the project name. As such, the default project when run against github repos is no longer valid (`/` is not allowed). This change attempts to normalise the supplied project name in an attempt to keep the existing behaviour "unchanged".

---

**Task name**: DockerCompose@0

**Description**: Fix default project name to ensure it complies with latest docker compose rules

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) #20047 

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected