### PR TITLE
Updated checks to new PAT format

### DIFF
--- a/Tasks/AppCenterTestV1/appcentertest.ts
+++ b/Tasks/AppCenterTestV1/appcentertest.ts
@@ -9,6 +9,7 @@ import { ToolRunner } from 'azure-pipelines-task-lib/toolrunner';
 var utils = require('./utils.js');
 
 const testRunIdLineRegexp = /Test run id: "([^"]+)"/;
+const personalAccessTokenRegexp = /^.{76}AZDO.{4}$/;
 
 function getEndpointAPIToken(endpointInputFieldName) {
     var errorMessage = tl.loc("CannotDecodeEndpoint");
@@ -206,7 +207,7 @@ async function setTestRunIdBuildPropertyAsync(testRunId: string) {
         let token = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
         let projectId = tl.getVariable('System.TeamProjectId');
         let buildId = tl.getVariable('Build.BuildId');
-        let auth = token.length == 52 ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
+        let auth = token.length == (52 || personalAccessTokenRegexp.test(token)) ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
         let vsts: apim.WebApi = new apim.WebApi(url, auth);
         let conn: lim.ConnectionData = await vsts.connect();
         let buildApi = await vsts.getBuildApi();

--- a/Tasks/AzureTestPlanV0/testPlanData.ts
+++ b/Tasks/AzureTestPlanV0/testPlanData.ts
@@ -9,6 +9,8 @@ import VSSInterfaces = require('azure-devops-node-api/interfaces/common/VSSInter
 import constants = require('./constants');
 import { ITestResultsApi } from "azure-devops-node-api/TestResultsApi";
 
+const personalAccessTokenRegexp = /^.{76}AZDO.{4}$/;
+
 export interface TestPlanData {
     listOfFQNOfTestCases: string[];
     testPlanId: number;
@@ -186,7 +188,7 @@ export async function getTestCaseListAsync(testPlanId: number, testSuiteId: numb
     let url = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
     let token = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
     let projectId = tl.getVariable('System.TeamProjectId');
-    let auth = token.length == 52 ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
+    let auth = (token.length == 52 || personalAccessTokenRegexp.test(token)) ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
     let vsts: apim.WebApi = new apim.WebApi(url, auth);
     let testPlanApi = await vsts.getTestPlanApi();
 
@@ -278,7 +280,7 @@ export async function getTestResultApiClient(){
     let url = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
     let token = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
 
-    let auth = token.length == 52 ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
+    let auth = (token.length == 52 || personalAccessTokenRegexp.test(token)) ? apim.getPersonalAccessTokenHandler(token) : apim.getBearerHandler(token);
     let vsts: apim.WebApi = new apim.WebApi(url, auth);
     let testResultsApi = await vsts.getTestResultsApi();
 


### PR DESCRIPTION
**Task name**: <Name of changed or new pipeline task>

**Description**: Azure DevOps has implemented a new format that is no longer 52 characters long but 84 characters long with a fixed signature 'AZDO'. To prepare for the transition between the new and old PAT format, I would like to change the PAT checks. We have already changed our documentation on the new PAT format: https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#changes-to-format

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
