### PR TITLE
[DotNetCoreCLIV2] Switched to Native Promises - dotnet pack - AB#2280370

### DIFF
--- a/Tasks/DotNetCoreCLIV2/packcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/packcommand.ts
@@ -135,7 +135,7 @@ export async function run(): Promise<void> {
     }
 }
 
-function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: string, nobuild: boolean, includeSymbols: boolean, includeSource: boolean, version: string, properties: string[], verbosity: string): Q.Promise<number> {
+async function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: string, nobuild: boolean, includeSymbols: boolean, includeSource: boolean, version: string, properties: string[], verbosity: string): Promise<number> {
     let dotnet = tl.tool(dotnetPath);
 
     dotnet.arg("pack");
@@ -175,5 +175,5 @@ function dotnetPackAsync(dotnetPath: string, packageFile: string, outputDir: str
         dotnet.arg(verbosity);
     }
 
-    return dotnet.exec({ cwd: path.dirname(packageFile) } as IExecOptions);
+    return dotnet.execAsync({ cwd: path.dirname(packageFile) } as IExecOptions) as Promise<number>;
 }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 256,
-    "Patch": 3
+    "Minor": 257,
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 256,
-    "Patch": 3
+    "Minor": 257,
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
Switching from `Q.Promise` to native async/await to prevent intermittent task hangs. Native Promises integrate better with the Node.js event loop, ensuring proper async flow and clean task completion. This change improves reliability and avoids issues caused by mixing legacy Q with modern async patterns.

---

### **Task Name**
DotNetCoreCLIV2

---

### **Description**
1. Refactored the `dotnetPackAsync` to return a native promise
2. Incremented the task version

---

### **Risk Assessment** (Low / Medium / High)  
Low, only switches from Q to Native promises.

---

### **Unit Tests Added or Updated** (Yes / No)  
No. Existing unit tests cover the flow.

---

### **Additional Testing Performed**
1. Create a private organization on Azure DevOps.
3. Compile and pack the task locally.
4. Push the task to the private organization using `tfx cli`.
5. Run a pipeline.

![image](https://github.com/user-attachments/assets/739d4fb6-0b70-4a6e-baf9-225483d2eeb3)

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
