### PR TITLE
Fix courtesy push by enablin npmci command for serverbuild

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -153,7 +153,7 @@ var getCommonPackInfo = function (modOutDir) {
 }
 exports.getCommonPackInfo = getCommonPackInfo;
 
-var buildNodeTask = function (taskPath, outDir) {
+var buildNodeTask = function (taskPath, outDir, isServerBuild) {
     var originalDir = shell.pwd().toString();
     cd(taskPath);
     var packageJsonPath = rp('package.json');
@@ -173,13 +173,20 @@ var buildNodeTask = function (taskPath, outDir) {
         } else if (devDeps >= 1) {
             fail('The package.json should not contain dev dependencies other than typescript. Move the dev dependencies into a package.json file under the Tests sub-folder. Offending package.json: ' + packageJsonPath);
         }
-
-        run('npm install');
+        if (isServerBuild) {
+            run('npm ci');
+        } else {
+            run('npm install');
+        }
     }
 
     if (test('-f', rp(path.join('Tests', 'package.json')))) {
         cd(rp('Tests'));
-        run('npm install');
+        if (isServerBuild) {
+            run('npm ci');
+        } else {
+            run('npm install');
+        }
         cd(taskPath);
     }
 

--- a/make.js
+++ b/make.js
@@ -229,14 +229,14 @@ CLI.serverBuild = async function(/** @type {{ task: string }} */ argv) {
         await util.installNodeAsync('20');
         ensureTool('node', '--version', `v${node20Version}`);
         for (const taskName of allTasksNode20) {
-            await buildTaskWrapped(taskName, allTasksNode20.length, 20);
+            await buildTaskWrapped(taskName, allTasksNode20.length, 20, !writeUpdatedsFromGenTasks);
         }
     } 
     if (allTasksDefault.length > 0) {
        await util.installNodeAsync('10');
         ensureTool('node', '--version', `v${node10Version}`);
         for (const taskName of allTasksDefault) {
-            await buildTaskWrapped(taskName, allTasksNode20.length, 10);
+            await buildTaskWrapped(taskName, allTasksNode20.length, 10, !writeUpdatedsFromGenTasks);
         }
     }
 
@@ -263,7 +263,7 @@ function getNodeVersion (taskName) {
 
 }
 
-async function buildTaskAsync(taskName, taskListLength, nodeVersion) {
+async function buildTaskAsync(taskName, taskListLength, nodeVersion, isServerBuild = false) {
     let isGeneratedTask = false;
     banner(`Building task ${taskName} using Node.js ${nodeVersion}`);
     const removeNodeModules = taskListLength > 1;
@@ -348,7 +348,7 @@ async function buildTaskAsync(taskName, taskListLength, nodeVersion) {
 
                 // npm install and compile
                 if ((mod.type === 'node' && mod.compile == true) || test('-f', path.join(modPath, 'tsconfig.json'))) {
-                    buildNodeTask(modPath, modOutDir);
+                    buildNodeTask(modPath, modOutDir, isServerBuild);
                 }
 
                 // copy default resources and any additional resources defined in the module's make.json
@@ -410,7 +410,7 @@ async function buildTaskAsync(taskName, taskListLength, nodeVersion) {
 
     // build Node task
     if (shouldBuildNode) {
-        buildNodeTask(taskPath, outDir);
+        buildNodeTask(taskPath, outDir, isServerBuild);
     }
 
     // remove the hashes for the common packages, they change every build


### PR DESCRIPTION
**Task name**: -

**Description**:
Fix courtesy push by enable npm ci command for serverbuild as npm install command might change package-lock file.
The behaviour for local build command (node make.js build will be the same) 

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
