### PR TITLE
Exclude signatures with example token from the guardian check

### DIFF
--- a/.gdn/.gdnbaselines
+++ b/.gdn/.gdnbaselines
@@ -47,7 +47,7 @@
         "default"
       ],
       "createdDate": "2024-09-24 08:56:24Z",
-      "justification": ""
+      "justification": "Skip the test file with example token"
     },
     "10281d0eb6e3cbd458b75591e8332638f1b0ac979db305d3ea11bc2cf12c7f83": {
       "signature": "10281d0eb6e3cbd458b75591e8332638f1b0ac979db305d3ea11bc2cf12c7f83",

--- a/.gdn/.gdnbaselines
+++ b/.gdn/.gdnbaselines
@@ -13,6 +13,42 @@
     }
   },
   "results": {
+    "463e7f06abef857daf3e4e724a9a24758bb12b3e3d4d883f27416e88ca27a0fc": {
+      "signature": "463e7f06abef857daf3e4e724a9a24758bb12b3e3d4d883f27416e88ca27a0fc",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-09-24 08:56:24Z",
+      "justification": "Skip the test file with example token"
+    },
+    "e977f8568efadb9b0d17073d76f54d53f67edc18bf716cf760385cf1fba1c58c": {
+      "signature": "e977f8568efadb9b0d17073d76f54d53f67edc18bf716cf760385cf1fba1c58c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-09-24 08:56:24Z",
+      "justification": "Skip the test file with example token"
+    },
+    "e535b5cd08b41e3889b71fe8f5b88a2fcc7cf7b5d170e92c3190eb467ab7bf3b": {
+      "signature": "e535b5cd08b41e3889b71fe8f5b88a2fcc7cf7b5d170e92c3190eb467ab7bf3b",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-09-24 08:56:24Z",
+      "justification": "Skip the test file with example token"
+    },
+    "d7423c13e23664907fac8e08985d5223a5187cb50aaff29b7eecde1d1cc40510": {
+      "signature": "d7423c13e23664907fac8e08985d5223a5187cb50aaff29b7eecde1d1cc40510",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-09-24 08:56:24Z",
+      "justification": ""
+    },
     "10281d0eb6e3cbd458b75591e8332638f1b0ac979db305d3ea11bc2cf12c7f83": {
       "signature": "10281d0eb6e3cbd458b75591e8332638f1b0ac979db305d3ea11bc2cf12c7f83",
       "alternativeSignatures": [


### PR DESCRIPTION
**Description**: This PR excludes signatures with example token from the guardian check.

This PR resolves Courtesy push problem.

**Related WI**: [AB#2217137](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2217137)

