### PR TITLE
Remove unused ADO suppression parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -178,10 +178,6 @@ extends:
             )
           )
         templateContext:
-          parameters:
-            sdl:
-              credscan:
-                suppressionsFile: $(Build.SourcesDirectory)/AzureDevOps/.config/CredScanSuppressions.json
           outputs:
           - output: nuget
             packagesToPush:  '$(Build.SourcesDirectory)/IndividualNugetPackagesDownloaded/IndividualNugetPackages/*/*.nupkg'


### PR DESCRIPTION
The pipeline which ran following the changes from #20889 didn't pick up the new suppression configuration, so remove the unused ADO parameter from the CI builds.

N/A to below, CI changes only, 

**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Risk Assesment(Low/Medium/High)**:

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**: <Add the list of tests Manual or Automated performed for your changes>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
