### PR TITLE
Update the DockerV2 task the docker common package dependency

### DIFF
--- a/Tasks/DockerV2/package-lock.json
+++ b/Tasks/DockerV2/package-lock.json
@@ -11,7 +11,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-docker-common": "2.254.0",
+        "azure-pipelines-tasks-docker-common": "2.256.0",
         "azure-pipelines-tasks-utility-common": "^3.238.0",
         "del": "2.2.0",
         "esprima": "2.7.1",
@@ -181,9 +181,9 @@
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/azure-pipelines-tasks-docker-common": {
-      "version": "2.254.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.254.0.tgz",
-      "integrity": "sha1-PkZ5LxSk9eiaSkPYbWg2YajYaG8=",
+      "version": "2.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.256.0.tgz",
+      "integrity": "sha1-ZDDrAbxIWWJ1USrOqLhI3cgCf4g=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",

--- a/Tasks/DockerV2/package.json
+++ b/Tasks/DockerV2/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-docker-common": "2.254.0",
+    "azure-pipelines-tasks-docker-common": "2.256.0",
     "azure-pipelines-tasks-utility-common": "^3.238.0",
     "del": "2.2.0",
     "esprima": "2.7.1",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.172.0",
   "demands": [],

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 254,
-    "Patch": 1
+    "Minor": 256,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.172.0",
   "demands": [],


### PR DESCRIPTION
**Task name**: DockerV2

**Description**: Update the **DockerV2** task the **docker** common package dependency to **[v2.256.0](https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/445)** to hide the docker execution output on error from the build page.

**Risk Assesment**: Low

**Added unit tests:** N

**Tests Performed**: Run the task using an invalid Dockerfile, both with and without **DistributedTask.Tasks.HideDockerExecTaskLogIssueErrorOutput** pipeline feature enabled.
The Dockerfile error output should be hidden from the build page when the feature is enabled.

**Documentation changes required:** N

**Attached related issue:** #20968
[AB#2270930](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2270930)

> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [x] Checked that applied changes work as expected
