### PR TITLE
Update default value to true for "allowApproversToApproveTheirOwnRuns" input

### DIFF
--- a/Tasks/ManualValidationV1/task.json
+++ b/Tasks/ManualValidationV1/task.json
@@ -15,7 +15,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 252,
+        "Minor": 253,
         "Patch": 0
     },
     "inputs": [

--- a/Tasks/ManualValidationV1/task.json
+++ b/Tasks/ManualValidationV1/task.json
@@ -15,7 +15,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 251,
+        "Minor": 252,
         "Patch": 0
     },
     "inputs": [
@@ -40,7 +40,7 @@
             "type": "boolean",
             "label": "Allow approvers to approve their own run",
             "required": false,
-            "defaultValue": "false",
+            "defaultValue": "true",
             "helpMarkDown": "If this is true, approver will be able to approve their own run"            
         },
         {

--- a/Tasks/ManualValidationV1/task.loc.json
+++ b/Tasks/ManualValidationV1/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 251,
+    "Minor": 252,
     "Patch": 0
   },
   "inputs": [
@@ -40,7 +40,7 @@
       "type": "boolean",
       "label": "ms-resource:loc.input.label.allowApproversToApproveTheirOwnRuns",
       "required": false,
-      "defaultValue": "false",
+      "defaultValue": "true",
       "helpMarkDown": "ms-resource:loc.input.help.allowApproversToApproveTheirOwnRuns"
     },
     {

--- a/Tasks/ManualValidationV1/task.loc.json
+++ b/Tasks/ManualValidationV1/task.loc.json
@@ -15,7 +15,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 252,
+    "Minor": 253,
     "Patch": 0
   },
   "inputs": [


### PR DESCRIPTION
**Task name**: ManualValidationV1

**Description**:  Before the new property allowApproversToApproveTheirOwnRuns was added, approvers were able to approve the runs triggered by themselves. In order to continue behaviour, making the default value to true. If it is required to restrict the pipeline triggerer from approving, the allowApproversToApproveTheirOwnRuns property should be set to false

**Documentation changes required:** (Y/N) Y

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
