### PR TITLE
[JavaToolInstallerV1] Added Localization - AB#2198814

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -574,6 +574,12 @@
           },
           {
             "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
+            "SourceFile": "Tasks\\JavaToolInstallerV1\\Strings\\resources.resjson\\en-US\\resources.resjson",
+            "CopyOption": "LangIDOnPath",
+            "OutputPath": "Tasks\\JavaToolInstallerV1\\Strings\\resources.resjson"
+          },
+          {
+            "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
             "SourceFile": "Tasks\\JenkinsDownloadArtifactsV1\\Strings\\resources.resjson\\en-US\\resources.resjson",
             "CopyOption": "LangIDOnPath",
             "OutputPath": "Tasks\\JenkinsDownloadArtifactsV1\\Strings\\resources.resjson"


### PR DESCRIPTION
**Task name**: java-tool-installer

**Description**: This PR adds the localization for the v1 version of the java-tool-installer

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) NA

**Attached related issue:** (Y/N) Y

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
