### PR TITLE
Fix typo in AzureCLIV2 help

### DIFF
--- a/Tasks/AzureCLIV2/task.json
+++ b/Tasks/AzureCLIV2/task.json
@@ -52,7 +52,7 @@
       "label": "Script Type",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Type of script: PowerShell/PowerShell Core/Bat/Shell script. Select Shell/PowerShell Core script when running on Linux agent or Batch/PowerShell/PowerShell Core script when running on Windows agent. PowerShell Core script can run on cross-platform agents (Linux, macOS, or Windows).",
+      "helpMarkDown": "Type of script: PowerShell/PowerShell Core/Batch/Shell script. Select Shell/PowerShell Core script when running on Linux agent or Batch/PowerShell/PowerShell Core script when running on Windows agent. PowerShell Core script can run on cross-platform agents (Linux, macOS, or Windows).",
       "options": {
         "ps": "PowerShell",
         "pscore": "PowerShell Core",


### PR DESCRIPTION
**Task name**: AzureCLIV2

**Description**: Fix typo in help popup

**Documentation changes required:** N

**Added unit tests:** N

**Attached related issue:** N

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
