### PR TITLE
Add ability to suppress github token warning

### DIFF
--- a/Tasks/UsePythonVersionV0/installpythonversion.ts
+++ b/Tasks/UsePythonVersionV0/installpythonversion.ts
@@ -47,7 +47,7 @@ async function downloadPythonVersion(versionSpec: string, parameters: TaskParame
     const additionalHeaders = {};
     if (parameters.githubToken) {
         additionalHeaders['Authorization'] = auth;
-    } else {
+    } else if (!parameters.suppressGitHubTokenWarning){
         task.warning(task.loc('MissingGithubToken'));
     }
 

--- a/Tasks/UsePythonVersionV0/interfaces.ts
+++ b/Tasks/UsePythonVersionV0/interfaces.ts
@@ -5,6 +5,7 @@ export interface TaskParameters {
     addToPath: boolean,
     architecture: string,
     githubToken?: string
+    suppressGitHubTokenWarning: boolean
 }
 
 export interface PythonRelease {

--- a/Tasks/UsePythonVersionV0/task.json
+++ b/Tasks/UsePythonVersionV0/task.json
@@ -14,7 +14,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 0,
-    "Minor": 246,
+    "Minor": 247,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/UsePythonVersionV0/task.loc.json
+++ b/Tasks/UsePythonVersionV0/task.loc.json
@@ -14,7 +14,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 0,
-    "Minor": 246,
+    "Minor": 247,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: UsePythonVersion@0

**Description**: Add a boolean flag that allows the user to disable the github PAT warning when downloading a python version.

**Documentation changes required:** Yes

**Added unit tests:** No (not sure how, to be honest)

**Attached related issue:** Yes. https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2220241

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected

Can someone please check if this works? I'm not sure how to perform testing.