### PR TITLE
Handle the case where projects input isn't set for test command in MTP mode

### DIFF
--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -188,7 +188,7 @@ export class dotNetExe {
             const dotnet = tl.tool(dotnetPath);
             dotnet.arg(this.command);
 
-            if (isMTP) {
+            if (isMTP && projectFile.length > 0) {
                 // https://github.com/dotnet/sdk/blob/cbb8f75623c4357919418d34c53218ca9b57358c/src/Cli/dotnet/Commands/Test/CliConstants.cs#L34
                 if (projectFile.endsWith(".proj") || projectFile.endsWith(".csproj") || projectFile.endsWith(".vbproj") || projectFile.endsWith(".fsproj")) {
                     dotnet.arg("--project");

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 258,
     "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 258,
     "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
### **Context**

When `projects` input isn't provided by the user, the task currently fails with:

> ##[error]Project file '' has an unrecognized extension.

---

### **Task Name**

DotNetCoreCLI

---

### **Description**

Handle the case when no projects is provided, which should test the whole solution.

---

### **Risk Assessment** (Low / Medium / High)  

Low: MTP support in DotNetCoreCLI is fairly new, and requires `dotnet.config` which is supported starting with .NET 10 SDK that is currently still in preview.

---

### **Unit Tests Added or Updated** (Yes / No)  

No

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Documentation Changes Required** (Yes / No)  
_Indicate whether related documentation needs to be updated._

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
