### PR TITLE
Change run to runAsync in NugetCommandV2 L0 tests

### DIFF
--- a/Tasks/NuGetCommandV2/Tests/L0.ts
+++ b/Tasks/NuGetCommandV2/Tests/L0.ts
@@ -1,499 +1,422 @@
-import * as assert from "assert";
-import * as ttm from "azure-pipelines-task-lib/mock-test";
-import * as path from "path";
+import * as assert from 'node:assert';
+import * as path from 'node:path';
+
+import * as ttm from 'azure-pipelines-task-lib/mock-test';
 
 describe('NuGetCommand Suite', function () {
     this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 10000);
 
-    before(() => {
-    });
-
-    after(() => {
-    });
-
-    it('restore single solution', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singlesln.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singlesln.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     }).timeout(20000);
 
-    it('restore single solution with CredentialProvider', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnCredentialProvider.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution with CredentialProvider', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnCredentialProvider.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
-        assert(tr.stdout.indexOf('credProviderPath = ') >= 0, "should have found credential provider path");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
+        assert(tr.stdout.indexOf('credProviderPath = ') >= 0, 'should have found credential provider path');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.warningIssues.length, 0, "should have no warnings");
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.warningIssues.length, 0, 'should have no warnings');
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore packages.config', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/pkgconfig.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore packages.config', async () => {
+        const tp = path.join(__dirname, './RestoreTests/pkgconfig.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore single solution with noCache', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnNoCache.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution with noCache', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnNoCache.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NoCache -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore single solution with disableParallelProcessing', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnDisableParallelProcessing.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution with disableParallelProcessing', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnDisableParallelProcessing.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -DisableParallelProcessing -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore single solution with nuget config', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnConfigFile.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution with nuget config', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnConfigFile.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore multiple solutions', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/multiplesln.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('restore multiple solutions', async () => {
+        const tp = path.join(__dirname, './RestoreTests/multiplesln.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 2, 'should have run NuGet twice');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet on single.sln');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\double\\double.sln -NonInteractive'), 'it should have run NuGet on double.sln');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore multiple solutions and parses pattern appropriately', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/multipleslnmultiplepattern.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('restore multiple solutions and parses pattern appropriately', async () => {
+        const tp = path.join(__dirname, './RestoreTests/multipleslnmultiplepattern.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 2, 'should have run NuGet twice');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive'), 'it should have run NuGet on single.sln');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\double\\double.sln -NonInteractive'), 'it should have run NuGet on double.sln');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore single solution mono', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnMono.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution mono', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnMono.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore select vsts source', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/selectSourceVsts.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select vsts source', async () => {
+        const tp = path.join(__dirname, './RestoreTests/selectSourceVsts.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with a vsts source');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore select nuget.org source', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/selectSourceNuGetOrg.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select nuget.org source', async () => {
+        const tp = path.join(__dirname, './RestoreTests/selectSourceNuGetOrg.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with nuget.org source');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore select multiple sources', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/selectSourceMultiple.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select multiple sources', async () => {
+        const tp = path.join(__dirname, './RestoreTests/selectSourceMultiple.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with multiple sources');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore select nuget.org source warns', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorWarn.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select nuget.org source warns', async () => {
+        const tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorWarn.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\packages.config -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with nuget.org source');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded with issues');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore select nuget.org source fails', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorFail.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select nuget.org source fails', async () => {
+        const tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorFail.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 0, 'should not run NuGet');
         assert(tr.failed, 'should have Failed');
-        assert.equal(tr.errorIssues.length, 2, "should have 2 errors");
-        done();
+        assert.equal(tr.errorIssues.length, 2, 'should have 2 errors');
     });
 
-    it('restore select nuget.org source on nuget config succeeds', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorOnConfig.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore select nuget.org source on nuget config succeeds', async () => {
+        const tp = path.join(__dirname, './RestoreTests/nugetOrgBehaviorOnConfig.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('pushes successfully to internal feed using NuGet.exe', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/internalFeedNuGet.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('pushes successfully to internal feed using NuGet.exe', async () => {
+        const tp = path.join(__dirname, './PublishTests/internalFeedNuGet.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe push c:\\agent\\home\\directory\\foo.nupkg -NonInteractive -Source https://vsts/packagesource -ApiKey VSTS'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('pushes successfully to internal feed using VstsNuGetPush.exe', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPush.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('pushes successfully to internal feed using VstsNuGetPush.exe', async () => {
+        const tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPush.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('VstsNuGetPush output here'), "should have VstsNuGetPush output");
+        assert(tr.stdOutContained('VstsNuGetPush output here'), 'should have VstsNuGetPush output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('pushes successfully to internal project scoped feed using VstsNuGetPush.exe', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushProjectScoped.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('pushes successfully to internal project scoped feed using VstsNuGetPush.exe', async () => {
+        const tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushProjectScoped.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/ProjectId/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('VstsNuGetPush output here'), "should have VstsNuGetPush output");
+        assert(tr.stdOutContained('VstsNuGetPush output here'), 'should have VstsNuGetPush output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('succeeds when conflict occurs using VstsNuGetPush.exe (allow conflict)', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushAllowConflict.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('succeeds when conflict occurs using VstsNuGetPush.exe (allow conflict)', async () => {
+        const tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushAllowConflict.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run VstsNuGetPush');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('VstsNuGetPush output here'), "should have VstsNuGetPush output");
+        assert(tr.stdOutContained('VstsNuGetPush output here'), 'should have VstsNuGetPush output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('succeeds when conflict occurs using NuGet.exe on Linux (allow conflict)', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflictOnLinux.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('succeeds when conflict occurs using NuGet.exe on Linux (allow conflict)', async () => {
+        const tp = path.join(__dirname, './PublishTests/failWithContinueOnConflictOnLinux.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet.exe once');
-        assert(tr.stdErrContained, "stderr output is here");
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('fails when conflict occurs using VstsNuGetPush.exe (disallow conflict)', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushDisallowConflict.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('fails when conflict occurs using VstsNuGetPush.exe (disallow conflict)', async () => {
+        const tp = path.join(__dirname, './PublishTests/internalFeedVstsNuGetPushDisallowConflict.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run VstsNuGetPush once');
         assert(tr.ran('c:\\agent\\home\\directory\\externals\\nuget\\VstsNuGetPush.exe c:\\agent\\home\\directory\\foo.nupkg -Source https://vsts/packagesource -AccessToken token -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('VstsNuGetPush output here'), "should have VstsNuGetPush output");
+        assert(tr.stdOutContained('VstsNuGetPush output here'), 'should have VstsNuGetPush output');
         assert(tr.failed, 'should have failed');
-        done();
     });
 
-    it('packs with prerelease', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packPrerelease.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('packs with prerelease', async () => {
+        const tp = path.join(__dirname, './PackTests/packPrerelease.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version x.y.z-CI-22220101-010101'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('packs with env var', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packEnvVar.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('packs with env var', async () => {
+        const tp = path.join(__dirname, './PackTests/packEnvVar.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version XX.YY.ZZ'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('packs with build number', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packBuildNumber.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('packs with build number', async () => {
+        const tp = path.join(__dirname, './PackTests/packBuildNumber.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -version 1.2.3'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('packs with base path', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packBasePath.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('packs with base path', async () => {
+        const tp = path.join(__dirname, './PackTests/packBasePath.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -BasePath C:\\src'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('packs tool', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packTool.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('packs tool', async () => {
+        const tp = path.join(__dirname, './PackTests/packTool.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe pack c:\\agent\\home\\directory\\foo.nuspec -NonInteractive -OutputDirectory C:\\out\\dir -Tool'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('works with custom command happy path', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './CustomCommandTests/customHappyPath.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('works with custom command happy path', async () => {
+        const tp = path.join(__dirname, './CustomCommandTests/customHappyPath.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe these are my arguments -NonInteractive'), 'it should have run NuGet');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore single solution with nuget config and multiple service connections', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/multipleServiceConnections.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run()
+    it('restore single solution with nuget config and multiple service connections', async () => {
+        const tp = path.join(__dirname, './RestoreTests/multipleServiceConnections.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config'), 'it should have run NuGet with ConfigFile specified');
         assert(tr.stdOutContained('setting console code page'), 'it should have run chcp');
         assert(tr.stdOutContained('adding token auth entry for feed https://endpoint1.visualstudio.com/path'), 'it should have added auth entry for endpoint 1');
         assert(tr.stdOutContained('adding token auth entry for feed https://endpoint2.visualstudio.com/path'), 'it should have added auth entry for endpoint 2');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
 
-    it('custom command fails when exit code !=0', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './CustomCommandTests/customFailPath.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-        assert(tr.stdErrContained, "stderr output is here");
+    it('custom command fails when exit code !=0', async () => {
+        const tp = path.join(__dirname, './CustomCommandTests/customFailPath.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.failed, 'should have failed');
-        assert.equal(tr.errorIssues.length, 1, "should have 1 error");
-        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
-        done();
+        assert.equal(tr.errorIssues.length, 1, 'should have 1 error');
+        assert.equal(tr.errorIssues[0], 'loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here', 'should have error from nuget');
     });
 
-    it('pack fails when exit code !=0', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PackTests/packFails.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-        assert(tr.stdErrContained, "stderr output is here");
+    it('pack fails when exit code !=0', async () => {
+        const tp = path.join(__dirname, './PackTests/packFails.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.failed, 'should have failed');
-        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
-        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
-        assert.equal(tr.errorIssues[1], "loc_mock_Error_PackageFailure", "should have error from task runner");
-        done();
+        assert.equal(tr.errorIssues.length, 2, 'should have 1 error from nuget and one from task');
+        assert.equal(tr.errorIssues[0], 'loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here', 'should have error from nuget');
+        assert.equal(tr.errorIssues[1], 'loc_mock_Error_PackageFailure', 'should have error from task runner');
     });
 
-    it('publish fails when duplicates are skipped and exit code!=[0|2] on Windows_NT', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/failWithContinueOnConflict.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-        assert(tr.stdErrContained, "stderr output is here");
+    it('publish fails when duplicates are skipped and exit code!=[0|2] on Windows_NT', async () => {
+        const tp = path.join(__dirname, './PublishTests/failWithContinueOnConflict.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.failed, 'should have failed');
-        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
-        assert.equal(tr.errorIssues[0], "Error: loc_mock_Error_UnexpectedErrorVstsNuGetPush 1 stderr output is here", "should have error from nuget");
-        assert.equal(tr.errorIssues[1], "loc_mock_PackagesFailedToPublish", "should have error from task runner");
-        done();
+        assert.equal(tr.errorIssues.length, 2, 'should have 1 error from nuget and one from task');
+        assert.equal(tr.errorIssues[0], 'Error: loc_mock_Error_UnexpectedErrorVstsNuGetPush 1 stderr output is here', 'should have error from nuget');
+        assert.equal(tr.errorIssues[1], 'loc_mock_PackagesFailedToPublish', 'should have error from task runner');
     });
 
-    it('publish fails when duplicates are NOT skipped and exit code!=0', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './PublishTests/failWithoutContinueOnConflict.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-        assert(tr.stdErrContained, "stderr output is here");
+    it('publish fails when duplicates are NOT skipped and exit code!=0', async () => {
+        const tp = path.join(__dirname, './PublishTests/failWithoutContinueOnConflict.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.failed, 'should have failed');
-        done();
     });
 
-    it('restore fails when exit code!=0', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/failRestore.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
-        assert(tr.stdErrContained, "stderr output is here");
+    it('restore fails when exit code!=0', async () => {
+        const tp = path.join(__dirname, './RestoreTests/failRestore.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.stdErrContained, 'stderr output is here');
         assert(tr.failed, 'should have failed');
-        assert.equal(tr.errorIssues.length, 2, "should have 1 error from nuget and one from task");
-        assert.equal(tr.errorIssues[0], "loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here", "should have error from nuget");
-        assert.equal(tr.errorIssues[1], "loc_mock_PackagesFailedToInstall", "should have error from task runner");
-        done();
+        assert.equal(tr.errorIssues.length, 2, 'should have 1 error from nuget and one from task');
+        assert.equal(tr.errorIssues[0], 'loc_mock_Error_NugetFailedWithCodeAndErr 1 stderr output is here', 'should have error from nuget');
+        assert.equal(tr.errorIssues[1], 'loc_mock_PackagesFailedToInstall', 'should have error from task runner');
     });
 
-    it('restore succeeds on ubuntu 22', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnUbuntu22.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('restore succeeds on ubuntu 22', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnUbuntu22.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore succeeds on ubuntu 24 with mono', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/singleslnUbuntu24Mono.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('restore succeeds on ubuntu 24 with mono', async () => {
+        const tp = path.join(__dirname, './RestoreTests/singleslnUbuntu24Mono.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.invokedToolCount == 1, 'should have run NuGet once');
         assert(tr.ran('/usr/bin/mono c:\\from\\tool\\installer\\nuget.exe restore ~/myagent/_work/1/s/single.sln -NonInteractive'), 'it should have run NuGet with mono');
-        assert(tr.stdOutContained('NuGet output here'), "should have nuget output");
+        assert(tr.stdOutContained('NuGet output here'), 'should have nuget output');
         assert(tr.succeeded, 'should have succeeded');
-        assert.equal(tr.errorIssues.length, 0, "should have no errors");
-        done();
+        assert.equal(tr.errorIssues.length, 0, 'should have no errors');
     });
 
-    it('restore fails on ubuntu 24 without mono', (done: Mocha.Done) => {
-        let tp = path.join(__dirname, './RestoreTests/failUbuntu24NoMono.js')
-        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
-
-        tr.run();
+    it('restore fails on ubuntu 24 without mono', async () => {
+        const tp = path.join(__dirname, './RestoreTests/failUbuntu24NoMono.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
         assert(tr.failed, 'should have failed');
-        assert.equal(tr.errorIssues.length, 1, "should have 1 error");
+        assert.equal(tr.errorIssues.length, 1, 'should have 1 error');
         assert(tr.invokedToolCount == 0, 'should have run no tools');
-        done();
     });
 });

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -10,29 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.3.1",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
+        "azure-pipelines-task-lib": "4.17.0",
         "azure-pipelines-tasks-packaging-common": "3.253.0",
         "azure-pipelines-tasks-utility-common": "^3.0.3",
         "xmlreader": "^0.2.3"
       },
       "devDependencies": {
         "typescript": "5.1.6"
-      }
-    },
-    "node_modules/@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/ini": {
@@ -65,11 +49,6 @@
       "version": "1.5.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "node_modules/@types/semver": {
       "version": "5.5.0",
@@ -159,16 +138,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/azure-devops-node-api": {
       "version": "14.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-14.1.0.tgz",
@@ -183,17 +152,27 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.0.0-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.0.0-preview.tgz",
-      "integrity": "sha512-BK+VOo42Bec72Wic6Vsm2MaAJezNyF05OYAQS5FuZJM5Z972lZqYpujtSc4BFKUhC3HO+F/Yf4xhAV2tZCzN9Q==",
+      "version": "4.17.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.0.tgz",
+      "integrity": "sha1-qZ0lMCwrYSBKIRKthCGtZ6V1oys=",
+      "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
-        "mockery": "^1.7.0",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
-        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib/node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/azure-pipelines-tasks-packaging-common": {
@@ -226,28 +205,6 @@
       "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
       "license": "MIT"
     },
-    "node_modules/azure-pipelines-tasks-packaging-common/node_modules/azure-pipelines-task-lib": {
-      "version": "4.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-      "integrity": "sha512-hjyDi5GI1cFmS2o6GzTFPqloeTZBeaTLOjPn/H3CVr0vV/MV+eYoWszVe9kn7XnRSiv22j3p4Rhw/Sy4v1okxA==",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-packaging-common/node_modules/azure-pipelines-task-lib/node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/azure-pipelines-tasks-utility-common": {
       "version": "3.212.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
@@ -277,28 +234,6 @@
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-      "version": "4.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.16.0.tgz",
-      "integrity": "sha512-hjyDi5GI1cFmS2o6GzTFPqloeTZBeaTLOjPn/H3CVr0vV/MV+eYoWszVe9kn7XnRSiv22j3p4Rhw/Sy4v1okxA==",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/typed-rest-client": {
@@ -355,11 +290,6 @@
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "license": "ISC"
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
@@ -383,11 +313,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -470,40 +395,10 @@
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -532,14 +427,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/des.js": {
@@ -656,19 +543,6 @@
         }
       }
     },
-    "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -712,14 +586,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -803,33 +669,6 @@
       "bin": {
         "he": "bin/he"
       }
-    },
-    "node_modules/http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
-      "dependencies": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
-      "dependencies": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "node_modules/http-response-object/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -965,11 +804,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/js-md4": {
       "version": "0.3.2",
@@ -1168,11 +1002,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha512-gUQA33ayi0tuAhr/rJNZPr7Q7uvlBt4gyJPbi0CDcAfIzIrDu1YgGMFgmAu3stJqBpK57m7+RxUbcS+pt59fKQ=="
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
@@ -1245,11 +1074,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parse-cache-control": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
@@ -1284,19 +1108,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/promise": {
-      "version": "8.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/promise/-/promise-8.3.0.tgz",
-      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
-      "dependencies": {
-        "asap": "~2.0.6"
-      }
-    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -1327,20 +1138,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -1465,14 +1262,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
@@ -1537,53 +1326,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
-      "dependencies": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
-      "dependencies": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "node_modules/then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
-      "dependencies": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/then-request/node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1628,11 +1370,6 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
     "node_modules/typescript": {
       "version": "5.1.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
@@ -1660,11 +1397,6 @@
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "3.4.0",

--- a/Tasks/NuGetCommandV2/package.json
+++ b/Tasks/NuGetCommandV2/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/node": "^20.3.1",
-    "azure-pipelines-task-lib": "^4.0.0-preview",
+    "azure-pipelines-task-lib": "4.17.0",
     "azure-pipelines-tasks-packaging-common": "3.253.0",
     "azure-pipelines-tasks-utility-common": "^3.0.3",
     "xmlreader": "^0.2.3"

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 253,
+    "Minor": 259,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 253,
+    "Minor": 259,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
### **Context**
This PR fixes the unit tests in NuGetCommandV2 tasks that are failing in the PR https://github.com/microsoft/azure-pipelines-tasks/pull/21065

[AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409)

---

### **Task Name**
NuGetCommandV2

---

### **Description**
This PR changes **run** to **runAsync** in unit tests.
Additionally, was bumped the **azure-pipelines-task-lib** package from `^4.0.0-preview` to `4.17.0`.
The issue is that the package is locally installed with version `4.17.0` since it can be resolved by constraint `^4.0.0-preview`, but in the CI environment, it was `^4.0.0-preview`, causing the types breaking.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
N/A

---

### **Additional Testing Performed**
N/A

---

### **Documentation Changes Required** (Yes / No)  
N/A

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
