### PR TITLE
Speed up buildconfig generation 6x (6m->1m)

### DIFF
--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -73,8 +73,11 @@ namespace BuildConfigGen
         {
             try
             {
+                Stopwatch sw = new Stopwatch();
+                sw.Start();
                 ensureUpdateModeVerifier = new EnsureUpdateModeVerifier(!writeUpdates);
                 MainInner(task, configs, currentSprint, writeUpdates, allTasks, getTaskVersionTable, debugAgentDir, includeLocalPackagesBuildConfig);
+                Console.WriteLine("Elapsed=" + sw.ToString());
             }
             catch (Exception e2)
             {
@@ -945,7 +948,7 @@ namespace BuildConfigGen
             HashSet<string> pathsToRemoveFromOutput;
 
             // In case if task was not generated yet, we don't need to get the list of files to remove, because taskOutput not exists yet
-            if (Directory.Exists(taskOutput) && !config.useAltGeneratedPath /* exclude alt which is .gitignore */)
+            if (Directory.Exists(taskOutput))
             {
                 pathsToRemoveFromOutput = new HashSet<string>(GitUtil.GetNonIgnoredFileListFromPath(gitRootPath, taskOutput));
             }


### PR DESCRIPTION
**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

Test here: https://github.com/microsoft/azure-pipelines-tasks/pull/20511

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

[AB#2121133](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2121133)
