### PR TITLE
[BUG]: InstallAppleCertificate@2 fails to expose APPLE_CERTIFICATE_SH…

### DIFF
--- a/Tasks/InstallAppleCertificateV2/Tests/L0DeleteCertDefaultKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0DeleteCertDefaultKeychain.ts
@@ -11,8 +11,8 @@ tr.setInput('keychain', 'default');
 tr.setInput('deleteCert', 'true');
 
 process.env['AGENT_VERSION'] = '2.116.0';
-process.env['VSTS_TASKVARIABLE_APPLE_CERTIFICATE_KEYCHAIN'] = '/usr/lib/login.keychain';
-process.env['VSTS_TASKVARIABLE_APPLE_CERTIFICATE_SHA1HASH'] = 'SHA1HASHOFP12CERTIFICATE';
+process.env['VSTS_TASKVARIABLE_KEYCHAINPATH'] = '/usr/lib/login.keychain';
+process.env['VSTS_TASKVARIABLE_CERTIFICATESHA1HASH'] = 'SHA1HASHOFP12CERTIFICATE';
 process.env['HOME'] = '/users/test';
 
 tr.registerMock('fs', {

--- a/Tasks/InstallAppleCertificateV2/Tests/L0DeleteTempKeychain.ts
+++ b/Tasks/InstallAppleCertificateV2/Tests/L0DeleteTempKeychain.ts
@@ -10,7 +10,7 @@ let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tr.setInput('keychain', 'temp');
 
 process.env['AGENT_VERSION'] = '2.116.0';
-process.env['VSTS_TASKVARIABLE_APPLE_CERTIFICATE_KEYCHAIN'] = '/build/temp/ios_signing_temp.keychain';
+process.env['VSTS_TASKVARIABLE_KEYCHAINPATH'] = '/build/temp/ios_signing_temp.keychain';
 process.env['HOME'] = '/users/test';
 
 tr.registerMock('fs', {

--- a/Tasks/InstallAppleCertificateV2/Tests/package.json
+++ b/Tasks/InstallAppleCertificateV2/Tests/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
-    "@types/node": "^10.17.0",
+    "@types/node": "^16.11.39",
     "@types/mocha": "^5.2.7"
   },
   "devDependencies": {

--- a/Tasks/InstallAppleCertificateV2/_buildConfigs/Node20/package.json
+++ b/Tasks/InstallAppleCertificateV2/_buildConfigs/Node20/package.json
@@ -21,7 +21,7 @@
     "@types/mocha": "^5.2.7",
     "azure-pipelines-tasks-securefiles-common": "2.1.0",
     "azure-pipelines-tasks-ios-signing-common": "2.227.0",
-    "azure-pipelines-task-lib": "^4.0.0-preview"
+    "azure-pipelines-task-lib": "^5.0.0-preview.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/InstallAppleCertificateV2/postinstallcert.ts
+++ b/Tasks/InstallAppleCertificateV2/postinstallcert.ts
@@ -12,10 +12,10 @@ async function run() {
             console.log(tl.loc('InstallRequiresMac'));
         } else {
             let keychain: string = tl.getInput('keychain');
-            let keychainPath: string = tl.getTaskVariable('APPLE_CERTIFICATE_KEYCHAIN');
+            let keychainPath: string = tl.getTaskVariable('keychainPath');
 
             let deleteCert: boolean = tl.getBoolInput('deleteCert');
-            let hash: string = tl.getTaskVariable('APPLE_CERTIFICATE_SHA1HASH');
+            let hash: string = tl.getTaskVariable('certificateSha1Hash');
             if (deleteCert && hash) {
                 await sign.deleteCert(keychainPath, hash);
             }

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -131,26 +131,22 @@
             "description": "The resolved Common Name of the subject in the signing certificate. Either supplied as an input or parsed from the P12 certificate file."
         },
         {
+            "name": "certificateSha1Hash",
+            "description": "The SHA1 hash (thumbprint) of the signing certificate.  Parsed from the P12 certificate file."
+        },
+        {
             "name": "keychainPath",
             "description": "The path for the keychain file with the certificate."
         }
     ],
     "prejobexecution": {
-        "Node10": {
-            "target": "preinstallcert.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
+        "Node20": {
             "target": "preinstallcert.js",
             "argumentFormat": ""
         }
     },
     "postjobexecution": {
-        "Node10": {
-            "target": "postinstallcert.js",
-            "argumentFormat": ""
-        },
-        "Node16": {
+        "Node20": {
             "target": "postinstallcert.js",
             "argumentFormat": ""
         }
@@ -162,10 +158,12 @@
         "settableVariables": {
             "allowed": [
                 "signingIdentity",
+                "certificateSha1Hash",
                 "keychainPassword",
                 "keychainPath",
                 "APPLE_CERTIFICATE_SIGNING_IDENTITY",
-                "APPLE_CERTIFICATE_KEYCHAIN"
+                "APPLE_CERTIFICATE_KEYCHAIN",
+                "APPLE_CERTIFICATE_SHA1HASH"
             ]
         }
     },

--- a/Tasks/InstallAppleCertificateV2/task.json
+++ b/Tasks/InstallAppleCertificateV2/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 238,
+        "Minor": 243,
         "Patch": 0
     },
     "releaseNotes": "Fixes codesign hangs on a self hosted agent. A Keychain password is now required to use `Default Keychain` or `Custom Keychain`. Microsoft hosted builds should use `Temporary Keychain`.",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 238,
+    "Minor": 243,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/InstallAppleCertificateV2/task.loc.json
+++ b/Tasks/InstallAppleCertificateV2/task.loc.json
@@ -131,6 +131,10 @@
       "description": "The resolved Common Name of the subject in the signing certificate. Either supplied as an input or parsed from the P12 certificate file."
     },
     {
+      "name": "certificateSha1Hash",
+      "description": "The SHA1 hash (thumbprint) of the signing certificate.  Parsed from the P12 certificate file."
+    },
+    {
       "name": "keychainPath",
       "description": "The path for the keychain file with the certificate."
     }
@@ -162,10 +166,12 @@
     "settableVariables": {
       "allowed": [
         "signingIdentity",
+        "certificateSha1Hash",
         "keychainPassword",
         "keychainPath",
         "APPLE_CERTIFICATE_SIGNING_IDENTITY",
-        "APPLE_CERTIFICATE_KEYCHAIN"
+        "APPLE_CERTIFICATE_KEYCHAIN",
+        "APPLE_CERTIFICATE_SHA1HASH"
       ]
     }
   },


### PR DESCRIPTION
…A1HASH #20165

**Task name**: InstallAppleCertificateV2

**Description**: Update task to expose SHA1 hash to external consumers

**Documentation changes required:** N

**Added unit tests:** Y - existing deletion tests updated to use updated task specific variable names

**Attached related issue:** Y - #20165 

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

NOTE: Don't have a local environment to test that the changes are working as expected