### PR TITLE
Skip manifest stability check for fleet

### DIFF
--- a/Tasks/KubernetesManifestV1/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV1/Tests/L0.ts
@@ -32,6 +32,7 @@ describe('Kubernetes Manifests Suite', function () {
         delete process.env[shared.TestEnvVars.baselineAndCanaryReplicas];
         delete process.env[shared.TestEnvVars.trafficSplitMethod];
         delete process.env[shared.TestEnvVars.containers];
+        delete process.env[shared.TestEnvVars.resourceType]
         delete process.env.RemoveNamespaceFromEndpoint;
     });
 
@@ -44,6 +45,18 @@ describe('Kubernetes Manifests Suite', function () {
         await tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('nginx-service 104.211.243.77') != -1, 'nginx-service external IP is 104.211.243.77')
+    });
+
+    it('Fleet deployment skips checkManifestStability step', async () => {
+        const tp = path.join(__dirname, 'TestSetup.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        process.env[shared.TestEnvVars.action] = shared.Actions.deploy;
+        process.env[shared.TestEnvVars.strategy] = shared.Strategy.none;
+        process.env[shared.TestEnvVars.imagePullSecrets] = 'test-key1\ntest-key2';
+        process.env[shared.TestEnvVars.resourceType] = 'Microsoft.ContainerService/fleets';
+        await tr.runAsync();
+        assert(tr.stdout.indexOf('checking manifest stability') === -1, 'checking manifest stability should not be printed');
+        assert(tr.succeeded, 'task should have succeeded');
     });
 
     it('Run successfully for deploy canary', async () => {

--- a/Tasks/KubernetesManifestV1/Tests/TestSetup.ts
+++ b/Tasks/KubernetesManifestV1/Tests/TestSetup.ts
@@ -49,6 +49,7 @@ tr.setInput('dockerComposeFile', process.env[shared.TestEnvVars.dockerComposeFil
 tr.setInput('kustomizationPath', process.env[shared.TestEnvVars.kustomizationPath] || '');
 tr.setInput('baselineAndCanaryReplicas', process.env[shared.TestEnvVars.baselineAndCanaryReplicas] || '0');
 tr.setInput('trafficSplitMethod', process.env[shared.TestEnvVars.trafficSplitMethod]);
+tr.setInput('resourceType', process.env[shared.TestEnvVars.resourceType] || '');
 
 process.env.SYSTEM_DEFAULTWORKINGDIRECTORY = testnamespaceWorkingDirectory;
 process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = teamFoundationCollectionUri;

--- a/Tasks/KubernetesManifestV1/Tests/TestShared.ts
+++ b/Tasks/KubernetesManifestV1/Tests/TestShared.ts
@@ -37,7 +37,8 @@ export let TestEnvVars = {
     isCanaryDeploymentPresent: "__isCanaryDeploymentPresent__",
     isBaselineDeploymentPresent: "__isBaselineDeploymentPresent__",
     baselineAndCanaryReplicas: "__baselineAndCanaryReplicas__",
-    trafficSplitMethod: "__trafficSplitMethod__"
+    trafficSplitMethod: "__trafficSplitMethod__",
+    resourceType: "__resourceType__"
 };
 
 export let OperatingSystems = {

--- a/Tasks/KubernetesManifestV1/package-lock.json
+++ b/Tasks/KubernetesManifestV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.254.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.254.2",
         "azure-pipelines-tasks-docker-common": "2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
         "azure-pipelines-tasks-utility-common": "^3.210.0",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.254.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.254.0.tgz",
-      "integrity": "sha1-JnYfgTgSyFpXAycIR9laKprGUJo=",
+      "version": "3.254.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.254.2.tgz",
+      "integrity": "sha1-xn3z/IjHJVGLK8T1AjS9F7W4CDk=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/KubernetesManifestV1/package.json
+++ b/Tasks/KubernetesManifestV1/package.json
@@ -8,7 +8,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.254.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.254.2",
     "azure-pipelines-tasks-docker-common": "2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-utility-common": "^3.210.0",

--- a/Tasks/KubernetesManifestV1/src/utils/DeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV1/src/utils/DeploymentHelper.ts
@@ -34,6 +34,13 @@ export async function deploy(kubectl: Kubectl, manifestFilePaths: string[], depl
 
     // check manifest stability
     const resourceTypes: Resource[] = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([KubernetesConstants.DiscoveryAndLoadBalancerResource.service]));
+    const resourceType = tl.getInput('resourceType') || ''
+
+    // for a fleet object, we do not check for manifest stability
+    if (resourceType.toLowerCase() != 'microsoft.containerservice/fleets') {
+        tl.debug('checking manifest stability');
+        await checkManifestStability(kubectl, resourceTypes)
+    }   
     await checkManifestStability(kubectl, resourceTypes);
 
     // print ingress resources

--- a/Tasks/KubernetesManifestV1/src/utils/DeploymentHelper.ts
+++ b/Tasks/KubernetesManifestV1/src/utils/DeploymentHelper.ts
@@ -41,7 +41,6 @@ export async function deploy(kubectl: Kubectl, manifestFilePaths: string[], depl
         tl.debug('checking manifest stability');
         await checkManifestStability(kubectl, resourceTypes)
     }   
-    await checkManifestStability(kubectl, resourceTypes);
 
     // print ingress resources
     const ingressResources: Resource[] = KubernetesObjectUtility.getResources(deployedManifestFiles, [KubernetesConstants.DiscoveryAndLoadBalancerResource.ingress]);

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 2
   },
   "demands": [],
   "groups": [],


### PR DESCRIPTION
**Task name**: KubernetesManifestV1
**Description**: Skip checking the manifest stability given the resource type is a fleet

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) Y

**Tests Performed**: Tested manually

**Documentation changes required:** (Y/N) N

**Attached related issue:** (Y/N) N
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
