### PR TITLE
Bumping up to fix the vstest task incorrect exit code when DonotPublishTestResults is used

### DIFF
--- a/Tasks/VsTestV3/make.json
+++ b/Tasks/VsTestV3/make.json
@@ -6,7 +6,7 @@
               "dest": "./"
             },
             {
-              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29729210/TestAgent.zip",
+              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29739532/TestAgent.zip",
               "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 254,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTestV3/task.loc.json
+++ b/Tasks/VsTestV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 254,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Bumping up to fix the vstest task incorrect exit code when DonotPublishTestResults is used

**Task name**: VsTest@3

**Description**: 
Changes are being done in Task Agent, to fix the issue where VsTest Task was always giving exit code as 1 when the flag DonotPublishTestResults is used. 

Fix of that is here: https://mseng.visualstudio.com/AzureDevOps/_git/AzureDevOps/pullrequest/834098
Link to New Blob Publish: https://dev.azure.com/mseng/AzureDevOps/_releaseProgress?_a=release-environment-logs&releaseId=22254365&environmentId=213841297

**Risk Assesment**: Low

**Added unit tests:** N

**Tests Performed**: 
Published Task to a test org and validated that things are working fine.

Before Fix:
![image](https://github.com/user-attachments/assets/e54821cb-6e19-4851-89d2-b0cba020febb)

After Fix:
![image](https://github.com/user-attachments/assets/b9fda7d5-5165-4cf7-b263-9dda37ea7b17)

![image](https://github.com/user-attachments/assets/88b09b18-545a-41bb-a3f2-ddc5a5ef7ff7)

**Documentation changes required:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
