### PR TITLE
Remove version property from DockerComposeV1 YAML

### DIFF
--- a/Tasks/DockerComposeV1/dockercomposeconnection.ts
+++ b/Tasks/DockerComposeV1/dockercomposeconnection.ts
@@ -70,7 +70,6 @@ export default class DockerComposeConnection extends ContainerConnection {
                 };
             }
             Utils.writeFileSync(this.finalComposeFile, yaml.safeDump({
-                version: this.dockerComposeVersion,
                 services: services
             }, { lineWidth: -1 } as any));
         });

--- a/Tasks/DockerComposeV1/dockercomposedigests.ts
+++ b/Tasks/DockerComposeV1/dockercomposedigests.ts
@@ -36,7 +36,6 @@ function writeImageDigestComposeFile(version: string, imageDigests: any, imageDi
         };
     });
     fs.writeFileSync(imageDigestComposeFile, yaml.safeDump({
-        version: version,
         services: services
     }, { lineWidth: -1 } as any));
 }

--- a/Tasks/DockerComposeV1/task.json
+++ b/Tasks/DockerComposeV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 243,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerComposeV1/task.loc.json
+++ b/Tasks/DockerComposeV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 243,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",


### PR DESCRIPTION
**Task name**: DockerComposeV1

**Description**: This PR removes version property from YAML generation

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
