### PR TITLE
#21020 - Fixes the typo: FileTranformation -> FileTransformation

### DIFF
--- a/Tasks/FileTransformV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/en-US/resources.resjson
@@ -47,5 +47,5 @@
   "loc.messages.SkippedUpdatingFile": "Skipped Updating file: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. Whether the Transformation is already applied for the MSBuild generated package during build. If yes, remove the <DependentUpon> tag for each config in the csproj file and rebuild. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. Ensure that the config file and transformation files are present in the same folder inside the package.",
-  "loc.messages.FileTranformationNotEnabled": "File Tranformation is not enabled. Please provide one of the following : XML Tranformation rules or JSON/XML target files for variable substitution."
+  "loc.messages.FileTransformationNotEnabled": "File Transformation is not enabled. Please provide one of the following : XML Tranformation rules or JSON/XML target files for variable substitution."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/es-ES/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "Actualización del archivo omitida: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. Si la transformación ya se ha aplicado para el paquete generado por MSBuild durante la compilación. Si es así, quite la etiqueta <DependentUpon> para cada configuración del archivo csproj y compile de nuevo. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. Asegúrese de que el archivo de configuración y los archivos de transformación están presentes en la misma carpeta dentro del paquete.",
-  "loc.messages.FileTranformationNotEnabled": "La transformación de archivos no está habilitada. Proporcione una de las opciones siguientes para la sustitución de variables: Reglas de transformación XML o Archivos de destino JSON/XML."
+  "loc.messages.FileTransformationNotEnabled": "La transformación de archivos no está habilitada. Proporcione una de las opciones siguientes para la sustitución de variables: Reglas de transformación XML o Archivos de destino JSON/XML."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/fr-FR/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "Mise à jour du fichier ignorée : %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. La transformation est-elle déjà appliquée pour le package MSBuild généré durant la build ? Si la réponse est oui, supprimez la balise <DependentUpon> pour chaque configuration dans le fichier csproj, puis effectuez une regénération. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. Vérifiez que le fichier config et les fichiers de transformation sont présents dans le même dossier à l'intérieur du package.",
-  "loc.messages.FileTranformationNotEnabled": "La transformation de fichier n'est pas activée. Indiquez l'un des éléments suivants : règles de transformation XML ou fichiers cibles JSON/XML pour la substitution de variable."
+  "loc.messages.FileTransformationNotEnabled": "La transformation de fichier n'est pas activée. Indiquez l'un des éléments suivants : règles de transformation XML ou fichiers cibles JSON/XML pour la substitution de variable."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/it-IT/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "L'aggiornamento del file %s è stato ignorato",
   "loc.messages.FailedToApplyTransformationReason1": "1. Verificare se la trasformazione è già stata applicata per il pacchetto generato da MSBuild durante la compilazione. In caso affermativo, rimuovere il tag <DependentUpon> per ogni file config nel file csproj e ricompilare. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. Assicurarsi che il file config e i file di trasformazione siano presenti nella stessa cartella all'interno del pacchetto.",
-  "loc.messages.FileTranformationNotEnabled": "La trasformazione file non è abilitata. Specificare uno dei valori seguenti: Regole di trasformazione XML o File di destinazione JSON/XML per la sostituzione delle variabili."
+  "loc.messages.FileTransformationNotEnabled": "La trasformazione file non è abilitata. Specificare uno dei valori seguenti: Regole di trasformazione XML o File di destinazione JSON/XML per la sostituzione delle variabili."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/ja-JP/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "ファイルの更新がスキップされました: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. ビルド中、MSBuild によって生成されたパッケージに対して変換が既に適用されたかどうか。適用された場合は、csproj ファイル内の各構成の <DependentUpon> タグを削除してから、リビルドします。",
   "loc.messages.FailedToApplyTransformationReason2": "2. 構成ファイルと変換ファイルがパッケージ内の同じフォルダーに存在すること。",
-  "loc.messages.FileTranformationNotEnabled": "ファイル変換が有効になっていません。XML 変換ルールか、変数の置換用の JSON または XML ターゲット ファイルのいずれか一方を指定してください。"
+  "loc.messages.FileTransformationNotEnabled": "ファイル変換が有効になっていません。XML 変換ルールか、変数の置換用の JSON または XML ターゲット ファイルのいずれか一方を指定してください。"
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/ko-KR/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "파일 %s 업데이트를 건너뜀",
   "loc.messages.FailedToApplyTransformationReason1": "1. 빌드 중 생성된 MSBuild 패키지에 대해 변환이 이미 적용되었는지 여부를 확인합니다. 그런 경우 csproj 파일에서 각 구성에 대해 <DependentUpon> 태그를 제거하고 다시 빌드합니다. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. 구성 파일 및 변환 파일이 패키지 내의 동일한 폴더에 있는지 확인합니다.",
-  "loc.messages.FileTranformationNotEnabled": "파일 변환을 사용할 수 없습니다. XML 변환 규칙 또는 변수 대체를 위한 JSON/XML 대상 파일 중 하나를 제공하세요."
+  "loc.messages.FileTransformationNotEnabled": "파일 변환을 사용할 수 없습니다. XML 변환 규칙 또는 변수 대체를 위한 JSON/XML 대상 파일 중 하나를 제공하세요."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/ru-RU/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "Пропущенный файл обновления: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. Применено ли преобразование к созданному пакету MSBuild во время сборки. Если это так, удалите тег <DependentUpon> для каждой конфигурации в CSPROJ-файле и повторите сборку. ",
   "loc.messages.FailedToApplyTransformationReason2": "2. Убедитесь, что файлы конфигурации и преобразования находятся в одной и той же папке в пакете.",
-  "loc.messages.FileTranformationNotEnabled": "Преобразование файлов не включено. Укажите одно из следующих: правила преобразования XML или целевые файлы JSON/XML для замены переменных."
+  "loc.messages.FileTransformationNotEnabled": "Преобразование файлов не включено. Укажите одно из следующих: правила преобразования XML или целевые файлы JSON/XML для замены переменных."
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/zh-CN/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "已跳过更新文件: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. 在生成期间是否已对 MSBuild 生成的包应用转换。如果已应用，请删除 csproj 文件中每个配置的 <DependentUpon> 标记，然后重新生成。",
   "loc.messages.FailedToApplyTransformationReason2": "2. 确保配置文件和转换文件位于包内的同一个文件夹中。",
-  "loc.messages.FileTranformationNotEnabled": "未启用文件转换。请提供以下项之一: XML 转换规则或 JSON/XML 目标文件，以进行变量替换。"
+  "loc.messages.FileTransformationNotEnabled": "未启用文件转换。请提供以下项之一: XML 转换规则或 JSON/XML 目标文件，以进行变量替换。"
 }

--- a/Tasks/FileTransformV2/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/FileTransformV2/Strings/resources.resjson/zh-TW/resources.resjson
@@ -43,5 +43,5 @@
   "loc.messages.SkippedUpdatingFile": "已跳過更新檔案: %s",
   "loc.messages.FailedToApplyTransformationReason1": "1. 是否已對建置期間由 MSBuild 產生的套件套用轉換。若已套用，請移除 csproj 檔案中每項設定的 <DependentUpon> 標記，然後重建。",
   "loc.messages.FailedToApplyTransformationReason2": "2. 確認組態檔與轉換檔皆位於套件內的同一個資料夾中。",
-  "loc.messages.FileTranformationNotEnabled": "未啟用檔案轉換功能。請提供下列其中一項: XML 轉換規則或 JSON/XML 目標檔案，以替代變數。"
+  "loc.messages.FileTransformationNotEnabled": "未啟用檔案轉換功能。請提供下列其中一項: XML 轉換規則或 JSON/XML 目標檔案，以替代變數。"
 }

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -127,6 +127,6 @@
     "SkippedUpdatingFile": "Skipped Updating file: %s",
     "FailedToApplyTransformationReason1": "1. Whether the Transformation is already applied for the MSBuild generated package during build. If yes, remove the <DependentUpon> tag for each config in the csproj file and rebuild. ",
     "FailedToApplyTransformationReason2": "2. Ensure that the config file and transformation files are present in the same folder inside the package.",
-    "FileTranformationNotEnabled": "File Tranformation is not enabled. Please provide one of the following : XML Tranformation rules or JSON/XML target files for variable substitution."
+    "FileTransformationNotEnabled": "File Transformation is not enabled. Please provide one of the following : XML Transformation rules or JSON/XML target files for variable substitution."
   }
 }

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -127,6 +127,6 @@
     "SkippedUpdatingFile": "ms-resource:loc.messages.SkippedUpdatingFile",
     "FailedToApplyTransformationReason1": "ms-resource:loc.messages.FailedToApplyTransformationReason1",
     "FailedToApplyTransformationReason2": "ms-resource:loc.messages.FailedToApplyTransformationReason2",
-    "FileTranformationNotEnabled": "ms-resource:loc.messages.FileTranformationNotEnabled"
+    "FileTransformationNotEnabled": "ms-resource:loc.messages.FileTransformationNotEnabled"
   }
 }

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 254,
+    "Minor": 257,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
Fixes two similar typos in an error message in FileTransform@2

loc.messages.FileTranformationNotEnabled -> loc.messages.FileTransformationNotEnabled
"File Tranformation is not enabled" -> "File Transformation is not enabled"

---

### **Risk Assessment** (Low / Medium / High)  
Low - just fixes a typo

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
None

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
