### PR TITLE
Fix xcode double build when setting packageApp true

### DIFF
--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -701,8 +701,8 @@ describe('Xcode L0 Suite', function () {
         assert(tr.invokedToolCount === 6, 'Should have ran 6 command lines.');
     });
 
-    it('should skip initial build when actions is only build and packageApp is true', async function () {
-        let tp = path.join(__dirname, 'L0BuildAndExportApp.js');
+    it('Skip initial build when action is set for packing', async function () {
+        let tp = path.join(__dirname, 'L0PackingBuild.js');
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
         await tr.runAsync();

--- a/Tasks/XcodeV5/Tests/L0.ts
+++ b/Tasks/XcodeV5/Tests/L0.ts
@@ -700,4 +700,25 @@ describe('Xcode L0 Suite', function () {
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.invokedToolCount === 6, 'Should have ran 6 command lines.');
     });
+
+    it('should skip initial build when actions is only build and packageApp is true', async function () {
+        let tp = path.join(__dirname, 'L0BuildAndExportApp.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        // Should run version check
+        assert(tr.ran('/home/bin/xcodebuild -version'), 'xcodebuild for version should have been run.');
+
+        // Should NOT run the initial build
+        assert(!tr.ran('/home/bin/xcodebuild -sdk iphoneos -configuration Release -workspace /user/build/MyApp.xcodeproj/project.xcworkspace -scheme MyScheme build CODE_SIGNING_ALLOWED=NO'),
+            'Initial build should have been skipped.');
+
+        // Should run archive step
+        assert(tr.ran('/home/bin/xcodebuild -workspace /user/build/MyApp.xcodeproj/project.xcworkspace -scheme MyScheme archive -sdk iphoneos -configuration Release -archivePath /user/build/MyScheme.xcarchive CODE_SIGNING_ALLOWED=NO'),
+            'Archive step should have been run.');
+
+        assert(tr.stderr.length === 0, 'should not have written to stderr');
+        assert(tr.succeeded, 'task should have succeeded');
+    });
 });

--- a/Tasks/XcodeV5/Tests/L0BuildAndExportApp.ts
+++ b/Tasks/XcodeV5/Tests/L0BuildAndExportApp.ts
@@ -1,0 +1,63 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'xcode.js');
+let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('actions', 'build');
+tr.setInput('configuration', 'Release');
+tr.setInput('sdk', 'iphoneos');
+tr.setInput('xcWorkspacePath', '**/*.xcodeproj/*.xcworkspace');
+tr.setInput('scheme', 'MyScheme');
+tr.setInput('packageApp', 'true');
+tr.setInput('signingOption', 'nosign');
+tr.setInput('args', '');
+tr.setInput('cwd', '/user/build');
+tr.setInput('xcodeVersion', 'default');
+tr.setInput('xcodeDeveloperDir', '');
+
+process.env['AGENT_VERSION'] =  '2.122.0';
+process.env['BUILD_SOURCESDIRECTORY'] = '/user/build';
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = "/user/build";
+process.env['HOME'] = '/users/test';
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers> {
+  "which": {
+    "xcodebuild": "/home/bin/xcodebuild"
+  },
+  "checkPath" : {
+    "/home/bin/xcodebuild": true
+  },
+  "exist": {
+    "/user/build/cert.p12": true
+  },
+  "getVariable": {
+    "build.sourcesDirectory": "/user/build",
+    "HOME": "/users/test"
+  },
+  "findMatch": {
+    "**/*.xcodeproj/*.xcworkspace": [
+      "/user/build/MyApp.xcodeproj/project.xcworkspace"
+    ]
+  },
+  "exec": {
+    "/home/bin/xcodebuild -version": {
+      "code": 0,
+      "stdout": "Xcode 12.4"
+    },
+    // This is the initial build command that should NOT be called
+    "/home/bin/xcodebuild -sdk iphoneos -configuration Release -workspace /user/build/MyApp.xcodeproj/project.xcworkspace -scheme MyScheme build CODE_SIGNING_ALLOWED=NO": {
+      "code": 0,
+      "stdout": "Should not run"
+    },
+    // This is the archive command that SHOULD be called
+    "/home/bin/xcodebuild -workspace /user/build/MyApp.xcodeproj/project.xcworkspace -scheme MyScheme archive -sdk iphoneos -configuration Release -archivePath /user/build/MyScheme.xcarchive CODE_SIGNING_ALLOWED=NO": {
+      "code": 0,
+      "stdout": "archive output"
+    }
+  }
+};
+tr.setAnswers(a);
+
+tr.run();

--- a/Tasks/XcodeV5/Tests/L0PackingBuild.ts
+++ b/Tasks/XcodeV5/Tests/L0PackingBuild.ts
@@ -5,7 +5,7 @@ import path = require('path');
 let taskPath = path.join(__dirname, '..', 'xcode.js');
 let tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-tr.setInput('actions', 'build');
+tr.setInput('actions', 'packing');
 tr.setInput('configuration', 'Release');
 tr.setInput('sdk', 'iphoneos');
 tr.setInput('xcWorkspacePath', '**/*.xcodeproj/*.xcworkspace');

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 5,
     "Minor": 248,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "This version of the task is compatible with Xcode 8 - 13. Features that were solely to maintain compatibility with Xcode 7 have been removed. This task has better options for using Microsoft-hosted macOS agents.",
   "demands": [

--- a/Tasks/XcodeV5/task.json
+++ b/Tasks/XcodeV5/task.json
@@ -49,7 +49,7 @@
       "label": "Actions",
       "defaultValue": "build",
       "required": true,
-      "helpMarkDown": "Enter a space-delimited list of actions. Some valid options are `build`, `clean`, `test`, `analyze`, and `archive`. For example,`clean build` will run a clean build."
+      "helpMarkDown": "Enter a space-delimited list of actions. Some valid options are `build`, `clean`, `test`, `analyze`, `packing` and `archive`. For example,`clean build` will run a clean build."
     },
     {
       "name": "configuration",

--- a/Tasks/XcodeV5/task.loc.json
+++ b/Tasks/XcodeV5/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 5,
     "Minor": 248,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/XcodeV5/xcode.ts
+++ b/Tasks/XcodeV5/xcode.ts
@@ -268,8 +268,19 @@ async function run() {
             }
         });
 
+        // Determine if we should skip the initial build step
+        const isOnlyBuildAction = actions.length === 1 && actions[0] === 'build';
+        let skipInitialBuild = false;
+        if (isOnlyBuildAction && packageApp && sdk !== 'iphonesimulator') {
+            // If only "build" is requested and packageApp is true, skip the initial build
+            skipInitialBuild = true;
+            tl.debug('Skipping initial build since only "build" action is specified and packageApp is true.');
+        }
+
         try {
-            await xcb.exec();
+            if (!skipInitialBuild) {
+                await xcb.exec();
+            }
         } catch (err) {
             if (buildOnlyDeviceErrorFound) {
                 // Tell the user they need to change Destination platform to fix this build error.

--- a/Tasks/XcodeV5/xcode.ts
+++ b/Tasks/XcodeV5/xcode.ts
@@ -269,9 +269,9 @@ async function run() {
         });
 
         // Determine if we should skip the initial build step
-        const isOnlyBuildAction = actions.length === 1 && actions[0] === 'build';
+        const isPackingAction = actions.length === 1 && actions[0] === 'packing';
         let skipInitialBuild = false;
-        if (isOnlyBuildAction && packageApp && sdk !== 'iphonesimulator') {
+        if (isPackingAction && packageApp && sdk !== 'iphonesimulator') {
             // If only "build" is requested and packageApp is true, skip the initial build
             skipInitialBuild = true;
             tl.debug('Skipping initial build since only "build" action is specified and packageApp is true.');


### PR DESCRIPTION
### **Context**
Avoid double build when actions = ['build'] and packageApp = true in Xcode task

---

### **Task Name**
XcodeV5

---

### **Description**
- Introduced logic to detect when actions only includes 'build' and packageApp is true
- In that case, the initial build is now skipped, as the build will be handled during the packaging step

---

### **Risk Assessment** (Low / Medium / High)  
Low. The logic change applies only to a specific condition (build-only action with packageApp enabled). Default behavior for other configurations remains unchanged.

---

### **Unit Tests Added or Updated** (Yes / No)  
Yes. Added 'should skip initial build when actions is only build and packageApp is true'

---

### **Additional Testing Performed**

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
