### PR TITLE
Adding Rollout option in KubernetesV1

### DIFF
--- a/Tasks/KubernetesV1/package-lock.json
+++ b/Tasks/KubernetesV1/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "KubernetesV1_Node20",
+  "name": "KubernetesV1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 250,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",
@@ -148,6 +148,7 @@
         "login": "login",
         "logout": "logout",
         "logs": "logs",
+        "rollout": "rollout",
         "run": "run",
         "set": "set",
         "top": "top"

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 250,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -148,6 +148,7 @@
         "login": "login",
         "logout": "logout",
         "logs": "logs",
+        "rollout": "rollout",
         "run": "run",
         "set": "set",
         "top": "top"


### PR DESCRIPTION
**Task name**: KubernetesV1

**Description**: Adding rollout option in task.json file as it was missing and not showing in the dropdown.

**Documentation changes required:** (Y/N) N

**Added unit tests:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/20562?reload=1?reload=1

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
