### PR TITLE
Add --kind to AzureContainerAppsV1 to support Azure Function Apps

### DIFF
--- a/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -30,6 +30,8 @@
   "loc.input.help.containerAppEnvironment": "The name of the Azure Container App environment to use with the application. If not provided, an existing environment in the resource group of the Container App will be used, otherwise, an environment will be created in the form of `<container-app-name>-env`.",
   "loc.input.label.runtimeStack": "Application runtime stack",
   "loc.input.help.runtimeStack": "The platform version stack that the application runs in when deployed to the Azure Container App. This should be provided in the form of `<platform>:<version>`. If not provided, this value is determined by Oryx based on the contents of the provided application. Please view the following document for more information on the supported runtime stacks for Oryx: https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md",
+  "loc.input.label.kind": "Container App kind",
+  "loc.input.help.kind": "Set to `functionapp` to get built in support and autoscaling to run Azure functions on Azure Container apps.",
   "loc.input.label.targetPort": "Application target port",
   "loc.input.help.targetPort": "The designated port for the application to run on. If no value is provided and the builder is used to build the runnable application image, the target port will be set to 80 for Python applications and 8080 for all other platform applications. If no value is provided when creating a Container App, the target port will default to 80. Note: when using this task to update a Container App, the target port may be updated if not provided based on changes to the ingress property.",
   "loc.input.label.location": "Location of the Container App",

--- a/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
@@ -103,6 +103,7 @@ export class azurecontainerapps {
     // Miscellaneous properties
     private static imageToBuild: string;
     private static runtimeStack: string;
+    private static kind: string;
     private static ingress: string;
     private static targetPort: string;
     private static shouldUseUpdateCommand: boolean;
@@ -415,6 +416,7 @@ export class azurecontainerapps {
         // Get the ingress inputs
         this.ingress = tl.getInput('ingress', false);
         this.targetPort = tl.getInput('targetPort', false);
+        this.kind = tl.getInput('kind', false);
 
         // If both ingress and target port were not provided for an existing Container App, or if ingress is to be disabled,
         // use the 'update' command, otherwise we should use the 'up' command that performs a PATCH operation on the ingress properties.
@@ -471,6 +473,11 @@ export class azurecontainerapps {
                 // Note: this step should be skipped if we're updating an existing Container App (ingress is enabled via a separate command)
                 this.commandLineArgs.push(`--ingress ${this.ingress}`);
                 this.commandLineArgs.push(`--target-port ${this.targetPort}`);
+            }
+
+            // Set the value of kind if provided
+            if (!util.isNullOrEmpty(this.kind)) {
+                this.commandLineArgs.push(`--kind ${this.kind}`);
             }
         }
 

--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 258,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
@@ -126,6 +126,13 @@
       "label": "Application runtime stack",
       "required": false,
       "helpMarkDown": "The platform version stack that the application runs in when deployed to the Azure Container App. This should be provided in the form of `<platform>:<version>`. If not provided, this value is determined by Oryx based on the contents of the provided application. Please view the following document for more information on the supported runtime stacks for Oryx: https://github.com/microsoft/Oryx/blob/main/doc/supportedRuntimeVersions.md"
+    },
+    {
+      "name": "kind",
+      "type": "string",
+      "label": "Container App kind",
+      "required": false,
+      "helpMarkDown": "Set to `functionapp` to get built in support and autoscaling to run Azure functions on Azure Container apps."
     },
     {
       "name": "targetPort",

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 255,
+    "Minor": 258,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
@@ -126,6 +126,13 @@
       "label": "ms-resource:loc.input.label.runtimeStack",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.runtimeStack"
+    },
+    {
+      "name": "kind",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.kind",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.kind"
     },
     {
       "name": "targetPort",


### PR DESCRIPTION
### **Context**

Azure Containers now support a new native hosting model for Azure Functions. Adding support for this in AzureContainerAppsV1.
📌 [Announcing Native Azure Functions Support in Azure Container Apps](https://techcommunity.microsoft.com/blog/appsonazureblog/announcing-native-azure-functions-support-in-azure-container-apps/4414039)

---

### **Task Name**
AzureContainerAppsV1

---

### **Description**
Add the `kind` input so `--kind functionapp` can be passed into `az containerapp create`

---

### **Risk Assessment** (Low / Medium / High)  
Low & backwards compatible - The kind field is not required and will have no impact if not defined.

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
None

---

### **Documentation Changes Required** (Yes / No)  
Yes

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
