### PR TITLE
Added delay in VsTestRunSummary for VsTestV3

### DIFF
--- a/Tasks/VsTestV3/make.json
+++ b/Tasks/VsTestV3/make.json
@@ -6,7 +6,7 @@
               "dest": "./"
             },
             {
-              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29739532/TestAgent.zip",
+              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/29810302/TestAgent.zip",
               "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 255,
+    "Patch": 0
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTestV3/task.loc.json
+++ b/Tasks/VsTestV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 255,
+    "Patch": 0
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
Added delay in VsTestRunSummary for VsTestV3

**Task name**: <Name of changed or new pipeline task>

**Description**: Added delay in VsTestRunSummary for VsTestV3.
 https://portal.microsofticm.com/imp/v5/incidents/details/611851609/summary

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** Present in ADO code

**Tests Performed**: Tested on self-hosted agnets in dev-box

![image](https://github.com/user-attachments/assets/9b357975-55a0-4667-909d-69b463789ade)



**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:** https://portal.microsofticm.com/imp/v5/incidents/details/611851609/summary

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
