### PR TITLE
Update ADO CredScan suppression file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,10 @@ parameters:
   displayName: skipTests (Not for production use)
   type: boolean
   default: false
+- name: skip_publish
+  displayName: skipPublish (Not for production use)
+  type: boolean
+  default: false
 - name: publishToDistributedTaskTest
   displayName: Publish to test feed (DistributedTasks-test), for infrastucture testing
   type: boolean
@@ -132,7 +136,7 @@ extends:
         timeoutInMinutes: 360
         dependsOn:
         - build_all_windows
-        condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'))
+        condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), eq(parameters.skip_publish, false))
         pool:
           name: 1ES-ABTT-Shared-Pool
           image: abtt-windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,11 @@ variables:
     value: 'true'
   ${{ else }}:
     value: 'false'
+- name: tasksSkipPublish
+  ${{ if eq(parameters.skip_publish, true) }}:
+    value: 'true'
+  ${{ else }}:
+    value: 'false'
 - name: DEPLOY_ALL_TASKSVAR
   ${{ if eq(parameters.deploy_all_tasks, true) }}:
     value: 'true'
@@ -136,7 +141,7 @@ extends:
         timeoutInMinutes: 360
         dependsOn:
         - build_all_windows
-        condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), eq(parameters.skip_publish, false))
+        condition: and(succeeded(), ne(variables['build.reason'], 'PullRequest'), eq(variables['tasksSkipPublish'], 'false'))
         pool:
           name: 1ES-ABTT-Shared-Pool
           image: abtt-windows-2022

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,8 +87,6 @@ extends:
       baseline:
         baselineSet: default
         baselineFile: $(Build.SourcesDirectory)/.gdn/.gdnbaselines
-      credscan:
-        suppressionsFile: $(Build.SourcesDirectory)/AzureDevOps/.config/CredScanSuppressions.json
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
         image: abtt-windows-2022
@@ -171,6 +169,10 @@ extends:
             )
           )
         templateContext:
+          parameters:
+            sdl:
+              credscan:
+                suppressionsFile: $(Build.SourcesDirectory)/AzureDevOps/.config/CredScanSuppressions.json
           outputs:
           - output: nuget
             packagesToPush:  '$(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded/IndividualNugetPackages/*/*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,6 +87,8 @@ extends:
       baseline:
         baselineSet: default
         baselineFile: $(Build.SourcesDirectory)/.gdn/.gdnbaselines
+      credscan:
+        suppressionsFile: $(Build.SourcesDirectory)/AzureDevOps/.config/CredScanSuppressions.json
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
         image: abtt-windows-2022


### PR DESCRIPTION
AzureDevOps repository has a checked in credential scanner suppression file which is currently not specified in Tasks builds, leading to CredScan CI failures.

N/A to below, CI changes only.

**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Attached related issue:** (Y/N) <Please add link to related issue here>

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
