### PR TITLE
Updated input language list for ATP: Switched to 'Python-PyTest' and removed 'Go', 'Jest'

### DIFF
--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 252,
-    "Patch": 9
+    "Minor": 253,
+    "Patch": 1
   },
   "preview": true,
   "demands": [],
@@ -79,9 +79,7 @@
       "options": {
         "JavaMaven": "Java-Maven",
         "JavaGradle": "Java-Gradle",
-        "Python": "Python",
-        "Go": "Go",
-        "Jest": "Jest"
+        "Python": "Python-PyTest"
       }
     },
     {

--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -77,9 +77,9 @@
       "label": "Select Test framework language",
       "helpMarkDown": "Test Framework Language of automated tests in test plan",
       "options": {
-        "JavaMaven": "Java-Maven",
-        "JavaGradle": "Java-Gradle",
-        "Python": "Python-PyTest"
+        "JavaMaven": "Java - Maven",
+        "JavaGradle": "Java - Gradle",
+        "Python": "Python - PyTest"
       }
     },
     {

--- a/Tasks/AzureTestPlanV0/task.loc.json
+++ b/Tasks/AzureTestPlanV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 252,
-    "Patch": 9
+    "Minor": 253,
+    "Patch": 1
   },
   "preview": true,
   "demands": [],
@@ -79,9 +79,7 @@
       "options": {
         "JavaMaven": "Java-Maven",
         "JavaGradle": "Java-Gradle",
-        "Python": "Python",
-        "Go": "Go",
-        "Jest": "Jest"
+        "Python": "Python-PyTest"
       }
     },
     {

--- a/Tasks/AzureTestPlanV0/task.loc.json
+++ b/Tasks/AzureTestPlanV0/task.loc.json
@@ -77,9 +77,9 @@
       "label": "ms-resource:loc.input.label.testLanguageInput",
       "helpMarkDown": "ms-resource:loc.input.help.testLanguageInput",
       "options": {
-        "JavaMaven": "Java-Maven",
-        "JavaGradle": "Java-Gradle",
-        "Python": "Python-PyTest"
+        "JavaMaven": "Java - Maven",
+        "JavaGradle": "Java - Gradle",
+        "Python": "Python - PyTest"
       }
     },
     {


### PR DESCRIPTION
**Task name**: AzureTestPlanV0

**Description**: Updated input language list for ATP: Switched to 'Python-PyTest' and removed 'Go', 'Jest'

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected

![image](https://github.com/user-attachments/assets/b25356a4-d404-4d48-9699-3694f17709d4)
