### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Check Deprecation.md file for the list of task which are no longer supported.
 
 See the documentation for [Continuous integration and deployment](https://aka.ms/tfbuild).
 
+Use the NuGet Authenticate task(https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) before running tasks NuGetRestore, NuGetCommand and VSBuild that need authentication.
+
 ## Writing Tasks
 
 If you need custom functionality in your build/release, it is usually simpler to use the existing script running tasks such as the PowerShell or Bash tasks.  Writing a new task may be appropriate if you need deeper integration or reusability in many build definitions

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check Deprecation.md file for the list of task which are no longer supported.
 
 See the documentation for [Continuous integration and deployment](https://aka.ms/tfbuild).
 
-Use the NuGet Authenticate task(https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) before running tasks NuGetRestore, NuGetCommand and VSBuild that need authentication.
+Use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task before running tasks NuGetRestore, NuGetCommand and VSBuild that need authentication.
 
 ## Writing Tasks
 


### PR DESCRIPTION
### **Context**
_Describe the context or motivation for this PR. Include links to any related Azure DevOps Work Items or GitHub issues._  
Fixes [AB#2237708](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2237708) 
VSBuild and NuGet restore were failing because of expired credentials. NuGetAuthenticate task should be used before them to ensure valid credentials are always applied.
📌 [How to link to ADO Work Items](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops)

---

### **Task Name**
_Name of the updated or newly created pipeline task._None

---

### **Description**
_Summarize the changes made in this PR clearly and concisely: Updated the README file to clearly state that the NuGetAuthenticate task should be used to ensure valid credentials are always applied.

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility): Low

---

### **Unit Tests Added or Updated** (Yes / No)  
_Indicate whether unit tests were added or modified to reflect these changes: No

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated: Yes

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
