### PR TITLE
Resolve the Kind null issue in the HelmDeployV1 task

### DIFF
--- a/Tasks/HelmDeployV1/src/utils.ts
+++ b/Tasks/HelmDeployV1/src/utils.ts
@@ -74,7 +74,13 @@ export function getManifestsFromRelease(helmCli: helmcli, releaseName: string): 
         helmCli.addArgument('--namespace '.concat(namespace));
 
     const execResult = helmCli.execHelmCommand(true);
+    const skipHelmManifestNullParts = tl.getPipelineFeature("SkipHelmManifestNullParts");
+
     yaml.safeLoadAll(execResult.stdout, (doc) => {
+        if (skipHelmManifestNullParts && doc === null) {
+            return;
+        }
+
         manifests.push(doc);
     });
 

--- a/Tasks/HelmDeployV1/task.json
+++ b/Tasks/HelmDeployV1/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/HelmDeployV1/task.loc.json
+++ b/Tasks/HelmDeployV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**: **HelmDeployV1**

**Description**: This PR adds the pipeline feature **SkipHelmManifestNullParts** to the **HelmDeployV1** task.
This feature allows task to skip the unparsed null parts from **js-yaml** on **helm get manifest** command.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** N

**Tests Performed**:
1. Create [a chart](https://helm.sh/docs/chart_template_guide/getting_started/) that based on Dockerfile with Nodejs http server
2. Add a pdb yaml template with conditional rendering. Please refer to [the example](https://stackoverflow.com/questions/73309521/azure-devops-helm-chart-warningcapturing-deployment-metadata-failed-with)
3. Enable/disable the feature **DistributedTask.Tasks.SkipHelmManifestNullParts** to resolve/encounter the error

**Documentation changes required:** N

**Attached related issue:** [AB#2270972](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2270972)
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
