### PR TITLE
Pass PAT to verifyMinAgentDemands check

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -31,10 +31,9 @@ steps:
     npm install
   displayName: npm install min agent demands
 
-- script: node ./ci/verifyMinAgentDemands/index.js --pat $(GitHubPAT)
-  # uncommnet this line once we will decide to return tocken to checks
-  # env: 
-  #   GITHUB_PAT: variables['GitHubPAT']
+- script: node ./ci/verifyMinAgentDemands/index.js
+  env:
+    GITHUB_PAT: variables['GitHubPAT']
   displayName: Verify min agent demands
 
 # Filter out unchanged tasks

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -31,7 +31,7 @@ steps:
     npm install
   displayName: npm install min agent demands
 
-- script: node ./ci/verifyMinAgentDemands/index.js
+- script: node ./ci/verifyMinAgentDemands/index.js --pat $(GitHubPAT)
   # uncommnet this line once we will decide to return tocken to checks
   # env: 
   #   GITHUB_PAT: variables['GitHubPAT']

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -33,7 +33,7 @@ steps:
 
 - script: node ./ci/verifyMinAgentDemands/index.js
   env:
-    GITHUB_PAT: variables['GitHubPAT']
+    GITHUB_PAT: $(GitHubPAT)
   displayName: Verify min agent demands
 
 # Filter out unchanged tasks


### PR DESCRIPTION
**Description**: This PR adds the **GITHUB_PAT** env variable to **verifyMinAgentDemands** check.
This check started to fail after #20353 when this PAT was removed and started exceeding the rate limit of GitHub API.

