### PR TITLE
Revert "Temporarily remove the push branch step"

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -150,55 +150,55 @@ steps:
         ne(variables['numTasks'], 0)
       )
 
-  # - template: /ci/generate-branch-name.yml@self
-  #   parameters:
-  #     prefix: releases
+  - template: /ci/generate-branch-name.yml@self
+    parameters:
+      prefix: releases
 
-  # - powershell: |
-  #     $releaseBranch = "$(branchName)"
+  - powershell: |
+      $releaseBranch = "$(branchName)"
 
-  #     # add config entry to avoid errors while pulling
-  #     git config --global user.email "$(username)@microsoft.com"
-  #     git config --global user.name "$(username)"
+      # add config entry to avoid errors while pulling
+      git config --global user.email "$(username)@microsoft.com"
+      git config --global user.name "$(username)"
 
-  #     Write-Host 'Enabling verbose git tracing..'
-  #     git config --global http.verbose true
-  #     $env:GIT_TRACE = 1
-  #     $env:GIT_CURL_VERBOSE = 1
+      Write-Host 'Enabling verbose git tracing..'
+      git config --global http.verbose true
+      $env:GIT_TRACE = 1
+      $env:GIT_CURL_VERBOSE = 1
 
-  #     # Pull commits from remote and push branch to git
-  #     git checkout -b $releaseBranch
-  #     Write-Host 'Trying to pull the remote branch..'
-  #     git pull https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
-  #     if (-not $?) {
-  #       Write-Host 'Failed to pull the remote branch. This is expected if the remote branch doesn't exist.
-  #     }
-  #     Write-Host 'Trying to push to the remote branch..'
-  #     git push https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
-  #   condition: |
-  #     and(
-  #       succeeded(),
-  #       in(variables['build.reason'], 'Schedule', 'Manual'),
-  #       eq(variables['COURTESY_PUSH'], 'true'),
-  #       eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  #     )
-  #   displayName: Push release branch
+      # Pull commits from remote and push branch to git
+      git checkout -b $releaseBranch
+      Write-Host 'Trying to pull the remote branch..'
+      git pull https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
+      if (-not $?) {
+        Write-Host 'Failed to pull the remote branch. This is expected if the remote branch doesn't exist.
+      }
+      Write-Host 'Trying to push to the remote branch..'
+      git push https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
+    condition: |
+      and(
+        succeeded(),
+        in(variables['build.reason'], 'Schedule', 'Manual'),
+        eq(variables['COURTESY_PUSH'], 'true'),
+        eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      )
+    displayName: Push release branch
 
-  # - powershell: |
-  #     $releaseBranch = "$(branchName)"
+  - powershell: |
+      $releaseBranch = "$(branchName)"
 
-  #     if ($(currentSprintWeek) -eq 3) {
-  #       cd $(System.DefaultWorkingDirectory)/ci/ci-release-notes
-  #       npm install
-  #       node release-notes.js --token $(GitHubPAT) --version $(currentSprint) --releaseBranch $releaseBranch
-  #     } else {
-  #       echo "Skipping since release notes generating on week 3"
-  #     }
-  #   condition: |
-  #     and(
-  #       succeeded(),
-  #       in(variables['build.reason'], 'Schedule', 'Manual'),
-  #       eq(variables['COURTESY_PUSH'], 'true'),
-  #       eq(variables['Build.SourceBranch'], 'refs/heads/master')
-  #     )
-  #   displayName: Create Release
+      if ($(currentSprintWeek) -eq 3) {
+        cd $(System.DefaultWorkingDirectory)/ci/ci-release-notes
+        npm install
+        node release-notes.js --token $(GitHubPAT) --version $(currentSprint) --releaseBranch $releaseBranch
+      } else {
+        echo "Skipping since release notes generating on week 3"
+      }
+    condition: |
+      and(
+        succeeded(),
+        in(variables['build.reason'], 'Schedule', 'Manual'),
+        eq(variables['COURTESY_PUSH'], 'true'),
+        eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      )
+    displayName: Create Release

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -31,7 +31,7 @@ steps:
     npm install
   displayName: npm install min agent demands
 
-- script: node ./ci/verifyMinAgentDemands/index.js --pat $(GitHubPAT)
+- script: node ./ci/verifyMinAgentDemands/index.js
   displayName: Verify min agent demands
 
 # Filter out unchanged tasks
@@ -169,12 +169,12 @@ steps:
       # Pull commits from remote and push branch to git
       git checkout -b $releaseBranch
       Write-Host 'Trying to pull the remote branch..'
-      git pull https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
+      git pull https://github.com/microsoft/azure-pipelines-tasks $releaseBranch
       if (-not $?) {
         Write-Host 'Failed to pull the remote branch. This is expected if the remote branch doesn't exist.
       }
       Write-Host 'Trying to push to the remote branch..'
-      git push https://$(GitHubPAT)@github.com/microsoft/azure-pipelines-tasks $releaseBranch
+      git push https://github.com/microsoft/azure-pipelines-tasks $releaseBranch
     condition: |
       and(
         succeeded(),
@@ -201,4 +201,5 @@ steps:
         eq(variables['COURTESY_PUSH'], 'true'),
         eq(variables['Build.SourceBranch'], 'refs/heads/master')
       )
+    continueOnError: true
     displayName: Create Release


### PR DESCRIPTION
Reverts microsoft/azure-pipelines-tasks#20333

+ Remove $(GitHubPAT) from "Push release branch" step (since this step works without the pat)
+ Remove $(GitHubPAT) from "Verify min agent demands" step (since this step works without the pat) to unblock PR checks

[AB#2209391](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2209391)
