### PR TITLE
Add enableHelm option for kustomize rendering

### DIFF
--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Außerkraftsetzungswerte, die festgelegt werden sollen",
   "loc.input.label.kustomizationPath": "Kustomization-Pfad",
   "loc.input.help.kustomizationPath": "Das Argument muss der Pfad zum Verzeichnis sein, das die Datei enthält, oder eine Git-Repository-URL mit einem Pfadsuffix, das denselben Wert in Bezug auf den Repositorystamm angibt.",
+  "loc.input.label.enableHelm": "Aktivieren Sie den Helm Chart-Inflationsgenerator",
+  "loc.input.help.enableHelm": "Auf „true“ setzen, um den Helm Chart-Inflationsgenerator mit „kustomize“ zu aktivieren.",
   "loc.input.label.resourceToPatch": "Ressource für Patch",
   "loc.input.help.resourceToPatch": "zum Identifizieren der Ressource",
   "loc.input.label.resourceFileToPatch": "Dateipfad",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Override values to set",
   "loc.input.label.kustomizationPath": "Kustomization Path",
   "loc.input.help.kustomizationPath": "The argument must be the path to the directory containing the file, or a git repository URL with a path suffix specifying same with respect to the repository root.",
+  "loc.input.label.enableHelm": "Enable Helm chart inflation generator",
+  "loc.input.help.enableHelm": "Enable the helm chart inflation generator with kustomize.",
   "loc.input.label.resourceToPatch": "Resource to patch",
   "loc.input.help.resourceToPatch": "to identify the resource",
   "loc.input.label.resourceFileToPatch": "File path",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/en-US/resources.resjson
@@ -48,7 +48,7 @@
   "loc.input.label.kustomizationPath": "Kustomization Path",
   "loc.input.help.kustomizationPath": "The argument must be the path to the directory containing the file, or a git repository URL with a path suffix specifying same with respect to the repository root.",
   "loc.input.label.enableHelm": "Enable Helm chart inflation generator",
-  "loc.input.help.enableHelm": "Enable the helm chart inflation generator with kustomize.",
+  "loc.input.help.enableHelm": "Set to true to enable the helm chart inflation generator with kustomize.",
   "loc.input.label.resourceToPatch": "Resource to patch",
   "loc.input.help.resourceToPatch": "to identify the resource",
   "loc.input.label.resourceFileToPatch": "File path",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Reemplazar valores para establecer",
   "loc.input.label.kustomizationPath": "Ruta de acceso de Kustomization",
   "loc.input.help.kustomizationPath": "El argumento debe ser la ruta de acceso al directorio que contiene el archivo o una dirección URL del repositorio de GIT con un sufijo de ruta de acceso que especifique lo mismo respecto a la raíz del repositorio.",
+  "loc.input.label.enableHelm": "Habilitar el generador de inflación de Helm Chart",
+  "loc.input.help.enableHelm": "Establezca en 'true' para habilitar el generador de inflación de Helm Chart con kustomize.",
   "loc.input.label.resourceToPatch": "Recurso para la revisión",
   "loc.input.help.resourceToPatch": "para identificar el recurso",
   "loc.input.label.resourceFileToPatch": "Ruta de acceso del archivo",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Valeurs de remplacement à définir",
   "loc.input.label.kustomizationPath": "Chemin de Kustomization",
   "loc.input.help.kustomizationPath": "L'argument doit être le chemin du répertoire contenant le fichier, ou une URL de dépôt GIT avec un suffixe de chemin spécifiant la même chose par rapport à la racine du dépôt.",
+  "loc.input.label.enableHelm": "Activer le générateur d'inflation de chart Helm",
+  "loc.input.help.enableHelm": "Définir à 'true' pour activer le générateur d'inflation de chart Helm avec kustomize.",
   "loc.input.label.resourceToPatch": "Ressource à corriger",
   "loc.input.help.resourceToPatch": "pour identifier la ressource",
   "loc.input.label.resourceFileToPatch": "Chemin du fichier",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Valori di override da impostare",
   "loc.input.label.kustomizationPath": "Percorso Kustomization",
   "loc.input.help.kustomizationPath": "L'argomento deve essere il percorso della directory contenente il file o un URL di repository GIT con un suffisso di percorso che specifica lo stesso rispetto alla radice del repository.",
+  "loc.input.label.enableHelm": "Abilitare il generatore di inflazione del Helm Chart",
+  "loc.input.help.enableHelm": "Impostare su "true" per abilitare il generatore di inflazione del Helm Chart con kustomize.",
   "loc.input.label.resourceToPatch": "Risorsa a cui applicare la patch",
   "loc.input.help.resourceToPatch": "per identificare la risorsa",
   "loc.input.label.resourceFileToPatch": "Percorso file",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "設定する値のオーバーライド",
   "loc.input.label.kustomizationPath": "Kustomization のパス",
   "loc.input.help.kustomizationPath": "引数には、ファイルが保存されているディレクトリへのパス、または同じファイルへのリポジトリのルートからのパスのサフィックスを含む Git リポジトリの URL を指定する必要があります。",
+  "loc.input.label.enableHelm": "Helm Chartインフレーションジェネレーターを有効にする",
+  "loc.input.help.enableHelm": "kustomize で Helm Chart インフレーション ジェネレーターを有効にするには、 'true' に設定します。",
   "loc.input.label.resourceToPatch": "修正するリソース",
   "loc.input.help.resourceToPatch": "リソースを識別するため",
   "loc.input.label.resourceFileToPatch": "ファイル パス",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "설정할 재정의 값입니다.",
   "loc.input.label.kustomizationPath": "Kustomization 경로",
   "loc.input.help.kustomizationPath": "인수는 파일을 포함하는 디렉터리의 경로이거나, 리포지토리 루트에 대해 동일한 경로를 지정하는 경로 접미사를 포함하는 git 리포지토리 URL이어야 합니다.",
+  "loc.input.label.enableHelm": "Helm Chart 인플레이션 생성기 활성화",
+  "loc.input.help.enableHelm": "'kustomize'로 Helm Chart 인플레이션 생성기를 활성화하려면 'true'로 설정합니다.",
   "loc.input.label.resourceToPatch": "패치할 리소스",
   "loc.input.help.resourceToPatch": "리소스를 식별합니다.",
   "loc.input.label.resourceFileToPatch": "파일 경로",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "Переопределение задаваемых значений",
   "loc.input.label.kustomizationPath": "Путь Kustomization",
   "loc.input.help.kustomizationPath": "Аргумент должен быть путем к каталогу, содержащему файл, или URL-адресом репозитория Git с суффиксом path, указывающим тот же путь относительно корня репозитория.",
+  "loc.input.label.enableHelm": "Включить генератор инфляции Helm Chart",
+  "loc.input.help.enableHelm": "Установите значение «true», чтобы включить генератор инфляции Helm Chart с помощью kustomize.",
   "loc.input.label.resourceToPatch": "Ресурс для исправления",
   "loc.input.help.resourceToPatch": "для идентификации ресурса",
   "loc.input.label.resourceFileToPatch": "Путь к файлу",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "替代要设置的值",
   "loc.input.label.kustomizationPath": "Kustomization 路径",
   "loc.input.help.kustomizationPath": "该参数必须是包含该文件的目录的路径，或带有路径后缀的 git 存储库 URL，该路径后缀指定与存储库根目录相同的路径。",
+  "loc.input.label.enableHelm": "启用 Helm Chart 膨胀生成器",
+  "loc.input.help.enableHelm": "设置为“true”以使用kustomize启用 Helm Chart 膨胀生成器。",
   "loc.input.label.resourceToPatch": "要修补的资源",
   "loc.input.help.resourceToPatch": "识别资源",
   "loc.input.label.resourceFileToPatch": "文件路径",

--- a/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/KubernetesManifestV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -47,6 +47,8 @@
   "loc.input.help.overrides": "覆寫值以進行設定",
   "loc.input.label.kustomizationPath": "Kustomization 路徑",
   "loc.input.help.kustomizationPath": "引數必須是包含檔案的目錄路徑，或路徑尾碼指定目標與儲存機制根路徑相同的 git 存放庫 URL。",
+  "loc.input.label.enableHelm": "啟用 Helm Chart 擴充產生器",
+  "loc.input.help.enableHelm": "將其設置為 'true' 以啟用使用 'kustomize' 的 Helm Chart 扩充生成器。",
   "loc.input.label.resourceToPatch": "要修補的資源",
   "loc.input.help.resourceToPatch": "以找出資源",
   "loc.input.label.resourceFileToPatch": "檔案路徑",

--- a/Tasks/KubernetesManifestV1/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV1/Tests/L0.ts
@@ -498,13 +498,26 @@ describe('Kubernetes Manifests Suite', function () {
         assert(tr.stdOutContained('kustomize kustomizationPath'), 'task should have invoked tool: kustomize');
     });
 
-    it('Kustomize bake should pass with image substituition', async () => {
+    it('Kustomize bake should pass with image substitution', async () => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kustomize';
         process.env[shared.TestEnvVars.kustomizationPath] = 'kustomizationPath';
         process.env[shared.TestEnvVars.containers] = 'nginx:1.1.1\nalpine';
+        process.env.KubectlMinorVersion = '14';
+        await tr.runAsync();
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(tr.stdOutContained('kustomize kustomizationPath'), 'task should have invoked tool: kustomize');
+    });
+
+    it('Kustomize bake should pass with enableHelm', async () => {
+        const tp = path.join(__dirname, 'TestSetup.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.action] = shared.Actions.bake;
+        process.env[shared.TestEnvVars.renderType] = 'kustomize';
+        process.env[shared.TestEnvVars.kustomizationPath] = 'kustomizationPath';
+        process.env[shared.TestEnvVars.enableHelm] = 'true';
         process.env.KubectlMinorVersion = '14';
         await tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');

--- a/Tasks/KubernetesManifestV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesManifestV1/Tests/TestSetup.ts
@@ -47,6 +47,7 @@ tr.setInput('secretName', process.env[shared.TestEnvVars.secretName] || '');
 tr.setInput('secretType', process.env[shared.TestEnvVars.secretType] || '');
 tr.setInput('dockerComposeFile', process.env[shared.TestEnvVars.dockerComposeFile] || '');
 tr.setInput('kustomizationPath', process.env[shared.TestEnvVars.kustomizationPath] || '');
+tr.setInput("enableHelm", process.env[shared.TestEnvVars.enableHelm] || '');
 tr.setInput('baselineAndCanaryReplicas', process.env[shared.TestEnvVars.baselineAndCanaryReplicas] || '0');
 tr.setInput('trafficSplitMethod', process.env[shared.TestEnvVars.trafficSplitMethod]);
 

--- a/Tasks/KubernetesManifestV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesManifestV1/Tests/TestShared.ts
@@ -14,6 +14,7 @@ export let TestEnvVars = {
     imagePullSecrets: "__imagePullSecrets__",
     dockerComposeFile: "__dockerComposeFile__",
     kustomizationPath: "__kustomizationPath__",
+    enableHelm: "__enableHelm__",
     renderType: "__renderType__",
     releaseName: "__releaseName__",
     helmChart: "__helmChart__",

--- a/Tasks/KubernetesManifestV1/src/actions/bake.ts
+++ b/Tasks/KubernetesManifestV1/src/actions/bake.ts
@@ -102,8 +102,8 @@ class KustomizeRenderEngine extends RenderEngine {
         const kubectlPath = await utils.getKubectl();
         this.validateKustomize(kubectlPath);
         const command = tl.tool(kubectlPath);
-        console.log(`[command] ${kubectlPath} kustomize ${tl.getPathInput('kustomizationPath')}`);
-        command.arg(['kustomize', tl.getPathInput('kustomizationPath')]);
+        console.log(`[command] ${kubectlPath} kustomize ${tl.getPathInput('kustomizationPath')} --enable_helm=${tl.getBoolInput('enableHelm')}`);
+        command.arg(['kustomize', tl.getPathInput('kustomizationPath')], '--enable_helm=', tl.getBoolInput('enableHelm'));
 
         const result = command.execSync({ silent: true } as IExecOptions);
         if (result.stderr) {

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -261,6 +261,15 @@
       "helpMarkDown": "The argument must be the path to the directory containing the file, or a git repository URL with a path suffix specifying same with respect to the repository root."
     },
     {
+      "name": "enableHelm",
+      "type": "boolean",
+      "label": "Enable Helm chart inflation generator",
+      "required": false,
+      "visibleRule": "action = bake && renderType = kustomize",
+      "defaultValue": "false",
+      "helpMarkDown": "Enable the helm chart inflation generator with kustomize."
+    },
+    {
       "name": "resourceToPatch",
       "type": "radio",
       "label": "Resource to patch",

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 250,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -261,6 +261,15 @@
       "helpMarkDown": "ms-resource:loc.input.help.kustomizationPath"
     },
     {
+      "name": "enableHelm",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.enableHelm",
+      "required": false,
+      "visibleRule": "action = bake && renderType = kustomize",
+      "defaultValue": "false",
+      "helpMarkDown": "ms-resource:loc.input.help.enableHelm"
+    },
+    {
       "name": "resourceToPatch",
       "type": "radio",
       "label": "ms-resource:loc.input.label.resourceToPatch",

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 250,
-    "Patch": 1
+    "Minor": 253,
+    "Patch": 2
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
**Task name**: KubernetesManifestsV1

**Description**: Add support for `--enable-helm` when using `kustomize` rendering

**Documentation changes required:** Y

**Added unit tests:** Y

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
