### PR TITLE
Add classic editor support to testSuite input dropdown for AzureTestPlanV0

### DIFF
--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -186,7 +186,8 @@
       "parameters": {
         "testPlan": "$(testPlan)"
       },
-      "resultSelector": "jsonpath:$.value[*]"
+      "resultSelector": "jsonpath:$.value[*]",
+      "resultTemplate": "{ \"Value\" : \"{{{id}}}\", \"DisplayValue\" : \"{{{id}}} - {{{name}}}\" }"
     }
   ],
   "instanceNameFormat": "Azure Test Plan - $(testSelector)",

--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 259,
-    "Patch": 5
+    "Minor": 256,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 256,
+    "Minor": 261,
     "Patch": 0
   },
   "preview": true,


### PR DESCRIPTION
**Task name**: AzureTestPlanV0

**Description**: add support for the classic UI editor for pipelines.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** N

**Tests Performed**: after a manual upload of the new build, the dropdown looked like this:

![CleanShot 2025-04-14 at 17 07 39](https://github.com/user-attachments/assets/2b2faaa5-5f86-4733-832d-39f93d2b2a25)

and the run didn't show "NaN,NaN,NaN,..." for the testSuite IDs anymore. It worked properly with this change.

**Documentation changes required:** N

**Attached related issue:** N

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected