### PR TITLE
Updating 7zip version along with task versions

### DIFF
--- a/Tasks/ArchiveFilesV2/make.json
+++ b/Tasks/ArchiveFilesV2/make.json
@@ -3,7 +3,7 @@
         "archivePackages": [
             {
                 "archiveName": "7zip.zip",
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/ArchiveFilesV2/task.json
+++ b/Tasks/ArchiveFilesV2/task.json
@@ -19,7 +19,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 2,
-    "Minor": 253,
+    "Minor": 254,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/ArchiveFilesV2/task.loc.json
+++ b/Tasks/ArchiveFilesV2/task.loc.json
@@ -19,7 +19,7 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 2,
-    "Minor": 253,
+    "Minor": 254,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/AzurePowerShellV2/make.json
+++ b/Tasks/AzurePowerShellV2/make.json
@@ -33,7 +33,7 @@
         ],
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 252,
+        "Minor": 254,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV3/make.json
+++ b/Tasks/AzurePowerShellV3/make.json
@@ -33,7 +33,7 @@
         ],
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 252,
+        "Minor": 254,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV4/make.json
+++ b/Tasks/AzurePowerShellV4/make.json
@@ -45,7 +45,7 @@
         ],
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/make.json
+++ b/Tasks/AzurePowerShellV5/make.json
@@ -43,7 +43,7 @@
         ],
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 252,
+    "Minor": 254,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/ExtractFilesV1/make.json
+++ b/Tasks/ExtractFilesV1/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./"
             }
         ]

--- a/Tasks/ExtractFilesV1/task.json
+++ b/Tasks/ExtractFilesV1/task.json
@@ -19,8 +19,8 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "instanceNameFormat": "Extract files $(message)",
   "inputs": [

--- a/Tasks/ExtractFilesV1/task.loc.json
+++ b/Tasks/ExtractFilesV1/task.loc.json
@@ -19,8 +19,8 @@
   "minimumAgentVersion": "2.182.1",
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [

--- a/Tasks/JavaToolInstallerV0/make.json
+++ b/Tasks/JavaToolInstallerV0/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./FileExtractor/"
             }
         ]

--- a/Tasks/JavaToolInstallerV0/task.json
+++ b/Tasks/JavaToolInstallerV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "satisfies": [
     "Java",

--- a/Tasks/JavaToolInstallerV0/task.loc.json
+++ b/Tasks/JavaToolInstallerV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "satisfies": [
     "Java",

--- a/Tasks/JavaToolInstallerV1/make.json
+++ b/Tasks/JavaToolInstallerV1/make.json
@@ -2,7 +2,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
                 "dest": "./FileExtractor/"
             }
         ]

--- a/Tasks/JavaToolInstallerV1/task.json
+++ b/Tasks/JavaToolInstallerV1/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 253,
+    "Minor": 254,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/JavaToolInstallerV1/task.loc.json
+++ b/Tasks/JavaToolInstallerV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 253,
+    "Minor": 254,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/JenkinsQueueJobV2/make.json
+++ b/Tasks/JenkinsQueueJobV2/make.json
@@ -3,7 +3,7 @@
 	    "archivePackages": [
 	        {
 	            "archiveName": "7zip.zip",
-	            "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.08/7zip.zip",
+	            "url": "https://vstsagenttools.blob.core.windows.net/tools/7zip/24.09/7zip.zip",
 	            "dest": "./"
 	        }
 	    ]

--- a/Tasks/JenkinsQueueJobV2/task.json
+++ b/Tasks/JenkinsQueueJobV2/task.json
@@ -14,8 +14,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 246,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "groups": [
     {

--- a/Tasks/JenkinsQueueJobV2/task.loc.json
+++ b/Tasks/JenkinsQueueJobV2/task.loc.json
@@ -14,8 +14,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 246,
-    "Patch": 3
+    "Minor": 254,
+    "Patch": 0
   },
   "groups": [
     {


### PR DESCRIPTION
**Task name**: <Name of changed or new pipeline task>

1. ArchiveFilesV2
2. AzurePowershellV2
3. AzurePowershellV3
4. AzurePowershellV4
5. AzurePowershellV5
6. ExtractFilesV1
7. JavaToolInstallerV0
8. JavaToolInstallerV1
9. JenkinsQueueJobV2

**Description**: <Describe your changes here>
The changes in this pull request update the 7zip version to 24.09 along with the task versions.


**Risk Assesment(Low/Medium/High)**:
Low
Reasons for classifying the risk as low:

- The new 24.09 version is compatible with our tasks.
- There are no functionality changes in the newer version.

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>
N


**Tests Performed**: <Add the list of tests Manual or Automated performed for your changes>

- Unit Tests performed
- Built and uploaded the tasks to test org and validated if the tasks work properly. 
- Validated the new tasks on the canarytest org: [results](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=145441&view=results)

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>
No


**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
