### PR TITLE
Added az version with Feature Flag enable

### DIFF
--- a/Tasks/AzureCLIV2/azureclitask.ts
+++ b/Tasks/AzureCLIV2/azureclitask.ts
@@ -49,9 +49,16 @@ export class azureclitask {
             tl.mkdirP(cwd);
             tl.cd(cwd);
 
-            const azVersionResult: IExecSyncResult = tl.execSync("az", "--version");
-            Utility.throwIfError(azVersionResult);
-            this.isSupportCertificateParameter = this.isAzVersionGreaterOrEqual(azVersionResult.stdout, "2.66.0");
+            if (tl.getPipelineFeature('UseAzVersion')) {
+                const azVersionResult: IExecSyncResult = tl.execSync("az", "version");
+                Utility.throwIfError(azVersionResult);
+                this.isSupportCertificateParameter = this.isAzVersionGreaterOrEqual(azVersionResult.stdout, "2.66.0");
+                
+            } else {
+                const azVersionResult: IExecSyncResult = tl.execSync("az", "--version");
+                Utility.throwIfError(azVersionResult);
+                this.isSupportCertificateParameter = this.isAzVersionGreaterOrEqual(azVersionResult.stdout, "2.66.0");
+            }
 
             // set az cli config dir
             this.setConfigDirectory();
@@ -199,7 +206,12 @@ export class azureclitask {
 
     private static isAzVersionGreaterOrEqual(azVersionResultOutput, versionToCompare) {
         try {
-            const versionMatch = azVersionResultOutput.match(/azure-cli\s+(\d+\.\d+\.\d+)/);
+            let versionMatch = [];
+            if (tl.getPipelineFeature('UseAzVersion')) {
+                versionMatch = azVersionResultOutput.match(/["']?azure-cli["']?\s*[:\s]\s*["']?(\d+\.\d+\.\d+)["']?/);
+            }else{
+                versionMatch = azVersionResultOutput.match(/azure-cli\s+(\d+\.\d+\.\d+)/);
+            }
 
             if (!versionMatch || versionMatch.length < 2) {
                 tl.error(`Can't parse az version from: ${azVersionResultOutput}`);                

--- a/Tasks/AzureCLIV2/task.json
+++ b/Tasks/AzureCLIV2/task.json
@@ -19,7 +19,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 256,
     "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureCLIV2/task.loc.json
+++ b/Tasks/AzureCLIV2/task.loc.json
@@ -19,7 +19,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 256,
     "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",


### PR DESCRIPTION
**Task name**:  AzureCLIV2

**Description**:  Added a feature flag (FF). When it is enabled, the task will run az version; otherwise, it will run az --version.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**: 

- Unit Tests performed
- Built and uploaded the tasks to test org and validated if the tasks work properly.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:**  [BUG 19039](https://github.com/microsoft/azure-pipelines-tasks/pull/19039)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
