### PR TITLE
Adding release annotation using connection string 

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/operations/ReleaseAnnotationUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/ReleaseAnnotationUtility.ts
@@ -8,7 +8,7 @@ var uuidV4 = require("uuid/v4");
 export async function addReleaseAnnotation(endpoint: AzureEndpoint, azureAppService: AzureAppService, isDeploymentSuccess: boolean): Promise<void> {
     try {
         var appSettings = await azureAppService.getApplicationSettings();
-        var instrumentationKey = appSettings && appSettings.properties && appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY;
+        var instrumentationKey = getInstrumentationKey(appSettings);
         if(instrumentationKey) {
             let appinsightsResources: ApplicationInsightsResources = new ApplicationInsightsResources(endpoint);
             var appInsightsResources = await appinsightsResources.list(null, [`$filter=InstrumentationKey eq '${instrumentationKey}'`]);
@@ -90,4 +90,21 @@ function getPipelineVariable(variableName: string): string | undefined {
     let variable = tl.getVariable(variableName);
     //we dont want to set a variable to be empty string
     return !!variable ? variable : undefined;
+}
+
+function getInstrumentationKey(appSettings: any): string | undefined {
+    let connectionString = appSettings?.properties?.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    if (connectionString) {
+        const FIELDS_SEPARATOR = ";";
+        const FIELD_KEY_VALUE_SEPARATOR = "=";
+
+        const kvPairs = connectionString.split(FIELDS_SEPARATOR);
+        for (const kvPair of kvPairs) {
+            const pair = kvPair.split(FIELD_KEY_VALUE_SEPARATOR);
+            if (pair.length === 2 && pair[0].trim().toLowerCase() === "instrumentationkey") {
+                return pair[1].trim();
+            }
+        }
+    }
+    return appSettings?.properties?.APPINSIGHTS_INSTRUMENTATIONKEY;
 }

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/operations/ReleaseAnnotationUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV5/operations/ReleaseAnnotationUtility.ts
@@ -8,7 +8,7 @@ var uuidV4 = require("uuid/v4");
 export async function addReleaseAnnotation(endpoint: AzureEndpoint, azureAppService: AzureAppService, isDeploymentSuccess: boolean): Promise<void> {
     try {
         var appSettings = await azureAppService.getApplicationSettings();
-        var instrumentationKey = appSettings && appSettings.properties && appSettings.properties.APPINSIGHTS_INSTRUMENTATIONKEY;
+        var instrumentationKey = getInstrumentationKey(appSettings);
         if(instrumentationKey) {
             let appinsightsResources: ApplicationInsightsResources = new ApplicationInsightsResources(endpoint);
             var appInsightsResources = await appinsightsResources.list(null, [`$filter=InstrumentationKey eq '${instrumentationKey}'`]);
@@ -90,4 +90,21 @@ function getPipelineVariable(variableName: string): string | undefined {
     let variable = tl.getVariable(variableName);
     //we dont want to set a variable to be empty string
     return !!variable ? variable : undefined;
+}
+
+function getInstrumentationKey(appSettings: any): string | undefined {
+    let connectionString = appSettings?.properties?.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    if (connectionString) {
+        const FIELDS_SEPARATOR = ";";
+        const FIELD_KEY_VALUE_SEPARATOR = "=";
+
+        const kvPairs = connectionString.split(FIELDS_SEPARATOR);
+        for (const kvPair of kvPairs) {
+            const pair = kvPair.split(FIELD_KEY_VALUE_SEPARATOR);
+            if (pair.length === 2 && pair[0].trim().toLowerCase() === "instrumentationkey") {
+                return pair[1].trim();
+            }
+        }
+    }
+    return appSettings?.properties?.APPINSIGHTS_INSTRUMENTATIONKEY;
 }

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 252,
-    "Patch": 5
+    "Minor": 254,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 252,
-    "Patch": 5
+    "Minor": 254,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
**Task name**: AzureRmWebAppDeploymentV4, AzureRmWebAppDeploymentV5

**Description**: The PR adds support for adding release annotations when the now recommended APPLICATIONINSIGHTS_CONNECTION_STRING setting is used on Azure, rather than the APPINSIGHTS_INSTRUMENTATIONKEY.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) N

**Tests Performed**: 
- Unit Tests performed
- Built and uploaded the tasks to test org and validated if the tasks work properly.

**Documentation changes required:** (Y/N) N

**Attached related issue:** (Y/N) https://github.com/microsoft/azure-pipelines-tasks/issues/20857

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
