### PR TITLE
Remove tsconfig.json from the non typescript projects

### DIFF
--- a/Tasks/Common/PowershellHelpers/tsconfig.json
+++ b/Tasks/Common/PowershellHelpers/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
-}

--- a/Tasks/Common/RemoteDeployer/tsconfig.json
+++ b/Tasks/Common/RemoteDeployer/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
-}

--- a/Tasks/Common/Sanitizer/tsconfig.json
+++ b/Tasks/Common/Sanitizer/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
-}

--- a/Tasks/Common/VstsAzureHelpers_/tsconfig.json
+++ b/Tasks/Common/VstsAzureHelpers_/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
-}

--- a/Tasks/Common/VstsAzureRestHelpers_/tsconfig.json
+++ b/Tasks/Common/VstsAzureRestHelpers_/tsconfig.json
@@ -1,6 +1,0 @@
-{
-    "compilerOptions": {
-        "target": "ES6",
-        "module": "commonjs"
-    }
-}

--- a/make-util.js
+++ b/make-util.js
@@ -253,11 +253,11 @@ var buildNodeTask = function (taskPath, outDir, isServerBuild) {
     // Use the tsc version supplied by the task if it is available, otherwise use the global default.
     if (overrideTscPath) {
         var tscExec = path.join(overrideTscPath, "bin", "tsc");
-        run(`node ${tscExec} --outDir "${outDir}" --rootDir "${taskPath}" ${getAdditionalTypeScriptArguments()}`);
+        run(`node ${tscExec} --outDir "${outDir}" --project ${taskPath}/tsconfig.json --rootDir "${taskPath}" ${getAdditionalTypeScriptArguments()}`);
         // Don't include typescript in node_modules
         rm("-rf", overrideTscPath);
     } else {
-        run(`tsc --outDir "${outDir}" --rootDir "${taskPath}" ${getAdditionalTypeScriptArguments()}`);
+        run(`tsc --outDir "${outDir}" --project ${taskPath}/tsconfig.json --rootDir "${taskPath}" ${getAdditionalTypeScriptArguments()}`);
     }
 
     cd(originalDir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/adm-zip": "^0.4.34",
         "@types/minimatch": "^3.0.2",
         "@types/minimist": "^1.2.5",
-        "@types/node": "^20.19.9",
         "@types/semver": "^5.5.0",
         "@types/shelljs": "^0.8.17",
         "@types/validator": "^13.15.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@types/adm-zip": "^0.4.34",
     "@types/minimatch": "^3.0.2",
     "@types/minimist": "^1.2.5",
-    "@types/node": "^20.19.9",
     "@types/semver": "^5.5.0",
     "@types/shelljs": "^0.8.17",
     "@types/validator": "^13.15.2",


### PR DESCRIPTION
### **Context**
For some reason we have tsconfig.json configurations for non-TypeScript projects that are written in PowerShell.
These TypeScript configurations [trigger](https://github.com/microsoft/azure-pipelines-tasks/pull/21068) npm installation that fails CI

---

### **Task Name**
N/A

---

### **Description**
This PR removes the tsconfig from the non-TypeScript projects

---

### **Risk Assessment** (**Low** / Medium / High)  

---

### **Unit Tests Added or Updated** (Yes / No)  
N

---

### **Additional Testing Performed**
N/A

---

### **Documentation Changes Required** (Yes / No)  
N

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
