### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 28850211

### DIFF
--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/de-DE/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Learn more about this task](https://aka.ms/azurefilecopyreadme) und zum Melden von Problemen mit dieser neuen Version der Aufgabe [here](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "Hiermit werden Dateien in Azure Blob Storage oder auf virtuelle Computer kopiert.",
   "loc.instanceNameFormat": "$(Destination)-Dateikopiervorgang",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "Quelle",
   "loc.input.help.SourcePath": "Der absolute Pfad des Quellordners oder der Datei auf dem lokalen Computer oder eine UNC-Freigabe. Der Ausdruck muss einen einzelnen Ordner oder eine Datei zurückgeben. Das Platzhaltersymbol (*) wird an beliebiger Stelle im Dateipfad oder im Dateinamen unterstützt.",
   "loc.input.label.ConnectedServiceNameARM": "Azure-Abonnement",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/es-ES/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Más información sobre esta tarea](https://aka.ms/azurefilecopyreadme) y para notificar cualquier problema con esta nueva versión de la tarea [aquí](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "Copiar archivos en Azure Blob Storage o en máquinas virtuales",
   "loc.instanceNameFormat": "Copia de archivo $(Destination)",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "Origen",
   "loc.input.help.SourcePath": "Ruta de acceso absoluta de la carpeta de origen, archivo en la máquina local o recurso compartido UNC. La expresión debe devolver un único archivo o carpeta. El uso del símbolo de comodín (*) se admite en cualquier parte de la ruta de acceso del archivo o del nombre de este.",
   "loc.input.label.ConnectedServiceNameARM": "Suscripción a Azure",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/fr-FR/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[En savoir plus sur cette tâche](https://aka.ms/azurefilecopyreadme) et signaler tout problème avec cette nouvelle version de la tâche [ici](https://github.com/microsoft/azure-pipelines-tasks/ issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "Copier des fichiers sur le Stockage Blob Azure ou des machines virtuelles",
   "loc.instanceNameFormat": "Copie de fichiers $(Destination)",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "Source",
   "loc.input.help.SourcePath": "Chemin absolu du dossier ou fichier source sur la machine locale, ou partage UNC. L'expression doit retourner un seul dossier ou fichier. Le symbole de caractère générique (*) est pris en charge n'importe où dans le chemin ou le nom de fichier.",
   "loc.input.label.ConnectedServiceNameARM": "Abonnement Azure",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/it-IT/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Altre informazioni su questa attività](https://aka.ms/azurefilecopyreadme) e [qui](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+) per segnalare eventuali problemi relativi alla nuova versione dell’attività",
   "loc.description": "Copia i file in Archiviazione BLOB di Azure nelle macchine virtuali",
   "loc.instanceNameFormat": "Copia dei file $(Destination)",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "Origine",
   "loc.input.help.SourcePath": "Percorso assoluto della cartella o del file di origine nel computer locale oppure condivisione UNC. L'espressione deve restituire una sola cartella o file. Il simbolo del carattere jolly (*) è supportato in qualsiasi punto del percorso o del nome file.",
   "loc.input.label.ConnectedServiceNameARM": "Sottoscrizione di Azure",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/ja-JP/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[このタスクの詳細](https://aka.ms/azurefilecopyreadme) およびこの新しいバージョンのタスクに関する問題を報告するには [こちら](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "Azure Blob Storage または仮想マシンにファイルをコピーします",
   "loc.instanceNameFormat": "$(Destination) ファイル コピー",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "ソース",
   "loc.input.help.SourcePath": "ソース フォルダーまたはローカル コンピューター上のファイルの絶対パス、もしくは UNC 共有。式は単一のフォルダーまたはファイルを返す必要があります。ワイルド カード記号 (*) はファイル パスまたはファイル名の任意の場所で使用できます。",
   "loc.input.label.ConnectedServiceNameARM": "Azure サブスクリプション",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/ko-KR/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[여기](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)에서 [이 작업에 대한 자세한 정보](https://aka.ms/azurefilecopyreadme)를 알아보고 이 새 버전의 작업과 관련된 문제를 보고하세요.",
   "loc.description": "Azure Blob Storage 또는 가상 머신에 파일을 복사합니다.",
   "loc.instanceNameFormat": "$(Destination) 파일 복사",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "원본",
   "loc.input.help.SourcePath": "소스 폴더, 로컬 머신의 파일 또는 UNC 공유에 대한 절대 경로입니다. 식은 단일 폴더 또는 파일을 반환해야 합니다. 와일드카드 기호(*)는 파일 경로 또는 파일 이름의 모든 위치에서 지원됩니다.",
   "loc.input.label.ConnectedServiceNameARM": "Azure 구독",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/ru-RU/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Узнайте больше об этой задаче](https://aka.ms/azurefilecopyreadme) и сообщайте о любых проблемах с новой версией задачи [здесь](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "Копировать файлы в хранилище BLOB-объектов Azure или виртуальные машины",
   "loc.instanceNameFormat": "Копирование файлов $(Destination)",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "Источник",
   "loc.input.help.SourcePath": "Абсолютный путь к исходной папке или файлу на локальном компьютере или общему ресурсу UNC. Выражение должно возвращать одну папку или один файл. Подстановочный знак (*) поддерживается в любом месте пути к файлу или имени файла.",
   "loc.input.label.ConnectedServiceNameARM": "Подписка Azure",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/zh-CN/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[详细了解此任务](https://aka.ms/azurefilecopyreadme)并在[此处](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)报告有关此新版本任务的任何问题",
   "loc.description": "将文件复制到 Azure Blob 存储或虚拟机",
   "loc.instanceNameFormat": "$(Destination) 文件复制",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "源",
   "loc.input.help.SourcePath": "源文件夹、本地计算机上的文件或 UNC 共享的绝对路径。表达式应返回单个文件夹或文件。支持在文件路径或文件名的任何位置使用通配符(*)。",
   "loc.input.label.ConnectedServiceNameARM": "Azure 订阅",

--- a/Tasks/AzureFileCopyV6/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/AzureFileCopyV6/Strings/resources.resjson/zh-TW/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[深入了解此工作](https://aka.ms/azurefilecopyreadme)。若要回報此工作之新版本 [這裡](https://github.com/microsoft/azure-pipelines-tasks/issues/new?assignees=&labels=regression%2Cbug&projects=&template=1.regression.yml&title=%5BREGRESSION%5D%3A+)",
   "loc.description": "將檔案複製到 Azure Blob 儲存體或虛擬機器",
   "loc.instanceNameFormat": "$(Destination) 檔案複製",
-  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.25.1) with version 10.25.1, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
+  "loc.releaseNotes": "What's new in Version 6.0: <br/>&nbsp;&nbsp; Support Workload identity federation and [Azure RBAC](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=portal), also use [AzCopy.exe](https://github.com/Azure/azure-storage-azcopy/tree/v10.24.0) with version 10.24.0, for more info:[here](https://github.com/Azure/azure-storage-azcopy/releases)",
   "loc.input.label.SourcePath": "來源",
   "loc.input.help.SourcePath": "來源資料夾、本機電腦檔案或 UNC 共用的絕對路徑。運算式應該傳回單一資料夾或檔案。支援在檔案路徑或檔案名稱的任何位置使用萬用字元符號 (*)。",
   "loc.input.label.ConnectedServiceNameARM": "Azure 訂用帳戶",

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "Der Inhalt der Datei wurde auf dem Datenträger synchronisiert. Der Inhalt ist \"%s\".",
   "loc.messages.ImageNameWithoutTag": "Imagename nicht mit Tag angegeben, Übertragung aller Imagetags mithilfe von Push angegeben.",
   "loc.messages.WritingDockerConfigToTempFile": "Die Docker-Konfiguration wird in eine temporäre Datei geschrieben. Dateipfad: %s, Docker-Konfiguration: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "Für die Aufgabe wird Docker Compose v1 verwendet. Diese Version hat das Ende der Lebensdauer erreicht und wird am 24. Juli von Agents entfernt, die von Microsoft gehostet werden. Pipelines, die auf von Microsoft gehosteten Agents ausgeführt werden, sollten aktualisiert werden, um Docker Compose v2-Kompatibilität zu gewährleisten, z. B. Verwenden kompatibler Containernamen. Anleitungen zu erforderlichen Updates finden Sie in der offiziellen Docker Compose-Dokumentation unter https://docs.docker.com/compose/migrate/"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "Se sincronizó el contenido del archivo con el disco. El contenido es %s.",
   "loc.messages.ImageNameWithoutTag": "El nombre de la imagen no se especifica con la etiqueta, insertando todas las etiquetas de la imagen especificada.",
   "loc.messages.WritingDockerConfigToTempFile": "Escribiendo la configuración de Docker en el archivo temporal. Ruta de acceso del archivo: %s. Configuración de Docker: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "La tarea usa Docker Compose V1, que finaliza su ciclo de vida y se quitará de los agentes hospedados por Microsoft el 24 de julio. Las canalizaciones que se ejecutan en agentes hospedados por Microsoft deben actualizarse para lograr compatibilidad con Docker Compose v2, para por ejemplo, usar nombres de contenedor compatibles. Para obtener instrucciones sobre las actualizaciones necesarias, consulte la documentación oficial de Docker Compose en https://docs.docker.com/compose/migrate/"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "Synchronisation effectuée du contenu du fichier sur le disque. Le contenu est %s.",
   "loc.messages.ImageNameWithoutTag": "Nom d'image non spécifié avec l'étiquette. Envoi (push) de toutes les étiquettes de l'image spécifiée.",
   "loc.messages.WritingDockerConfigToTempFile": "Écriture de la configuration Docker dans le fichier temporaire. Chemin de fichier : %s. Configuration Docker : %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "La tâche utilise Docker Compose V1, qui est en fin de vie et sera supprimé des agents hébergés par Microsoft le 24 juillet. Les pipelines exécutés sur des agents hébergés par Microsoft doivent être mis à jour pour la compatibilité avec Docker Compose v2, par exemple utiliser des noms de conteneurs compatibles. Pour obtenir de l’aide sur les mises à jour requises, veuillez consulter la documentation Docker Compose officielle à l’adresse https://docs.docker.com/compose/migrate/"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "Il contenuto del file è stato sincronizzato con il disco. Il contenuto è %s.",
   "loc.messages.ImageNameWithoutTag": "Il nome dell'immagine non è specificato con tag. Verrà eseguito il push di tutti i tag dell'immagine specificata.",
   "loc.messages.WritingDockerConfigToTempFile": "Scrittura della configurazione di Docker nel file temporaneo. Percorso del file: %s. Configurazione di Docker: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "L'attività usa Docker Compose V1, che è alla fine del ciclo di vita e verrà rimosso dagli agenti ospitati da Microsoft il 24 luglio. Le pipeline in esecuzione in agenti ospitati da Microsoft devono essere aggiornate per Docker Compose compatibilità v2, ad esempio usare nomi di contenitori compatibili. Per indicazioni sull’aggiornamento richiesto, fare rifermento alla documentazione ufficiale di Docker Compose al collegamento fornito: https://docs.docker.com/compose/migrate/"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "ファイルの内容がディスクに同期されました。内容は %s です。",
   "loc.messages.ImageNameWithoutTag": "イメージ名がタグに指定されていません。指定されたイメージのすべてのタグをプッシュしています。",
   "loc.messages.WritingDockerConfigToTempFile": "Docker 構成を一時ファイルに書き込んでいます。ファイル パス: %s、Docker 構成: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "このタスクが使用している Docker Compose V1 は、製品寿命が切れ Microsoft がホストするエージェントから 7 月 24 日に削除されます。Microsoft がホストするエージェントで実行されているパイプラインは、互換性のあるコンテナー名を使用するなどして、Docker Compose v2 互換に更新する必要があります。必要な更新プログラムのガイダンスについては、https://docs.docker.com/compose/migrate/ で公式の Docker Compose ドキュメントを参照してください"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "파일 콘텐츠를 디스크에 동기화했습니다. 콘텐츠는 %s입니다.",
   "loc.messages.ImageNameWithoutTag": "태그로 지정되지 않은 이미지 이름으로, 지정한 이미지의 모든 태그를 푸시합니다.",
   "loc.messages.WritingDockerConfigToTempFile": "임시 파일에 Docker 구성을 쓰는 중입니다. 파일 경로: %s, Docker 구성: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "이 작업은 Docker Compose V1을 사용하고 있습니다. 이 V1은 수명이 종료되며 7월 24일 Microsoft 호스팅 에이전트에서 제거됩니다. Docker Compose v2 호환성을 위해 Microsoft 호스팅 에이전트에서 실행되는 파이프라인을 업데이트해야 합니다(예: 호환되는 컨테이너 이름 사용). 필요한 업데이트에 대한 지침은 https://docs.docker.com/compose/migrate/에서 공식 Docker Compose 설명서를 참조하세요."
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "Содержимое файла синхронизировано с диском. Содержимое: %s.",
   "loc.messages.ImageNameWithoutTag": "Имя образа указано без тега; передаются все теги указанного образа.",
   "loc.messages.WritingDockerConfigToTempFile": "Запись конфигурации Docker во временный файл. Путь к файлу: %s, конфигурация Docker: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "Задача использует Docker Compose версии 1, у которого заканчивается срок службы и который будет удален 24 июля из агентов с размещением в Майкрософт. Конвейеры, работающие на агентах с размещением в Майкрософт, следует обновить для совместимости с Docker Compose версии 2, например использовать совместимые имена контейнеров. Инструкции по необходимым обновлениям можно найти в официальной документации Docker Compose на странице https://docs.docker.com/compose/migrate/"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "文件内容已同步到磁盘。内容为 %s。",
   "loc.messages.ImageNameWithoutTag": "未使用标记指定映像名，推送指定映像的所有标记。",
   "loc.messages.WritingDockerConfigToTempFile": "正在将 Docker 配置写入临时文件。文件路径: %s，Docker 配置: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "该任务正在使用 Docker Compose V1，此服务的生命周期已结束，将于 7 月 24 日从 Microsoft 托管代理中删除。应更新在 Microsoft 托管代理上运行的管道，以实现 Docker Compose v2 兼容性，例如使用兼容的容器名称。有关必需更新的指南，请参阅官方 Docker Compose 文档(https://docs.docker.com/compose/migrate/)"
 }

--- a/Tasks/DockerComposeV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/DockerComposeV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -81,6 +81,6 @@
   "loc.messages.FileContentSynced": "檔案內容已同步到磁碟。內容為 %s。",
   "loc.messages.ImageNameWithoutTag": "未使用標籤指定映像名稱，因此會推送指定映像的所有標籤。",
   "loc.messages.WritingDockerConfigToTempFile": "正在將 Docker 設定寫入暫存檔案。檔案路徑: %s，Docker 設定: %s",
-  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://aka.ms/azdo-docker-compose-v1",
+  "loc.messages.InvalidProjectName": "The project name \"%s\" must be a valid docker compose project name. Follow the link for more details: https://docs.docker.com/compose/project-name/#set-a-project-name",
   "loc.messages.MigrateToDockerComposeV2": "此工作使用 Docker Compose V1，該版本已終止服務且將於 7 月 24 日從 Microsoft 裝載代理程式中移除。應更新在 Microsoft 裝載代理程式上執行的 Pipelines 以實現 Docker Compose v2 相容性 (例如使用相容的容器名稱)。如需所需更新的指引，請於 https://docs.docker.com/compose/migrate/ 參閱官方 Docker Compose 文件"
 }

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Manuelle Überprüfung",
   "loc.helpMarkDown": "[Weitere Informationen zu dieser Aufgabe](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Manuelle Validierung",
   "loc.input.label.notifyUsers": "Benutzer benachrichtigen",
   "loc.input.help.notifyUsers": "Senden Sie eine E-Mail an bestimmte Benutzer (oder Gruppen), um diese über ausstehende manuelle Überprüfungen zu informieren. Nur Benutzer mit der Berechtigung zur Erstellung von Warteschlangen können manuelle Überprüfungen vornehmen.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Validación manual",
   "loc.helpMarkDown": "[Obtener más información acerca de esta tarea](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Validación manual",
   "loc.input.label.notifyUsers": "Notificar a los usuarios",
   "loc.input.help.notifyUsers": "Envíe un correo electrónico de validación manual pendiente a usuarios (o grupos) específicos. Solo los usuarios con permiso para poner la compilación en cola pueden realizar una validación manual.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Validation manuelle",
   "loc.helpMarkDown": "[En savoir plus sur cette tâche](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Validation manuelle",
   "loc.input.label.notifyUsers": "Notifier les utilisateurs",
   "loc.input.help.notifyUsers": "Envoyez un e-mail relatif à une validation manuelle en attente à des utilisateurs (ou groupes) spécifiques. Seuls les utilisateurs dotés d'une autorisation de mise en file d'attente des builds peuvent agir sur une validation manuelle.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Convalida manuale",
   "loc.helpMarkDown": "[Altre informazioni su questa attività](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Convalida manuale",
   "loc.input.label.notifyUsers": "Invia notifica agli utenti",
   "loc.input.help.notifyUsers": "Consente di inviare un messaggio di posta elettronica relativo a una convalida manuale in sospeso a utenti o gruppi specifici. Solo gli utenti con l'autorizzazione per compilazione coda possono intervenire su una convalida manuale.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手動検証",
   "loc.helpMarkDown": "[このタスクの詳細を表示](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手動検証",
   "loc.input.label.notifyUsers": "ユーザーに通知",
   "loc.input.help.notifyUsers": "手動検証の保留のメールを特定のユーザー (またはグループ) に送信します。手動検証について決定を下せるのは、ビルドをキューに挿入のアクセス許可があるユーザーだけです。",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "수동 유효성 검사",
   "loc.helpMarkDown": "[이 작업에 대한 자세한 정보](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "수동 유효성 검사",
   "loc.input.label.notifyUsers": "사용자 알림",
   "loc.input.help.notifyUsers": "수동 유효성 검사 보류 중 전자 메일을 특정 사용자나 그룹에 보냅니다. 큐 빌드 권한이 있는 사용자만 수동 유효성 검사를 수행할 수 있습니다.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Проверка вручную",
   "loc.helpMarkDown": "[См. дополнительные сведения об этой задаче](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Проверка вручную",
   "loc.input.label.notifyUsers": "Уведомить пользователей",
   "loc.input.help.notifyUsers": "Отправка отдельным пользователям или группам электронного письма об ожидаемой проверке вручную. Выполнить действия по проверке вручную могут только пользователи с разрешением для очереди сборок.",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手动验证",
   "loc.helpMarkDown": "[详细了解此任务](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手动验证",
   "loc.input.label.notifyUsers": "通知用户",
   "loc.input.help.notifyUsers": "将手动验证挂起电子邮件发送到特定用户(或组)。仅具有队列生成权限的用户才可执行手动验证。",

--- a/Tasks/ManualValidationV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/ManualValidationV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手動驗證",
   "loc.helpMarkDown": "[深入了解此工作](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手動驗證",
   "loc.input.label.notifyUsers": "通知使用者",
   "loc.input.help.notifyUsers": "將手動驗證暫止電子郵件傳送給特定使用者 (或群組)。只有具有佇列組建權限的使用者，才能對手動驗證採取行動。",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Manuelle Überprüfung",
   "loc.helpMarkDown": "[Weitere Informationen zu dieser Aufgabe](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Manuelle Validierung",
   "loc.input.label.notifyUsers": "Benutzer benachrichtigen",
   "loc.input.help.notifyUsers": "Senden Sie eine E-Mail an bestimmte Benutzer (oder Gruppen), um diese über ausstehende manuelle Überprüfungen zu informieren. Nur in den genehmigenden Personen angegebene Benutzer können eine manuelle Überprüfung durchführen.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Validación manual",
   "loc.helpMarkDown": "[Obtener más información acerca de esta tarea](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Validación manual",
   "loc.input.label.notifyUsers": "Notificar a los usuarios",
   "loc.input.help.notifyUsers": "Envíe un correo electrónico de validación manual pendiente a usuarios (o grupos) específicos. Solo los usuarios especificados en los aprobadores pueden actuar en una validación manual.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Validation manuelle",
   "loc.helpMarkDown": "[En savoir plus sur cette tâche](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Validation manuelle",
   "loc.input.label.notifyUsers": "Notifier les utilisateurs",
   "loc.input.help.notifyUsers": "Envoyez un e-mail relatif à une validation manuelle en attente à des utilisateurs (ou groupes) spécifiques. Seuls les utilisateurs spécifiés dans les approbateurs peuvent agir sur une validation manuelle.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Convalida manuale",
   "loc.helpMarkDown": "[Altre informazioni su questa attività](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Convalida manuale",
   "loc.input.label.notifyUsers": "Invia notifica agli utenti",
   "loc.input.help.notifyUsers": "Consente di inviare un messaggio di posta elettronica relativo a una convalida manuale in sospeso a utenti o gruppi specifici. Solo gli utenti specificati nei responsabili approvazione possono eseguire una convalida manuale.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手動検証",
   "loc.helpMarkDown": "[このタスクの詳細を表示](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手動検証",
   "loc.input.label.notifyUsers": "ユーザーに通知",
   "loc.input.help.notifyUsers": "手動検証の保留のメールを特定のユーザー (またはグループ) に送信します。承認者に指定されたユーザーのみが手動検証を操作できます。",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "수동 유효성 검사",
   "loc.helpMarkDown": "[이 작업에 대한 자세한 정보](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "수동 유효성 검사",
   "loc.input.label.notifyUsers": "사용자 알림",
   "loc.input.help.notifyUsers": "수동 유효성 검사 보류 중 전자 메일을 특정 사용자나 그룹에 보냅니다. 승인자에 지정된 사용자만 수동 유효성 검사를 수행할 수 있습니다.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "Проверка вручную",
   "loc.helpMarkDown": "[См. дополнительные сведения об этой задаче](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "Проверка вручную",
   "loc.input.label.notifyUsers": "Уведомить пользователей",
   "loc.input.help.notifyUsers": "Отправка отдельным пользователям или группам электронного письма об ожидаемой проверке вручную. Только пользователи, указанные в списке утверждающих, могут выполнять проверку вручную.",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手动验证",
   "loc.helpMarkDown": "[详细了解此任务](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手动验证",
   "loc.input.label.notifyUsers": "通知用户",
   "loc.input.help.notifyUsers": "将手动验证挂起电子邮件发送到特定用户(或组)。只有审批者中指定的用户才能执行手动验证。",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,7 +1,7 @@
 {
   "loc.friendlyName": "手動驗證",
   "loc.helpMarkDown": "[深入了解此工作](https://aka.ms/manual-validation)",
-  "loc.description": "Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
+  "loc.description": "[PREVIEW] Pause a pipeline run to wait for manual interaction. Works only with YAML pipelines.",
   "loc.instanceNameFormat": "手動驗證",
   "loc.input.label.notifyUsers": "通知使用者",
   "loc.input.help.notifyUsers": "將手動驗證待決電子郵件傳送給特定使用者 (或群組)。只有核准者中指定的使用者可以執行手動驗證。",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.