### PR TITLE
Update to have  IgnoreMatch as default import mode

### DIFF
--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/appConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/appConfigurationClient.ts
@@ -95,6 +95,4 @@ export class AppConfigurationClient {
             yield setting
         }
     }
-
-
 }

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/appConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/appConfigurationClient.ts
@@ -1,7 +1,7 @@
 /**
  * Mock App config Client
  */
-import { SetConfigurationSettingResponse } from '@azure/app-configuration';
+import { SetConfigurationSettingResponse, ListConfigurationSettingsOptions, ConfigurationSetting } from '@azure/app-configuration';
 
 export class AppConfigurationClient {
 
@@ -22,4 +22,79 @@ export class AppConfigurationClient {
 
         return response
     }
+
+    public listConfigurationSettings(options?: ListConfigurationSettingsOptions) {
+
+        // Polyfill Symbol.asyncIterator,Since the property is readonly, only assign it when it doesn't exist:
+        if (typeof (Symbol as any).asyncIterator === 'undefined') {
+            (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+        }
+        const iter = this.getListConfigurationSettingsIterator();
+
+        return {
+            next() {
+                return iter.next();
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        }
+    }
+
+    private async *getListConfigurationSettingsIterator(): AsyncIterableIterator<ConfigurationSetting> {
+
+        let items: Array<ConfigurationSetting> = [
+            {
+                etag: "",
+                key: "Mvc:FontColor",
+                label: "development",
+                contentType: "media",
+                value: "orange",
+                lastModified: null,
+                isReadOnly: false
+            },
+            {
+                etag: "",
+                key: "Mvc:BackGroundColor",
+                label: "",
+                contentType: "media",
+                value: "white",
+                lastModified: null,
+                isReadOnly: false
+            },
+            {
+                etag: "",
+                key: "Message",
+                label: "",
+                contentType: "media",
+                value: "Test 1",
+                lastModified: null,
+                isReadOnly: false
+            },
+            {
+                etag: "",
+                key: "Message1",
+                label: " ",
+                contentType: "media",
+                value: "Test 1",
+                lastModified: null,
+                isReadOnly: false
+            },
+            {
+                etag: "",
+                key: "Settings:KeyVault:Message",
+                label: " ",
+                contentType: "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+                value: JSON.stringify({ uri: "https://vaultName.vault.azure.net/secrets/TestMessage" }), //secret url to key vault
+                lastModified: null,
+                isReadOnly: false
+            },
+        ]
+        for (let setting of items) {
+
+            yield setting
+        }
+    }
+
+
 }

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/conflictAppConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/conflictAppConfigurationClient.ts
@@ -2,7 +2,7 @@
  * Mock App config Client, that throws an 409 status code 
 */
 import { RestError } from "@azure/core-rest-pipeline";
-import { SetConfigurationSettingResponse } from '@azure/app-configuration';
+import { SetConfigurationSettingResponse, ListConfigurationSettingsOptions, ConfigurationSetting } from '@azure/app-configuration';
 
 class ConflictAppConfigurationClient {
 
@@ -10,6 +10,78 @@ class ConflictAppConfigurationClient {
       const message: string = "{\"type\":\"https://test.azconfig.io/errors/key-locked\",\"title\":\"Modifing key 'app:Fruit:Banana:0' is not allowed\",\"name\":\"app:Settings:BackgroundColor\",\"detail\":\"The key is read-only. To allow modification unlock it first.\",\"status\":409}";
       
       return Promise.reject(new RestError(message, {statusCode: 409}));
+    }
+
+    public listConfigurationSettings(options?: ListConfigurationSettingsOptions) {
+      // Polyfill Symbol.asyncIterator,Since the property is readonly, only assign it when it doesn't exist:
+      if (typeof (Symbol as any).asyncIterator === 'undefined') {
+        (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+      }
+
+      const iter = this.getListConfigurationSettingsIterator();
+
+      return {
+        next() {
+            return iter.next();
+        },
+        [Symbol.asyncIterator]() {
+            return this;
+        },
+      }
+    }
+
+    private async *getListConfigurationSettingsIterator(): AsyncIterableIterator<ConfigurationSetting> {
+      let items: Array<ConfigurationSetting> = [
+        {
+          etag: "",
+          key: "Mvc:FontColor",
+          label: "development",
+          contentType: "media",
+          value: "orange",
+          lastModified: null,
+          isReadOnly: false
+        },
+        {
+            etag: "",
+            key: "Mvc:BackGroundColor",
+            label: "",
+            contentType: "media",
+            value: "white",
+            lastModified: null,
+            isReadOnly: false
+        },
+        {
+            etag: "",
+            key: "Message",
+            label: "",
+            contentType: "media",
+            value: "Test 1",
+            lastModified: null,
+            isReadOnly: false
+        },
+        {
+            etag: "",
+            key: "Message1",
+            label: " ",
+            contentType: "media",
+            value: "Test 1",
+            lastModified: null,
+            isReadOnly: false
+        },
+        {
+            etag: "",
+            key: "Settings:KeyVault:Message",
+            label: " ",
+            contentType: "application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8",
+            value: JSON.stringify({ uri: "https://vaultName.vault.azure.net/secrets/TestMessage" }), //secret url to key vault
+            lastModified: null,
+            isReadOnly: false
+        }
+      ];
+
+      for (let setting of items) {
+        yield setting
+      }
     }
 }
 exports.AppConfigurationClient = ConflictAppConfigurationClient;

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/forbiddenConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/forbiddenConfigurationClient.ts
@@ -1,14 +1,28 @@
-/**
- * Mock App config Client, that throws an 403 status code 
-*/
+import { ListConfigurationSettingsOptions, ConfigurationSetting } from "@azure/app-configuration";
 import { RestError } from "@azure/core-rest-pipeline";
-import { ConfigurationSetting } from "@azure/app-configuration";
 
 class ForbiddenAppConfigurationClient {
 
-    public async listConfigurationSettings(): Promise<IteratorResult<ConfigurationSetting, any>> {
-      
-      return Promise.reject(new RestError('', {statusCode: 403}));
+    public listConfigurationSettings(options?: ListConfigurationSettingsOptions) {
+
+        // Polyfill Symbol.asyncIterator,Since the property is readonly, only assign it when it doesn't exist:
+        if (typeof (Symbol as any).asyncIterator === 'undefined') {
+            (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+        }
+        const iter = this.getListConfigurationSettingsIterator();
+
+        return {
+            next() {
+                return iter.next();
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        }
+    }
+
+    private async *getListConfigurationSettingsIterator(): AsyncIterableIterator<ConfigurationSetting> {
+        return Promise.reject(new RestError('', { statusCode: 403 }));
     }
 }
 

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/forbiddenConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/forbiddenConfigurationClient.ts
@@ -2,11 +2,11 @@
  * Mock App config Client, that throws an 403 status code 
 */
 import { RestError } from "@azure/core-rest-pipeline";
-import { SetConfigurationSettingResponse } from "@azure/app-configuration";
+import { ConfigurationSetting } from "@azure/app-configuration";
 
 class ForbiddenAppConfigurationClient {
 
-    public async setConfigurationSetting(): Promise<SetConfigurationSettingResponse> {
+    public async listConfigurationSettings(): Promise<IteratorResult<ConfigurationSetting, any>> {
       
       return Promise.reject(new RestError('', {statusCode: 403}));
     }

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/unauthorizedAppConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/unauthorizedAppConfigurationClient.ts
@@ -1,12 +1,12 @@
 /**
  * Mock App config Client, that throws an 401 status code 
 */
-import { SetConfigurationSettingResponse } from "@azure/app-configuration";
+import { ConfigurationSetting } from "@azure/app-configuration";
 import { RestError, RawHttpHeaders, PipelineRequest, createHttpHeaders, HttpHeaders } from "@azure/core-rest-pipeline";
 
 class UnauthorizedAppConfigurationClient {
 
-    public async setConfigurationSetting(): Promise<SetConfigurationSettingResponse> {
+    public async listConfigurationSettings(): Promise<IteratorResult<ConfigurationSetting, any>> {
         const rawHttpHeaders: RawHttpHeaders = {
             "user-agent": "AzurePipelines.AzureAppConfiguration.Push",
             "x-ms-client-request-id": "12345908",

--- a/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/unauthorizedAppConfigurationClient.ts
+++ b/Tasks/AzureAppConfigurationPushV10/Tests/mock_node_modules/app-configuration/unauthorizedAppConfigurationClient.ts
@@ -1,12 +1,30 @@
 /**
- * Mock App config Client, that throws an 401 status code 
+ * Mock App config Client, that throws an 403=1 status code 
 */
-import { ConfigurationSetting } from "@azure/app-configuration";
+import { ConfigurationSetting, ListConfigurationSettingsOptions } from "@azure/app-configuration";
 import { RestError, RawHttpHeaders, PipelineRequest, createHttpHeaders, HttpHeaders } from "@azure/core-rest-pipeline";
 
 class UnauthorizedAppConfigurationClient {
 
-    public async listConfigurationSettings(): Promise<IteratorResult<ConfigurationSetting, any>> {
+    public listConfigurationSettings(options?: ListConfigurationSettingsOptions) {
+
+        // Polyfill Symbol.asyncIterator,Since the property is readonly, only assign it when it doesn't exist:
+        if (typeof (Symbol as any).asyncIterator === 'undefined') {
+            (Symbol as any).asyncIterator = Symbol.asyncIterator || Symbol('asyncIterator');
+        }
+        const iter = this.getListConfigurationSettingsIterator();
+
+        return {
+            next() {
+                return iter.next();
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        }
+    }
+
+    private async *getListConfigurationSettingsIterator(): AsyncIterableIterator<ConfigurationSetting> {
         const rawHttpHeaders: RawHttpHeaders = {
             "user-agent": "AzurePipelines.AzureAppConfiguration.Push",
             "x-ms-client-request-id": "12345908",

--- a/Tasks/AzureAppConfigurationPushV10/task.json
+++ b/Tasks/AzureAppConfigurationPushV10/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 10,
         "Minor": 245,
-        "Patch": 1
+        "Patch": 0
     },
     "instanceNameFormat": "Azure App Configuration",
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureAppConfigurationPushV10/task.json
+++ b/Tasks/AzureAppConfigurationPushV10/task.json
@@ -10,7 +10,7 @@
     "version": {
         "Major": 10,
         "Minor": 245,
-        "Patch": 0
+        "Patch": 1
     },
     "instanceNameFormat": "Azure App Configuration",
     "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureAppConfigurationPushV10/task.loc.json
+++ b/Tasks/AzureAppConfigurationPushV10/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 10,
     "Minor": 245,
-    "Patch": 1
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureAppConfigurationPushV10/task.loc.json
+++ b/Tasks/AzureAppConfigurationPushV10/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 10,
     "Minor": 245,
-    "Patch": 0
+    "Patch": 1
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureAppConfigurationPushV10/taskParameters.ts
+++ b/Tasks/AzureAppConfigurationPushV10/taskParameters.ts
@@ -83,7 +83,7 @@ export class TaskParameters {
             throw new ArgumentError(tl.loc("OnlySupportedImportModeOptions", All, IgnoreMatch));
         }
 
-        taskParameters.importMode = importMode == IgnoreMatch ? ImportMode.IgnoreMatch: ImportMode.All;
+        taskParameters.importMode = importMode == All ? ImportMode.All: ImportMode.IgnoreMatch;
 
         try {
 


### PR DESCRIPTION
**Task name**:  AzureAppConfigurationPushTask

**Description**:  Update to have IgnoreMatch as the default import mode

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
