### PR TITLE
Make test plan api call to support all test suites

### DIFF
--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 253,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "demands": [],
@@ -146,7 +146,7 @@
     {
       "target": "testSuite",
       "endpointId": "tfs:teamfoundation",
-      "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans/{{testPlan}}/suites?$asTreeView=true&api-version=3.0-preview.2",
+      "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans/{{testPlan}}/suites?api-version=3.0-preview.2",
       "parameters": {
         "testPlan": "$(testPlan)"
       },

--- a/Tasks/AzureTestPlanV0/task.loc.json
+++ b/Tasks/AzureTestPlanV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 253,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "demands": [],
@@ -146,7 +146,7 @@
     {
       "target": "testSuite",
       "endpointId": "tfs:teamfoundation",
-      "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans/{{testPlan}}/suites?$asTreeView=true&api-version=3.0-preview.2",
+      "endpointUrl": "{{endpoint.url}}/{{system.teamProject}}/_apis/test/plans/{{testPlan}}/suites?api-version=3.0-preview.2",
       "parameters": {
         "testPlan": "$(testPlan)"
       },


### PR DESCRIPTION
**Task name**: AzureTestPlanV0

**Description**: Make test plan api call to support all test suites (including sub test suites)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected


Demo Test Plan

![image](https://github.com/user-attachments/assets/902ef8d8-1d99-4f0d-a44b-f8205e6d65b4)

Before change

![image](https://github.com/user-attachments/assets/60a5d99e-f067-4e55-b5c6-1b5447ab3349)

After change

![image](https://github.com/user-attachments/assets/d3417d41-246d-4e50-8a60-5d3f18475b18)
