### PR TITLE
Fix buildconfig

### DIFF
--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -145,11 +145,21 @@ namespace BuildConfigGen
                     if (configs == null)
                     {
                         var tasks = MakeOptionsReader.ReadMakeOptions(gitRootPath);
-                        var taskMakeOptions = tasks[t];
-                        configs = string.Join('|', taskMakeOptions.Configs);
+                        if (tasks.ContainsKey(t))
+                        {
+                            var taskMakeOptions = tasks[t];
+                            configs = string.Join('|', taskMakeOptions.Configs);
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Config was not found for the task: {t}, skipping");
+                        }
                     }
 
-                    MainUpdateTask(t, configs!, writeUpdates, currentSprint, debugConfGen);
+                    if (configs != null)
+                    {
+                        MainUpdateTask(t, configs!, writeUpdates, currentSprint, debugConfGen);
+                    }
                 }
             }
 

--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -142,23 +142,29 @@ namespace BuildConfigGen
                 // 3. Ideally default windows exception will occur and errors reported to WER/watson.  I'm not sure this is happening, perhaps DragonFruit is handling the exception
                 foreach (var t in task!.Split(',', '|'))
                 {
+                    // If config weren't passed, constract specific config for each task, otherwise we might have problems if first task has 2 configs, but the other 1,0 or diffrenet ones
                     if (configs == null)
                     {
                         var tasks = MakeOptionsReader.ReadMakeOptions(gitRootPath);
                         if (tasks.ContainsKey(t))
                         {
                             var taskMakeOptions = tasks[t];
-                            configs = string.Join('|', taskMakeOptions.Configs);
+                            var taskConfigs = string.Join('|', taskMakeOptions.Configs);
+                            MainUpdateTask(t, taskConfigs!, writeUpdates, currentSprint, debugConfGen);
                         }
                         else
                         {
                             Console.WriteLine($"Config was not found for the task: {t}, skipping");
                         }
                     }
+                    else
+                    {
+                        // If configs was passed as arguments, just execute it
+                        MainUpdateTask(t, configs!, writeUpdates, currentSprint, debugConfGen);
+                    }
 
                     if (configs != null)
                     {
-                        MainUpdateTask(t, configs!, writeUpdates, currentSprint, debugConfGen);
                     }
                 }
             }

--- a/make-util.js
+++ b/make-util.js
@@ -1787,7 +1787,7 @@ var processGeneratedTasks = function(baseConfigToolPath, taskList, makeOptions, 
     const programPath = getBuildConfigGenerator(baseConfigToolPath);
     const args = [
         "--task",
-        tasks
+        `"${tasks}"`
     ];
 
     if (sprintNumber) {


### PR DESCRIPTION
**Task name**: -

**Description**: 
After the PR https://github.com/microsoft/azure-pipelines-tasks/pull/20108, the PRs started to fail.
Added check to make sure that config exists for the task, also wrapped arguments with quote marks.

Example of failed run: https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=28887029&view=results

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Failed run https://dev.azure.com/mseng/PipelineTools/_build/results?buildId=28887029&view=results

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
