### PR TITLE
Added customLogger input in VsTestV3

### DIFF
--- a/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
@@ -72,7 +72,7 @@
   "loc.input.label.configuration": "Build configuration",
   "loc.input.help.configuration": "Build configuration against which the tests should be reported. If you have defined a variable for configuration in your build task, use that here.",
   "loc.input.label.customLoggerConfig": "Custom Logger Configuration",
-  "loc.input.help.customLoggerConfig": "Use this option if you have a custom logger. The feature needs to be enabled for your organization first, otherwise the custom logger will not be used. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
+  "loc.input.help.customLoggerConfig": "Use this option if you have a custom logger. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
   "loc.input.label.publishRunAttachments": "Upload test attachments",
   "loc.input.help.publishRunAttachments": "Opt in/out of publishing run level attachments.",
   "loc.input.label.donotPublishTestResults": "Disable publishing test results",

--- a/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
@@ -72,7 +72,7 @@
   "loc.input.label.configuration": "Build configuration",
   "loc.input.help.configuration": "Build configuration against which the tests should be reported. If you have defined a variable for configuration in your build task, use that here.",
   "loc.input.label.customLoggerConfig": "Custom Logger Configuration",
-  "loc.input.help.customLoggerConfig": "You can use this option if you want to use a custom logger. Currently, this feature is available to a limited set of customers. If it is not enabled for your account, the custom logger will not be used. To configure, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
+  "loc.input.help.customLoggerConfig": "Use this option if you have a custom logger. The feature needs to be enabled for your organization first, otherwise the custom logger will not be used. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
   "loc.input.label.publishRunAttachments": "Upload test attachments",
   "loc.input.help.publishRunAttachments": "Opt in/out of publishing run level attachments.",
   "loc.input.label.donotPublishTestResults": "Disable publishing test results",

--- a/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/VsTestV3/Strings/resources.resjson/en-US/resources.resjson
@@ -71,6 +71,8 @@
   "loc.input.help.platform": "Build platform against which the tests should be reported. If you have defined a variable for platform in your build task, use that here.",
   "loc.input.label.configuration": "Build configuration",
   "loc.input.help.configuration": "Build configuration against which the tests should be reported. If you have defined a variable for configuration in your build task, use that here.",
+  "loc.input.label.customLoggerConfig": "Custom Logger Configuration",
+  "loc.input.help.customLoggerConfig": "You can use this option if you want to use a custom logger. Currently, this feature is available to a limited set of customers. If it is not enabled for your account, the custom logger will not be used. To configure, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
   "loc.input.label.publishRunAttachments": "Upload test attachments",
   "loc.input.help.publishRunAttachments": "Opt in/out of publishing run level attachments.",
   "loc.input.label.donotPublishTestResults": "Disable publishing test results",

--- a/Tasks/VsTestV3/inputdatacontract.ts
+++ b/Tasks/VsTestV3/inputdatacontract.ts
@@ -28,6 +28,7 @@ export interface TestReportingSettings {
     TestSourceSettings : TestSourceSettings;
     ExecutionStatusSettings : ExecutionStatusSettings;
     DonotPublishTestResults : boolean;
+    CustomLoggerConfig : string;
 }
 
 export interface TestSelectionSettings {

--- a/Tasks/VsTestV3/inputparser.ts
+++ b/Tasks/VsTestV3/inputparser.ts
@@ -179,6 +179,8 @@ function getTestReportingSettings(inputDataContract : idc.InputDataContract) : i
     inputDataContract.TestReportingSettings.ExecutionStatusSettings.MinimumExecutedTestsExpected = 0;
     inputDataContract.TestReportingSettings.ExecutionStatusSettings.ActionOnThresholdNotMet = "donothing";
     inputDataContract.TestReportingSettings.ExecutionStatusSettings.IgnoreTestFailures = utils.Helper.stringToBool(tl.getVariable('vstest.ignoretestfailures'));
+    inputDataContract.TestReportingSettings.CustomLoggerConfig = tl.getInput('customLoggerConfig');
+    
     if (utils.Helper.isNullEmptyOrUndefined(inputDataContract.TestReportingSettings.TestRunTitle)) {
 
         let definitionName = tl.getVariable('BUILD_DEFINITIONNAME');

--- a/Tasks/VsTestV3/make.json
+++ b/Tasks/VsTestV3/make.json
@@ -6,7 +6,7 @@
               "dest": "./"
             },
             {
-              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29341948/TestAgent.zip",
+              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29729210/TestAgent.zip",
               "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -424,7 +424,7 @@
       "label": "Custom Logger Configuration",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "You can use this option if you want to use a custom logger. Currently, this feature is available to a limited set of customers. If it is not enabled for your account, the custom logger will not be used. To configure, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
+      "helpMarkDown": "Use this option if you have a custom logger. The feature needs to be enabled for your organization first, otherwise the custom logger will not be used. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
       "groupName": "reportingOptions"
     },
     {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 0
   },
   "demands": [
     "vstest"
@@ -416,6 +416,15 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "Build configuration against which the tests should be reported. If you have defined a variable for configuration in your build task, use that here.",
+      "groupName": "reportingOptions"
+    },
+    {
+      "name": "customLoggerConfig",
+      "type": "string",
+      "label": "Custom Logger Configuration",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "You can use this option if you want to use a custom logger. Currently, this feature is available to a limited set of customers. If it is not enabled for your account, the custom logger will not be used. To configure, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
       "groupName": "reportingOptions"
     },
     {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -424,7 +424,7 @@
       "label": "Custom Logger Configuration",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Use this option if you have a custom logger. The feature needs to be enabled for your organization first, otherwise the custom logger will not be used. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
+      "helpMarkDown": "Use this option if you have a custom logger. To use, provide the logger name along with its parameters in the following format: 'friendlyName;key1=value1;key2=value2;....'",
       "groupName": "reportingOptions"
     },
     {

--- a/Tasks/VsTestV3/task.loc.json
+++ b/Tasks/VsTestV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 254,
+    "Patch": 0
   },
   "demands": [
     "vstest"
@@ -416,6 +416,15 @@
       "defaultValue": "",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.configuration",
+      "groupName": "reportingOptions"
+    },
+    {
+      "name": "customLoggerConfig",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.customLoggerConfig",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.customLoggerConfig",
       "groupName": "reportingOptions"
     },
     {


### PR DESCRIPTION
**Task name**: VsTestV3

**Description**: Added customLogger input in VsTestV3
Changes in ADO Org : 
1. https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/833105
2. https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/831629


**Risk Assesment(Low/Medium/High)**:
Low
1. Everything is behind featureFlags
2. Enough Manual/Automated testing is done

**Added unit tests:** (Y/N) N/A
Already added in ADO 

**Tests Performed**: 
**Manual Testing**
**VsTestV3(Single Agent) without customLoggerConfig**
1. No impact on Single Agent flows when customLoggerConfig is not provided

**VsTestV3(Single Agent) with customLoggerConfig**
1. No impact on Single Agent flows when customLoggerConfig is provided but FF to enable this feature is not enabled at ADO side
2. Custom Fields are successfully added when customLoggerConfig is provided with correct format
3. Task Fails when customLoggerConfig is provided with wrong formats
4. Correct behaviour of task when runsettings is having full or partial LoggerRunSettings elements

**VsTestV3(Multiple Agent) without customLoggerConfig**
1. No impact on distributed flows when customLoggerConfig is not provided

**VsTestV3(Multiple Agent) with customLoggerConfig**
1. No impact on distributed flows when customLoggerConfig is provided
2. No impact on distributed flows when customLoggerConfig is provided with wrong format


**Documentation changes required:** N/A

**Attached related issue:** N/A

**Checklist**:
- [X] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [X] Checked that applied changes work as expected
