### PR TITLE
Use win-x64 for Windows

### DIFF
--- a/Tasks/FuncToolsInstallerV0/src/utils.ts
+++ b/Tasks/FuncToolsInstallerV0/src/utils.ts
@@ -103,7 +103,7 @@ function getDownloadUrl(version: string) {
 
         case 'Windows_NT':
         default:
-            return util.format(downloadUrlFormat, version, 'win-x86', version);
+            return util.format(downloadUrlFormat, version, 'win-x64', version);
 
     }
 }


### PR DESCRIPTION
#20376

**Task name**: FuncToolsInstaller@0

**Description**: Use win-x64 for Windows

**Documentation changes required:** Y

**Added unit tests:** N

**Attached related issue:** Y

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it (note: I'd think we need to bump the version, but will await for instructions)
- [ ] Checked that applied changes work as expected (note: could you please advice on how to test)
