### PR TITLE
Upgrade version of basic-ftp package to latest version 

### DIFF
--- a/Tasks/FtpUploadV2/package-lock.json
+++ b/Tasks/FtpUploadV2/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "^4.16.0",
-        "basic-ftp": "^4.6.6"
+        "basic-ftp": "^5.0.5"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -67,11 +67,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/basic-ftp": {
-      "version": "4.6.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/basic-ftp/-/basic-ftp-4.6.6.tgz",
-      "integrity": "sha512-5nTclY5mVxjeFoq9cBTzgQvcM1UfeGTd4hCCvb8AgC88wHMDQCD4UX5hZo2jaiSh96Nf+gFy1joNI9iH639bvQ==",
+      "version": "5.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha1-FKR09f/+zKH09AbxwmsY+AAiWsA=",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/Tasks/FtpUploadV2/package.json
+++ b/Tasks/FtpUploadV2/package.json
@@ -17,7 +17,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "^4.16.0",
-    "basic-ftp": "^4.6.6"
+    "basic-ftp": "^5.0.5"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/FtpUploadV2/task.json
+++ b/Tasks/FtpUploadV2/task.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "FTP Upload: $(rootFolder)",

--- a/Tasks/FtpUploadV2/task.loc.json
+++ b/Tasks/FtpUploadV2/task.loc.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.182.1",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
**Task name**: FtpUpload@2

**Description**: FtpUpload@2 task depends on npm package basic-ftp version 4.6.6 for creation of ftp client. A bug is reported during file upload for basic-ftp package version 4.6.6 https://github.com/patrickjuchli/basic-ftp/issues/205, which is fixed in the latest releases, can be checked in release history https://github.com/patrickjuchli/basic-ftp/releases . To avoid similar issues in FtpUpload@2 task basic-ftp version should be upgraded to latest release

**Risk Assesment(Low/Medium/High)**: low

**Added unit tests:** N

**Tests Performed**: Unit tests executed, tested using canarytest pipeline: https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=151836&view=results
Refactored ftp upload pipeline in azure-pipeline-canary repository as fix to 'Can't detect task folder to replace' issue because of injected code, PR: https://github.com/microsoft/azure-pipelines-canary/pull/1173
Updated canarytest pipeline to use PR branch for testing:
![ftpPipeline](https://github.com/user-attachments/assets/01161184-d2f5-4ba9-aa5a-540811558036)
corresponding build: https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=151837&view=results

**Documentation changes required:** N

**Attached related issue:** [AB#2267269](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2267269)
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
