### PR TITLE
Update ubuntu version for canary tests CI check

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -24,7 +24,7 @@ jobs:
 - job: detect_changes
   displayName: Detect changes
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-22.04
   steps:
   - script: |
       git fetch origin master

--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -6,7 +6,7 @@ parameters:
 
 variables:
 - name: includeLocalPackagesBuildConfigParameter
-  ${{ if eq(parameters.includeLocalPackagesBuildConfig, true) }}: 
+  ${{ if eq(parameters.includeLocalPackagesBuildConfig, true) }}:
     value: '--includeLocalPackagesBuildConfig'
   ${{ else }}:
     value: ''
@@ -24,7 +24,7 @@ jobs:
 - job: detect_changes
   displayName: Detect changes
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-latest
   steps:
   - script: |
       git fetch origin master


### PR DESCRIPTION
**Description:** [Ubuntu 20.04 has reached its deprecation date as of April 30th](https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/).
We need to upgrade canary check CI in Azure Pipelines Tasks repository to the next or latest supported version of Ubuntu.

**Related WI:** [AB#2277385](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2277385)
