### PR TITLE
Reverted copyFilesV2 to 5.0.0-preview.0

### DIFF
--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -74,9 +74,6 @@ describe('CopyFiles L0 Suite', function () {
         let runner2: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -107,8 +104,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
             'should have copied dir2 file3');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -118,9 +113,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0copySubtractExclude.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -142,8 +134,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             !runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
             'should not have copied dir2 file1');
-        // }, runner, done);
-        // });
         done();
 
     });
@@ -154,13 +144,8 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0failsIfContentsNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(runner.failed, 'should have failed');
         assert(runner.createdErrorIssue('Error: Input required: Contents'), 'should have created error issue');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -170,13 +155,8 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(runner.failed, 'should have failed');
         assert(runner.createdErrorIssue('Error: Input required: SourceFolder'), 'should have created error issue');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -186,13 +166,8 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0failsIfTargetFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(runner.failed, 'should have failed');
         assert(runner.createdErrorIssue('Error: Input required: TargetFolder'), 'should have created error issue');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -202,13 +177,8 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotFound.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        //     .then(() => {
-        //         runValidations(() => {
         assert(runner.failed, 'should have failed');
         assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -218,13 +188,8 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0failsIfTargetFileIsDir.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(runner.failed, 'should have failed');
         assert(runner.createdErrorIssue(`Error: loc_mock_TargetIsDir ${path.normalize('/srcDir/someOtherDir/file1.file')} ${path.normalize('/destDir/someOtherDir/file1.file')}`), 'should have created error issue');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -234,9 +199,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0skipsIfExists.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -252,8 +214,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -263,9 +223,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0overwritesIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        //     .then(() => {
-        //         runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -281,8 +238,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        //     }, runner, done);
-        // });
         done();
     });
 
@@ -292,9 +247,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0preservesTimestampIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        //     .then(() => {
-        //         runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -313,8 +265,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        //     }, runner, done);
-        // });
         done();
     });
 
@@ -324,9 +274,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0cleansIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -348,8 +295,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -359,9 +304,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndDestDoesntExist.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         // This will fail if stat is called with throwEnoent=true
         assert(
             runner.succeeded,
@@ -384,8 +326,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -395,9 +335,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndTargetIsFile.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -416,8 +353,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -427,9 +362,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0rootsPatterns.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -442,8 +374,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
             'should have copied file1');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -451,9 +381,6 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0IgnoresMakeDirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -464,8 +391,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
             'should have copied file2');
-        // }, runner, done);
-        // });
         done();
     });
 
@@ -473,14 +398,10 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0FailsIfThereIsMkdirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
+
         assert(
             runner.failed,
             'should have failed');
-        // }, runner, done);
-        // });
         done();
     });
 

--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -28,42 +28,43 @@ describe('CopyFiles L0 Suite', function () {
 
         let tp = path.join(__dirname, 'L0copyAllFiles.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(tp);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
-                        'should have mkdirP someOtherDir2');
-                    assert(
-                        !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir3')}`),
-                        'should not have mkdirP someOtherDir3');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied dir1 file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied dir1 file2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
-                        'should have copied dir2 file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
-                        'should have copied dir2 file2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
-                        'should have copied dir2 file3');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
+            'should have mkdirP someOtherDir2');
+        assert(
+            !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir3')}`),
+            'should not have mkdirP someOtherDir3');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied dir1 file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied dir1 file2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
+            'should have copied dir2 file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
+            'should have copied dir2 file2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
+            'should have copied dir2 file3');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('copy files from srcdir to destdir with brackets in src path', (done: Mocha.Done) => {
@@ -72,42 +73,43 @@ describe('CopyFiles L0 Suite', function () {
         let testPath = path.join(__dirname, 'L0copyAllFilesWithBracketsInSrcPath.js');
         let runner2: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
-                        'should have mkdirP someOtherDir2');
-                    assert(
-                        !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir3')}`),
-                        'should not have mkdirP someOtherDir3');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied dir1 file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied dir1 file2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
-                        'should have copied dir2 file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
-                        'should have copied dir2 file2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
-                        'should have copied dir2 file3');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
+            'should have mkdirP someOtherDir2');
+        assert(
+            !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir3')}`),
+            'should not have mkdirP someOtherDir3');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied dir1 file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied dir1 file2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
+            'should have copied dir2 file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
+            'should have copied dir2 file2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir [bracket]/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
+            'should have copied dir2 file3');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('copy files and subtract based on exclude pattern', (done: Mocha.Done) => {
@@ -115,32 +117,34 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0copySubtractExclude.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
-                        'should not have mkdirP someOtherDir2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied dir1 file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied dir1 file2');
-                    assert(
-                        !runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
-                        'should not have copied dir2 file1');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            !runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir2')}`),
+            'should not have mkdirP someOtherDir2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied dir1 file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied dir1 file2');
+        assert(
+            !runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file1.file')} to ${path.normalize('/destDir/someOtherDir2/file1.file')}`),
+            'should not have copied dir2 file1');
+        // }, runner, done);
+        // });
+        done();
 
     });
 
@@ -149,13 +153,15 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0failsIfContentsNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(runner.failed, 'should have failed');
-                    assert(runner.createdErrorIssue('Error: Input required: Contents'), 'should have created error issue');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(runner.failed, 'should have failed');
+        assert(runner.createdErrorIssue('Error: Input required: Contents'), 'should have created error issue');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('fails if SourceFolder not set', (done: Mocha.Done) => {
@@ -163,13 +169,15 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(runner.failed, 'should have failed');
-                    assert(runner.createdErrorIssue('Error: Input required: SourceFolder'), 'should have created error issue');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(runner.failed, 'should have failed');
+        assert(runner.createdErrorIssue('Error: Input required: SourceFolder'), 'should have created error issue');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('fails if TargetFolder not set', (done: Mocha.Done) => {
@@ -177,13 +185,15 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0failsIfTargetFolderNotSet.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(runner.failed, 'should have failed');
-                    assert(runner.createdErrorIssue('Error: Input required: TargetFolder'), 'should have created error issue');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(runner.failed, 'should have failed');
+        assert(runner.createdErrorIssue('Error: Input required: TargetFolder'), 'should have created error issue');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('fails if SourceFolder not found', (done: Mocha.Done) => {
@@ -191,13 +201,15 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0failsIfSourceFolderNotFound.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(runner.failed, 'should have failed');
-                    assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        //     .then(() => {
+        //         runValidations(() => {
+        assert(runner.failed, 'should have failed');
+        assert(runner.createdErrorIssue(`Error: Not found ${path.normalize('/srcDir')}`), 'should have created error issue');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('fails if target file is a directory', (done: Mocha.Done) => {
@@ -205,13 +217,15 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0failsIfTargetFileIsDir.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(runner.failed, 'should have failed');
-                    assert(runner.createdErrorIssue(`Error: loc_mock_TargetIsDir ${path.normalize('/srcDir/someOtherDir/file1.file')} ${path.normalize('/destDir/someOtherDir/file1.file')}`), 'should have created error issue');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(runner.failed, 'should have failed');
+        assert(runner.createdErrorIssue(`Error: loc_mock_TargetIsDir ${path.normalize('/srcDir/someOtherDir/file1.file')} ${path.normalize('/destDir/someOtherDir/file1.file')}`), 'should have created error issue');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('skips if exists', (done: Mocha.Done) => {
@@ -219,26 +233,28 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0skipsIfExists.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        !runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should not have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            !runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should not have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('overwrites if specified', (done: Mocha.Done) => {
@@ -246,27 +262,28 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0overwritesIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        //     .then(() => {
+        //         runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        //     }, runner, done);
+        // });
+        done();
     });
 
     it('preserves timestamp if specified', (done: Mocha.Done) => {
@@ -274,29 +291,31 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0preservesTimestampIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`Calling fs.utimes on ${path.normalize('/destDir')}`),
-                        'should have copied timestamp');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        //     .then(() => {
+        //         runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`Calling fs.utimes on ${path.normalize('/destDir')}`),
+            'should have copied timestamp');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        //     }, runner, done);
+        // });
+        done();
     });
 
     it('cleans if specified', (done: Mocha.Done) => {
@@ -304,33 +323,34 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0cleansIfSpecified.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
-                        'should have cleaned destDir/clean-subDir');
-                    assert(
-                        runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
-                        'should have cleaned destDir/clean-file.txt');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
+            'should have cleaned destDir/clean-subDir');
+        assert(
+            runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
+            'should have cleaned destDir/clean-file.txt');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it("skips cleaning when destination folder doesn't exist", (done: Mocha.Done) => {
@@ -338,34 +358,35 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndDestDoesntExist.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    // This will fail if stat is called with throwEnoent=true
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
-                        'should have skipped cleaning non-existent directory');
-                    assert(
-                        !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
-                        'should have skipped cleaning non-existent directory');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        // This will fail if stat is called with throwEnoent=true
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-subDir')}`),
+            'should have skipped cleaning non-existent directory');
+        assert(
+            !runner.stdOutContained(`rmRF ${path.normalize('/destDir/clean-file.txt')}`),
+            'should have skipped cleaning non-existent directory');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('cleans if specified and target is file', (done: Mocha.Done) => {
@@ -373,30 +394,31 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0cleansIfSpecifiedAndTargetIsFile.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`rmRF ${path.normalize('/destDir')}`),
-                        'should have cleaned destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                        'should have mkdirP destDir');
-                    assert(
-                        runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
-                        'should have mkdirP someOtherDir');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`rmRF ${path.normalize('/destDir')}`),
+            'should have cleaned destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+            'should have mkdirP destDir');
+        assert(
+            runner.stdOutContained(`creating path: ${path.join('/destDir', 'someOtherDir')}`),
+            'should have mkdirP someOtherDir');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('roots patterns', (done: Mocha.Done) => {
@@ -404,59 +426,62 @@ describe('CopyFiles L0 Suite', function () {
 
         let testPath = path.join(__dirname, 'L0rootsPatterns.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
-                        'should have copied file1');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file2.file')} to ${path.normalize('/destDir/someOtherDir2/file2.file')}`),
+            'should have copied file1');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('ignores errors during target folder creation if ignoreMakeDirErrors is true', (done: Mocha.Done) => {
         let testPath = path.join(__dirname, 'L0IgnoresMakeDirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.succeeded,
+            'should have succeeded');
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+            'should have copied file1');
 
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.succeeded,
-                        'should have succeeded');
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                        'should have copied file1');
-
-                    assert(
-                        runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                        'should have copied file2');
-                }, runner, done);
-            });
+        assert(
+            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+            'should have copied file2');
+        // }, runner, done);
+        // });
+        done();
     });
 
     it('fails if there are errors during target folder creation if ignoreMakeDirErrors is false', (done: Mocha.Done) => {
         let testPath = path.join(__dirname, 'L0FailsIfThereIsMkdirError.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-        // runner.run();
-        runner.runAsync()
-            .then(() => {
-                runValidations(() => {
-                    assert(
-                        runner.failed,
-                        'should have failed');
-                }, runner, done);
-            });
+        runner.run();
+        // runner.runAsync()
+        // .then(() => {
+        // runValidations(() => {
+        assert(
+            runner.failed,
+            'should have failed');
+        // }, runner, done);
+        // });
+        done();
     });
 
     if (process.platform == 'win32') {
@@ -465,33 +490,29 @@ describe('CopyFiles L0 Suite', function () {
 
             let testPath = path.join(__dirname, 'L0overwritesReadonly.js');
             let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(testPath);
-
-            runner.runAsync()
-                .then(() => {
-                    runValidations(() => {
-                        assert(
-                            runner.succeeded,
-                            'should have succeeded');
-                        assert(
-                            runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
-                            'should have mkdirP destDir');
-                        assert(
-                            runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
-                            'should have mkdirP someOtherDir');
-                        assert(
-                            runner.stdOutContained(`chmodSync ${path.normalize('/destDir/someOtherDir/file1.file')} ${(6 << 6) + (6 << 3) + 6}`), // rw-rw-rw-
-                            'should have chmod file1');
-                        assert(
-                            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
-                            'should have copied file1');
-                        assert(
-                            !runner.stdOutContained(`chmodSync ${path.normalize('/destDir/someOtherDir/file2.file')} ${(6 << 6) + (6 << 3) + 6}`), // rw-rw-rw-
-                            'should not have chmod file2');
-                        assert(
-                            runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
-                            'should have copied file2');
-                    }, runner, done);
-                });
+            runner.run();
+            assert(
+                runner.succeeded,
+                'should have succeeded');
+            assert(
+                runner.stdOutContained(`creating path: ${path.normalize('/destDir')}`),
+                'should have mkdirP destDir');
+            assert(
+                runner.stdOutContained(`creating path: ${path.normalize('/destDir/someOtherDir')}`),
+                'should have mkdirP someOtherDir');
+            assert(
+                runner.stdOutContained(`chmodSync ${path.normalize('/destDir/someOtherDir/file1.file')} ${(6 << 6) + (6 << 3) + 6}`), // rw-rw-rw-
+                'should have chmod file1');
+            assert(
+                runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file1.file')} to ${path.normalize('/destDir/someOtherDir/file1.file')}`),
+                'should have copied file1');
+            assert(
+                !runner.stdOutContained(`chmodSync ${path.normalize('/destDir/someOtherDir/file2.file')} ${(6 << 6) + (6 << 3) + 6}`), // rw-rw-rw-
+                'should not have chmod file2');
+            assert(
+                runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir/file2.file')} to ${path.normalize('/destDir/someOtherDir/file2.file')}`),
+                'should have copied file2');
+            done();
         });
     }
 

--- a/Tasks/CopyFilesV2/Tests/L0.ts
+++ b/Tasks/CopyFilesV2/Tests/L0.ts
@@ -29,9 +29,6 @@ describe('CopyFiles L0 Suite', function () {
         let tp = path.join(__dirname, 'L0copyAllFiles.js');
         let runner: mocktest.MockTestRunner = new mocktest.MockTestRunner(tp);
         runner.run();
-        // runner.runAsync()
-        // .then(() => {
-        // runValidations(() => {
         assert(
             runner.succeeded,
             'should have succeeded');
@@ -62,8 +59,6 @@ describe('CopyFiles L0 Suite', function () {
         assert(
             runner.stdOutContained(`copying ${path.normalize('/srcDir/someOtherDir2/file3.file')} to ${path.normalize('/destDir/someOtherDir2/file3.file')}`),
             'should have copied dir2 file3');
-        // }, runner, done);
-        // });
         done();
     });
 

--- a/Tasks/CopyFilesV2/package-lock.json
+++ b/Tasks/CopyFilesV2/package-lock.json
@@ -12,10 +12,28 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.11.0",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "^5.0.0-preview.0"
+        "azure-pipelines-task-lib": "5.0.0-preview.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
+      }
+    },
+    "node_modules/@types/concat-stream": {
+      "version": "1.6.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/mocha": {
@@ -31,44 +49,40 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha1-h3KSyqkffBshMDKzRiZQW3RmJMI=",
+      "license": "MIT"
+    },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
-    "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
-      }
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "license": "MIT"
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.0.tgz",
-      "integrity": "sha1-GbkcHwj52ul/aWHMdDFNpRCwTVI=",
+      "version": "5.0.0-preview.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.0.0-preview.0.tgz",
+      "integrity": "sha1-pZt5Dh2Y9RiYB5mMyi4tcevhD5Q=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.7.2",
+        "semver": "^5.1.0",
         "shelljs": "^0.8.5",
+        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
       }
     },
@@ -86,46 +100,167 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha1-I43pNdKippKSjFOMfM+pEGf9Bio=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "license": "Apache-2.0"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha1-pgT6EORDv5jKlCKNnuvMLoosjuE=",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "engines": [
+        "node >= 0.8"
       ],
       "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "license": "MIT",
       "engines": {
-        "node": ">=4.0"
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha1-+bz4dBjOdIUTwMNJS7SOwnDJesw=",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/fs.realpath": {
@@ -134,9 +269,59 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -168,6 +353,18 @@
         "node": "*"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has/-/has-1.0.3.tgz",
@@ -179,18 +376,74 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
+        "has-symbols": "^1.0.3"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
+      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -225,6 +478,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -257,22 +525,16 @@
         "node": "*"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
-    },
-    "node_modules/nodejs-file-downloader": {
-      "version": "4.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
-      "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
-      "license": "ISC",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "https-proxy-agent": "^5.0.0",
-        "mime-types": "^2.1.27",
-        "sanitize-filename": "^1.6.3"
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha1-g3UmXiG8IND6WCwi4bE0hdbgAhM=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/once": {
@@ -282,6 +544,11 @@
       "dependencies": {
         "wrappy": "1"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -296,6 +563,21 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "8.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha1-jLMz0e3rYe8jhp+7ik6gJ5q2Dgo=",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -304,6 +586,42 @@
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
       }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "license": "MIT"
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
@@ -332,14 +650,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
-      "license": "WTFPL OR ISC",
-      "dependencies": {
-        "truncate-utf8-bytes": "^1.0.0"
-      }
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "5.7.2",
@@ -365,6 +694,93 @@
         "node": ">=4"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha1-1rtrN5Asb+9RdOX1M/q0xzKib0I=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha1-Ed2hnVNo5Azp7CvcH7DsvAeQ7Oo=",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "license": "MIT"
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -376,14 +792,62 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/truncate-utf8-bytes": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "license": "WTFPL",
+    "node_modules/sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
+      "license": "MIT",
       "dependencies": {
-        "utf8-byte-length": "^1.0.1"
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
+    },
+    "node_modules/sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
+      "license": "MIT",
+      "dependencies": {
+        "get-port": "^3.1.0"
+      }
+    },
+    "node_modules/then-request": {
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/then-request/node_modules/@types/node": {
+      "version": "8.10.66",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M=",
+      "license": "MIT"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.1.6",
@@ -403,11 +867,11 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
-    "node_modules/utf8-byte-length": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
-      "license": "(WTFPL OR MIT)"
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "3.4.0",

--- a/Tasks/CopyFilesV2/package.json
+++ b/Tasks/CopyFilesV2/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^20.11.0",
     "@types/mocha": "^5.2.7",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^5.0.0-preview.0"
+    "azure-pipelines-task-lib": "5.0.0-preview.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/CopyFilesV2/task.json
+++ b/Tasks/CopyFilesV2/task.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "releaseNotes": "Match pattern consistency.",

--- a/Tasks/CopyFilesV2/task.loc.json
+++ b/Tasks/CopyFilesV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 255,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
**Task name**: CopyFilesV2

**Description**: Changing task-liv version to previous v5.0.0-preview.0 version

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) No

**Tests Performed**: Unit tests for copy task

**Documentation changes required:** (Y/N) N

**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
