### PR TITLE
Add Mac Arm64 support for Node

### DIFF
--- a/BuildConfigGen/dev.sh
+++ b/BuildConfigGen/dev.sh
@@ -32,7 +32,7 @@ function detect_platform_and_runtime_id ()
         fi
 
     elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
-        DETECTED_RUNTIME_ID='osx-$(uname -m)'
+        DETECTED_RUNTIME_ID="osx-$(uname -m)"
     fi
 }
 

--- a/BuildConfigGen/dev.sh
+++ b/BuildConfigGen/dev.sh
@@ -32,7 +32,7 @@ function detect_platform_and_runtime_id ()
         fi
 
     elif [[ "$CURRENT_PLATFORM" == 'darwin' ]]; then
-        DETECTED_RUNTIME_ID='osx-x64'
+        DETECTED_RUNTIME_ID='osx-$(uname -m)'
     fi
 }
 

--- a/_generated/UsePythonVersionV0_Node20/.npmrc
+++ b/_generated/UsePythonVersionV0_Node20/.npmrc
@@ -1,1 +1,5 @@
 scripts-prepend-node-path=true
+
+registry=https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/
+
+always-auth=true

--- a/make-util.js
+++ b/make-util.js
@@ -379,6 +379,10 @@ var installNodeAsync = async function (nodeVersion) {
         case 'darwin':
             var arch = run('uname -m')
             var nodeMajorVersionNumber = parseInt(nodeVersion.match(/\d+/)[0], 10);
+            if (isNaN(nodeMajorVersionNumber)) {
+                console.debug("Couldn't parse Node version; falling back to use version Node 14.");
+                nodeMajorVersionNumber = 14
+            }
             if (nodeMajorVersionNumber < 16) { // arm64 support started since node16
                 arch = 'x64'
             }

--- a/make-util.js
+++ b/make-util.js
@@ -378,7 +378,8 @@ var installNodeAsync = async function (nodeVersion) {
     switch (platform) {
         case 'darwin':
             var arch = run('uname -m')
-            if (nodeVersion <= versions[14]) { // arm64 support started since node16
+            var nodeMajorVersionNumber = parseInt(nodeVersion.match(/\d+/)[0], 10);
+            if (nodeMajorVersionNumber < 16) { // arm64 support started since node16
                 arch = 'x64'
             }
 

--- a/make-util.js
+++ b/make-util.js
@@ -377,8 +377,13 @@ var installNodeAsync = async function (nodeVersion) {
     var nodeUrl = 'https://nodejs.org/dist';
     switch (platform) {
         case 'darwin':
-            var nodeArchivePath = await downloadArchiveAsync(nodeUrl + '/' + nodeVersion + '/node-' + nodeVersion + '-darwin-x64.tar.gz');
-            addPath(path.join(nodeArchivePath, 'node-' + nodeVersion + '-darwin-x64', 'bin'));
+            var arch = run('uname -m')
+            if (nodeVersion <= versions[14]) { // arm64 support started since node16
+                arch = 'x64'
+            }
+
+            var nodeArchivePath = await downloadArchiveAsync(nodeUrl + '/' + nodeVersion + '/node-' + nodeVersion + '-darwin-' + arch + '.tar.gz');
+            addPath(path.join(nodeArchivePath, 'node-' + nodeVersion + '-darwin-' + arch, 'bin'))
             break;
         case 'linux':
             var nodeArchivePath = await downloadArchiveAsync(nodeUrl + '/' + nodeVersion + '/node-' + nodeVersion + '-linux-x64.tar.gz');


### PR DESCRIPTION
**Description**: This add support of installing the arm64 version of Node on Mac. This will allow to add more native support for tasks to support arm64 instead of relying on emulation in some cases which is not installed by default.

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** https://github.com/microsoft/azure-pipelines-tasks/issues/20763

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
