### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 29287109

### DIFF
--- a/Tasks/ManualValidationV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "Senden Sie eine E-Mail an bestimmte Benutzer (oder Gruppen), um diese über ausstehende manuelle Überprüfungen zu informieren. Nur in den genehmigenden Personen angegebene Benutzer können eine manuelle Überprüfung durchführen.",
   "loc.input.label.approvers": "Genehmigende Personen",
   "loc.input.help.approvers": "Geben Sie Benutzer/Gruppen/Projektteams durch Kommas getrennt an, um auf eine manuelle Überprüfung zu reagieren. Wenn keine Eingabe vorhanden ist, können Benutzer mit der Berechtigung zum Erstellen einer Warteschlange Maßnahmen ergreifen.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "Anleitung",
   "loc.input.help.instructions": "Diese Anweisungen werden dem Benutzer angezeigt, damit dieser die manuelle Überprüfung fortsetzen oder ablehnen kann. Basierend auf diesen Anweisungen kann der Benutzer eine fundierte Entscheidung zu dieser manuellen Überprüfung treffen.",
   "loc.input.label.onTimeout": "Bei Zeitlimit",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "Envíe un correo electrónico de validación manual pendiente a usuarios (o grupos) específicos. Solo los usuarios especificados en los aprobadores pueden actuar en una validación manual.",
   "loc.input.label.approvers": "Aprobadores",
   "loc.input.help.approvers": "Especifique usuarios, grupos o equipos de proyecto separados por comas para actuar en una validación manual. En ausencia de entrada, los usuarios con permiso para crear colas podrán actuar.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "Instrucciones",
   "loc.input.help.instructions": "Estas instrucciones se mostrarán al usuario para reanudar o rechazar la validación manual. En función de ellas, el usuario tomará una decisión informada sobre esta validación manual.",
   "loc.input.label.onTimeout": "Al agotarse el tiempo de espera",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "Envoyez un e-mail relatif à une validation manuelle en attente à des utilisateurs (ou groupes) spécifiques. Seuls les utilisateurs spécifiés dans les approbateurs peuvent agir sur une validation manuelle.",
   "loc.input.label.approvers": "Approbateurs",
   "loc.input.help.approvers": "Spécifiez les utilisateurs/groupes/équipes de projet séparés par des virgules pour agir sur une validation manuelle. En l’absence d’entrée, les utilisateurs disposant de l’autorisation de génération de file d’attente pourront prendre des mesures.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "Instructions",
   "loc.input.help.instructions": "Ces instructions sont montrées à l'utilisateur pour lui permettre de reprendre ou de rejeter la validation manuelle. En fonction de ces instructions, l'utilisateur prend une décision en connaissance de cause sur cette validation manuelle.",
   "loc.input.label.onTimeout": "Au délai d'expiration",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "Consente di inviare un messaggio di posta elettronica relativo a una convalida manuale in sospeso a utenti o gruppi specifici. Solo gli utenti specificati nei responsabili approvazione possono eseguire una convalida manuale.",
   "loc.input.label.approvers": "Responsabili approvazione",
   "loc.input.help.approvers": "Specificare utenti/gruppi/team di progetto separati da virgole che possono eseguire una convalida manuale. In assenza di input, gli utenti con l'autorizzazione di compilazione della coda saranno in grado di intervenire.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "Istruzioni",
   "loc.input.help.instructions": "Queste istruzioni verranno visualizzate agli utenti per consentire loro di riprendere o rifiutare la convalida manuale. Usando queste istruzioni l'utente potrà prendere una decisione basata su informazioni aggiornate in merito a questa convalida manuale.",
   "loc.input.label.onTimeout": "In caso di timeout",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "手動検証の保留のメールを特定のユーザー (またはグループ) に送信します。承認者に指定されたユーザーのみが手動検証を操作できます。",
   "loc.input.label.approvers": "承認者",
   "loc.input.help.approvers": "手動検証を操作するには、ユーザー/グループ/プロジェクト チームをコンマで区切って指定します。入力がない場合、キュー ビルドのアクセス許可を持つユーザーがアクションを実行できます。",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "手順",
   "loc.input.help.instructions": "手動検証を再開または拒否できるよう、ユーザーにこの指示が表示されます。これらの指示に基づき、ユーザーは十分な情報を得たうえで、この手動検証について決定します。",
   "loc.input.label.onTimeout": "タイムアウト時",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "수동 유효성 검사 보류 중 전자 메일을 특정 사용자나 그룹에 보냅니다. 승인자에 지정된 사용자만 수동 유효성 검사를 수행할 수 있습니다.",
   "loc.input.label.approvers": "승인자",
   "loc.input.help.approvers": "수동 유효성 검사를 수행하려면 사용자, 그룹, 프로젝트 팀을 쉼표로 구분하여 지정하세요. 입력이 없으면 큐 빌드 권한이 있는 사용자가 작업을 수행할 수 있습니다.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "지침",
   "loc.input.help.instructions": "이 지침은 사용자가 수동 유효성 검사를 다시 시작하거나 거부하려는 경우 표시됩니다. 사용자는 해당 지침에 따라 이 수동 유효성 검사에 대해 합리적인 결정을 내리게 됩니다.",
   "loc.input.label.onTimeout": "시간 초과 시",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "Отправка отдельным пользователям или группам электронного письма об ожидаемой проверке вручную. Только пользователи, указанные в списке утверждающих, могут выполнять проверку вручную.",
   "loc.input.label.approvers": "Утверждающие",
   "loc.input.help.approvers": "Укажите пользователей, группы или проектные команды через запятую, чтобы выполнить ручную проверку. При отсутствии ввода пользователи с разрешением на построение очереди смогут предпринять действия.",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "Инструкции",
   "loc.input.help.instructions": "Эти инструкции будут показаны пользователю для возобновления или отклонения проверки вручную. На их основе пользователь должен принять взвешенное решение об этой проверке вручную.",
   "loc.input.label.onTimeout": "По истечении времени ожидания",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "将手动验证挂起电子邮件发送到特定用户(或组)。只有审批者中指定的用户才能执行手动验证。",
   "loc.input.label.approvers": "审批者",
   "loc.input.help.approvers": "指定用户/组/项目团队(以逗号分隔)，以执行手动验证。如果没有输入，则具有队列生成权限的用户将能够执行操作。",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "说明",
   "loc.input.help.instructions": "将向用户显示这些说明，以便恢复或拒绝手动验证。用户根据这些说明，对此手动验证作出知情的决策。",
   "loc.input.label.onTimeout": "超时时",

--- a/Tasks/ManualValidationV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/ManualValidationV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -7,6 +7,8 @@
   "loc.input.help.notifyUsers": "將手動驗證待決電子郵件傳送給特定使用者 (或群組)。只有核准者中指定的使用者可以執行手動驗證。",
   "loc.input.label.approvers": "核准者",
   "loc.input.help.approvers": "指定以逗號分隔以進行手動驗證的使用者/群組/專案小組。在沒有輸入的情況下，具有佇列建置權限的使用者將可以採取動作。",
+  "loc.input.label.allowApproversToApproveTheirOwnRuns": "Allow approvers to approve their own run",
+  "loc.input.help.allowApproversToApproveTheirOwnRuns": "If this is true, approver will be able to approve their own run",
   "loc.input.label.instructions": "指示",
   "loc.input.help.instructions": "使用者會看到這些指示，以繼續或拒絕手動驗證。使用者將會根據這些指示，對此手動驗證做出經旁徵博引的決定。",
   "loc.input.label.onTimeout": "逾時時",

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/de-DE/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "Anmeldeinformationen für Registrierungen außerhalb dieser Organisation/Sammlung",
   "loc.input.help.customEndpoint": "Anmeldeinformationen zur Verwendung für externe Registrierungen in der NPMRC-Datei des Projekts. Lassen Sie dieses Feld bei Registrierungen in dieser Organisation/Sammlung leer. Es werden automatisch die Anmeldeinformationen für den Build verwendet.",
   "loc.input.label.workloadIdentityServiceConnection": "Dienstverbindung „Azure DevOps“",
-  "loc.input.help.workloadIdentityServiceConnection": "Wenn diese Option festgelegt ist, ist feedUrl erforderlich. Dienstverbindungen für externe Organisationen/Sammlungen und benutzerdefinierte Endpunkte sind nicht kompatibel.",
+  "loc.input.help.workloadIdentityServiceConnection": "Anmeldeinformationen für Registrierungen, die sich in der .npmrc-Datei eines Projekts befinden. Verwenden Sie feedUrl, um die Anmeldeinformationen für die einzelne Registrierung in einer .npmrc-Datei anzugeben. Nicht kompatibel mit customEndpoint.",
   "loc.input.label.feedUrl": "Azure Artifacts-URL",
   "loc.input.help.feedUrl": "Wenn diese Option festgelegt ist, ist azureDevOpsServiceConnection erforderlich. Nicht kompatibel mit customEndpoint. Die Feed-URL muss im npm-Registrierung Format vorliegen, z. B. https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "Buildanmeldeinformationen gefunden",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "Authentifizierungsinformationen der Dienstverbindung %s werden für Feed %s hinzugefügt",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "Die Authentifizierung für den Feed %s wurde erfolgreich hinzugefügt.",
   "loc.messages.FailedToGetServiceConnectionAuth": "Verbundanmeldeinformationen können nicht von der Dienstverbindung abgerufen werden: %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "Sowohl die Feed-URL als auch die Dienstverbindung müssen festgelegt werden und dürfen nicht leer sein.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "Wenn eine Feed-URL angegeben wird, muss die „Azure DevOps“-Dienstverbindung angegeben werden und darf nicht leer sein.",
   "loc.messages.SkippingParsingNpmrc": "Analyse von npmrc wird übersprungen.",
   "loc.messages.DuplicateCredentials": "Die Authentifizierung für die Registrierung „%s“ wurde zuvor festgelegt. Wird mit neuer Konfiguration überschrieben.",
   "loc.messages.FoundEndpointCredentials": "Es wurden festgelegte Anmeldeinformationen für die Dienstverbindung „%s“ gefunden."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/es-ES/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "Credenciales para registros fuera de esta organización o colección",
   "loc.input.help.customEndpoint": "Credenciales que deben usarse para registros externos que están en el archivo .npmrc del proyecto. Para registros en esta organización o colección, deje este valor en blanco; se usarán automáticamente las credenciales de la compilación.",
   "loc.input.label.workloadIdentityServiceConnection": "Conexión de servicio de \"Azure DevOps\"",
-  "loc.input.help.workloadIdentityServiceConnection": "Si se establece, se requiere feedUrl. Las conexiones de servicio para organizaciones o colecciones externas y puntos de conexión personalizados no son compatibles.",
+  "loc.input.help.workloadIdentityServiceConnection": "Las credenciales que se usan para los registros se encuentran en el archivo .npmrc de un proyecto. Se usan con feedUrl para especificar las credenciales usadas para el registro único en un archivo .npmrc. No es compatible con customEndpoint.",
   "loc.input.label.feedUrl": "Dirección URL de Azure Artifacts",
   "loc.input.help.feedUrl": "Si se establece, se requiere azureDevOpsServiceConnection. No es compatible con customEndpoint. La dirección URL de la fuente debe tener el formato de registro npm, por ejemplo, https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "Credenciales de compilación encontradas",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "Agregando información de autenticación de la conexión de servicio %s para la fuente %s",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "Se agregó correctamente la autenticación para la fuente %s.",
   "loc.messages.FailedToGetServiceConnectionAuth": "No se pueden obtener las credenciales federadas de la conexión de servicio: %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "Tanto la dirección URL de la fuente como la conexión de servicio deben establecerse y no pueden estar vacías.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "Si se proporciona la dirección URL de la fuente de distribución, debe proporcionarse la conexión del servicio \"Azure DevOps\" y no puede estar vacía.",
   "loc.messages.SkippingParsingNpmrc": "Omitiendo análisis de npmrc",
   "loc.messages.DuplicateCredentials": "La autenticación para el registro \"%s\" se estableció previamente. Sobrescribiendo con la nueva configuración.",
   "loc.messages.FoundEndpointCredentials": "Se encontraron credenciales establecidas para la conexión de servicio \"%s\"."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/fr-FR/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "Informations d'identification des registres situés en dehors de cette organisation/collection",
   "loc.input.help.customEndpoint": "Informations d'identification à utiliser pour les registres externes situés dans le fichier .npmrc du projet. Pour les registres présents dans cette organisation/collection, n'indiquez aucune valeur. Les informations d'identification de la build sont utilisées automatiquement.",
   "loc.input.label.workloadIdentityServiceConnection": "Connexion au service « Azure DevOps »",
-  "loc.input.help.workloadIdentityServiceConnection": "Si ce paramètre est défini, feedUrl est obligatoire. Les connexions de service pour les organisations/collections externes et les points de terminaison personnalisés ne sont pas compatibles.",
+  "loc.input.help.workloadIdentityServiceConnection": "Informations d’identification à utiliser pour les registres qui ont localisé le fichier .npmrc d’un projet. Utilisez feedUrl pour spécifier les informations d’identification utilisées pour le registre unique dans un fichier .npmrc. Non compatible avec customEndpoint.",
   "loc.input.label.feedUrl": "URL Azure Artifacts",
   "loc.input.help.feedUrl": "Si cette option est définie, workloadIdentityServiceConnection est requis. Non compatible avec customEndpoint. L’URL du flux doit être au format registre npm, par exemple, https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "Informations d'identification de build trouvées",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "Ajout d’informations d’authentification à partir des %s de connexion de service pour les %s de flux",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "Authentification ajoutée pour le flux %s.",
   "loc.messages.FailedToGetServiceConnectionAuth": "Impossible d’obtenir les informations d’identification fédérées à partir de la connexion de service : %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "L’URL du flux et la connexion de service doivent être définies et ne peuvent pas être vides.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "Si l’URL du flux est fournie, la connexion de service « Azure DevOps » doit être fournie et ne peut pas être vide.",
   "loc.messages.SkippingParsingNpmrc": "Analyse npmrc ignorée",
   "loc.messages.DuplicateCredentials": "L’authentification du registre « %s » a été précédemment définie. Remplacement par une nouvelle configuration.",
   "loc.messages.FoundEndpointCredentials": "Informations d’identification définies pour la connexion de service « %s »."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/it-IT/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "Credenziali per i registri esterni a questa organizzazione/raccolta",
   "loc.input.help.customEndpoint": "Credenziali da usare per i registri esterni situati nel file del progetto con estensione npmrc. Per i registri in questa organizzazione/raccolta lasciare vuoto il campo. Verranno usate automaticamente le credenziali della compilazione.",
   "loc.input.label.workloadIdentityServiceConnection": "Connessione al servizio 'Azure DevOps'",
-  "loc.input.help.workloadIdentityServiceConnection": "Se questa impostazione è impostata, feedUrl è obbligatorio. Le connessioni al servizio per organizzazioni esterne/raccolte ed endpoint personalizzati non sono compatibili.",
+  "loc.input.help.workloadIdentityServiceConnection": "Credenziali da utilizzare per i registri che individuano il file .npmrc di un progetto. Usa con feedUrl per specificare le credenziali usate per il singolo registro in un file .npmrc. Non compatibile con customEndpoint.",
   "loc.input.label.feedUrl": "Azure Artifacts URL",
   "loc.input.help.feedUrl": "Con questa impostazione è necessario azureDevOpsServiceConnection. Non compatibile con customEndpoint. L'URL del feed deve essere nel formato registro npm, ad esempio https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "Sono state trovate le credenziali di compilazione",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "Aggiunta di informazioni di autenticazione dalla connessione al servizio %s per il feed %s",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "L'autenticazione per il feed %s è stata aggiunta.",
   "loc.messages.FailedToGetServiceConnectionAuth": "Non è possibile ottenere le credenziali federate dalla connessione al servizio: %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "L'URL del feed e la connessione al servizio devono essere impostati e non possono essere vuoti.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "Se viene specificato l'URL del feed, la connessione al servizio 'Azure DevOps' deve essere specificata e non può essere vuota.",
   "loc.messages.SkippingParsingNpmrc": "L'analisi di npmrc verrà ignorata",
   "loc.messages.DuplicateCredentials": "L'autenticazione per il '%s' del Registro di sistema è stata impostata in precedenza. Sovrascrittura con nuova configurazione.",
   "loc.messages.FoundEndpointCredentials": "Trovate credenziali impostate per la connessione al servizio '%s'."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ja-JP/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "この組織/コレクション外のレジストリの資格情報",
   "loc.input.help.customEndpoint": "プロジェクトの .npmrc にある外部レジストリに使用する資格情報です。この組織/コレクションのレジストリの場合は、空白のままにします。ビルドの資格情報が自動的に使用されます。",
   "loc.input.label.workloadIdentityServiceConnection": "'Azure DevOps' サービス接続",
-  "loc.input.help.workloadIdentityServiceConnection": "これが設定されている場合は feedUrl が必須です。外部組織/コレクションおよびカスタム エンドポイントのサービス接続に互換性がありません。",
+  "loc.input.help.workloadIdentityServiceConnection": "プロジェクトの .npmrc ファイルにあるレジストリに使用する資格情報。feedUrl と共に使用して、.npmrc ファイルの中で、単一のレジストリに使用される資格情報を指定します。customEndpoint とは互換性がありません。",
   "loc.input.label.feedUrl": "Azure Artifacts URL",
   "loc.input.help.feedUrl": "これが設定されている場合は azureDevOpsServiceConnection が必須です。customEndpoint と互換性がありません。フィード URL は npm レジストリ形式にする必要があります (例: https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/)",
   "loc.messages.FoundBuildCredentials": "ビルドの資格情報が見つかりました",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "フィード %s のサービス接続 %s から認証情報を追加しています",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "フィード %s の認証が正常に追加されました。",
   "loc.messages.FailedToGetServiceConnectionAuth": "サービス接続からフェデレーション資格情報を取得できません: %s。",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "フィード URL とサービス接続の両方を設定する必要があり、これらを空にすることはできません。",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "フィード URL を指定する場合は、'Azure DevOps' サービス接続を指定する必要があり、また、これを空にすることはできません。",
   "loc.messages.SkippingParsingNpmrc": "npmrc の解析をスキップしています",
   "loc.messages.DuplicateCredentials": "レジストリ '%s' の認証は以前に設定されています。新しい構成で上書きしています。",
   "loc.messages.FoundEndpointCredentials": "'%s' サービス接続用に設定された資格情報が見つかりました。"

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ko-KR/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "이 조직/컬렉션 외부 레지스트리에 대한 자격 증명",
   "loc.input.help.customEndpoint": "외부 레지스트리에 사용할 자격 증명으로, 프로젝트의 .npmrc에 있습니다. 이 조직/컬렉션에 있는 레지스트리의 경우 이 필드를 비워 둡니다. 빌드의 자격 증명이 자동으로 사용됩니다.",
   "loc.input.label.workloadIdentityServiceConnection": "'Azure DevOps' 서비스 연결",
-  "loc.input.help.workloadIdentityServiceConnection": "이 설정을 지정하면 feedUrl이 필요합니다. 외부 조직/컬렉션 및 사용자 지정 엔드포인트에 대한 서비스 연결은 호환되지 않습니다.",
+  "loc.input.help.workloadIdentityServiceConnection": "프로젝트의 .npmrc 파일을 찾은 레지스트리에 사용할 자격 증명입니다. feedUrl과 함께 사용하여 .npmrc 파일의 단일 레지스트리에 사용되는 자격 증명을 지정합니다. customEndpoint와 호환되지 않습니다.",
   "loc.input.label.feedUrl": "Azure Artifacts URL",
   "loc.input.help.feedUrl": "이 설정을 지정하면 azureDevOpsServiceConnection이 필요합니다. customEndpoint와 호환되지 않습니다. 피드 URL은 npm 레지스트리 형식(예: https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/)이어야 합니다.",
   "loc.messages.FoundBuildCredentials": "빌드 자격 증명을 찾았습니다.",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "피드 %s에 대한 서비스 연결 %s의 인증 정보를 추가하는 중",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "피드 %s에 대한 인증을 추가했습니다.",
   "loc.messages.FailedToGetServiceConnectionAuth": "서비스 연결에서 페더레이션 자격 증명을 가져올 수 없습니다. %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "피드 URL과 서비스 연결을 모두 설정해야 하며 비워 둘 수 없습니다.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "피드 URL이 제공되면 'Azure DevOps' 서비스 연결을 제공해야 하며 비워 둘 수 없습니다.",
   "loc.messages.SkippingParsingNpmrc": "npmrc 구문 분석 건너뛰기",
   "loc.messages.DuplicateCredentials": "레지스트리 '%s'에 대한 인증이 이전에 설정되었습니다. 새 구성으로 덮어씁니다.",
   "loc.messages.FoundEndpointCredentials": "'%s' 서비스 연결에 대해 설정된 자격 증명을 찾았습니다."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/ru-RU/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "Учетные данные для реестров за пределами этой организации или коллекции",
   "loc.input.help.customEndpoint": "Учетные данные, которые следует использовать для внешних реестров, находящихся в файле NPMRC проекта. Для реестров в данной организации или коллекции оставьте это поле пустым; учетные данные сборки используются автоматически.",
   "loc.input.label.workloadIdentityServiceConnection": "Подключение службы \"Azure DevOps\"",
-  "loc.input.help.workloadIdentityServiceConnection": "Если этот параметр задан, требуется feedUrl. Подключения к службам для внешних организаций/коллекции и настраиваемых конечных точек несовместимы.",
+  "loc.input.help.workloadIdentityServiceConnection": "Учетные данные для использования в реестрах, расположенных в NPMRC-файле проекта. Используйте с feedUrl, чтобы указать учетные данные, применяемые для одного реестра в файле NPMRC. Несовместимо с customEndpoint.",
   "loc.input.label.feedUrl": "URL-адрес Azure Artifacts",
   "loc.input.help.feedUrl": "Если этот параметр задан, требуется azureDevOpsServiceConnection. Несовместимо с customEndpoint. URL-адрес веб-канала должен быть в формате реестра npm, например https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "Найдены учетные данные сборки",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "Добавление сведений о проверке подлинности из подключения службы %s для веб-канала %s",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "Проверка подлинности для веб-канала %s добавлена.",
   "loc.messages.FailedToGetServiceConnectionAuth": "Не удалось получить федеративные учетные данные из подключения службы: %s.",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "Необходимо настроить и URL-адрес веб-канала, и подключение к службе. Они не могут быть пустыми.",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "Если указан URL-адрес канала, необходимо указать подключение службы \"Azure DevOps\" и оно не может быть пустым.",
   "loc.messages.SkippingParsingNpmrc": "Пропуск синтаксического анализа npmrc",
   "loc.messages.DuplicateCredentials": "Проверка подлинности для реестра \"%s\" была настроена ранее. Перезапись с новой конфигурацией.",
   "loc.messages.FoundEndpointCredentials": "Найдены настроенные учетные данные для подключения к службе \"%s\"."

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/zh-CN/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "用于此组织/集合外部的注册表的凭据",
   "loc.input.help.customEndpoint": "用于位于项目的 .npmrc 中的外部注册表的凭据。对于此组织/集合中的注册表，请将其留空；将自动使用生成的凭据。",
   "loc.input.label.workloadIdentityServiceConnection": "\"Azure DevOps\" 服务连接",
-  "loc.input.help.workloadIdentityServiceConnection": "如果已设置此项，则需要 feedUrl。外部组织/集合和自定义终结点的服务连接不兼容。",
+  "loc.input.help.workloadIdentityServiceConnection": "用于注册表的凭据位于项目的 .npmrc 文件中。与 feedUrl 一起使用以指定 .npmrc 文件中用于单个注册表的凭据。与 customEndpoint 不兼容。",
   "loc.input.label.feedUrl": "Azure Artifacts URL",
   "loc.input.help.feedUrl": "如果设定了此设置，则需要 azureDevOpsServiceConnection。与 customEndpoint 不兼容。源 URL 应采用 npm 注册表格式，例如 https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "找到生成凭据",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "正在为源 %s 添加服务连接 %s 中的身份验证信息",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "已成功为源 %s 添加身份验证。",
   "loc.messages.FailedToGetServiceConnectionAuth": "无法从服务连接 %s 获取联合凭据。",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "源 URL 和服务连接都需要进行设置，不能为空。",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "如果提供了源 URL，则必须提供 \"Azure DevOps\" 服务连接，并且该连接不能为空。",
   "loc.messages.SkippingParsingNpmrc": "正在跳过分析 npmrc",
   "loc.messages.DuplicateCredentials": "注册表“%s”的身份验证已在以前设置。正在使用新配置覆盖。",
   "loc.messages.FoundEndpointCredentials": "已找到为“%s”服务连接设置的凭据。"

--- a/Tasks/NpmAuthenticateV0/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/NpmAuthenticateV0/Strings/resources.resjson/zh-TW/resources.resjson
@@ -8,7 +8,7 @@
   "loc.input.label.customEndpoint": "此組織/集合外部登錄的認證",
   "loc.input.help.customEndpoint": "要用於專案 .npmrc 中外部登錄的認證。針對此組織/集合中的登錄，請將此欄位保留空白，系統會自動使用組建的認證。",
   "loc.input.label.workloadIdentityServiceConnection": "'Azure DevOps' 服務連線",
-  "loc.input.help.workloadIdentityServiceConnection": "如果設定此選項，則需要 feedUrl。外部組織/集合和自訂端點的服務連線不相容。",
+  "loc.input.help.workloadIdentityServiceConnection": "要用於找到專案 .npmrc 檔案之登錄的認證。搭配 feedUrl 使用，以指定用於 .npmrc 檔案中單一登錄的認證。與 customEndpoint 不相容。",
   "loc.input.label.feedUrl": "Azure Artifacts URL",
   "loc.input.help.feedUrl": "如果設定此選項，則需要 azureDevOpsServiceConnection。與 customEndpoint 不相容。摘要 URL 應該為 npm 登錄格式，例如 https://pkgs.dev.azure.com/{ORG_NAME}/{PROJECT}/_packaging/{FEED_NAME}/npm/registry/",
   "loc.messages.FoundBuildCredentials": "找到組建認證",
@@ -34,7 +34,7 @@
   "loc.messages.Info_AddingFederatedFeedAuth": "正在新增摘要 %s 的服務連線 %s 驗證資訊",
   "loc.messages.Info_SuccessAddingFederatedFeedAuth": "已成功為摘要 %s 新增驗證。",
   "loc.messages.FailedToGetServiceConnectionAuth": "無法取得服務連線的同盟認證: %s。",
-  "loc.messages.MissingFeedUrlOrServiceConnection": "摘要 URL 和服務連線都必須設定，且不能是空的。",
+  "loc.messages.MissingFeedUrlOrServiceConnection": "如果提供摘要 URL，則必須提供「Azure DevOps」服務連線，而且不能是空的。",
   "loc.messages.SkippingParsingNpmrc": "正在略過剖析 npmrc",
   "loc.messages.DuplicateCredentials": "登錄 '%s' 的驗證先前已設定。正在使用新設定覆寫。",
   "loc.messages.FoundEndpointCredentials": "找到 '%s' 服務連線的設定認證。"


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.