### PR TITLE
Update webdeployment-common package in tasks

### DIFF
--- a/Tasks/AzureFunctionAppContainerV1/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureFunctionAppContainerV1/_buildConfigs/Node20/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "moment": "2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureFunctionAppContainerV1/package-lock.json
+++ b/Tasks/AzureFunctionAppContainerV1/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "moment": "2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -255,9 +255,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureFunctionAppContainerV1/package-lock.json
+++ b/Tasks/AzureFunctionAppContainerV1/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "moment": "2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureFunctionAppContainerV1/package.json
+++ b/Tasks/AzureFunctionAppContainerV1/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "moment": "2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureFunctionAppContainerV1/package.json
+++ b/Tasks/AzureFunctionAppContainerV1/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "moment": "2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureFunctionAppContainerV1/task.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppContainerV1/task.loc.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV1/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureFunctionAppV1/_buildConfigs/Node20/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV1/package-lock.json
+++ b/Tasks/AzureFunctionAppV1/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.3",
         "q": "1.4.1",
@@ -318,9 +318,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureFunctionAppV1/package-lock.json
+++ b/Tasks/AzureFunctionAppV1/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.3",
         "q": "1.4.1",
@@ -318,9 +318,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureFunctionAppV1/package.json
+++ b/Tasks/AzureFunctionAppV1/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV1/package.json
+++ b/Tasks/AzureFunctionAppV1/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV2/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureFunctionAppV2/_buildConfigs/Node20/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV2/package-lock.json
+++ b/Tasks/AzureFunctionAppV2/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureFunctionAppV2/package-lock.json
+++ b/Tasks/AzureFunctionAppV2/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -325,9 +325,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureFunctionAppV2/package.json
+++ b/Tasks/AzureFunctionAppV2/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV2/package.json
+++ b/Tasks/AzureFunctionAppV2/package.json
@@ -24,7 +24,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV2/task.json
+++ b/Tasks/AzureFunctionAppV2/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "What's new in version 2.* <br /> Removed WAR Deploy Support, setting Web.Config options, and the option for the Startup command for Linux Azure Function Apps.",

--- a/Tasks/AzureFunctionAppV2/task.loc.json
+++ b/Tasks/AzureFunctionAppV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureMysqlDeploymentV1/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/_buildConfigs/Node20/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.245.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "compress-commons": "1.1.0",
         "crc32-stream": "1.0.0",
         "moment": "^2.29.4",
@@ -235,9 +235,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.245.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "compress-commons": "1.1.0",
         "crc32-stream": "1.0.0",
         "moment": "^2.29.4",
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureMysqlDeploymentV1/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.245.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureMysqlDeploymentV1/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.245.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/AzureRmWebAppDeploymentV3/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/_buildConfigs/Node20/package.json
@@ -24,7 +24,7 @@
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
@@ -16,7 +16,7 @@
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
         "decompress-zip": "^0.3.3",
         "ltx": "2.8.0",
         "moment": "^2.29.4",
@@ -251,9 +251,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
@@ -16,7 +16,7 @@
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "decompress-zip": "^0.3.3",
         "ltx": "2.8.0",
         "moment": "^2.29.4",
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureRmWebAppDeploymentV3/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package.json
@@ -24,7 +24,7 @@
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureRmWebAppDeploymentV3/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package.json
@@ -24,7 +24,7 @@
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",
     "moment": "^2.29.4",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureRmWebAppDeploymentV4/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/_buildConfigs/Node20/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.254.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.255.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.255.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.255.0.tgz",
-      "integrity": "sha1-UK0jnAf5p75pX638DQ1SfUZ9O4U=",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.255.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 256,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureRmWebAppDeploymentV5/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/_buildConfigs/Node20/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "uuid": "3.1.0",
@@ -230,9 +230,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureRmWebAppDeploymentV5/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV5/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "uuid": "3.1.0",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 255,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureWebAppContainerV1/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureWebAppContainerV1/_buildConfigs/Node20/package.json
@@ -25,7 +25,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "xml2js": "^0.6.0"

--- a/Tasks/AzureWebAppContainerV1/package-lock.json
+++ b/Tasks/AzureWebAppContainerV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "xml2js": "^0.6.0"
@@ -260,9 +260,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureWebAppContainerV1/package-lock.json
+++ b/Tasks/AzureWebAppContainerV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "xml2js": "^0.6.0"
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureWebAppContainerV1/package.json
+++ b/Tasks/AzureWebAppContainerV1/package.json
@@ -25,7 +25,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "xml2js": "^0.6.0"

--- a/Tasks/AzureWebAppContainerV1/package.json
+++ b/Tasks/AzureWebAppContainerV1/package.json
@@ -25,7 +25,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "xml2js": "^0.6.0"

--- a/Tasks/AzureWebAppContainerV1/task.json
+++ b/Tasks/AzureWebAppContainerV1/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureWebAppContainerV1/task.loc.json
+++ b/Tasks/AzureWebAppContainerV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureWebAppV1/_buildConfigs/Node20/package.json
+++ b/Tasks/AzureWebAppV1/_buildConfigs/Node20/package.json
@@ -25,7 +25,7 @@
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureWebAppV1/package-lock.json
+++ b/Tasks/AzureWebAppV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-task-lib": "^4.13.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
-        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -303,9 +303,9 @@
       "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA=="
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/AzureWebAppV1/package-lock.json
+++ b/Tasks/AzureWebAppV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-task-lib": "^4.13.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
-        "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -303,9 +303,10 @@
       "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA=="
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/AzureWebAppV1/package.json
+++ b/Tasks/AzureWebAppV1/package.json
@@ -25,7 +25,7 @@
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
-    "azure-pipelines-tasks-webdeployment-common": "4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureWebAppV1/package.json
+++ b/Tasks/AzureWebAppV1/package.json
@@ -25,7 +25,7 @@
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
-    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureWebAppV1/task.json
+++ b/Tasks/AzureWebAppV1/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/AzureWebAppV1/task.loc.json
+++ b/Tasks/AzureWebAppV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 257,
     "Patch": 0
   },
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/FileTransformV1/_buildConfigs/Node20/package.json
+++ b/Tasks/FileTransformV1/_buildConfigs/Node20/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV1/package-lock.json
+++ b/Tasks/FileTransformV1/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/FileTransformV1/package-lock.json
+++ b/Tasks/FileTransformV1/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/FileTransformV1/package.json
+++ b/Tasks/FileTransformV1/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV1/package.json
+++ b/Tasks/FileTransformV1/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV1/task.json
+++ b/Tasks/FileTransformV1/task.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "instanceNameFormat": "File Transform: $(Package)",
   "groups": [

--- a/Tasks/FileTransformV1/task.loc.json
+++ b/Tasks/FileTransformV1/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "groups": [

--- a/Tasks/FileTransformV2/_buildConfigs/Node20/package.json
+++ b/Tasks/FileTransformV2/_buildConfigs/Node20/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "4.254.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/package-lock.json
+++ b/Tasks/FileTransformV2/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/FileTransformV2/package-lock.json
+++ b/Tasks/FileTransformV2/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "4.254.0",
+        "azure-pipelines-tasks-webdeployment-common": "4.256.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.254.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.254.0.tgz",
-      "integrity": "sha1-F+3Yo+B7OYMIUAk0VBw/c1bbLMg=",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/FileTransformV2/package.json
+++ b/Tasks/FileTransformV2/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/package.json
+++ b/Tasks/FileTransformV2/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "4.254.0",
+    "azure-pipelines-tasks-webdeployment-common": "4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/_buildConfigs/Node20/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/_buildConfigs/Node20/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.0.tgz",
-      "integrity": "sha512-S/l0Ag22Fc/aq8DvA8MdJ5MwVUzbar/i/aJntyRs8kCKqE7NhE5W1I/wIvVBQe3GDaQWOzh4vHmkBn8Sm5kzWw==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "q": "1.4.1"
       },
       "devDependencies": {
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
@@ -20,7 +20,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "q": "1.4.1"
   },
   "devDependencies": {

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/_buildConfigs/Node20/package.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/_buildConfigs/Node20/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "4.3.1",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "normalize-path": "2.0.1",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
         "azure-pipelines-task-lib": "4.3.1",
-        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+        "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "compress-commons": "1.1.0",
         "crc32-stream": "1.0.0",
         "normalize-path": "2.0.1",
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
-      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "version": "4.257.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.257.0.tgz",
+      "integrity": "sha1-h/80cAuUnxF4dT7KqJUoP2NF/G0=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^20.3.1",
         "@types/q": "1.0.7",
         "azure-pipelines-task-lib": "4.3.1",
-        "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
         "compress-commons": "1.1.0",
         "crc32-stream": "1.0.0",
         "normalize-path": "2.0.1",
@@ -163,9 +163,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.243.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.243.1.tgz",
-      "integrity": "sha512-FWjNQDguvLmqfKgCYxcevgvid5RJdv3FrqyrAmMfIe0gLOpyp57yjQ6QCaO5GFc3niWV/MgIxadqlnwrq2haUQ==",
+      "version": "4.256.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.256.0.tgz",
+      "integrity": "sha1-EAdNJki8Lnme+ZRjyGfzLHgyDFE=",
+      "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "4.3.1",
-    "azure-pipelines-tasks-webdeployment-common": "^4.243.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "normalize-path": "2.0.1",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^20.3.1",
     "@types/q": "1.0.7",
     "azure-pipelines-task-lib": "4.3.1",
-    "azure-pipelines-tasks-webdeployment-common": "^4.256.0",
+    "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",
     "normalize-path": "2.0.1",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 246,
-    "Patch": 1
+    "Minor": 257,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",


### PR DESCRIPTION
**Task name**: AzureFunctionAppContainerV1,
AzureFunctionAppV1,
AzureFunctionAppV2,
AzureMysqlDeploymentV1,
AzureRmWebAppDeploymentV3,
AzureRmWebAppDeploymentV4,
AzureRmWebAppDeploymentV5,
AzureWebAppContainerV1,
AzureWebAppV1,
FileTransformV1,
FileTransformV2,
IISWebAppDeploymentOnMachineGroupV0,
MysqlDeploymentOnMachineGroupV1

**Description**: Update the common package in the tasks to address the CVE issue related to 7zip that is used in the webdeployment-common package

**Risk Assesment(Low/Medium/High)**: **Medium**

**Added unit tests:** N

**Tests Performed**: N

**Documentation changes required:** N

**Attached related issue:** [AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409), #20993
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [x] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
