### PR TITLE
Updating webdeployment common package Version in FileTransformV2

### DIFF
--- a/Tasks/FileTransformV2/_buildConfigs/Node20/package-lock.json
+++ b/Tasks/FileTransformV2/_buildConfigs/Node20/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "4.247.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.252.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,8 +152,8 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.247.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.247.0.tgz",
+      "version": "4.252.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.252.0.tgz",
       "integrity": "sha512-f8gLQtJ4+ZMTO17jV37cHb+Au2S+kNuLGoCV3yKF8m19e6f+OVwG91OI2UL3DkC1nHRWmi794rmaNoAMFO34yg==",
       "license": "MIT",
       "dependencies": {

--- a/Tasks/FileTransformV2/_buildConfigs/Node20/package.json
+++ b/Tasks/FileTransformV2/_buildConfigs/Node20/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "4.247.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.252.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/package-lock.json
+++ b/Tasks/FileTransformV2/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "4.247.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.252.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.247.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.247.0.tgz",
-      "integrity": "sha512-f8gLQtJ4+ZMTO17jV37cHb+Au2S+kNuLGoCV3yKF8m19e6f+OVwG91OI2UL3DkC1nHRWmi794rmaNoAMFO34yg==",
+      "version": "4.252.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.252.0.tgz",
+      "integrity": "sha1-nMojK4+FYyrgbsgJ3gGfxywfbwI=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/FileTransformV2/package.json
+++ b/Tasks/FileTransformV2/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "4.247.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.252.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 252,
+    "Patch": 0
   },
   "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",
   "instanceNameFormat": "File Transform: $(Package)",

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 252,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: FileTransformV2

**Description**: Updating webdeployment common package Version to skip empty object json files in FileTransformV2 task

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** [BUG 20584](https://github.com/microsoft/azure-pipelines-tasks/issues/20584)
[Webdeployment common package PR](https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/431)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
