### PR TITLE
Update CoreAz.ps1 to use the latest Resolve-AzError

### DIFF
--- a/Tasks/AzurePowerShellV5/CoreAz.ps1
+++ b/Tasks/AzurePowerShellV5/CoreAz.ps1
@@ -35,7 +35,7 @@ try {
 }
 catch {
     Write-Host "An error occurred in Initialize-AzModule"
-    Resolve-Error $_ | ConvertTo-Json -Depth 5 | Write-Host
+    Resolve-AzError $_ | ConvertTo-Json -Depth 5 | Write-Host
     throw
 }
 


### PR DESCRIPTION
The script is using Resolve-Error old commandlet from 12.4.0 but this commandlet is deprecated in newer Azure Powershell versions and is failing for Self-hosted agents with newer version of Azure Powershell. So customers are having to downgrade Azure Powershell version to make this task work.


##[error]Process 'openssl.exe' exited with code '-1073741515'. An error occurred in Initialize-AzModule
##[error]The term 'Resolve-Error' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again. ##[error]PowerShell exited with code '1'.;
..
..
System.Management.Automation.CommandNotFoundException: The term 'Resolve-Error' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

**Task name**: <Name of changed or new pipeline task>

**Description**: <Describe your changes here>

**Risk Assesment(Low/Medium/High)**:

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**: <Add the list of tests Manual or Automated performed for your changes>

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
