### PR TITLE
Support application insights connection string for web apps

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV3/operations/ReleaseAnnotationUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV3/operations/ReleaseAnnotationUtility.ts
@@ -1,6 +1,6 @@
 import tl = require('azure-pipelines-task-lib/task');
 import { AzureAppService } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-app-service';
-import { AzureApplicationInsights, ApplicationInsightsResources} from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-appinsights';
+import { AzureApplicationInsights, ApplicationInsightsResources } from 'azure-pipelines-tasks-azure-arm-rest/azure-arm-appinsights';
 import { AzureEndpoint } from 'azure-pipelines-tasks-azure-arm-rest/azureModels';
 
 var uuidV4 = require("uuid/v4");
@@ -8,7 +8,7 @@ var uuidV4 = require("uuid/v4");
 export async function addReleaseAnnotation(endpoint: AzureEndpoint, azureAppService: AzureAppService, isDeploymentSuccess: boolean): Promise<void> {
     try {
         var appSettings = await azureAppService.getApplicationSettings();
-        var instrumentationKey = appSettings && appSettings.properties && appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY;
+        var instrumentationKey = getInstrumentationKey(appSettings);
         if(instrumentationKey) {
             let appinsightsResources: ApplicationInsightsResources = new ApplicationInsightsResources(endpoint);
             var appInsightsResources = await appinsightsResources.list(null, [`$filter=InstrumentationKey eq '${instrumentationKey}'`]);
@@ -31,7 +31,7 @@ export async function addReleaseAnnotation(endpoint: AzureEndpoint, azureAppServ
     }
 }
 
-function getReleaseAnnotation(isDeploymentSuccess: boolean): {[key: string]: any} {
+function getReleaseAnnotation(isDeploymentSuccess: boolean): { [key: string]: any } {
     let annotationName = "Release Annotation";
     let releaseUri = tl.getVariable("Release.ReleaseUri");
     let buildUri = tl.getVariable("Build.BuildUri");
@@ -42,7 +42,7 @@ function getReleaseAnnotation(isDeploymentSuccess: boolean): {[key: string]: any
     else if (!!buildUri) {
         annotationName = `${tl.getVariable("Build.DefinitionName")} - ${tl.getVariable("Build.BuildNumber")}`;
     }
- 
+
     let releaseAnnotationProperties = {
         "Label": isDeploymentSuccess ? "Success" : "Error", // Label decides the icon for release annotation
         "Deployment Uri": getDeploymentUri(),
@@ -90,4 +90,21 @@ function getPipelineVariable(variableName: string): string | undefined {
     let variable = tl.getVariable(variableName);
     //we dont want to set a variable to be empty string
     return !!variable ? variable : undefined;
+}
+
+function getInstrumentationKey(appSettings: any): string | undefined {
+    let connectionString = appSettings?.properties?.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    if (connectionString) {
+        const FIELDS_SEPARATOR = ";";
+        const FIELD_KEY_VALUE_SEPARATOR = "=";
+
+        const kvPairs = connectionString.split(FIELDS_SEPARATOR);
+        for (const kvPair of kvPairs) {
+            const pair = kvPair.split(FIELD_KEY_VALUE_SEPARATOR);
+            if (pair.length === 2 && pair[0].trim().toLowerCase() === "instrumentationkey") {
+                return pair[1].trim();
+            }
+        }
+    }
+    return appSettings?.properties?.APPINSIGHTS_INSTRUMENTATIONKEY;
 }

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/ReleaseAnnotationUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/ReleaseAnnotationUtility.ts
@@ -8,7 +8,7 @@ var uuidV4 = require("uuid/v4");
 export async function addReleaseAnnotation(endpoint: AzureEndpoint, azureAppService: AzureAppService, isDeploymentSuccess: boolean): Promise<void> {
     try {
         var appSettings = await azureAppService.getApplicationSettings();
-        var instrumentationKey = appSettings && appSettings.properties && appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY;
+        var instrumentationKey = getInstrumentationKey(appSettings);
         if(instrumentationKey) {
             let appinsightsResources: ApplicationInsightsResources = new ApplicationInsightsResources(endpoint);
             var appInsightsResources = await appinsightsResources.list(null, [`$filter=InstrumentationKey eq '${instrumentationKey}'`]);
@@ -42,7 +42,7 @@ function getReleaseAnnotation(isDeploymentSuccess: boolean): {[key: string]: any
     else if (!!buildUri) {
         annotationName = `${tl.getVariable("Build.DefinitionName")} - ${tl.getVariable("Build.BuildNumber")}`;
     }
- 
+
     let releaseAnnotationProperties = {
         "Label": isDeploymentSuccess ? "Success" : "Error", // Label decides the icon for release annotation
         "Deployment Uri": getDeploymentUri(),
@@ -90,4 +90,21 @@ function getPipelineVariable(variableName: string): string | undefined {
     let variable = tl.getVariable(variableName);
     //we dont want to set a variable to be empty string
     return !!variable ? variable : undefined;
+}
+
+function getInstrumentationKey(appSettings: any): string | undefined {
+    let connectionString = appSettings?.properties?.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    if (connectionString) {
+        const FIELDS_SEPARATOR = ";";
+        const FIELD_KEY_VALUE_SEPARATOR = "=";
+
+        const kvPairs = connectionString.split(FIELDS_SEPARATOR);
+        for (const kvPair of kvPairs) {
+            const pair = kvPair.split(FIELD_KEY_VALUE_SEPARATOR);
+            if (pair.length === 2 && pair[0].trim().toLowerCase() === "instrumentationkey") {
+                return pair[1].trim();
+            }
+        }
+    }
+    return appSettings?.properties?.APPINSIGHTS_INSTRUMENTATIONKEY;
 }

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV3, AzureRmWebAppDeploymentV4

**Description**: The PR adds support for adding release annotations when the now recommended APPLICATIONINSIGHTS_CONNECTION_STRING setting is used on Azure, rather than the APPINSIGHTS_INSTRUMENTATIONKEY, for all tasks supporting this feature.

**Documentation changes required:** (Y/N) 

**Added unit tests:** (Y/N) 

**Attached related issue:** (Y/N) #20380 #19855

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
