### PR TITLE
Change run to runAsync in L0 tests

### DIFF
--- a/Tasks/DownloadGitHubNugetPackageV1/Tests/L0.ts
+++ b/Tasks/DownloadGitHubNugetPackageV1/Tests/L0.ts
@@ -1,16 +1,17 @@
-import assert = require('assert');
-import path = require('path');
+import assert = require('node:assert');
+import path = require('node:path');
+
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('DownloadGitHubNugetPackageV1 Suite', function () {
   this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
-  it('No package name provided should fail', (done: Mocha.Done) => {
+  it('No package name provided should fail', async (done: Mocha.Done) => {
     const tp: string = path.join(__dirname, 'L0NoPackageNameShouldFail.js');
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
     try {
-      tr.run();
+      tr.runAsync();
 
       assert(tr.stdOutContained('Error_InvalidPackageName'));
       assert(tr.failed, 'task should have failed');
@@ -24,16 +25,16 @@ describe('DownloadGitHubNugetPackageV1 Suite', function () {
     };
   });
 
-  it('Invalid package name provided should fail', (done: Mocha.Done) => {
+  it('Invalid package name provided should fail', async (done: Mocha.Done) => {
     const tp: string = path.join(__dirname, 'L0InvalidPackageNameShouldFail.js');
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-    
+
     try {
-      tr.run();
+      tr.runAsync();
 
       assert(tr.stdOutContained('Error_InvalidPackageName'));
       assert(tr.failed, 'task should have failed');
-      
+
       done();
     } catch (err) {
       console.log(tr.stdout);
@@ -43,12 +44,12 @@ describe('DownloadGitHubNugetPackageV1 Suite', function () {
     };
   });
 
-  it('No endpoint provided should fail', (done: Mocha.Done) => {
+  it('No endpoint provided should fail', async (done: Mocha.Done) => {
     const tp: string = path.join(__dirname, 'L0NoEndpointProvidedShouldFail.js');
     const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
     try {
-      tr.run();
+      tr.runAsync();
 
       assert(tr.stdOutContained("Cannot read property 'toLowerCase' of undefined"));
       assert(tr.failed, 'task should have failed');

--- a/Tasks/KubernetesManifestV0/Tests/L0.ts
+++ b/Tasks/KubernetesManifestV0/Tests/L0.ts
@@ -1,13 +1,15 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as assert from 'assert';
+import * as assert from 'node:assert';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import * as tl from 'azure-pipelines-task-lib';
+import { IExecSyncResult } from 'azure-pipelines-task-lib/toolrunner';
+import * as yaml from 'js-yaml';
+
 import * as shared from './TestShared';
 import * as utils from '../src/utils/utilities';
 import { updateImagePullSecrets, updateImageDetails } from '../src/utils/KubernetesObjectUtility';
-import * as yaml from 'js-yaml';
-import { IExecSyncResult } from 'azure-pipelines-task-lib/toolrunner';
 
 describe('Kubernetes Manifests Suite', function () {
     this.timeout(30000);
@@ -40,19 +42,19 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run successfuly for deploy with none strategy', (done: Mocha.Done) => {
+    it('Run successfuly for deploy with none strategy', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.deploy;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.none;
         process.env[shared.TestEnvVars.imagePullSecrets] = 'test-key1\ntest-key2';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('nginx-service 104.211.243.77') != -1, 'nginx-service external IP is 104.211.243.77')
         done();
     });
 
-    it('Run successfully for deploy canary', (done: Mocha.Done) => {
+    it('Run successfully for deploy canary', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.deploy;
@@ -62,7 +64,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.isStableDeploymentPresent] = 'true';
         process.env[shared.TestEnvVars.isCanaryDeploymentPresent] = 'false';
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'false';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('nginx-deployment-canary created') != -1, 'Canary deployment is created');
         assert(tr.stdout.indexOf('nginx-deployment-baseline created') != -1, 'Baseline deployment is created');
@@ -73,7 +75,7 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should fail when canary deployment already exits', (done: Mocha.Done) => {
+    it('Run should fail when canary deployment already exits', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.deploy;
@@ -82,29 +84,29 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.isStableDeploymentPresent] = 'true';
         process.env[shared.TestEnvVars.isCanaryDeploymentPresent] = 'true';
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         done();
     });
 
-    it('Run should fail for promote with none strategy', (done: Mocha.Done) => {
+    it('Run should fail for promote with none strategy', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.promote;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.none;
         process.env[shared.TestEnvVars.imagePullSecrets] = 'test-key';
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'task should have failed');
         done();
     });
 
-    it('Run successfuly for promote with canary strategy when baseline resource exists', (done: Mocha.Done) => {
+    it('Run successfuly for promote with canary strategy when baseline resource exists', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.promote;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.canary;
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('nginx-deployment created') != -1, 'deployment is created');
         assert(tr.stdout.indexOf('Rollout status has been skipped for Deployment as only updateStartegy:\'RollingUpdate\' is allowed') != -1, 'deployment rollout status skipped');
@@ -115,13 +117,13 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run successfuly for promote with canary strategy when baseline resource does not exist', (done: Mocha.Done) => {
+    it('Run successfuly for promote with canary strategy when baseline resource does not exist', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.promote;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.canary;
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'false';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('nginx-deployment created') != -1, 'deployment is created');
         assert(tr.stdout.indexOf('Rollout status has been skipped for Deployment as only updateStartegy:\'RollingUpdate\' is allowed') != -1, 'deployment rollout status skipped');
@@ -132,63 +134,63 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run successfuly for reject with canary strategy when baseline resource exists', (done: Mocha.Done) => {
+    it('Run successfuly for reject with canary strategy when baseline resource exists', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.reject;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.canary;
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('"azure-pipelines/version": "baseline"') != -1, 'nginx-deployment-baseline workload exists');
         assert(tr.stdout.indexOf('"nginx-deployment-canary" deleted. "nginx-deployment-baseline" deleted') != -1, 'Baseline and Canary workloads deleted');
         done();
     });
 
-    it('Run successfuly for reject with canary strategy when baseline resource does not exist', (done: Mocha.Done) => {
+    it('Run successfuly for reject with canary strategy when baseline resource does not exist', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.reject;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.canary;
         process.env[shared.TestEnvVars.isBaselineDeploymentPresent] = 'false';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('"azure-pipelines/version": "baseline"') == -1, 'nginx-deployment-baseline workload does not exist');
         assert(tr.stdout.indexOf('"nginx-deployment-canary" deleted') != -1, 'Canary workload deleted');
         done();
     });
 
-    it('Run should fail for reject with none strategy', (done: Mocha.Done) => {
+    it('Run should fail for reject with none strategy', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.reject;
         process.env[shared.TestEnvVars.strategy] = shared.Strategy.none;
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'task should have failed');
         done();
     });
 
-    it('Run successfuly for delete with arguments', (done: Mocha.Done) => {
+    it('Run successfuly for delete with arguments', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         process.env[shared.TestEnvVars.arguments] = 'deployment nginx-deployment'
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.delete;
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('deleted successfuly') != -1, 'Deleted successfuly');
         done();
     });
 
-    it('Run should fail for delete with no arguments', (done: Mocha.Done) => {
+    it('Run should fail for delete with no arguments', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.delete;
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'task should have failed');
         done();
     });
 
-    it('Run should succeed with helm bake and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -196,13 +198,13 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmChart] = 'helmChart';
         process.env[shared.TestEnvVars.renderType] = 'helm';
         process.env[shared.TestEnvVars.helmVersion] = "v2";
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should succeed with helm3 bake and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm3 bake and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -210,13 +212,13 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmChart] = 'helmChart';
         process.env[shared.TestEnvVars.renderType] = 'helm';
         process.env[shared.TestEnvVars.helmVersion] = "v3";
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should succeed with helm2 type (backward compat) with helm2 and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm2 type (backward compat) with helm2 and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -224,13 +226,13 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmChart] = 'helmChart';
         process.env[shared.TestEnvVars.renderType] = 'helm2';
         process.env[shared.TestEnvVars.helmVersion] = "v2";
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should succeed with helm bake overriding release name and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake overriding release name and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -239,14 +241,14 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.renderType] = 'helm';
         process.env[shared.TestEnvVars.helmVersion] = "v2";
         process.env[shared.TestEnvVars.releaseName] = 'newReleaseName';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--name newReleaseName') > -1, 'bake should have overriden release name');
         done();
     });
 
-    it('Run should succeed with helm3 bake overriding release name and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm3 bake overriding release name and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -255,7 +257,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.renderType] = 'helm';
         process.env[shared.TestEnvVars.helmVersion] = "v3";
         process.env[shared.TestEnvVars.releaseName] = 'newReleaseName';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
@@ -263,7 +265,7 @@ describe('Kubernetes Manifests Suite', function () {
         done(tr.stderr);
     });
 
-    it('Run should succeed with helm2 type (backward compat) and helm3 bake overriding release name and honor namespace field', (done: Mocha.Done) => {
+    it('Run should succeed with helm2 type (backward compat) and helm3 bake overriding release name and honor namespace field', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -272,7 +274,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.renderType] = 'helm2';
         process.env[shared.TestEnvVars.helmVersion] = "v3";
         process.env[shared.TestEnvVars.releaseName] = 'newReleaseName';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
@@ -280,7 +282,7 @@ describe('Kubernetes Manifests Suite', function () {
         done(tr.stderr);
     });
 
-    it('Run should succeed with helm bake overriding release name and use default namespace when not found in endpoint either', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake overriding release name and use default namespace when not found in endpoint either', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -289,7 +291,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmVersion] = "v2";
         process.env[shared.TestEnvVars.releaseName] = 'newReleaseName';
         process.env.RemoveNamespaceFromEndpoint = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--name newReleaseName') > -1, 'bake should have overriden release name');
@@ -298,7 +300,7 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should succeed with helm bake overriding release name and use default namespace when not found in endpoint either', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake overriding release name and use default namespace when not found in endpoint either', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -307,7 +309,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmVersion] = "v3";
         process.env[shared.TestEnvVars.releaseName] = 'newReleaseName';
         process.env.RemoveNamespaceFromEndpoint = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('newReleaseName') > -1, 'bake should have overriden release name');
@@ -317,7 +319,7 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should succeed with helm bake should override values with : correctly', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake should override values with : correctly', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -326,7 +328,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmVersion] = "v2";
         process.env[shared.TestEnvVars.overrides] = 'name:value:with:colons';
         process.env.RemoveNamespaceFromEndpoint = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
@@ -335,7 +337,7 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should succeed with helm3 bake should override values with : correctly', (done: Mocha.Done) => {
+    it('Run should succeed with helm3 bake should override values with : correctly', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -344,7 +346,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.helmVersion] = "v3";
         process.env[shared.TestEnvVars.overrides] = 'name:value:with:colons';
         process.env.RemoveNamespaceFromEndpoint = 'true';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         assert(tr.stdout.indexOf('--namespace default') > -1, 'should have used default namespace');
@@ -353,7 +355,7 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should succeed with helm bake with image substituion', (done: Mocha.Done) => {
+    it('Run should succeed with helm bake with image substituion', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -362,19 +364,19 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.renderType] = 'helm';
         process.env[shared.TestEnvVars.helmVersion] = "v2";
         process.env[shared.TestEnvVars.containers] = 'nginx:1.1.1';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should successfully create secret', (done: Mocha.Done) => {
+    it('Run should successfully create secret', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.createSecret;
         process.env[shared.TestEnvVars.secretName] = 'secret';
         process.env[shared.TestEnvVars.secretType] = 'generic';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('delete secret') > -1, 'task should have deleted secret');
         assert(tr.stdout.indexOf('create secret') > -1, 'task should have created secret');
@@ -382,20 +384,20 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should scale', (done: Mocha.Done) => {
+    it('Run should scale', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.scale;
         process.env[shared.TestEnvVars.kind] = 'replicaset';
         process.env[shared.TestEnvVars.replicas] = '1';
         process.env[shared.TestEnvVars.name] = 'r1';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('scale replicaset/r1') > -1, 'task should have run scale command');
         done();
     });
 
-    it('Run should succeessfully patch', (done: Mocha.Done) => {
+    it('Run should succeessfully patch', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.patch;
@@ -403,7 +405,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.mergeStrategy] = 'merge';
         process.env[shared.TestEnvVars.name] = 'r1';
         process.env[shared.TestEnvVars.patch] = 'somePatch';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         done();
     });
@@ -450,40 +452,40 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Run should bake docker-compose files using kompose', (done: Mocha.Done) => {
+    it('Run should bake docker-compose files using kompose', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kompose';
         process.env[shared.TestEnvVars.dockerComposeFile] = 'dockerComposeFilePath';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('Kubernetes files created') > 0, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should bake docker-compose files using kompose with image substituion', (done: Mocha.Done) => {
+    it('Run should bake docker-compose files using kompose with image substituion', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kompose';
         process.env[shared.TestEnvVars.dockerComposeFile] = 'dockerComposeFilePath';
         process.env[shared.TestEnvVars.containers] = 'nginx:1.1.1';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdout.indexOf('Kubernetes files created') > 0, 'task should have succeeded');
         assert(tr.stdout.indexOf('set manifestsBundle') > -1, 'task should have set manifestsBundle output variable');
         done();
     });
 
-    it('Run should fail when docker-compose file path is not supplied', (done: Mocha.Done) => {
+    it('Run should fail when docker-compose file path is not supplied', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kompose';
         process.env[shared.TestEnvVars.dockerComposeFile] = '';
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'task should have failed');
         assert(tr.stdout.indexOf('Input required: dockerComposeFile') > 0, 'proper error message should have been thrown');
         done();
@@ -507,33 +509,33 @@ describe('Kubernetes Manifests Suite', function () {
         done();
     });
 
-    it('Kustomize bake should fail when kubectl version is lower than v1.14', (done: Mocha.Done) => {
+    it('Kustomize bake should fail when kubectl version is lower than v1.14', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kustomize';
         process.env[shared.TestEnvVars.kustomizationPath] = 'kustomizationPath';
         process.env.KubectlMinorVersion = '13';
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'task should have failed');
         assert(tr.stdout.indexOf('KubectlShouldBeUpgraded') > 0, 'proper error message should have been thrown');
         done();
     });
 
-    it('Kustomize bake should pass when kubectl version is greater than or equal to v1.14', (done: Mocha.Done) => {
+    it('Kustomize bake should pass when kubectl version is greater than or equal to v1.14', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
         process.env[shared.TestEnvVars.renderType] = 'kustomize';
         process.env[shared.TestEnvVars.kustomizationPath] = 'kustomizationPath';
         process.env.KubectlMinorVersion = '14';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdOutContained('kustomize kustomizationPath'), 'task should have invoked tool: kustomize');
         done();
     });
 
-    it('Kustomize bake should pass with image substituition', (done: Mocha.Done) => {
+    it('Kustomize bake should pass with image substituition', async (done: Mocha.Done) => {
         const tp = path.join(__dirname, 'TestSetup.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
         process.env[shared.TestEnvVars.action] = shared.Actions.bake;
@@ -541,7 +543,7 @@ describe('Kubernetes Manifests Suite', function () {
         process.env[shared.TestEnvVars.kustomizationPath] = 'kustomizationPath';
         process.env[shared.TestEnvVars.containers] = 'nginx:1.1.1\nalpine';
         process.env.KubectlMinorVersion = '14';
-        tr.run();
+        tr.runAsync();
         assert(tr.succeeded, 'task should have succeeded');
         assert(tr.stdOutContained('kustomize kustomizationPath'), 'task should have invoked tool: kustomize');
         done();

--- a/Tasks/NuGetCommandV2/Tests/L0.ts
+++ b/Tasks/NuGetCommandV2/Tests/L0.ts
@@ -11,11 +11,11 @@ describe('NuGetCommand Suite', function () {
     after(() => {
     });
 
-    it('restore single solution', (done: Mocha.Done) => {
+    it('restore single solution', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singlesln.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -25,11 +25,11 @@ describe('NuGetCommand Suite', function () {
         done();
     }).timeout(20000);
 
-    it('restore single solution with CredentialProvider', (done: Mocha.Done) => {
+    it('restore single solution with CredentialProvider', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnCredentialProvider.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -41,11 +41,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore packages.config', (done: Mocha.Done) => {
+    it('restore packages.config', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/pkgconfig.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -55,11 +55,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore single solution with noCache', (done: Mocha.Done) => {
+    it('restore single solution with noCache', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnNoCache.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NoCache -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -69,11 +69,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore single solution with disableParallelProcessing', (done: Mocha.Done) => {
+    it('restore single solution with disableParallelProcessing', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnDisableParallelProcessing.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -DisableParallelProcessing -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -83,11 +83,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore single solution with nuget config', (done: Mocha.Done) => {
+    it('restore single solution with nuget config', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnConfigFile.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -97,11 +97,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore multiple solutions', (done: Mocha.Done) => {
+    it('restore multiple solutions', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/multiplesln.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.invokedToolCount == 2, 'should have run NuGet twice');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet on single.sln');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\double\\double.sln -NonInteractive'), 'it should have run NuGet on double.sln');
@@ -112,11 +112,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore multiple solutions and parses pattern appropriately', (done: Mocha.Done) => {
+    it('restore multiple solutions and parses pattern appropriately', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/multipleslnmultiplepattern.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.invokedToolCount == 2, 'should have run NuGet twice');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet on single.sln');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\double\\double.sln -NonInteractive'), 'it should have run NuGet on double.sln');
@@ -127,11 +127,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore single solution mono', (done: Mocha.Done) => {
+    it('restore single solution mono', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnMono.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -140,11 +140,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore select vsts source', (done: Mocha.Done) => {
+    it('restore select vsts source', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/selectSourceVsts.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with a vsts source');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -153,11 +153,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore select nuget.org source', (done: Mocha.Done) => {
+    it('restore select nuget.org source', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/selectSourceNuGetOrg.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with nuget.org source');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -166,11 +166,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore select multiple sources', (done: Mocha.Done) => {
+    it('restore select multiple sources', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/selectSourceMultiple.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with multiple sources');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -179,11 +179,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore select nuget.org source warns', (done: Mocha.Done) => {
+    it('restore select nuget.org source warns', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorWarn.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with nuget.org source');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -192,22 +192,22 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore select nuget.org source fails', (done: Mocha.Done) => {
+    it('restore select nuget.org source fails', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorFail.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 0, 'should not run NuGet');
         assert(tr.failed, 'should have Failed');
         assert.equal(tr.errorIssues.length, 2, "should have 2 errors");
         done();
     });
 
-    it('restore select nuget.org source on nuget config succeeds', (done: Mocha.Done) => {
+    it('restore select nuget.org source on nuget config succeeds', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorOnConfig.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -217,11 +217,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('pushes successfully to internal feed using NuGet.exe', (done: Mocha.Done) => {
+    it('pushes successfully to internal feed using NuGet.exe', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/internalFeedNuGet.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe push c:\\agent\\home\\directory\\foo.nupkg -NonInteractive -Source https://vsts/packagesource -ApiKey VSTS'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -231,11 +231,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('pushes successfully to internal feed using VstsNuGetPush.exe', (done: Mocha.Done) => {
+    it('pushes successfully to internal feed using VstsNuGetPush.exe', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPush.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -245,11 +245,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('pushes successfully to internal project scoped feed using VstsNuGetPush.exe', (done: Mocha.Done) => {
+    it('pushes successfully to internal project scoped feed using VstsNuGetPush.exe', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushProjectScoped.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/ProjectId/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -259,11 +259,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('succeeds when conflict occurs using VstsNuGetPush.exe (allow conflict)', (done: Mocha.Done) => {
+    it('succeeds when conflict occurs using VstsNuGetPush.exe (allow conflict)', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushAllowConflict.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run VstsNuGetPush');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -273,11 +273,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('succeeds when conflict occurs using NuGet.exe on Linux (allow conflict)', (done: Mocha.Done) => {
+    it('succeeds when conflict occurs using NuGet.exe on Linux (allow conflict)', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflictOnLinux.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet.exe once');
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.succeeded, 'should have succeeded');
@@ -285,11 +285,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('fails when conflict occurs using VstsNuGetPush.exe (disallow conflict)', (done: Mocha.Done) => {
+    it('fails when conflict occurs using VstsNuGetPush.exe (disallow conflict)', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushDisallowConflict.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -298,11 +298,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('packs with prerelease', (done: Mocha.Done) => {
+    it('packs with prerelease', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packPrerelease.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version x.y.z-CI-22220101-010101'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -312,11 +312,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('packs with env var', (done: Mocha.Done) => {
+    it('packs with env var', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packEnvVar.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version XX.YY.ZZ'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -326,11 +326,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('packs with build number', (done: Mocha.Done) => {
+    it('packs with build number', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packBuildNumber.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version 1.2.3'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -340,11 +340,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('packs with base path', (done: Mocha.Done) => {
+    it('packs with base path', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packBasePath.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -BasePath C:\\src'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -354,11 +354,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('packs tool', (done: Mocha.Done) => {
+    it('packs tool', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packTool.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -Tool'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -368,11 +368,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('works with custom command happy path', (done: Mocha.Done) => {
+    it('works with custom command happy path', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './CustomCommandTests/customHappyPath.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe these are my arguments -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -382,11 +382,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore single solution with nuget config and multiple service connections', (done: Mocha.Done) => {
+    it('restore single solution with nuget config and multiple service connections', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/multipleServiceConnections.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
@@ -399,11 +399,11 @@ describe('NuGetCommand Suite', function () {
     });
 
 
-    it('custom command fails when exit code !=0', (done: Mocha.Done) => {
+    it('custom command fails when exit code !=0', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './CustomCommandTests/customFailPath.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 1, "should have 1 error");
@@ -411,11 +411,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('pack fails when exit code !=0', (done: Mocha.Done) => {
+    it('pack fails when exit code !=0', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PackTests/packFails.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
@@ -424,11 +424,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('publish fails when duplicates are skipped and exit code!=[0|2] on Windows_NT', (done: Mocha.Done) => {
+    it('publish fails when duplicates are skipped and exit code!=[0|2] on Windows_NT', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflict.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
@@ -437,21 +437,21 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('publish fails when duplicates are NOT skipped and exit code!=0', (done: Mocha.Done) => {
+    it('publish fails when duplicates are NOT skipped and exit code!=0', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './PublishTests/failWithoutContinueOnConflict.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
         done();
     });
 
-    it('restore fails when exit code!=0', (done: Mocha.Done) => {
+    it('restore fails when exit code!=0', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/failRestore.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.stdErrContained, "stderr output is here");
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
@@ -460,11 +460,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore succeeds on ubuntu 22', (done: Mocha.Done) => {
+    it('restore succeeds on ubuntu 22', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnUbuntu22.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -473,11 +473,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore succeeds on ubuntu 24 with mono', (done: Mocha.Done) => {
+    it('restore succeeds on ubuntu 24 with mono', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/singleslnUbuntu24Mono.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
@@ -486,11 +486,11 @@ describe('NuGetCommand Suite', function () {
         done();
     });
 
-    it('restore fails on ubuntu 24 without mono', (done: Mocha.Done) => {
+    it('restore fails on ubuntu 24 without mono', async (done: Mocha.Done) => {
         let tp = path.join(__dirname, './RestoreTests/failUbuntu24NoMono.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run();
+        tr.runAsync();
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 1, "should have 1 error");
         assert(tr.invokedToolCount == 0, 'should have run no tools');

--- a/Tasks/NuGetPublisherV0/Tests/L0.ts
+++ b/Tasks/NuGetPublisherV0/Tests/L0.ts
@@ -1,34 +1,29 @@
-import * as path from 'path';
-import * as assert from 'assert';
+import * as path from 'node:path';
+import * as assert from 'node:assert';
+
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('NuGetPublisher Suite', function () {
-    before(() => {
-    });
-
-    after(() => {
-    });
-    
-    it('publish single package internally', (done: MochaDone) => {
+    it('publish single package internally', async (done: MochaDone) => {
         let tp = path.join(__dirname, 'internal.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync();
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe push -NonInteractive c:\\agent\\home\\directory\\package.nupkg -Source testFeedUri -ApiKey VSTS -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'should have pushed packages');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
         assert(tr.succeeded, 'should have succeeded');
-        assert(tr.invokedToolCount == 1, 'should have run NuGet');      
+        assert(tr.invokedToolCount == 1, 'should have run NuGet');
         assert.equal(tr.warningIssues.length, 0, "should have no warnings");
         assert.equal(tr.errorIssues.length, 0, "should have no errors");
         done();
     }).timeout(20000);
-    
-    it('publish single package externally', (done: MochaDone) => {
+
+    it('publish single package externally', async (done: MochaDone) => {
         let tp = path.join(__dirname, 'external.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync();
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe push -NonInteractive c:\\agent\\home\\directory\\package.nupkg -Source https://example.feed.com -ApiKey secret'), 'should have pushed packages');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
         assert(tr.stdOutContained('NuGet output here'), "should have nuget output");

--- a/Tasks/NuGetRestoreV1/Tests/L0.ts
+++ b/Tasks/NuGetRestoreV1/Tests/L0.ts
@@ -1,23 +1,17 @@
-import * as path from 'path';
-import * as assert from 'assert';
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
-describe('NuGetRestore Suite', function () {
-    before(() => {
-    });
-
-    after(() => {
-    });
-
+describe('NuGetRestore Suite', async () => {
     it('restore solution', (done: Mocha.Done) => {
         let tp = path.join(__dirname, 'singlesln.js')
         let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
-        tr.run()
+        tr.runAsync()
         assert(tr.failed, 'should have failed');
         assert.equal(tr.errorIssues.length, 1, "should have 1 error");
         assert.equal(tr.errorIssues[0], "loc_mock_DeprecatedTask", "Error should be about deprecation");
         done();
     }).timeout(20000);
-
 });


### PR DESCRIPTION
### **Context**
Several tests use `run` from **azure-pipelines-task-lib** that was removed in https://github.com/microsoft/azure-pipelines-task-lib/pull/932

---

### **Task Name**


---

### **Description**
This PR changes `run` to `runAsync`

---

### **Risk Assessment** (**Low** / Medium / High)  


---

### **Unit Tests Added or Updated** (Yes / No)  
N
---

### **Additional Testing Performed**
N
---

### **Documentation Changes Required** (Yes / No)  
N
---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
