### PR TITLE
Fixes missing closing } in Russian resources

### DIFF
--- a/Tasks/AzureFunctionAppV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/AzureFunctionAppV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -177,4 +177,5 @@
   "loc.messages.SyncFunctionTriggersSuccess": "Синхронизация триггеров для приложения-функции успешно завершена.",
   "loc.messages.UpdatedRunFromPackageSettings": "Параметр приложения WEBSITE_RUN_FROM_PACKAGE изменен на %s",
   "loc.messages.DeploymentTypeNotSupportedForLinuxConsumption": "Параметр \"Тип развертывания\" не применяется для Потребление Linux.",
-  "loc.messages.DeploymentTypeNotSupportedForFlexConsumption": "Параметр \"Тип развертывания\" не применяется для Потребление Flex.",
+  "loc.messages.DeploymentTypeNotSupportedForFlexConsumption": "Параметр \"Тип развертывания\" не применяется для Потребление Flex."
+}

--- a/Tasks/AzureFunctionAppV2/task.json
+++ b/Tasks/AzureFunctionAppV2/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 244,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "What's new in version 2.* <br /> Removed WAR Deploy Support, setting Web.Config options, and the option for the Startup command for Linux Azure Function Apps.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV2/task.loc.json
+++ b/Tasks/AzureFunctionAppV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 244,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Task name**: AzureFunctionApp

**Description**: Added missing `}` at the end of the resource file

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** Y

Fixes: #20293

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
