### PR TITLE
Handle the case where `projects` input isn't set for test command in MTP mode

### DIFF
--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -188,7 +188,7 @@ export class dotNetExe {
             const dotnet = tl.tool(dotnetPath);
             dotnet.arg(this.command);
 
-            if (isMTP) {
+            if (isMTP && projectFile.length > 0) {
                 // https://github.com/dotnet/sdk/blob/cbb8f75623c4357919418d34c53218ca9b57358c/src/Cli/dotnet/Commands/Test/CliConstants.cs#L34
                 if (projectFile.endsWith(".proj") || projectFile.endsWith(".csproj") || projectFile.endsWith(".vbproj") || projectFile.endsWith(".fsproj")) {
                     dotnet.arg("--project");


### PR DESCRIPTION
Currently, this fails with:

> ##[error]Project file '' has an unrecognized extension.

### **Context**
_Describe the context or motivation for this PR. Include links to any related Azure DevOps Work Items or GitHub issues._  
📌 [How to link to ADO Work Items](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops)

---

### **Task Name**
_Name of the updated or newly created pipeline task._

---

### **Description**
_Summarize the changes made in this PR clearly and concisely._

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility)._

---

### **Unit Tests Added or Updated** (Yes / No)  
_Indicate whether unit tests were added or modified to reflect these changes._

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated._

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
