### PR TITLE
Removing duplicate output in KubernetesV1 task

### DIFF
--- a/Tasks/KubernetesV1/src/kubernetes.ts
+++ b/Tasks/KubernetesV1/src/kubernetes.ts
@@ -138,7 +138,6 @@ function executeKubectlCommand(clusterConnection: ClusterConnection, command: st
     var result = [];
     return commandImplementation.run(clusterConnection, command, (data) => result.push(data))
         .fin(function cleanup() {
-            console.log("commandOutput" + result);
             const resultString = result.toString();
             const commandOutputLength = resultString.length;
             if (commandOutputLength > environmentVariableMaximumSize) {

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 254,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 254,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: KubernetesV1 

**Description**:  Eliminating duplicate output in logs.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**: 
    -  Unit Tests performed
    -  Built and uploaded the tasks to test org and validated if the tasks work properly.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:**  [GitHub Bug](https://github.com/microsoft/azure-pipelines-tasks/issues/19379?reload=1?reload=1)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
