### PR TITLE
updating common package versions for AzureRmWebbAppDeployment and Docker AB#2262367

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/_buildConfigs/Node20/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.246.4",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.254.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.246.4",
-        "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "4.254.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -230,9 +230,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.254.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.254.0.tgz",
+      "integrity": "sha1-F+3Yo+B7OYMIUAk0VBw/c1bbLMg=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.246.4",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.254.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 254,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 254,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/DockerV2/_buildConfigs/Node20/package.json
+++ b/Tasks/DockerV2/_buildConfigs/Node20/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-docker-common": "2.247.0",
+    "azure-pipelines-tasks-docker-common": "2.254.0",
     "azure-pipelines-tasks-utility-common": "^3.238.0",
     "del": "2.2.0",
     "esprima": "2.7.1",

--- a/Tasks/DockerV2/package-lock.json
+++ b/Tasks/DockerV2/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "DockerV2_Node20",
+  "name": "DockerV2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -11,7 +11,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-docker-common": "2.247.0",
+        "azure-pipelines-tasks-docker-common": "2.254.0",
         "azure-pipelines-tasks-utility-common": "^3.238.0",
         "del": "2.2.0",
         "esprima": "2.7.1",
@@ -181,9 +181,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/azure-pipelines-tasks-docker-common": {
-      "version": "2.247.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.247.0.tgz",
-      "integrity": "sha512-D4tU++q/4XU4HtFEgNThBF9RIWRz6IjP1C5j4lByoMXqWZDYSkCVzAfd/ow5lGw9WyX+PXtxiZ/9+SNKF8hKLA==",
+      "version": "2.254.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.254.0.tgz",
+      "integrity": "sha1-PkZ5LxSk9eiaSkPYbWg2YajYaG8=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",

--- a/Tasks/DockerV2/package.json
+++ b/Tasks/DockerV2/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-docker-common": "2.247.0",
+    "azure-pipelines-tasks-docker-common": "2.254.0",
     "azure-pipelines-tasks-utility-common": "^3.238.0",
     "del": "2.2.0",
     "esprima": "2.7.1",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 248,
+    "Minor": 254,
     "Patch": 1
   },
   "minimumAgentVersion": "2.172.0",

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 248,
+    "Minor": 254,
     "Patch": 1
   },
   "minimumAgentVersion": "2.172.0",


### PR DESCRIPTION
**Task name**: DockerV2 and AzureRmWebAppDeploymentV4

**Description**: updating common package dependencies for both tasks

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) No

**Tests Performed**: verified AzureRmWebAppDeploymentV4 for connection string input and its working fine and for Docker reading from the image is also working as expected

**Documentation changes required:** (Y/N) N

**Attached related issue:** (Y/N) [Bug1](https://github.com/microsoft/azure-pipelines-tasks/issues/20743), [bug2](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2262367)
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
