### PR TITLE
Changes for Supporting Global Version

### DIFF
--- a/BuildConfigGen/TaskVersion.cs
+++ b/BuildConfigGen/TaskVersion.cs
@@ -36,6 +36,11 @@ internal class TaskVersion : IComparable<TaskVersion>, IEquatable<TaskVersion>
 
     public TaskVersion(int major, int minor, int overidePatch)
     {
+        if (overidePatch < 0)
+        {
+            throw new Exception($"Bug, overridePatch must be >=0, got {overidePatch}");
+        }
+
         Major = major;
         Minor = minor;
         Patch = overidePatch;


### PR DESCRIPTION
**Task name**: None, Changes are to the BuildConfigGen project.

**Description**:  PR contains changes to update the Globalversion when any task is updated.

**Risk Assesment(Low/Medium/High)**: Low

**Added unit tests:** (Y/N) <Please mark if unit tests were added or updated according changes>

**Tests Performed**: 
1. Ran the `node make.js build --task` on couple of tasks to validate.
2. Ran the `node make.js build --task <task> --includeLocalPackagesBuildConfig` to validate.

**Documentation changes required:** (Y/N) <Please mark if documentation changes are required>

**Attached related issue:** (Y/N) <Please add link to related issue here>
> Note: For adding link to ADO WI see [here](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops).

**Checklist**:
- [ ] Task version was bumped - please check [instruction](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md) how to do it
- [ ] Checked that applied changes work as expected
