### PR TITLE
Update azure-pipelines-tasks-utility-common to 3.258.0 Part 4

### DIFF
--- a/Tasks/AzureTestPlanV0/package-lock.json
+++ b/Tasks/AzureTestPlanV0/package-lock.json
@@ -17,7 +17,7 @@
         "azure-devops-node-api": "^12.2.0",
         "azure-pipelines-task-lib": "^4.15.0",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
-        "azure-pipelines-tasks-utility-common": "^3.212.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "azure-pipelines-tool-lib": "^2.0.0-preview",
         "performance-now": "0.2.0",
         "typed-rest-client": "^1.8.9"
@@ -287,9 +287,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.246.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.246.0.tgz",
-      "integrity": "sha1-+AfA6GAxHX81X9Y4YhTuuacwa2A=",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "~16.11.39",

--- a/Tasks/AzureTestPlanV0/package.json
+++ b/Tasks/AzureTestPlanV0/package.json
@@ -25,7 +25,7 @@
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.15.0",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
-    "azure-pipelines-tasks-utility-common": "^3.212.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-devops-node-api": "^12.2.0",
     "azure-pipelines-tool-lib": "^2.0.0-preview",
     "typed-rest-client": "^1.8.9",

--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "demands": [],
@@ -205,6 +205,5 @@
     "chmodGradlew": "Used 'chmod' method for gradlew file to make it executable.",
     "NoMatchingFilesFound": "No test result files matching '%s' were found.",
     "MultipleMatchingGradlewFound": "Multiple gradlew files found. Selecting the first matched instance"
-    
   }
 }

--- a/Tasks/AzureTestPlanV0/task.loc.json
+++ b/Tasks/AzureTestPlanV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 3
+    "Patch": 4
   },
   "preview": true,
   "demands": [],

--- a/Tasks/ContainerStructureTestV0/package-lock.json
+++ b/Tasks/ContainerStructureTestV0/package-lock.json
@@ -16,7 +16,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.1.0",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
-        "azure-pipelines-tasks-utility-common": "^3.238.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "typed-rest-client": "^1.8.11"
       },
@@ -265,21 +265,40 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.238.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.238.0.tgz",
-      "integrity": "sha512-/eoL+wQbQM07m36C6uoG6CMEF/0mNto7XxHXxXsqY+74qowqfD1MFkxU14qnuEE2oxg9rAtz+Zt80RUlZfX9xA==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
+        "@types/node": "~16.11.39",
         "azure-pipelines-task-lib": "^4.11.0",
         "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.7.2"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.60.tgz",
-      "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
+    },
+    "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.7",

--- a/Tasks/ContainerStructureTestV0/package.json
+++ b/Tasks/ContainerStructureTestV0/package.json
@@ -24,7 +24,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.1.0",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
-    "azure-pipelines-tasks-utility-common": "^3.238.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-tool-lib": "^2.0.7",
     "typed-rest-client": "^1.8.11"
   },

--- a/Tasks/ContainerStructureTestV0/task.json
+++ b/Tasks/ContainerStructureTestV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 259,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/ContainerStructureTestV0/task.loc.json
+++ b/Tasks/ContainerStructureTestV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 259,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],


### PR DESCRIPTION
### **Context**
[AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409)

---

### **Task Name**
AzureTestPlanV0,
ContainerStructureTestV0

---

### **Description**
Update azure-pipelines-tasks-utility-common to 3.258.0 to utilize new version of 7zip.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
N/A

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
