### PR TITLE
Update the check tasks versions step's condition in CI

### DIFF
--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 255,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -108,7 +108,6 @@ steps:
 
 - script: node ./ci/check-downgrading.js --task "$(task_pattern_fordowngradingcheck)" --sprint $(currentSprint) --week $(currentSprintWeek)
   displayName: Check for downgrading tasks
-  # remove SourceBranch condition after merging users/merlynop/node20merge-2 ; see https://github.com/microsoft/azure-pipelines-tasks/pull/20819
   condition: |
     and(
       succeeded(),
@@ -116,7 +115,7 @@ steps:
       ne(variables['COURTESY_PUSH'], 'true'),
       eq(variables['build.reason'], 'PullRequest'),
       eq(variables['System.PullRequest.TargetBranch'], 'master'),
-      ne(variables['System.PullRequest.SourceBranch'], 'users/merlynop/node20merge-2')
+      not(contains(variables['BRANCH_EXCLUDED_FROM_VERSION_CHECK'], variables['System.PullRequest.SourceBranch']))
     )
 
 # Clean


### PR DESCRIPTION
### **Description**
Update the check tasks versions step's condition to specify which branches shouldn't be cheked

**Related WI**: [AB#2277360](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2277360)

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
