### PR TITLE
url changes from google cloud to K8 for Kubernetes V0 and V1 tasks

### DIFF
--- a/Tasks/KubernetesV0/package-lock.json
+++ b/Tasks/KubernetesV0/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "KubernetesV0_Node20",
+  "name": "KubernetesV0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14,7 +14,7 @@
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "4.3.1",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
-        "azure-pipelines-tasks-kubernetes-common": "^2.212.0",
+        "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
         "azure-pipelines-tasks-utility-common": "3.212.0",
         "del": "2.2.0",
         "js-yaml": "3.13.1"
@@ -357,9 +357,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-kubernetes-common": {
-      "version": "2.245.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-kubernetes-common/-/azure-pipelines-tasks-kubernetes-common-2.245.0.tgz",
-      "integrity": "sha1-1TOV+ekE9HePjzeV+nTyeq+bGlw=",
+      "version": "2.252.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-kubernetes-common/-/azure-pipelines-tasks-kubernetes-common-2.252.0.tgz",
+      "integrity": "sha1-+tZKw8P5Ka3z2O3GmFXDYfgXe4E=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "5.2.7",

--- a/Tasks/KubernetesV0/package.json
+++ b/Tasks/KubernetesV0/package.json
@@ -9,7 +9,7 @@
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "4.3.1",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
-    "azure-pipelines-tasks-kubernetes-common": "^2.212.0",
+    "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
     "azure-pipelines-tasks-utility-common": "3.212.0",
     "del": "2.2.0",
     "js-yaml": "3.13.1"

--- a/Tasks/KubernetesV0/src/utilities.ts
+++ b/Tasks/KubernetesV0/src/utilities.ts
@@ -82,14 +82,14 @@ function getkubectlDownloadURL(version: string) : string {
     switch(os.type())
     {
         case 'Linux':
-            return util.format("https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl", version);
+            return util.format("https://dl.k8s.io/release/%s/bin/linux/amd64/kubectl", version);
 
         case 'Darwin':
-            return util.format("https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl", version);
+            return util.format("https://dl.k8s.io/release/%s/bin/darwin/amd64/kubectl", version);
 
         default:
         case 'Windows_NT':
-            return util.format("https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe", version);   
+            return util.format("https://dl.k8s.io/release/%s/bin/windows/amd64/kubectl.exe", version);   
 
     }
 }

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 4
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 4
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV1/package-lock.json
+++ b/Tasks/KubernetesV1/package-lock.json
@@ -15,7 +15,7 @@
         "azure-pipelines-task-lib": "^4.16.0",
         "azure-pipelines-tasks-azure-arm-rest": "3.250.0",
         "azure-pipelines-tasks-docker-common": "2.242.0",
-        "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
+        "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
         "azure-pipelines-tasks-utility-common": "^3.210.0",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "del": "2.2.0",
@@ -282,9 +282,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-kubernetes-common": {
-      "version": "2.245.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-kubernetes-common/-/azure-pipelines-tasks-kubernetes-common-2.245.0.tgz",
-      "integrity": "sha1-1TOV+ekE9HePjzeV+nTyeq+bGlw=",
+      "version": "2.252.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-kubernetes-common/-/azure-pipelines-tasks-kubernetes-common-2.252.0.tgz",
+      "integrity": "sha1-+tZKw8P5Ka3z2O3GmFXDYfgXe4E=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "5.2.7",

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -10,7 +10,7 @@
     "azure-pipelines-task-lib": "^4.16.0",
     "azure-pipelines-tasks-azure-arm-rest": "3.250.0",
     "azure-pipelines-tasks-docker-common": "2.242.0",
-    "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
+    "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
     "azure-pipelines-tasks-utility-common": "^3.210.0",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "del": "2.2.0",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 253,
-    "Patch": 0
+    "Minor": 254,
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 253,
-    "Patch": 0
+    "Minor": 254,
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: KubernetesV0 and KubernetesV1

**Description**: Download Urls have been changed from google cloud to K8

**Documentation changes required:** (Y/N) 
N
**Added unit tests:** (Y/N)
N
**Attached related issue:** (Y/N) <Please add link to related issue here>
[Bug1](https://github.com/microsoft/azure-pipelines-tasks/issues/20888)
**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
yes. tested in the pipeline and Urls are changed from google cloud to K8