### PR TITLE
Read arguments when using dotnet push

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/PushTests/skipDuplicate.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/PushTests/skipDuplicate.ts
@@ -1,0 +1,63 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import util = require('../DotnetMockHelper');
+
+let taskPath = path.join(__dirname, '../..', 'dotnetcore.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+let nmh: util.DotnetMockHelper = new util.DotnetMockHelper(tmr);
+nmh.setNugetVersionInputDefault();
+tmr.setInput('command', 'push');
+tmr.setInput('searchPatternPush', 'foo.nupkg');
+tmr.setInput('nuGetFeedType', 'internal');
+tmr.setInput('feedPublish', 'ProjectId/FeedFooId');
+tmr.setInput('arguments', '--skip-duplicate');
+
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "osType": {},
+    "checkPath": {
+        "c:\\agent\\home\\directory\\foo.nupkg": true,
+        "c:\\path\\dotnet.exe": true
+    },
+    "which": {
+        "dotnet": "c:\\path\\dotnet.exe"
+    },
+    "exec": {
+        // First push succeeds
+        "c:\\path\\dotnet.exe nuget push c:\\agent\\home\\directory\\foo.nupkg --source https://vsts/packagesource --api-key VSTS": {
+            "code": 0,
+            "stdout": "dotnet output",
+            "stderr": ""
+        },
+        // Second push (duplicate) also succeeds due to --skip-duplicate
+        "c:\\path\\dotnet.exe nuget push c:\\agent\\home\\directory\\foo.nupkg --source https://vsts/packagesource --api-key VSTS --skip-duplicate": {
+            "code": 0,
+            "stdout": "Package already exists, skipping due to --skip-duplicate",
+            "stderr": ""
+        }
+    },
+    "exist": {},
+    "stats": {
+        "c:\\agent\\home\\directory\\foo.nupkg": {
+            "isFile": true
+        }
+    },
+    "rmRF": {
+        "c:\\agent\\home\\directory\\NuGet_1": {
+            "success": true
+        }
+    },
+    "findMatch": {
+        "fromMockedUtility-foo.nupkg" : ["c:\\agent\\home\\directory\\foo.nupkg"]
+    }
+};
+nmh.setAnswers(a);
+nmh.registerNugetUtilityMock(["c:\\agent\\home\\directory\\foo.nupkg"]);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+nmh.RegisterLocationServiceMocks();
+
+// Simulate pushing the same package twice
+tmr.run();
+tmr.run();

--- a/Tasks/DotNetCoreCLIV2/Tests/PushTests/skipDuplicate.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/PushTests/skipDuplicate.ts
@@ -48,7 +48,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         }
     },
     "findMatch": {
-        "fromMockedUtility-foo.nupkg" : ["c:\\agent\\home\\directory\\foo.nupkg"]
+        "fromMockedUtility-foo.nupkg": ["c:\\agent\\home\\directory\\foo.nupkg"]
     }
 };
 nmh.setAnswers(a);

--- a/Tasks/DotNetCoreCLIV2/package-lock.json
+++ b/Tasks/DotNetCoreCLIV2/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsts-tasks-dotnetcoreexe",
-  "version": "2.129.4",
+  "version": "2.258.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsts-tasks-dotnetcoreexe",
-      "version": "2.129.4",
+      "version": "2.258.0",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",

--- a/Tasks/DotNetCoreCLIV2/package.json
+++ b/Tasks/DotNetCoreCLIV2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-tasks-dotnetcoreexe",
-  "version": "2.129.4",
+  "version": "2.258.0",
   "description": "Dotnet core exe",
   "main": "dotnetcore.js",
   "scripts": {

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -15,293 +15,298 @@ import { WebRequest, WebRequestOptions, sendRequest } from 'azure-pipelines-task
 import { getRequestTimeout } from './Common/utility';
 
 interface EndpointCredentials {
-    endpoint: string;
-    username?: string;
-    password: string;
+  endpoint: string;
+  username?: string;
+  password: string;
 }
 
 export async function run(): Promise<void> {
-    let packagingLocation: pkgLocationUtils.PackagingLocation;
-    try {
-        const timeout: number = getRequestTimeout();
-        const webApiOptions: RequestOptions = { 
-            socketTimeout: timeout,
-            globalAgentOptions: {
+  let packagingLocation: pkgLocationUtils.PackagingLocation;
+  try {
+    const timeout: number = getRequestTimeout();
+    const webApiOptions: RequestOptions = {
+      socketTimeout: timeout,
+      globalAgentOptions: {
                 timeout: timeout,
-            } 
-        };
-        packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet, webApiOptions);
-    } catch (error) {
-        tl.debug('Unable to get packaging URIs');
-        logError(error);
-        throw error;
+      }
+    };
+    packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet, webApiOptions);
+  } catch (error) {
+    tl.debug('Unable to get packaging URIs');
+    logError(error);
+    throw error;
+  }
+
+  const buildIdentityDisplayName: string = null;
+  const buildIdentityAccount: string = null;
+  try {
+    // Get list of files to publish
+    const searchPatternInput = tl.getPathInput('searchPatternPush', true, false);
+    const findOptions: tl.FindOptions = <tl.FindOptions>{};
+    const matchOptions: tl.MatchOptions = <tl.MatchOptions>{};
+    const searchPatterns: string[] = nutil.getPatternsArrayFromInput(searchPatternInput);
+    const filesList = tl.findMatch(undefined, searchPatterns, findOptions, matchOptions);
+
+    filesList.forEach(packageFile => {
+      if (!tl.stats(packageFile).isFile()) {
+        throw new Error(tl.loc('Error_PushNotARegularFile', packageFile));
+      }
+    });
+
+    if (filesList.length < 1) {
+      tl.setResult(tl.TaskResult.Failed, tl.loc('Info_NoPackagesMatchedTheSearchPattern'));
+      return;
     }
 
-    const buildIdentityDisplayName: string = null;
-    const buildIdentityAccount: string = null;
-    try {
-        // Get list of files to publish
-        const searchPatternInput = tl.getPathInput('searchPatternPush', true, false);
-        const findOptions: tl.FindOptions = <tl.FindOptions>{};
-        const matchOptions: tl.MatchOptions = <tl.MatchOptions>{};
-        const searchPatterns: string[] = nutil.getPatternsArrayFromInput(searchPatternInput);
-        const filesList = tl.findMatch(undefined, searchPatterns, findOptions, matchOptions);
+    // Get the info the type of feed
+    let nugetFeedType = tl.getInput('nuGetFeedType') || 'internal';
 
-        filesList.forEach(packageFile => {
-            if (!tl.stats(packageFile).isFile()) {
-                throw new Error(tl.loc('Error_PushNotARegularFile', packageFile));
-            }
-        });
+    // Make sure the feed type is an expected one
+    const normalizedNuGetFeedType = ['internal', 'external'].find(x => nugetFeedType.toUpperCase() === x.toUpperCase());
+    if (!normalizedNuGetFeedType) {
+      throw new Error(tl.loc('UnknownFeedType', nugetFeedType));
+    }
+    nugetFeedType = normalizedNuGetFeedType;
 
-        if (filesList.length < 1) {
-            tl.setResult(tl.TaskResult.Failed, tl.loc('Info_NoPackagesMatchedTheSearchPattern'));
-            return;
-        }
+    const serviceUri = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
+    let urlPrefixes = packagingLocation.PackagingUris;
+    tl.debug(`discovered URL prefixes: ${urlPrefixes}`);
 
-        // Get the info the type of feed
-        let nugetFeedType = tl.getInput('nuGetFeedType') || 'internal';
+    // Note to readers: This variable will be going away once we have a fix for the location service for
+    // customers behind proxies
+    const testPrefixes = tl.getVariable('DotNetCoreCLITask.ExtraUrlPrefixesForTesting');
+    if (testPrefixes) {
+      urlPrefixes = urlPrefixes.concat(testPrefixes.split(';'));
+      tl.debug(`all URL prefixes: ${urlPrefixes}`);
+    }
 
-        // Make sure the feed type is an expected one
-        const normalizedNuGetFeedType = ['internal', 'external'].find(x => nugetFeedType.toUpperCase() === x.toUpperCase());
-        if (!normalizedNuGetFeedType) {
-            throw new Error(tl.loc('UnknownFeedType', nugetFeedType));
-        }
-        nugetFeedType = normalizedNuGetFeedType;
+    // Read arguments so users can specify extra arguments like --skip-duplicate
+    let dotnetArguments: string = tl.getInput('arguments', false) || '';
 
-        const serviceUri = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
-        let urlPrefixes = packagingLocation.PackagingUris;
-        tl.debug(`discovered URL prefixes: ${urlPrefixes}`);
+    // Setting up auth info
+    let accessToken;
+    const isInternalFeed: boolean = nugetFeedType === 'internal';
+    accessToken = await getAccessToken(isInternalFeed, urlPrefixes);
+    const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
 
-        // Note to readers: This variable will be going away once we have a fix for the location service for
-        // customers behind proxies
-        const testPrefixes = tl.getVariable('DotNetCoreCLITask.ExtraUrlPrefixesForTesting');
-        if (testPrefixes) {
-            urlPrefixes = urlPrefixes.concat(testPrefixes.split(';'));
-            tl.debug(`all URL prefixes: ${urlPrefixes}`);
-        }
+    let configFile = null;
+    let apiKey: string;
 
-        // Setting up auth info
-        let accessToken;
-        const isInternalFeed: boolean = nugetFeedType === 'internal';
-        accessToken = await getAccessToken(isInternalFeed, urlPrefixes);
-        const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
-
-        let configFile = null;
-        let apiKey: string;
-
-        // dotnet nuget push does not currently accept a --config-file parameter
-        // so we are going to work around this by creating a temporary working directory for dotnet with
-        // a nuget config file it will load by default.
-        const tempNuGetConfigDirectory = path.join(NuGetConfigHelper2.getTempNuGetConfigBasePath(), 'NuGet_' + tl.getVariable('build.buildId'));
-        const tempNuGetPath = path.join(tempNuGetConfigDirectory, 'nuget.config');
-        tl.mkdirP(tempNuGetConfigDirectory);
-        let credCleanup = () => {
-            if (tl.exist(tempNuGetConfigDirectory)) {
+    // dotnet nuget push does not currently accept a --config-file parameter
+    // so we are going to work around this by creating a temporary working directory for dotnet with
+    // a nuget config file it will load by default.
+    const tempNuGetConfigDirectory = path.join(NuGetConfigHelper2.getTempNuGetConfigBasePath(), 'NuGet_' + tl.getVariable('build.buildId'));
+    const tempNuGetPath = path.join(tempNuGetConfigDirectory, 'nuget.config');
+    tl.mkdirP(tempNuGetConfigDirectory);
+    let credCleanup = () => {
+      if (tl.exist(tempNuGetConfigDirectory)) {
                 tl.rmRF(tempNuGetConfigDirectory)
-            }
-        };
+      }
+    };
 
-        let feedUri: string = undefined;
+    let feedUri: string = undefined;
 
-        let authInfo: auth.NuGetExtendedAuthInfo;
-        let nuGetConfigHelper: NuGetConfigHelper2;
+    let authInfo: auth.NuGetExtendedAuthInfo;
+    let nuGetConfigHelper: NuGetConfigHelper2;
 
-        if (isInternalFeed) {
-            authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
-            nuGetConfigHelper = new NuGetConfigHelper2(
-                null,
+    if (isInternalFeed) {
+      authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
+      nuGetConfigHelper = new NuGetConfigHelper2(
+        null,
                 null, /* nugetConfigPath */
-                authInfo,
-                { credProviderFolder: null, extensionsDisabled: true },
-                tempNuGetPath,
+        authInfo,
+        { credProviderFolder: null, extensionsDisabled: true },
+        tempNuGetPath,
                 false /* useNugetToModifyConfigFile */);
 
-            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+      const feed = getProjectAndFeedIdFromInputParam('feedPublish');
 
             feedUri = await nutil.getNuGetFeedRegistryUrl(packagingLocation.DefaultPackagingUri, feed.feedId, feed.projectId, null, accessToken, /* useSession */ true);
-            nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
-            configFile = nuGetConfigHelper.tempNugetConfigPath;
+      nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
+      configFile = nuGetConfigHelper.tempNugetConfigPath;
 
-            apiKey = 'VSTS';
-        } else {
-            const externalAuthArr = commandHelper.GetExternalAuthInfoArray('externalEndpoint');
-            authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
-            nuGetConfigHelper = new NuGetConfigHelper2(
-                null,
+      apiKey = 'VSTS';
+    } else {
+      const externalAuthArr = commandHelper.GetExternalAuthInfoArray('externalEndpoint');
+      authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
+      nuGetConfigHelper = new NuGetConfigHelper2(
+        null,
                 null, /* nugetConfigPath */
-                authInfo,
-                { credProviderFolder: null, extensionsDisabled: true },
-                tempNuGetPath,
+        authInfo,
+        { credProviderFolder: null, extensionsDisabled: true },
+        tempNuGetPath,
                 false /* useNugetToModifyConfigFile */);
 
-            const externalAuth = externalAuthArr[0];
+      const externalAuth = externalAuthArr[0];
 
-            if (!externalAuth) {
-                tl.setResult(tl.TaskResult.Failed, tl.loc('Error_NoSourceSpecifiedForPush'));
-                return;
-            }
+      if (!externalAuth) {
+        tl.setResult(tl.TaskResult.Failed, tl.loc('Error_NoSourceSpecifiedForPush'));
+        return;
+      }
 
-            nuGetConfigHelper.addSourcesToTempNuGetConfig([externalAuth.packageSource]);
-            feedUri = externalAuth.packageSource.feedUri;
-            configFile = nuGetConfigHelper.tempNugetConfigPath;
+      nuGetConfigHelper.addSourcesToTempNuGetConfig([externalAuth.packageSource]);
+      feedUri = externalAuth.packageSource.feedUri;
+      configFile = nuGetConfigHelper.tempNugetConfigPath;
 
-            const authType: auth.ExternalAuthType = externalAuth.authType;
-            switch (authType) {
+      const authType: auth.ExternalAuthType = externalAuth.authType;
+      switch (authType) {
                 case (auth.ExternalAuthType.UsernamePassword):
                 case (auth.ExternalAuthType.Token):
-                    apiKey = 'RequiredApiKey';
-                    break;
+          apiKey = 'RequiredApiKey';
+          break;
                 case (auth.ExternalAuthType.ApiKey):
-                    const apiKeyAuthInfo = externalAuth as auth.ApiKeyExternalAuthInfo;
-                    apiKey = apiKeyAuthInfo.apiKey;
-                    break;
-                default:
-                    break;
-            }
-        }
-        // Setting creds in the temp NuGet.config if needed
-        nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
-        const dotnetPath = tl.which('dotnet', true);
-        try {
-            for (const packageFile of filesList) {
-                await dotNetNuGetPushAsync(dotnetPath, packageFile, feedUri, apiKey, configFile, tempNuGetConfigDirectory);
-            }
-        } finally {
-            credCleanup();
-        }
-
-        tl.setResult(tl.TaskResult.Succeeded, tl.loc('PackagesPublishedSuccessfully'));
-
-    } catch (err) {
-        tl.error(err);
-
-        if (buildIdentityDisplayName || buildIdentityAccount) {
-            tl.warning(tl.loc('BuildIdentityPermissionsHint', buildIdentityDisplayName, buildIdentityAccount));
-        }
-
-        tl.setResult(tl.TaskResult.Failed, tl.loc('PackagesFailedToPublish'));
+          const apiKeyAuthInfo = externalAuth as auth.ApiKeyExternalAuthInfo;
+          apiKey = apiKeyAuthInfo.apiKey;
+          break;
+        default:
+          break;
+      }
     }
+    // Setting creds in the temp NuGet.config if needed
+    nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
+    const dotnetPath = tl.which('dotnet', true);
+    try {
+      for (const packageFile of filesList) {
+                await dotNetNuGetPushAsync(dotnetPath, packageFile, feedUri, apiKey, dotnetArguments, configFile, tempNuGetConfigDirectory);
+      }
+    } finally {
+      credCleanup();
+    }
+
+    tl.setResult(tl.TaskResult.Succeeded, tl.loc('PackagesPublishedSuccessfully'));
+
+  } catch (err) {
+    tl.error(err);
+
+    if (buildIdentityDisplayName || buildIdentityAccount) {
+      tl.warning(tl.loc('BuildIdentityPermissionsHint', buildIdentityDisplayName, buildIdentityAccount));
+    }
+
+    tl.setResult(tl.TaskResult.Failed, tl.loc('PackagesFailedToPublish'));
+  }
 }
 
-function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: string, apiKey: string, configFile: string, workingDirectory: string): Q.Promise<number> {
-    const dotnet = tl.tool(dotnetPath);
+function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: string, apiKey: string, dotnetArguments: string, configFile: string, workingDirectory: string): Q.Promise<number> {
+  const dotnet = tl.tool(dotnetPath);
 
-    dotnet.arg('nuget');
-    dotnet.arg('push');
+  dotnet.arg('nuget');
+  dotnet.arg('push');
 
-    dotnet.arg(packageFile);
+  dotnet.arg(packageFile);
 
-    dotnet.arg('--source');
-    dotnet.arg(feedUri);
+  dotnet.arg('--source');
+  dotnet.arg(feedUri);
 
-    dotnet.arg('--api-key');
-    dotnet.arg(apiKey);
+  dotnet.arg('--api-key');
+  dotnet.arg(apiKey);
 
-    // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
-    const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
-    return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
+  dotnet.line(dotnetArguments);
+
+  // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
+  const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
+  return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
 }
 
 async function getAccessToken(isInternalFeed: boolean, uriPrefixes: any): Promise<string> {
-    let accessToken: string;
-    let allowServiceConnection = tl.getVariable('PUBLISH_VIA_SERVICE_CONNECTION');
+  let accessToken: string;
+  let allowServiceConnection = tl.getVariable('PUBLISH_VIA_SERVICE_CONNECTION');
 
-    if (allowServiceConnection) {
-        let endpoint = tl.getInput('externalEndpoint', false);
+  if (allowServiceConnection) {
+    let endpoint = tl.getInput('externalEndpoint', false);
 
-        if (endpoint && isInternalFeed === true) {
+    if (endpoint && isInternalFeed === true) {
             tl.debug("Found external endpoint, will use token for auth");
-            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
-            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
-            switch (endpointScheme) {
+      let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+      let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+      switch (endpointScheme) {
                 case ("token"):
                     accessToken = endpointAuth.parameters["apitoken"];
-                    break;
-                default:
+          break;
+        default:
                     tl.warning(tl.loc("Warning_UnsupportedServiceConnectionAuth"));
-                    break;
-            }
-        }
-        if (!accessToken && isInternalFeed === true) {
+          break;
+      }
+    }
+    if (!accessToken && isInternalFeed === true) {
             tl.debug("Checking for auth from Cred Provider.");
-            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+      const feed = getProjectAndFeedIdFromInputParam('feedPublish');
             const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
 
-            if (JsonEndpointsString) {
-                tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
-                tl.debug(`Endpoints found: ${JsonEndpointsString}`);
+      if (JsonEndpointsString) {
+        tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
+        tl.debug(`Endpoints found: ${JsonEndpointsString}`);
 
-                let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
-                let matchingEndpoint: EndpointCredentials;
-                for (const e of endpointsArray.endpointCredentials) {
-                    for (const prefix of uriPrefixes) {
-                        if (e.endpoint.toUpperCase().startsWith(prefix.toUpperCase())) {
-                            let isServiceConnectionValid = await tryServiceConnection(e, feed);
-                            if (isServiceConnectionValid) {
-                                matchingEndpoint = e;
-                                break;
-                            }
-                        }
-                    }
-                    if (matchingEndpoint) {
-                        accessToken = matchingEndpoint.password;
-                        break;
-                    }
-                }
+        let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
+        let matchingEndpoint: EndpointCredentials;
+        for (const e of endpointsArray.endpointCredentials) {
+          for (const prefix of uriPrefixes) {
+            if (e.endpoint.toUpperCase().startsWith(prefix.toUpperCase())) {
+              let isServiceConnectionValid = await tryServiceConnection(e, feed);
+              if (isServiceConnectionValid) {
+                matchingEndpoint = e;
+                break;
+              }
             }
+          }
+          if (matchingEndpoint) {
+            accessToken = matchingEndpoint.password;
+            break;
+          }
         }
-        if (accessToken) {
-            return accessToken;
-        }
+      }
     }
+    if (accessToken) {
+      return accessToken;
+    }
+  }
 
-    tl.debug('Defaulting to use the System Access Token.');
-    accessToken = pkgLocationUtils.getSystemAccessToken();
-    return accessToken;
+  tl.debug('Defaulting to use the System Access Token.');
+  accessToken = pkgLocationUtils.getSystemAccessToken();
+  return accessToken;
 }
 
 async function tryServiceConnection(endpoint: EndpointCredentials, feed: any): Promise<boolean> {
-    // Create request
-    const request = new WebRequest();
-    const token64 = Buffer.from(`${endpoint.username}:${endpoint.password}`).toString('base64');
-    request.uri = endpoint.endpoint;
-    request.method = 'GET';
-    request.headers = {
+  // Create request
+  const request = new WebRequest();
+  const token64 = Buffer.from(`${endpoint.username}:${endpoint.password}`).toString('base64');
+  request.uri = endpoint.endpoint;
+  request.method = 'GET';
+  request.headers = {
         "Content-Type": "application/json",
         "Authorization": "Basic " + token64
-    };
+  };
 
-    const timeout: number = getRequestTimeout();
+  const timeout: number = getRequestTimeout();
     const retriableErrorCodes = ["ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "ESOCKETTIMEDOUT", "ECONNREFUSED", "EHOSTUNREACH", "EPIPE", "EA_AGAIN"];
-    const retriableStatusCodes = [408, 409, 500, 502, 503, 504];
+  const retriableStatusCodes = [408, 409, 500, 502, 503, 504];
 
-    const options: WebRequestOptions = {
-        retryCount: 3,
-        retryIntervalInSeconds: 5,
-        retriableErrorCodes,
-        retriableStatusCodes,
-        retryRequestTimedout: true,
-        socketTimeout: timeout,
-        httpGlobalAgentOptions: {
-            timeout: timeout
-        }
-    };
-
-    const response = await sendRequest(request, options);
-
-    if (response.statusCode == 200) {
-        if (response.body) {
-            for (const entry of response.body.resources) {
-                if (entry['@type'] === 'AzureDevOpsProjectId' && !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))) {
-                    return false;
-                }
-                if (entry['@type'] === 'VssFeedId' && !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))) {
-                    return false;
-                }
-            }
-            // We found matches in feedId and projectId, return the service connection
-            return true;
-        }
+  const options: WebRequestOptions = {
+    retryCount: 3,
+    retryIntervalInSeconds: 5,
+    retriableErrorCodes,
+    retriableStatusCodes,
+    retryRequestTimedout: true,
+    socketTimeout: timeout,
+    httpGlobalAgentOptions: {
+      timeout: timeout
     }
-    return false;
+  };
+
+  const response = await sendRequest(request, options);
+
+  if (response.statusCode == 200) {
+    if (response.body) {
+      for (const entry of response.body.resources) {
+                if (entry['@type'] === 'AzureDevOpsProjectId' && !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))) {
+          return false;
+        }
+                if (entry['@type'] === 'VssFeedId' && !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))) {
+          return false;
+        }
+      }
+      // We found matches in feedId and projectId, return the service connection
+      return true;
+    }
+  }
+  return false;
 }

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -121,14 +121,7 @@ export async function run(): Promise<void> {
 
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
 
-            feedUri = await nutil.getNuGetFeedRegistryUrl(
-                packagingLocation.DefaultPackagingUri,
-                feed.feedId,
-                feed.projectId,
-                null,
-                accessToken,
-        /* useSession */ true
-            );
+            feedUri = await nutil.getNuGetFeedRegistryUrl(packagingLocation.DefaultPackagingUri, feed.feedId, feed.projectId, null, accessToken, /* useSession */ true);
             nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
             configFile = nuGetConfigHelper.tempNugetConfigPath;
 
@@ -229,22 +222,22 @@ async function getAccessToken(isInternalFeed: boolean, uriPrefixes: any): Promis
         let endpoint = tl.getInput('externalEndpoint', false);
 
         if (endpoint && isInternalFeed === true) {
-            tl.debug('Found external endpoint, will use token for auth');
+            tl.debug("Found external endpoint, will use token for auth");
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch (endpointScheme) {
-                case 'token':
+                case "token":
                     accessToken = endpointAuth.parameters['apitoken'];
                     break;
                 default:
-                    tl.warning(tl.loc('Warning_UnsupportedServiceConnectionAuth'));
+                    tl.warning(tl.loc("Warning_UnsupportedServiceConnectionAuth"));
                     break;
             }
         }
         if (!accessToken && isInternalFeed === true) {
-            tl.debug('Checking for auth from Cred Provider.');
+            tl.debug("Checking for auth from Cred Provider.");
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
-            const JsonEndpointsString = process.env['VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'];
+            const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
 
             if (JsonEndpointsString) {
                 tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
@@ -286,12 +279,12 @@ async function tryServiceConnection(endpoint: EndpointCredentials, feed: any): P
     request.uri = endpoint.endpoint;
     request.method = 'GET';
     request.headers = {
-        'Content-Type': 'application/json',
-        Authorization: 'Basic ' + token64
+        "Content-Type": "application/json",
+        Authorization: "Basic " + token64
     };
 
     const timeout: number = getRequestTimeout();
-    const retriableErrorCodes = ['ETIMEDOUT', 'ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE', 'EA_AGAIN'];
+    const retriableErrorCodes = ["ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "ESOCKETTIMEDOUT", "ECONNREFUSED", "EHOSTUNREACH", "EPIPE", "EA_AGAIN"];
     const retriableStatusCodes = [408, 409, 500, 502, 503, 504];
 
     const options: WebRequestOptions = {
@@ -311,16 +304,10 @@ async function tryServiceConnection(endpoint: EndpointCredentials, feed: any): P
     if (response.statusCode == 200) {
         if (response.body) {
             for (const entry of response.body.resources) {
-                if (
-                    entry['@type'] === 'AzureDevOpsProjectId' &&
-                    !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))
-                ) {
+                if (entry['@type'] === 'AzureDevOpsProjectId' && !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))) {
                     return false;
                 }
-                if (
-                    entry['@type'] === 'VssFeedId' &&
-                    !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))
-                ) {
+                if (entry['@type'] === 'VssFeedId' && !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))) {
                     return false;
                 }
             }

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -24,11 +24,11 @@ export async function run(): Promise<void> {
     let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
         const timeout: number = getRequestTimeout();
-        const webApiOptions: RequestOptions = {
+        const webApiOptions: RequestOptions = { 
             socketTimeout: timeout,
             globalAgentOptions: {
-                timeout: timeout
-            }
+                timeout: timeout,
+            } 
         };
         packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet, webApiOptions);
     } catch (error) {
@@ -100,7 +100,7 @@ export async function run(): Promise<void> {
         tl.mkdirP(tempNuGetConfigDirectory);
         let credCleanup = () => {
             if (tl.exist(tempNuGetConfigDirectory)) {
-                tl.rmRF(tempNuGetConfigDirectory);
+                tl.rmRF(tempNuGetConfigDirectory)
             }
         };
 
@@ -113,12 +113,11 @@ export async function run(): Promise<void> {
             authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
             nuGetConfigHelper = new NuGetConfigHelper2(
                 null,
-                null /* nugetConfigPath */,
+                null, /* nugetConfigPath */
                 authInfo,
                 { credProviderFolder: null, extensionsDisabled: true },
                 tempNuGetPath,
-                false /* useNugetToModifyConfigFile */
-            );
+                false /* useNugetToModifyConfigFile */);
 
             const feed = getProjectAndFeedIdFromInputParam('feedPublish');
 
@@ -139,12 +138,11 @@ export async function run(): Promise<void> {
             authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
             nuGetConfigHelper = new NuGetConfigHelper2(
                 null,
-                null /* nugetConfigPath */,
+                null, /* nugetConfigPath */
                 authInfo,
                 { credProviderFolder: null, extensionsDisabled: true },
                 tempNuGetPath,
-                false /* useNugetToModifyConfigFile */
-            );
+                false /* useNugetToModifyConfigFile */);
 
             const externalAuth = externalAuthArr[0];
 
@@ -159,11 +157,11 @@ export async function run(): Promise<void> {
 
             const authType: auth.ExternalAuthType = externalAuth.authType;
             switch (authType) {
-                case auth.ExternalAuthType.UsernamePassword:
-                case auth.ExternalAuthType.Token:
+                case (auth.ExternalAuthType.UsernamePassword):
+                case (auth.ExternalAuthType.Token):
                     apiKey = 'RequiredApiKey';
                     break;
-                case auth.ExternalAuthType.ApiKey:
+                case (auth.ExternalAuthType.ApiKey):
                     const apiKeyAuthInfo = externalAuth as auth.ApiKeyExternalAuthInfo;
                     apiKey = apiKeyAuthInfo.apiKey;
                     break;

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -185,15 +185,7 @@ export async function run(): Promise<void> {
     }
 }
 
-function dotNetNuGetPushAsync(
-    dotnetPath: string,
-    packageFile: string,
-    feedUri: string,
-    apiKey: string,
-    dotnetArguments: string,
-    configFile: string,
-    workingDirectory: string
-): Q.Promise<number> {
+function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: string, apiKey: string, dotnetArguments: string, configFile: string, workingDirectory: string): Q.Promise<number> {
     const dotnet = tl.tool(dotnetPath);
 
     dotnet.arg('nuget');
@@ -226,7 +218,7 @@ async function getAccessToken(isInternalFeed: boolean, uriPrefixes: any): Promis
             let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch (endpointScheme) {
-                case "token":
+                case ("token"):
                     accessToken = endpointAuth.parameters['apitoken'];
                     break;
                 default:
@@ -280,7 +272,7 @@ async function tryServiceConnection(endpoint: EndpointCredentials, feed: any): P
     request.method = 'GET';
     request.headers = {
         "Content-Type": "application/json",
-        Authorization: "Basic " + token64
+        "Authorization": "Basic " + token64
     };
 
     const timeout: number = getRequestTimeout();

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -15,298 +15,320 @@ import { WebRequest, WebRequestOptions, sendRequest } from 'azure-pipelines-task
 import { getRequestTimeout } from './Common/utility';
 
 interface EndpointCredentials {
-  endpoint: string;
-  username?: string;
-  password: string;
+    endpoint: string;
+    username?: string;
+    password: string;
 }
 
 export async function run(): Promise<void> {
-  let packagingLocation: pkgLocationUtils.PackagingLocation;
-  try {
-    const timeout: number = getRequestTimeout();
-    const webApiOptions: RequestOptions = {
-      socketTimeout: timeout,
-      globalAgentOptions: {
-                timeout: timeout,
-      }
-    };
-    packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet, webApiOptions);
-  } catch (error) {
-    tl.debug('Unable to get packaging URIs');
-    logError(error);
-    throw error;
-  }
-
-  const buildIdentityDisplayName: string = null;
-  const buildIdentityAccount: string = null;
-  try {
-    // Get list of files to publish
-    const searchPatternInput = tl.getPathInput('searchPatternPush', true, false);
-    const findOptions: tl.FindOptions = <tl.FindOptions>{};
-    const matchOptions: tl.MatchOptions = <tl.MatchOptions>{};
-    const searchPatterns: string[] = nutil.getPatternsArrayFromInput(searchPatternInput);
-    const filesList = tl.findMatch(undefined, searchPatterns, findOptions, matchOptions);
-
-    filesList.forEach(packageFile => {
-      if (!tl.stats(packageFile).isFile()) {
-        throw new Error(tl.loc('Error_PushNotARegularFile', packageFile));
-      }
-    });
-
-    if (filesList.length < 1) {
-      tl.setResult(tl.TaskResult.Failed, tl.loc('Info_NoPackagesMatchedTheSearchPattern'));
-      return;
-    }
-
-    // Get the info the type of feed
-    let nugetFeedType = tl.getInput('nuGetFeedType') || 'internal';
-
-    // Make sure the feed type is an expected one
-    const normalizedNuGetFeedType = ['internal', 'external'].find(x => nugetFeedType.toUpperCase() === x.toUpperCase());
-    if (!normalizedNuGetFeedType) {
-      throw new Error(tl.loc('UnknownFeedType', nugetFeedType));
-    }
-    nugetFeedType = normalizedNuGetFeedType;
-
-    const serviceUri = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
-    let urlPrefixes = packagingLocation.PackagingUris;
-    tl.debug(`discovered URL prefixes: ${urlPrefixes}`);
-
-    // Note to readers: This variable will be going away once we have a fix for the location service for
-    // customers behind proxies
-    const testPrefixes = tl.getVariable('DotNetCoreCLITask.ExtraUrlPrefixesForTesting');
-    if (testPrefixes) {
-      urlPrefixes = urlPrefixes.concat(testPrefixes.split(';'));
-      tl.debug(`all URL prefixes: ${urlPrefixes}`);
-    }
-
-    // Read arguments so users can specify extra arguments like --skip-duplicate
-    let dotnetArguments: string = tl.getInput('arguments', false) || '';
-
-    // Setting up auth info
-    let accessToken;
-    const isInternalFeed: boolean = nugetFeedType === 'internal';
-    accessToken = await getAccessToken(isInternalFeed, urlPrefixes);
-    const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
-
-    let configFile = null;
-    let apiKey: string;
-
-    // dotnet nuget push does not currently accept a --config-file parameter
-    // so we are going to work around this by creating a temporary working directory for dotnet with
-    // a nuget config file it will load by default.
-    const tempNuGetConfigDirectory = path.join(NuGetConfigHelper2.getTempNuGetConfigBasePath(), 'NuGet_' + tl.getVariable('build.buildId'));
-    const tempNuGetPath = path.join(tempNuGetConfigDirectory, 'nuget.config');
-    tl.mkdirP(tempNuGetConfigDirectory);
-    let credCleanup = () => {
-      if (tl.exist(tempNuGetConfigDirectory)) {
-                tl.rmRF(tempNuGetConfigDirectory)
-      }
-    };
-
-    let feedUri: string = undefined;
-
-    let authInfo: auth.NuGetExtendedAuthInfo;
-    let nuGetConfigHelper: NuGetConfigHelper2;
-
-    if (isInternalFeed) {
-      authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
-      nuGetConfigHelper = new NuGetConfigHelper2(
-        null,
-                null, /* nugetConfigPath */
-        authInfo,
-        { credProviderFolder: null, extensionsDisabled: true },
-        tempNuGetPath,
-                false /* useNugetToModifyConfigFile */);
-
-      const feed = getProjectAndFeedIdFromInputParam('feedPublish');
-
-            feedUri = await nutil.getNuGetFeedRegistryUrl(packagingLocation.DefaultPackagingUri, feed.feedId, feed.projectId, null, accessToken, /* useSession */ true);
-      nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
-      configFile = nuGetConfigHelper.tempNugetConfigPath;
-
-      apiKey = 'VSTS';
-    } else {
-      const externalAuthArr = commandHelper.GetExternalAuthInfoArray('externalEndpoint');
-      authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
-      nuGetConfigHelper = new NuGetConfigHelper2(
-        null,
-                null, /* nugetConfigPath */
-        authInfo,
-        { credProviderFolder: null, extensionsDisabled: true },
-        tempNuGetPath,
-                false /* useNugetToModifyConfigFile */);
-
-      const externalAuth = externalAuthArr[0];
-
-      if (!externalAuth) {
-        tl.setResult(tl.TaskResult.Failed, tl.loc('Error_NoSourceSpecifiedForPush'));
-        return;
-      }
-
-      nuGetConfigHelper.addSourcesToTempNuGetConfig([externalAuth.packageSource]);
-      feedUri = externalAuth.packageSource.feedUri;
-      configFile = nuGetConfigHelper.tempNugetConfigPath;
-
-      const authType: auth.ExternalAuthType = externalAuth.authType;
-      switch (authType) {
-                case (auth.ExternalAuthType.UsernamePassword):
-                case (auth.ExternalAuthType.Token):
-          apiKey = 'RequiredApiKey';
-          break;
-                case (auth.ExternalAuthType.ApiKey):
-          const apiKeyAuthInfo = externalAuth as auth.ApiKeyExternalAuthInfo;
-          apiKey = apiKeyAuthInfo.apiKey;
-          break;
-        default:
-          break;
-      }
-    }
-    // Setting creds in the temp NuGet.config if needed
-    nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
-    const dotnetPath = tl.which('dotnet', true);
+    let packagingLocation: pkgLocationUtils.PackagingLocation;
     try {
-      for (const packageFile of filesList) {
+        const timeout: number = getRequestTimeout();
+        const webApiOptions: RequestOptions = {
+            socketTimeout: timeout,
+            globalAgentOptions: {
+                timeout: timeout
+            }
+        };
+        packagingLocation = await pkgLocationUtils.getPackagingUris(pkgLocationUtils.ProtocolType.NuGet, webApiOptions);
+    } catch (error) {
+        tl.debug('Unable to get packaging URIs');
+        logError(error);
+        throw error;
+    }
+
+    const buildIdentityDisplayName: string = null;
+    const buildIdentityAccount: string = null;
+    try {
+        // Get list of files to publish
+        const searchPatternInput = tl.getPathInput('searchPatternPush', true, false);
+        const findOptions: tl.FindOptions = <tl.FindOptions>{};
+        const matchOptions: tl.MatchOptions = <tl.MatchOptions>{};
+        const searchPatterns: string[] = nutil.getPatternsArrayFromInput(searchPatternInput);
+        const filesList = tl.findMatch(undefined, searchPatterns, findOptions, matchOptions);
+
+        filesList.forEach(packageFile => {
+            if (!tl.stats(packageFile).isFile()) {
+                throw new Error(tl.loc('Error_PushNotARegularFile', packageFile));
+            }
+        });
+
+        if (filesList.length < 1) {
+            tl.setResult(tl.TaskResult.Failed, tl.loc('Info_NoPackagesMatchedTheSearchPattern'));
+            return;
+        }
+
+        // Get the info the type of feed
+        let nugetFeedType = tl.getInput('nuGetFeedType') || 'internal';
+
+        // Make sure the feed type is an expected one
+        const normalizedNuGetFeedType = ['internal', 'external'].find(x => nugetFeedType.toUpperCase() === x.toUpperCase());
+        if (!normalizedNuGetFeedType) {
+            throw new Error(tl.loc('UnknownFeedType', nugetFeedType));
+        }
+        nugetFeedType = normalizedNuGetFeedType;
+
+        const serviceUri = tl.getEndpointUrl('SYSTEMVSSCONNECTION', false);
+        let urlPrefixes = packagingLocation.PackagingUris;
+        tl.debug(`discovered URL prefixes: ${urlPrefixes}`);
+
+        // Note to readers: This variable will be going away once we have a fix for the location service for
+        // customers behind proxies
+        const testPrefixes = tl.getVariable('DotNetCoreCLITask.ExtraUrlPrefixesForTesting');
+        if (testPrefixes) {
+            urlPrefixes = urlPrefixes.concat(testPrefixes.split(';'));
+            tl.debug(`all URL prefixes: ${urlPrefixes}`);
+        }
+
+        // Read arguments so users can specify extra arguments like --skip-duplicate
+        let dotnetArguments: string = tl.getInput('arguments', false) || '';
+
+        // Setting up auth info
+        let accessToken;
+        const isInternalFeed: boolean = nugetFeedType === 'internal';
+        accessToken = await getAccessToken(isInternalFeed, urlPrefixes);
+        const internalAuthInfo = new auth.InternalAuthInfo(urlPrefixes, accessToken, /*useCredProvider*/ null, true);
+
+        let configFile = null;
+        let apiKey: string;
+
+        // dotnet nuget push does not currently accept a --config-file parameter
+        // so we are going to work around this by creating a temporary working directory for dotnet with
+        // a nuget config file it will load by default.
+        const tempNuGetConfigDirectory = path.join(NuGetConfigHelper2.getTempNuGetConfigBasePath(), 'NuGet_' + tl.getVariable('build.buildId'));
+        const tempNuGetPath = path.join(tempNuGetConfigDirectory, 'nuget.config');
+        tl.mkdirP(tempNuGetConfigDirectory);
+        let credCleanup = () => {
+            if (tl.exist(tempNuGetConfigDirectory)) {
+                tl.rmRF(tempNuGetConfigDirectory);
+            }
+        };
+
+        let feedUri: string = undefined;
+
+        let authInfo: auth.NuGetExtendedAuthInfo;
+        let nuGetConfigHelper: NuGetConfigHelper2;
+
+        if (isInternalFeed) {
+            authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo);
+            nuGetConfigHelper = new NuGetConfigHelper2(
+                null,
+                null /* nugetConfigPath */,
+                authInfo,
+                { credProviderFolder: null, extensionsDisabled: true },
+                tempNuGetPath,
+                false /* useNugetToModifyConfigFile */
+            );
+
+            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+
+            feedUri = await nutil.getNuGetFeedRegistryUrl(
+                packagingLocation.DefaultPackagingUri,
+                feed.feedId,
+                feed.projectId,
+                null,
+                accessToken,
+        /* useSession */ true
+            );
+            nuGetConfigHelper.addSourcesToTempNuGetConfig([<auth.IPackageSource>{ feedName: feed.feedId, feedUri: feedUri, isInternal: true }]);
+            configFile = nuGetConfigHelper.tempNugetConfigPath;
+
+            apiKey = 'VSTS';
+        } else {
+            const externalAuthArr = commandHelper.GetExternalAuthInfoArray('externalEndpoint');
+            authInfo = new auth.NuGetExtendedAuthInfo(internalAuthInfo, externalAuthArr);
+            nuGetConfigHelper = new NuGetConfigHelper2(
+                null,
+                null /* nugetConfigPath */,
+                authInfo,
+                { credProviderFolder: null, extensionsDisabled: true },
+                tempNuGetPath,
+                false /* useNugetToModifyConfigFile */
+            );
+
+            const externalAuth = externalAuthArr[0];
+
+            if (!externalAuth) {
+                tl.setResult(tl.TaskResult.Failed, tl.loc('Error_NoSourceSpecifiedForPush'));
+                return;
+            }
+
+            nuGetConfigHelper.addSourcesToTempNuGetConfig([externalAuth.packageSource]);
+            feedUri = externalAuth.packageSource.feedUri;
+            configFile = nuGetConfigHelper.tempNugetConfigPath;
+
+            const authType: auth.ExternalAuthType = externalAuth.authType;
+            switch (authType) {
+                case auth.ExternalAuthType.UsernamePassword:
+                case auth.ExternalAuthType.Token:
+                    apiKey = 'RequiredApiKey';
+                    break;
+                case auth.ExternalAuthType.ApiKey:
+                    const apiKeyAuthInfo = externalAuth as auth.ApiKeyExternalAuthInfo;
+                    apiKey = apiKeyAuthInfo.apiKey;
+                    break;
+                default:
+                    break;
+            }
+        }
+        // Setting creds in the temp NuGet.config if needed
+        nuGetConfigHelper.setAuthForSourcesInTempNuGetConfig();
+        const dotnetPath = tl.which('dotnet', true);
+        try {
+            for (const packageFile of filesList) {
                 await dotNetNuGetPushAsync(dotnetPath, packageFile, feedUri, apiKey, dotnetArguments, configFile, tempNuGetConfigDirectory);
-      }
-    } finally {
-      credCleanup();
+            }
+        } finally {
+            credCleanup();
+        }
+
+        tl.setResult(tl.TaskResult.Succeeded, tl.loc('PackagesPublishedSuccessfully'));
+    } catch (err) {
+        tl.error(err);
+
+        if (buildIdentityDisplayName || buildIdentityAccount) {
+            tl.warning(tl.loc('BuildIdentityPermissionsHint', buildIdentityDisplayName, buildIdentityAccount));
+        }
+
+        tl.setResult(tl.TaskResult.Failed, tl.loc('PackagesFailedToPublish'));
     }
-
-    tl.setResult(tl.TaskResult.Succeeded, tl.loc('PackagesPublishedSuccessfully'));
-
-  } catch (err) {
-    tl.error(err);
-
-    if (buildIdentityDisplayName || buildIdentityAccount) {
-      tl.warning(tl.loc('BuildIdentityPermissionsHint', buildIdentityDisplayName, buildIdentityAccount));
-    }
-
-    tl.setResult(tl.TaskResult.Failed, tl.loc('PackagesFailedToPublish'));
-  }
 }
 
-function dotNetNuGetPushAsync(dotnetPath: string, packageFile: string, feedUri: string, apiKey: string, dotnetArguments: string, configFile: string, workingDirectory: string): Q.Promise<number> {
-  const dotnet = tl.tool(dotnetPath);
+function dotNetNuGetPushAsync(
+    dotnetPath: string,
+    packageFile: string,
+    feedUri: string,
+    apiKey: string,
+    dotnetArguments: string,
+    configFile: string,
+    workingDirectory: string
+): Q.Promise<number> {
+    const dotnet = tl.tool(dotnetPath);
 
-  dotnet.arg('nuget');
-  dotnet.arg('push');
+    dotnet.arg('nuget');
+    dotnet.arg('push');
 
-  dotnet.arg(packageFile);
+    dotnet.arg(packageFile);
 
-  dotnet.arg('--source');
-  dotnet.arg(feedUri);
+    dotnet.arg('--source');
+    dotnet.arg(feedUri);
 
-  dotnet.arg('--api-key');
-  dotnet.arg(apiKey);
+    dotnet.arg('--api-key');
+    dotnet.arg(apiKey);
 
-  dotnet.line(dotnetArguments);
+    dotnet.line(dotnetArguments);
 
-  // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
-  const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
-  return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
+    // dotnet.exe v1 and v2 do not accept the --verbosity parameter for the "nuget push"" command, although it does for other commands
+    const envWithProxy = ngRunner.setNuGetProxyEnvironment(process.env, /*configFile*/ null, feedUri);
+    return dotnet.exec({ cwd: workingDirectory, env: envWithProxy } as IExecOptions);
 }
 
 async function getAccessToken(isInternalFeed: boolean, uriPrefixes: any): Promise<string> {
-  let accessToken: string;
-  let allowServiceConnection = tl.getVariable('PUBLISH_VIA_SERVICE_CONNECTION');
+    let accessToken: string;
+    let allowServiceConnection = tl.getVariable('PUBLISH_VIA_SERVICE_CONNECTION');
 
-  if (allowServiceConnection) {
-    let endpoint = tl.getInput('externalEndpoint', false);
+    if (allowServiceConnection) {
+        let endpoint = tl.getInput('externalEndpoint', false);
 
-    if (endpoint && isInternalFeed === true) {
-            tl.debug("Found external endpoint, will use token for auth");
-      let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
-      let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
-      switch (endpointScheme) {
-                case ("token"):
-                    accessToken = endpointAuth.parameters["apitoken"];
-          break;
-        default:
-                    tl.warning(tl.loc("Warning_UnsupportedServiceConnectionAuth"));
-          break;
-      }
-    }
-    if (!accessToken && isInternalFeed === true) {
-            tl.debug("Checking for auth from Cred Provider.");
-      const feed = getProjectAndFeedIdFromInputParam('feedPublish');
-            const JsonEndpointsString = process.env["VSS_NUGET_EXTERNAL_FEED_ENDPOINTS"];
-
-      if (JsonEndpointsString) {
-        tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
-        tl.debug(`Endpoints found: ${JsonEndpointsString}`);
-
-        let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
-        let matchingEndpoint: EndpointCredentials;
-        for (const e of endpointsArray.endpointCredentials) {
-          for (const prefix of uriPrefixes) {
-            if (e.endpoint.toUpperCase().startsWith(prefix.toUpperCase())) {
-              let isServiceConnectionValid = await tryServiceConnection(e, feed);
-              if (isServiceConnectionValid) {
-                matchingEndpoint = e;
-                break;
-              }
+        if (endpoint && isInternalFeed === true) {
+            tl.debug('Found external endpoint, will use token for auth');
+            let endpointAuth = tl.getEndpointAuthorization(endpoint, true);
+            let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
+            switch (endpointScheme) {
+                case 'token':
+                    accessToken = endpointAuth.parameters['apitoken'];
+                    break;
+                default:
+                    tl.warning(tl.loc('Warning_UnsupportedServiceConnectionAuth'));
+                    break;
             }
-          }
-          if (matchingEndpoint) {
-            accessToken = matchingEndpoint.password;
-            break;
-          }
         }
-      }
-    }
-    if (accessToken) {
-      return accessToken;
-    }
-  }
+        if (!accessToken && isInternalFeed === true) {
+            tl.debug('Checking for auth from Cred Provider.');
+            const feed = getProjectAndFeedIdFromInputParam('feedPublish');
+            const JsonEndpointsString = process.env['VSS_NUGET_EXTERNAL_FEED_ENDPOINTS'];
 
-  tl.debug('Defaulting to use the System Access Token.');
-  accessToken = pkgLocationUtils.getSystemAccessToken();
-  return accessToken;
+            if (JsonEndpointsString) {
+                tl.debug(`Feed details ${feed.feedId} ${feed.projectId}`);
+                tl.debug(`Endpoints found: ${JsonEndpointsString}`);
+
+                let endpointsArray: { endpointCredentials: EndpointCredentials[] } = JSON.parse(JsonEndpointsString);
+                let matchingEndpoint: EndpointCredentials;
+                for (const e of endpointsArray.endpointCredentials) {
+                    for (const prefix of uriPrefixes) {
+                        if (e.endpoint.toUpperCase().startsWith(prefix.toUpperCase())) {
+                            let isServiceConnectionValid = await tryServiceConnection(e, feed);
+                            if (isServiceConnectionValid) {
+                                matchingEndpoint = e;
+                                break;
+                            }
+                        }
+                    }
+                    if (matchingEndpoint) {
+                        accessToken = matchingEndpoint.password;
+                        break;
+                    }
+                }
+            }
+        }
+        if (accessToken) {
+            return accessToken;
+        }
+    }
+
+    tl.debug('Defaulting to use the System Access Token.');
+    accessToken = pkgLocationUtils.getSystemAccessToken();
+    return accessToken;
 }
 
 async function tryServiceConnection(endpoint: EndpointCredentials, feed: any): Promise<boolean> {
-  // Create request
-  const request = new WebRequest();
-  const token64 = Buffer.from(`${endpoint.username}:${endpoint.password}`).toString('base64');
-  request.uri = endpoint.endpoint;
-  request.method = 'GET';
-  request.headers = {
-        "Content-Type": "application/json",
-        "Authorization": "Basic " + token64
-  };
+    // Create request
+    const request = new WebRequest();
+    const token64 = Buffer.from(`${endpoint.username}:${endpoint.password}`).toString('base64');
+    request.uri = endpoint.endpoint;
+    request.method = 'GET';
+    request.headers = {
+        'Content-Type': 'application/json',
+        Authorization: 'Basic ' + token64
+    };
 
-  const timeout: number = getRequestTimeout();
-    const retriableErrorCodes = ["ETIMEDOUT", "ECONNRESET", "ENOTFOUND", "ESOCKETTIMEDOUT", "ECONNREFUSED", "EHOSTUNREACH", "EPIPE", "EA_AGAIN"];
-  const retriableStatusCodes = [408, 409, 500, 502, 503, 504];
+    const timeout: number = getRequestTimeout();
+    const retriableErrorCodes = ['ETIMEDOUT', 'ECONNRESET', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ECONNREFUSED', 'EHOSTUNREACH', 'EPIPE', 'EA_AGAIN'];
+    const retriableStatusCodes = [408, 409, 500, 502, 503, 504];
 
-  const options: WebRequestOptions = {
-    retryCount: 3,
-    retryIntervalInSeconds: 5,
-    retriableErrorCodes,
-    retriableStatusCodes,
-    retryRequestTimedout: true,
-    socketTimeout: timeout,
-    httpGlobalAgentOptions: {
-      timeout: timeout
-    }
-  };
-
-  const response = await sendRequest(request, options);
-
-  if (response.statusCode == 200) {
-    if (response.body) {
-      for (const entry of response.body.resources) {
-                if (entry['@type'] === 'AzureDevOpsProjectId' && !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))) {
-          return false;
+    const options: WebRequestOptions = {
+        retryCount: 3,
+        retryIntervalInSeconds: 5,
+        retriableErrorCodes,
+        retriableStatusCodes,
+        retryRequestTimedout: true,
+        socketTimeout: timeout,
+        httpGlobalAgentOptions: {
+            timeout: timeout
         }
-                if (entry['@type'] === 'VssFeedId' && !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))) {
-          return false;
+    };
+
+    const response = await sendRequest(request, options);
+
+    if (response.statusCode == 200) {
+        if (response.body) {
+            for (const entry of response.body.resources) {
+                if (
+                    entry['@type'] === 'AzureDevOpsProjectId' &&
+                    !(entry['label'].toUpperCase() === feed.projectId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.projectId.toUpperCase()))
+                ) {
+                    return false;
+                }
+                if (
+                    entry['@type'] === 'VssFeedId' &&
+                    !(entry['label'].toUpperCase() === feed.feedId.toUpperCase() || entry['@id'].toUpperCase().endsWith(feed.feedId.toUpperCase()))
+                ) {
+                    return false;
+                }
+            }
+            // We found matches in feedId and projectId, return the service connection
+            return true;
         }
-      }
-      // We found matches in feedId and projectId, return the service connection
-      return true;
     }
-  }
-  return false;
+    return false;
 }

--- a/Tasks/DotNetCoreCLIV2/pushcommand.ts
+++ b/Tasks/DotNetCoreCLIV2/pushcommand.ts
@@ -219,7 +219,7 @@ async function getAccessToken(isInternalFeed: boolean, uriPrefixes: any): Promis
             let endpointScheme = tl.getEndpointAuthorizationScheme(endpoint, true).toLowerCase();
             switch (endpointScheme) {
                 case ("token"):
-                    accessToken = endpointAuth.parameters['apitoken'];
+                    accessToken = endpointAuth.parameters["apitoken"];
                     break;
                 default:
                     tl.warning(tl.loc("Warning_UnsupportedServiceConnectionAuth"));


### PR DESCRIPTION
### **Context**

This PR aims to address #20981 by providing an option to pass `--skip-duplicate` in the arguments input and have these arguments be applied when using the `dotnet push` command.

---

### **Task Name**

DotNetCoreCLI@2

---

### **Description**


* Read arguments input and add it to the dotnet command when using `dotnet nuget push`.
* Add a test to verify the argumetns are being read correctly and adding `--skip-duplicates` works correctly.

---

### **Risk Assessment** (Low / Medium / High) 

The risk of the change is minimal considering it is the inclusion of an already optional paramter.

---

### **Unit Tests Added or Updated** (Yes / No) 

One unit test was added to test the specific use case that motivates this PR and the implementation.

---

### **Documentation Changes Required** (Yes / No) 

Yes the following documentation needs to be updated to state that the arguments input is also used when `command = push`

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected