### PR TITLE
Replace deprecated Buffer method with Buffer.from() to resolve warning

### DIFF
--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/FileEncoding.ts
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/operations/FileEncoding.ts
@@ -17,19 +17,19 @@ export class FileEncoding {
 function detectFileEncodingWithBOM(buffer: Buffer): FileEncoding {
     tl.debug('Detecting file encoding using BOM');
     var type: string;
-    if (buffer.slice(0, 3).equals(new Buffer([239, 187, 191]))) {
+    if (buffer.slice(0, 3).equals(Buffer.from([239, 187, 191]))) {
         type = 'utf-8';
     }
-    else if (buffer.slice(0, 4).equals(new Buffer([255, 254, 0, 0]))) {
+    else if (buffer.slice(0, 4).equals(Buffer.from([255, 254, 0, 0]))) {
         type = 'utf-32le';
     }
-    else if (buffer.slice(0, 2).equals(new Buffer([254, 255]))) {
+    else if (buffer.slice(0, 2).equals(Buffer.from([254, 255]))) {
         type = 'utf-16be';
     }
-    else if (buffer.slice(0, 2).equals(new Buffer([255, 254]))) {
+    else if (buffer.slice(0, 2).equals(Buffer.from([255, 254]))) {
         type = 'utf-16le';
     }
-    else if (buffer.slice(0, 4).equals(new Buffer([0, 0, 254, 255]))) {
+    else if (buffer.slice(0, 4).equals(Buffer.from([0, 0, 254, 255]))) {
         type = 'utf-32be';
     }
     else {

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 256,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
**Task name**:  AzureResourceManagerTemplateDeploymentV3

**Description**:  Replaced the deprecated Buffer() constructor with Buffer.from() to eliminate the warning message. Buffer.from() is the recommended method for creating buffers from existing data and ensures compatibility with the latest Node.js versions.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**:

- Unit Tests performed
- Built and uploaded the tasks to test org and validated if the tasks work properly.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue: [BUG 19821](https://github.com/microsoft/azure-pipelines-tasks/issues/19821)

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
