### PR TITLE
Swap NuGetCommandV2 tool invocations to async

### DIFF
--- a/Tasks/NuGetCommandV2/Tests/L0.ts
+++ b/Tasks/NuGetCommandV2/Tests/L0.ts
@@ -406,6 +406,8 @@ describe('NuGetCommand Suite', function () {
         tr.run();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
+        assert.equal(tr.errorIssues.length, 1, "should have 1 error");
+        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
         done();
     });
 
@@ -416,6 +418,9 @@ describe('NuGetCommand Suite', function () {
         tr.run();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
+        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
+        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
+        assert.equal(tr.errorIssues[1], "loc_mock_Error_PackageFailure", "should have error from task runner");
         done();
     });
 
@@ -426,6 +431,9 @@ describe('NuGetCommand Suite', function () {
         tr.run();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
+        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
+        assert.equal(tr.errorIssues[0], "Error: loc_mock_Error_UnexpectedErrorVstsNuGetPush 1 stderr output is here", "should have error from nuget");
+        assert.equal(tr.errorIssues[1], "loc_mock_PackagesFailedToPublish", "should have error from task runner");
         done();
     });
 
@@ -446,6 +454,9 @@ describe('NuGetCommand Suite', function () {
         tr.run();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
+        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
+        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
+        assert.equal(tr.errorIssues[1], "loc_mock_PackagesFailedToInstall", "should have error from task runner");
         done();
     });
 

--- a/Tasks/NuGetCommandV2/Tests/RestoreTests/failRestore.ts
+++ b/Tasks/NuGetCommandV2/Tests/RestoreTests/failRestore.ts
@@ -33,6 +33,9 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     },
     "findMatch": {
         "single.sln" : ["c:\\agent\\home\\directory\\single.sln"]
+    },
+    "rmRF": {
+        "c:\\agent\\home\\directory\\tempNuGet_.config": { success: true }
     }
 };
 nmh.setAnswers(a);

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tasks-packaging-common": "3.252.0",
+        "azure-pipelines-tasks-packaging-common": "3.253.0",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
         "xmlreader": "^0.2.3"
       },
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-packaging-common": {
-      "version": "3.252.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.252.0.tgz",
-      "integrity": "sha1-L46gHt/jPI0vjvHQE24lM6P3lxQ=",
+      "version": "3.253.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-packaging-common/-/azure-pipelines-tasks-packaging-common-3.253.0.tgz",
+      "integrity": "sha1-1uKrjevDUNLlSU2i5DnNJd0GVko=",
       "license": "MIT",
       "dependencies": {
         "@types/ini": "1.3.30",

--- a/Tasks/NuGetCommandV2/package.json
+++ b/Tasks/NuGetCommandV2/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "^4.0.0-preview",
-    "azure-pipelines-tasks-packaging-common": "3.252.0",
+    "azure-pipelines-tasks-packaging-common": "3.253.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
     "xmlreader": "^0.2.3"
   },

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 253,
     "Patch": 1
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 253,
-    "Patch": 1
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 253,
     "Patch": 1
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 2,
     "Minor": 253,
-    "Patch": 1
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
**Task name**: NuGetCommandV2

**Description**: NuGetCommandV2 currently runs the NuGet tools in a synchronous execution which will buffer all of the results of stdout and stderr. This is causing issues with large projects which contain 1M+ characters of log execution resulting in the error `The nuget command failed with exit code(null) and error()`.

Move tool invocations to an async wrapper which will stream output live to the console and not buffer stdout. The stderr output is kept in memory to write timeline results at the end of the task run.

Example showing timeline results are the same between legacy task (NuGetCommand) and this version (NuGetCommandTest).
![timeline results](https://github.com/user-attachments/assets/955ff9c6-31c9-4247-8f02-8bce0bcb916f)

Example showing the new streaming text (click to play):
![streaming text](https://i.imgur.com/pezdwss.gif)

**Documentation changes required:** N

**Added unit tests:** Y

**Attached related issue:** #20351 

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
