### PR TITLE
Removing lower versions of openssl which causing vulnerability issues

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 252,
+        "Minor": 255,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 252,
+        "Minor": 255,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 252,
+        "Minor": 255,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 254,
+        "Minor": 255,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 254,
+        "Minor": 255,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 255,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 255,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 254,
-    "Patch": 2
+    "Minor": 255,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 254,
-    "Patch": 2
+    "Minor": 255,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -1,6 +1,5 @@
 ﻿$featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION)
 }
 
 function Add-Certificate {
@@ -363,24 +362,11 @@ function ConvertTo-Pfx {
     else {
         [System.IO.File]::WriteAllText($pfxPasswordFilePath, $pfxFilePassword, [System.Text.Encoding]::ASCII)
     }
-
-    if(-not $featureFlags.useOpenssLatestVersion) {
-     $openSSLExePath = "$PSScriptRoot\openssl\openssl.exe"
-     $env:OPENSSL_CONF = "$PSScriptRoot\openssl\openssl.cnf"
-     $env:RANDFILE=".rnd"
-
-     $openSSLArgs = "pkcs12 -export -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
-    }
-   else{
      $openSSLExePath = "$PSScriptRoot\opensslv4\openssl.exe"
      $env:OPENSSL_CONF = "$PSScriptRoot\opensslv4\openssl.cnf"
      $env:RANDFILE=".rnd"
-
      $openSSLArgs = "pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
-     }
-     
-    $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero
-
+     $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero
     return $pfxFilePath, $pfxFilePassword
 }
 

--- a/Tasks/Common/VstsAzureHelpers_/make.json
+++ b/Tasks/Common/VstsAzureHelpers_/make.json
@@ -134,16 +134,6 @@
         ],
         "archivePackages": [
             {
-                "archiveName": "openssl.zip",
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/openssl/1.0.2/M153/openssl.zip",
-                "dest": "./openssl"
-            },
-            {
-                "archiveName": "openssl_new.zip",
-                "url": "https://vstsagenttools.blob.core.windows.net/tools/openssl/3.3.1/M245/openssl.zip",
-                "dest": "./opensslv3"
-            },
-            {
                 "archiveName": "openssl_new3.4.0.zip",
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip",
                 "dest": "./opensslv4"

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 255,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 255,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 255,
+        "Minor": 256,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 256,
+        "Minor": 257,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 252,
+        "Minor": 255,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 252,
+    "Minor": 255,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
**Task name**: AzurePowerShellV2-5, AzureFileCopy@1-6, 

**Description**: Removing lower versions of openssl which causing vulnerability issues

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) N

**Tests Performed**: manually tested in private org

**Documentation changes required:** (Y/N) Y
https://dev.azure.com/mseng/AzureDevOps/_wiki/wikis/AzureDevOps.wiki/46329/Update-Openssl-Version-for-Vulnerability-issues

**Attached related issue:** (Y/N) Y
[https://github.com/microsoft/azure-pipelines-tasks/pull/url](url)
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
