### PR TITLE
Add support for Microsoft.Testing.Platform in DotNetCoreCLIV2

### DIFF
--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -3,6 +3,7 @@ import tr = require("azure-pipelines-task-lib/toolrunner");
 import path = require("path");
 import fs = require("fs");
 import ltx = require("ltx");
+import * as toml from 'toml';
 var archiver = require('archiver');
 var uuidV4 = require('uuid/v4');
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
@@ -145,13 +146,27 @@ export class dotNetExe {
         }
     }
 
+    private getIsMicrosoftTestingPlatform(): boolean {
+        if (!tl.exists("dotnet.config")) {
+            return false;
+        }
+
+        let dotnetConfig = fs.readFileSync("dotnet.config", 'utf8');
+        return toml.parse(dotnetConfig).dotnet?.test?.runner?.name === 'Microsoft.Testing.Platform';
+    }
+
     private async executeTestCommand(): Promise<void> {
         const dotnetPath = tl.which('dotnet', true);
         console.log(tl.loc('DeprecatedDotnet2_2_And_3_0'));
         const enablePublishTestResults: boolean = tl.getBoolInput('publishTestResults', false) || false;
         const resultsDirectory = tl.getVariable('Agent.TempDirectory');
         if (enablePublishTestResults && enablePublishTestResults === true) {
-            this.arguments = ` --logger trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
+            const isMTP: boolean = this.getIsMicrosoftTestingPlatform();
+            if (isMTP) {
+                this.arguments = ` --report-trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
+            } else {
+                this.arguments = ` --logger trx --results-directory "${resultsDirectory}" `.concat(this.arguments);
+            }
         }
 
         // Remove old trx files
@@ -171,6 +186,19 @@ export class dotNetExe {
             const projectFile = projectFiles[fileIndex];
             const dotnet = tl.tool(dotnetPath);
             dotnet.arg(this.command);
+            // https://github.com/dotnet/sdk/blob/cbb8f75623c4357919418d34c53218ca9b57358c/src/Cli/dotnet/Commands/Test/CliConstants.cs#L34
+            if (projectFile.endsWith(".proj") || projectFile.EndsWith(".csproj") || projectFile.EndsWith(".vbproj") || projectFile.EndsWith(".fsproj")) {
+                dotnet.arg("--project");
+            }
+            else if (projectFile.endsWith(".sln") || projectFile.endsWith(".slnx") || projectFile.endsWith(".slnf")) {
+                dotnet.arg("--solution");
+            }
+            else {
+                tl.error(`Project file '${projectFile}' has an unrecognized extension.`);
+                failedProjects.push(projectFile);
+                continue;
+            }
+
             dotnet.arg(projectFile);
             dotnet.line(this.arguments);
             try {

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 247,
-    "Patch": 3
+    "Minor": 255,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "dotnet $(command)",


### PR DESCRIPTION
**Task name**: DotNetCoreCLIV2

**Description**: Add support for MTP

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** N

**Tests Performed**: 

**Documentation changes required:** Yes.

**Attached related issue:** Partially linked to https://github.com/microsoft/azure-pipelines-tasks/issues/20958, but is a bit different. The linked issue requests support for MTP using the "VSTest mode of dotnet test". We have a new dotnet test mode for MTP that's shipping in .NET 10 SDK. That's what I'm adding in this PR.

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
