### PR TITLE
Add CI check to verify the relation between a node executor and a minimum agent version

### DIFF
--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -35,9 +35,6 @@ steps:
   displayName: Check Is Forked PR
   condition: eq(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true')
 
-- script: node ./ci/check-node-executor-agent-version.js
-  displayName: Verify node executor and related minimum agent version
-
 # Verify min agent demands
 - script: |
     cd ci/verifyMinAgentDemands

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -35,6 +35,9 @@ steps:
   displayName: Check Is Forked PR
   condition: eq(variables['SYSTEM.PULLREQUEST.ISFORK'], 'true')
 
+- script: node ./ci/check-node-executor-agent-version.js
+  displayName: Verify node executor and related minimum agent version
+
 # Verify min agent demands
 - script: |
     cd ci/verifyMinAgentDemands

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -109,6 +109,9 @@ steps:
     )
   displayName: Push release branch
 
+- script: node ./ci/check-node-executor-agent-version.js --task "$(task_pattern)"
+  displayName: Verify node executor and related minimum agent version
+
 - script: node ./ci/check-downgrading.js --task "$(task_pattern_fordowngradingcheck)" --sprint $(currentSprint) --week $(currentSprintWeek)
   displayName: Check for downgrading tasks
   # remove SourceBranch condition after merging users/merlynop/node20merge-2 ; see https://github.com/microsoft/azure-pipelines-tasks/pull/20819

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -109,8 +109,8 @@ steps:
     )
   displayName: Push release branch
 
-- script: node ./ci/check-node-executor-agent-version.js --task "$(task_pattern)"
-  displayName: Verify node executor and related minimum agent version
+- script: node ./ci/check-node-executor-agent-version.js --task "$(getTaskPattern.task_pattern)"
+  displayName: Verify relation between node executor and minimum agent version
 
 - script: node ./ci/check-downgrading.js --task "$(task_pattern_fordowngradingcheck)" --sprint $(currentSprint) --week $(currentSprintWeek)
   displayName: Check for downgrading tasks

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -111,6 +111,12 @@ steps:
 
 - script: node ./ci/check-node-executor-agent-version.js --task "$(getTaskPattern.task_pattern)"
   displayName: Verify relation between node executor and minimum agent version
+  condition: |
+    and(
+      succeeded(),
+      eq(variables['build.reason'], 'PullRequest'),
+      ne(variables['numTasks'], 0)
+    )
 
 - script: node ./ci/check-downgrading.js --task "$(task_pattern_fordowngradingcheck)" --sprint $(currentSprint) --week $(currentSprintWeek)
   displayName: Check for downgrading tasks

--- a/ci/check-node-executor-agent-version.js
+++ b/ci/check-node-executor-agent-version.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+const basePath = path.join(__dirname, '..', 'Tasks');
+const tasks = fs.readdirSync(basePath).map(x => ({
+    name: x,
+    path: path.resolve(basePath, x),
+})).filter(x => fs.existsSync(path.join(x.path, 'task.json')));
+
+const versionMap = new Map([
+    ['Node10', '2.144.0'],
+    ['Node16', '2.209.0'],
+    ['Node20_1', '3.232.1'],
+]);
+
+const problems = [];
+
+for (const task of tasks) {
+    const taskJson = JSON.parse(fs.readFileSync(path.join(task.path, 'task.json'), 'utf8'));
+
+    if (!taskJson.hasOwnProperty('execution')) {
+        continue;
+    }
+
+    const taskMinimumAgentVersion = taskJson.minimumAgentVersion;
+    
+    if (taskMinimumAgentVersion === undefined) {
+        problems.push(`The minimum agent version is not defined in ${task.name} task`);
+        continue;
+    }
+    
+    const handlers = Object.keys(taskJson.execution);
+
+    for (const key of versionMap.entries()) {
+        if (handlers.includes(key[0]) && semver.gt(taskMinimumAgentVersion, key[1])) {
+            break;
+        }
+
+        problems.push(`The minimum agent version is not correct for ${key[0]} executor in ${task.name} task, should be min ${key[1]}`);
+    }
+}
+
+if (problems.length > 0) {
+    console.log(problems.join('\n'));
+    process.exit(1);
+}

--- a/ci/check-node-executor-agent-version.js
+++ b/ci/check-node-executor-agent-version.js
@@ -1,12 +1,33 @@
 const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
+const { resolveTaskList } = require('./ci-util');
+
+const argv = require('minimist')(process.argv.slice(2));
+
+// --task "@({tasks_names})"
+if (!argv.task) {
+  console.log(`$(task_pattern) variable is empty or not set. Aborting...`);
+  process.exit(0);
+};
+
+const handleAllTasks = argv.task === 'all';
+const changedTasks = [];
+
+if (!handleAllTasks) {
+    changedTasks.push(...resolveTaskList(argv.task));
+
+    if (changedTasks.length === 0) {
+        console.log(`There are no changed tasks`);
+        process.exit(0);
+    }
+};
 
 const basePath = path.join(__dirname, '..', 'Tasks');
-const tasks = fs.readdirSync(basePath).map(x => ({
-    name: x,
-    path: path.resolve(basePath, x),
-})).filter(x => fs.existsSync(path.join(x.path, 'task.json')));
+const tasks = fs.readdirSync(basePath)
+    .filter(x => changedTasks.includes(x) || handleAllTasks)
+    .map(x => ({ name: x, path: path.resolve(basePath, x) }))
+    .filter(x => fs.existsSync(path.join(x.path, 'task.json')));
 
 const versionMap = new Map([
     ['Node10', '2.144.0'],
@@ -33,15 +54,17 @@ for (const task of tasks) {
     const handlers = Object.keys(taskJson.execution);
 
     for (const key of versionMap.entries()) {
-        if (handlers.includes(key[0]) && semver.gt(taskMinimumAgentVersion, key[1])) {
+        if (handlers.includes(key[0]) && semver.gte(taskMinimumAgentVersion, key[1])) {
             break;
         }
 
         problems.push(`The minimum agent version is not correct for ${key[0]} executor in ${task.name} task, should be min ${key[1]}`);
+        break;
     }
 }
 
 if (problems.length > 0) {
+    console.log(`Found ${problems.length} problems:`);
     console.log(problems.join('\n'));
     process.exit(1);
 }

--- a/make.js
+++ b/make.js
@@ -234,6 +234,13 @@ CLI.build = async function(/** @type {{ task: string }} */ argv)
 
     writeUpdatedsFromGenTasks = true;
     await CLI.serverBuild(argv);
+    CLI.validate(argv);
+}
+
+CLI.validate = function()
+{
+    const allTasks = getTaskList(taskList);
+    run(`node ci/check-node-executor-agent-version.js --task "@(${allTasks.join("|")})"`);
 }
 
 CLI.buildandtest = async function (/** @type {{ task: string }} */ argv) {


### PR DESCRIPTION
**Description**: This PR adds check that verifies the relation between a node executor and a minimum agent version

**Attached related issue:** [AB#2287182](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2287182)