### PR TITLE
Update azure-pipelines-tasks-utility-common to 3.258.0 Part 3

### DIFF
--- a/Tasks/DownloadPackageV0/package-lock.json
+++ b/Tasks/DownloadPackageV0/package-lock.json
@@ -13,7 +13,7 @@
         "azure-devops-node-api": "^11.2.0",
         "azure-pipelines-task-lib": "^4.1.0",
         "azure-pipelines-tasks-packaging-common": "^3.206.0",
-        "azure-pipelines-tasks-utility-common": "^3.210.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1"
       },
@@ -239,23 +239,40 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.242.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.242.0.tgz",
-      "integrity": "sha512-PCpJj2f+v1SxjP+NYtSeTQdgPE1WuadzeKcjaqzXSuHGf4KbDcVSQVD2IEo3dAGrvVfLZLnk4B2x/rwbWzminQ==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
+        "@types/node": "~16.11.39",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.7.2"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.108",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.108.tgz",
-      "integrity": "sha512-fj42LD82fSv6yN9C6Q4dzS+hujHj+pTv0IpRR3kI20fnYeS0ytBpjFO9OjmDowSPPt4lNKN46JLaKbCyP+BW2A==",
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
       "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",
@@ -528,6 +545,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -959,6 +986,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -1045,6 +1078,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/DownloadPackageV0/package.json
+++ b/Tasks/DownloadPackageV0/package.json
@@ -21,7 +21,7 @@
     "azure-devops-node-api": "^11.2.0",
     "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tasks-packaging-common": "^3.206.0",
-    "azure-pipelines-tasks-utility-common": "^3.210.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "decompress-zip": "0.3.3",
     "extract-zip": "2.0.1"
   },

--- a/Tasks/DownloadPackageV0/task.json
+++ b/Tasks/DownloadPackageV0/task.json
@@ -9,8 +9,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/DownloadPackageV0/task.loc.json
+++ b/Tasks/DownloadPackageV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/DownloadPackageV1/package-lock.json
+++ b/Tasks/DownloadPackageV1/package-lock.json
@@ -14,7 +14,7 @@
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "3.3.1",
         "azure-pipelines-tasks-packaging-common": "^3.246.1",
-        "azure-pipelines-tasks-utility-common": "^3.241.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1",
         "tar-fs": "1.16.4"
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.246.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.246.0.tgz",
-      "integrity": "sha1-+AfA6GAxHX81X9Y4YhTuuacwa2A=",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "~16.11.39",

--- a/Tasks/DownloadPackageV1/package.json
+++ b/Tasks/DownloadPackageV1/package.json
@@ -22,7 +22,7 @@
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "3.3.1",
     "azure-pipelines-tasks-packaging-common": "^3.246.1",
-    "azure-pipelines-tasks-utility-common": "^3.241.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "decompress-zip": "0.3.3",
     "tar-fs": "1.16.4",
     "extract-zip": "2.0.1"

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/NpmV0/package-lock.json
+++ b/Tasks/NpmV0/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "4.2.0",
         "azure-pipelines-tasks-packaging-common": "^3.244.0",
-        "azure-pipelines-tasks-utility-common": "^3.0.2"
+        "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -243,34 +243,63 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.219.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.219.1.tgz",
-      "integrity": "sha512-VyssHbJQ40aRBq1m0oSG4XCesbRPzsH3Ao8lohmsQZl+GN17TeCnKmr/OoVYsqgtG9TEw59pG4WYW++lsLeeew==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.23",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.23.tgz",
-      "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
-      "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
+      "version": "4.17.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
+      "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
-        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
@@ -570,6 +599,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -977,6 +1016,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -1050,6 +1095,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/NpmV0/package.json
+++ b/Tasks/NpmV0/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "azure-pipelines-task-lib": "4.2.0",
     "azure-pipelines-tasks-packaging-common": "^3.244.0",
-    "azure-pipelines-tasks-utility-common": "^3.0.2",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "@types/node": "^20.3.1"
   },
   "devDependencies": {

--- a/Tasks/NpmV0/task.json
+++ b/Tasks/NpmV0/task.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV0/task.loc.json
+++ b/Tasks/NpmV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV1/package-lock.json
+++ b/Tasks/NpmV1/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "4.3.1",
         "azure-pipelines-tasks-packaging-common": "^3.244.0",
-        "azure-pipelines-tasks-utility-common": "^3.242.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "ini": "^1.3.4",
         "mockery": "^1.7.0"
       },
@@ -250,21 +250,24 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.242.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.242.0.tgz",
-      "integrity": "sha512-PCpJj2f+v1SxjP+NYtSeTQdgPE1WuadzeKcjaqzXSuHGf4KbDcVSQVD2IEo3dAGrvVfLZLnk4B2x/rwbWzminQ==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
+        "@types/node": "~16.11.39",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.7.2"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.98",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.98.tgz",
-      "integrity": "sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/adm-zip": {
       "version": "0.5.14",
@@ -286,6 +289,22 @@
         "semver": "^5.1.0",
         "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
@@ -571,6 +590,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -978,6 +1007,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -1051,6 +1086,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/NpmV1/package.json
+++ b/Tasks/NpmV1/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "4.3.1",
     "azure-pipelines-tasks-packaging-common": "^3.244.0",
-    "azure-pipelines-tasks-utility-common": "^3.242.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "ini": "^1.3.4",
     "mockery": "^1.7.0"
   },

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/package-lock.json
+++ b/Tasks/NuGetCommandV2/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "4.17.0",
         "azure-pipelines-tasks-packaging-common": "3.253.0",
-        "azure-pipelines-tasks-utility-common": "^3.0.3",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "xmlreader": "^0.2.3"
       },
       "devDependencies": {
@@ -206,21 +206,24 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",

--- a/Tasks/NuGetCommandV2/package.json
+++ b/Tasks/NuGetCommandV2/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "4.17.0",
     "azure-pipelines-tasks-packaging-common": "3.253.0",
-    "azure-pipelines-tasks-utility-common": "^3.0.3",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "xmlreader": "^0.2.3"
   },
   "devDependencies": {

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
+    "Minor": 260,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
+    "Minor": 260,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NuGetInstallerV0/package-lock.json
+++ b/Tasks/NuGetInstallerV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.17.2",
         "azure-pipelines-tasks-packaging-common": "3.206.0",
-        "azure-pipelines-tasks-utility-common": "^3.198.1",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "xmlreader": "^0.2.3"
       },
       "devDependencies": {
@@ -207,49 +207,71 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
+      "version": "3.4.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-3.4.13.tgz",
+      "integrity": "sha1-/okOUX+4QGIL4oTuIT6B1wKx92s=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.0-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
-      "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
+        "azure-pipelines-task-lib": "^4.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
       }
     },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
-      "version": "1.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-tool-lib/node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
+      "license": "MIT",
       "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
@@ -389,6 +411,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/esprima": {
@@ -616,6 +648,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -664,6 +702,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/NuGetInstallerV0/package.json
+++ b/Tasks/NuGetInstallerV0/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^20.3.1",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-tasks-packaging-common": "3.206.0",
-    "azure-pipelines-tasks-utility-common": "^3.198.1",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-task-lib": "^4.17.2",
     "xmlreader": "^0.2.3"
   },

--- a/Tasks/NuGetInstallerV0/task.json
+++ b/Tasks/NuGetInstallerV0/task.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetInstallerV0/task.loc.json
+++ b/Tasks/NuGetInstallerV0/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/package-lock.json
+++ b/Tasks/NuGetPublisherV0/package-lock.json
@@ -12,31 +12,13 @@
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "^4.3.1",
         "azure-pipelines-tasks-packaging-common": "^3.220.0",
-        "azure-pipelines-tasks-utility-common": "^3.210.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "ini": "^1.3.4",
         "mockery": "^1.7.0",
         "xmlreader": "^0.2.3"
       },
       "devDependencies": {
         "typescript": "5.1.6"
-      }
-    },
-    "node_modules/@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/ini": {
@@ -75,12 +57,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
-      "license": "MIT"
-    },
     "node_modules/@types/semver": {
       "version": "5.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/semver/-/semver-5.5.0.tgz",
@@ -99,6 +75,18 @@
         "node": ">=0.3.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/argparse/-/argparse-1.0.10.tgz",
@@ -112,18 +100,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/azure-devops-node-api": {
       "version": "10.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
@@ -134,24 +110,28 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
-      "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
+      "version": "4.17.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
       "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
-        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
       }
     },
-    "node_modules/azure-pipelines-task-lib/node_modules/mockery": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+    "node_modules/azure-pipelines-task-lib/node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/azure-pipelines-tasks-packaging-common": {
       "version": "3.220.0",
@@ -182,26 +162,46 @@
       "integrity": "sha512-XAMpaw1s1+6zM+jn2tmw8MyaRDIJfXxqmIQIS0HfoGYPuf7dUWeiUKopwq13KFX9lEp1+THGtlaaYx39Nxr58g=="
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.12.tgz",
-      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.4.tgz",
-      "integrity": "sha512-LgAelZKJe3k/t3NsKSKzjeRviphns0w0p5tgwz8uHN70I9m2TToiOKl+fogrdXcM6+jiLBk5KTqrcRBqPpv/XA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
@@ -236,12 +236,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
@@ -254,57 +248,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
       "license": "MIT",
       "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
       "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/esprima": {
@@ -319,18 +292,24 @@
         "node": ">=4"
       }
     },
-    "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha1-pgT6EORDv5jKlCKNnuvMLoosjuE=",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
       "engines": {
-        "node": ">= 0.12"
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -354,15 +333,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -418,35 +388,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
       "license": "MIT",
       "dependencies": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">= 6"
       }
-    },
-    "node_modules/http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "node_modules/http-response-object/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -500,10 +453,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -539,7 +492,7 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -548,7 +501,7 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -556,6 +509,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",
@@ -573,6 +532,24 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mockery/-/mockery-1.7.0.tgz",
       "integrity": "sha512-gUQA33ayi0tuAhr/rJNZPr7Q7uvlBt4gyJPbi0CDcAfIzIrDu1YgGMFgmAu3stJqBpK57m7+RxUbcS+pt59fKQ=="
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/object-inspect/-/object-inspect-1.12.3.tgz",
@@ -589,11 +566,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/parse-cache-control": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -606,21 +578,6 @@
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
-    "node_modules/promise": {
-      "version": "8.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/promise/-/promise-8.3.0.tgz",
-      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
-      "license": "MIT",
-      "dependencies": {
-        "asap": "~2.0.6"
-      }
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -644,21 +601,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/rechoir": {
@@ -688,11 +630,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/sax": {
       "version": "0.5.8",
@@ -747,15 +692,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -767,56 +703,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
-      "license": "MIT",
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "license": "WTFPL",
       "dependencies": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
+        "utf8-byte-length": "^1.0.1"
       }
-    },
-    "node_modules/sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
-      "license": "MIT",
-      "dependencies": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "node_modules/then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/then-request/node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
-      "license": "MIT"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -835,12 +729,6 @@
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.1.6",
@@ -865,11 +753,11 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-5.25.3.tgz",
       "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
       "version": "3.4.0",

--- a/Tasks/NuGetPublisherV0/package.json
+++ b/Tasks/NuGetPublisherV0/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "azure-pipelines-task-lib": "^4.3.1",
     "azure-pipelines-tasks-packaging-common": "^3.220.0",
-    "azure-pipelines-tasks-utility-common": "^3.210.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "ini": "^1.3.4",
     "mockery": "^1.7.0",
     "xmlreader": "^0.2.3",

--- a/Tasks/NuGetPublisherV0/task.json
+++ b/Tasks/NuGetPublisherV0/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 260,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetPublisherV0/task.loc.json
+++ b/Tasks/NuGetPublisherV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 260,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/package-lock.json
+++ b/Tasks/NuGetRestoreV1/package-lock.json
@@ -14,27 +14,11 @@
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.3.1",
         "azure-pipelines-tasks-packaging-common": "^3.220.0",
-        "azure-pipelines-tasks-utility-common": "3.198.1",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "xmlreader": "^0.2.3"
       },
       "devDependencies": {
         "typescript": "5.1.6"
-      }
-    },
-    "node_modules/@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/ini": {
@@ -73,11 +57,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
-    },
     "node_modules/@types/semver": {
       "version": "5.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/semver/-/semver-5.5.0.tgz",
@@ -96,6 +75,18 @@
         "node": ">=0.3.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/argparse/-/argparse-1.0.10.tgz",
@@ -109,16 +100,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/azure-devops-node-api": {
       "version": "10.2.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
@@ -129,17 +110,27 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.3.1.tgz",
-      "integrity": "sha512-AEwz0+Sofv80UviCYsS6fzyX5zzsLapmNCMNUoaRePZQVN+oQBStix1DGg4fdZf9zJ6acNd9xEBZQWbWuZu5Zg==",
+      "version": "4.17.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
+      "license": "MIT",
       "dependencies": {
+        "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
+        "semver": "^5.7.2",
         "shelljs": "^0.8.5",
-        "sync-request": "6.1.0",
         "uuid": "^3.0.1"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib/node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/azure-pipelines-tasks-packaging-common": {
@@ -171,69 +162,46 @@
       "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.198.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.198.1.tgz",
-      "integrity": "sha512-XxXLwrz06lSXP31JGCcgp2DCuVwcKLCjma55DtsjDe8L8sngKfmTBIiSuZe41aP+KlRtqo8n1I/FBQNPWxGw9w==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^10.17.0",
-        "azure-pipelines-task-lib": "^3.1.0",
-        "azure-pipelines-tool-lib": "^1.0.2",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-    },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
-    },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.4.0.tgz",
-      "integrity": "sha512-3eC4OTFw+7xD7A2aUhxR/j+jRlTI+vVfS0CGxt1pCLs4c/KmY0tQWgbqjD3157kmiucWxELBvgZHaD2gCBe9fg==",
-      "dependencies": {
-        "minimatch": "3.0.5",
-        "mockery": "^2.1.0",
-        "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.5",
-        "sync-request": "6.1.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-tool-lib": {
-      "version": "1.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-1.3.2.tgz",
-      "integrity": "sha512-PtYcd3E2ouwZhLuaOpWA00FYoLjRuJs1V8mNu3u6lBnqeYd4jh/8VL/of6nchm8f2NM6Div+EEnbOcmWvcptPg==",
-      "dependencies": {
-        "@types/semver": "^5.3.0",
-        "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^3.1.10",
-        "semver": "^5.7.0",
-        "semver-compare": "^1.0.0",
-        "typed-rest-client": "^1.8.6",
-        "uuid": "^3.3.2"
-      }
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
-      "version": "1.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
       "dependencies": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.4.tgz",
-      "integrity": "sha512-LgAelZKJe3k/t3NsKSKzjeRviphns0w0p5tgwz8uHN70I9m2TToiOKl+fogrdXcM6+jiLBk5KTqrcRBqPpv/XA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
@@ -273,11 +241,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
@@ -290,52 +253,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "engines": [
-        "node >= 0.8"
-      ],
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/esprima": {
@@ -350,17 +297,24 @@
         "node": ">=4"
       }
     },
-    "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha1-pgT6EORDv5jKlCKNnuvMLoosjuE=",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.12"
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -385,14 +339,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -458,32 +404,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
+      "license": "MIT",
       "dependencies": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+        "agent-base": "6",
+        "debug": "4"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">= 6"
       }
-    },
-    "node_modules/http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
-      "dependencies": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "node_modules/http-response-object/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -537,10 +469,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "3.13.1",
@@ -575,7 +508,8 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -583,13 +517,20 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",
@@ -602,10 +543,23 @@
         "node": "*"
       }
     },
-    "node_modules/mockery": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
@@ -623,11 +577,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/parse-cache-control": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -640,19 +589,6 @@
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/promise": {
-      "version": "8.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/promise/-/promise-8.3.0.tgz",
-      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
-      "dependencies": {
-        "asap": "~2.0.6"
-      }
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -675,20 +611,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/rechoir": {
@@ -718,10 +640,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/sax": {
       "version": "0.5.8",
@@ -776,14 +702,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -795,52 +713,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "license": "WTFPL",
       "dependencies": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
+        "utf8-byte-length": "^1.0.1"
       }
-    },
-    "node_modules/sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
-      "dependencies": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "node_modules/then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
-      "dependencies": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/then-request/node_modules/@types/node": {
-      "version": "8.10.66",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-8.10.66.tgz",
-      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -859,11 +739,6 @@
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
       }
-    },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
       "version": "5.1.6",
@@ -888,10 +763,11 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-5.25.3.tgz",
       "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/uuid": {
       "version": "3.4.0",

--- a/Tasks/NuGetRestoreV1/package.json
+++ b/Tasks/NuGetRestoreV1/package.json
@@ -22,7 +22,7 @@
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.3.1",
     "azure-pipelines-tasks-packaging-common": "^3.220.0",
-    "azure-pipelines-tasks-utility-common": "3.198.1",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "xmlreader": "^0.2.3"
   },
   "devDependencies": {

--- a/Tasks/NuGetRestoreV1/task.json
+++ b/Tasks/NuGetRestoreV1/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 260,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetRestoreV1/task.loc.json
+++ b/Tasks/NuGetRestoreV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 260,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetToolInstallerV0/package-lock.json
+++ b/Tasks/NuGetToolInstallerV0/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^20.3.1",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-tasks-packaging-common": "^3.221.0",
-        "azure-pipelines-tasks-utility-common": "^3.210.0"
+        "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -160,30 +160,50 @@
       "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.0-preview",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.0-preview.tgz",
-      "integrity": "sha512-OeivwKLpLMsvGpZ2H+2UPxFwwqNkV8TzfKByqjYAllzGDAw4BvciAdjCMwkpGdTOnzfPbRpr33sy48kn7RqfKA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
+        "azure-pipelines-task-lib": "^4.1.0",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
@@ -251,6 +271,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/esprima": {
@@ -426,6 +456,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -476,6 +512,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/NuGetToolInstallerV0/package.json
+++ b/Tasks/NuGetToolInstallerV0/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^20.3.1",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-tasks-packaging-common": "^3.221.0",
-    "azure-pipelines-tasks-utility-common": "^3.210.0"
+    "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/NuGetToolInstallerV0/task.json
+++ b/Tasks/NuGetToolInstallerV0/task.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/NuGetToolInstallerV0/task.loc.json
+++ b/Tasks/NuGetToolInstallerV0/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/NuGetToolInstallerV1/package-lock.json
+++ b/Tasks/NuGetToolInstallerV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^20.3.1",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-tasks-packaging-common": "^3.221.0",
-        "azure-pipelines-tasks-utility-common": "^3.210.0"
+        "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -160,26 +160,46 @@
       "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.4.tgz",
-      "integrity": "sha512-LgAelZKJe3k/t3NsKSKzjeRviphns0w0p5tgwz8uHN70I9m2TToiOKl+fogrdXcM6+jiLBk5KTqrcRBqPpv/XA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
@@ -251,6 +271,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/esprima": {
@@ -426,6 +456,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -476,6 +512,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/NuGetToolInstallerV1/package.json
+++ b/Tasks/NuGetToolInstallerV1/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^20.3.1",
     "@types/uuid": "^8.3.0",
     "azure-pipelines-tasks-packaging-common": "^3.221.0",
-    "azure-pipelines-tasks-utility-common": "^3.210.0"
+    "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/NuGetToolInstallerV1/task.json
+++ b/Tasks/NuGetToolInstallerV1/task.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/NuGetToolInstallerV1/task.loc.json
+++ b/Tasks/NuGetToolInstallerV1/task.loc.json
@@ -14,8 +14,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "satisfies": [

--- a/Tasks/PipAuthenticateV0/package-lock.json
+++ b/Tasks/PipAuthenticateV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.1.0",
         "azure-pipelines-tasks-packaging-common": "3.242.2",
-        "azure-pipelines-tasks-utility-common": "3.212.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "typed-rest-client": "^1.8.9"
       },
@@ -212,21 +212,40 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.212.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.212.0.tgz",
-      "integrity": "sha512-8vz51N7SOyprBHUjJz0HttVjk9+p9Y9wI/VO2ighotfdHvmgK3RB+1u6rsC6mHeVbGdpT51Luu9J6BMRMOXSig==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",
@@ -458,6 +477,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -812,6 +841,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -885,6 +920,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/PipAuthenticateV0/package.json
+++ b/Tasks/PipAuthenticateV0/package.json
@@ -22,7 +22,7 @@
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tasks-packaging-common": "3.242.2",
-    "azure-pipelines-tasks-utility-common": "3.212.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "typed-rest-client": "^1.8.9"
   },

--- a/Tasks/PipAuthenticateV0/task.json
+++ b/Tasks/PipAuthenticateV0/task.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/PipAuthenticateV0/task.loc.json
+++ b/Tasks/PipAuthenticateV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/package-lock.json
+++ b/Tasks/TwineAuthenticateV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.0.1-preview",
         "azure-pipelines-tasks-packaging-common": "^3.244.0",
-        "azure-pipelines-tasks-utility-common": "^3.242.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "ini": "^1.3.6"
       },
       "devDependencies": {
@@ -211,21 +211,40 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.242.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.242.0.tgz",
-      "integrity": "sha512-PCpJj2f+v1SxjP+NYtSeTQdgPE1WuadzeKcjaqzXSuHGf4KbDcVSQVD2IEo3dAGrvVfLZLnk4B2x/rwbWzminQ==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
+        "@types/node": "~16.11.39",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.7.2"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.58",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.58.tgz",
-      "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",
@@ -457,6 +476,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -811,6 +840,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "3.13.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -884,6 +919,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/TwineAuthenticateV0/package.json
+++ b/Tasks/TwineAuthenticateV0/package.json
@@ -23,7 +23,7 @@
     "azure-pipelines-task-lib": "^4.0.1-preview",
     "ini": "^1.3.6",
     "azure-pipelines-tasks-packaging-common": "^3.244.0",
-    "azure-pipelines-tasks-utility-common": "^3.242.0"
+    "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/TwineAuthenticateV0/task.json
+++ b/Tasks/TwineAuthenticateV0/task.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV0/task.loc.json
+++ b/Tasks/TwineAuthenticateV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/package-lock.json
+++ b/Tasks/UniversalPackagesV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
         "azure-pipelines-tasks-packaging-common": "^3.246.1",
-        "azure-pipelines-tasks-utility-common": "^3.238.0"
+        "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -194,21 +194,24 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.242.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.242.0.tgz",
-      "integrity": "sha512-PCpJj2f+v1SxjP+NYtSeTQdgPE1WuadzeKcjaqzXSuHGf4KbDcVSQVD2IEo3dAGrvVfLZLnk4B2x/rwbWzminQ==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
+        "@types/node": "~16.11.39",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.7.2"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.101",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.101.tgz",
-      "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/argparse": {
       "version": "1.0.10",
@@ -234,6 +237,22 @@
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",
@@ -466,6 +485,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/diff": {
@@ -900,6 +929,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -979,6 +1014,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.0.5",

--- a/Tasks/UniversalPackagesV0/package.json
+++ b/Tasks/UniversalPackagesV0/package.json
@@ -22,7 +22,7 @@
     "@types/uuid": "^8.3.0",
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tasks-packaging-common": "^3.246.1",
-    "azure-pipelines-tasks-utility-common": "^3.238.0"
+    "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/UniversalPackagesV0/task.json
+++ b/Tasks/UniversalPackagesV0/task.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/UniversalPackagesV0/task.loc.json
+++ b/Tasks/UniversalPackagesV0/task.loc.json
@@ -9,8 +9,8 @@
   "category": "Package",
   "version": {
     "Major": 0,
-    "Minor": 248,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
### **Context**
[AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409)

---

### **Task Name**
DownloadPackageV0,
DownloadPackageV1,
NpmV0,
NpmV1,
NuGetInstallerV0,
NuGetToolInstallerV0,
NuGetToolInstallerV1,
PipAuthenticateV0,
TwineAuthenticateV0,
UniversalPackagesV0

---

### **Description**
Update azure-pipelines-tasks-utility-common to 3.258.0 to utilize new version of 7zip.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
N/A

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
