### PR TITLE
Update azure-pipelines-tasks-utility-common to 3.258.0 Part 5

### DIFF
--- a/Tasks/AzureIoTEdgeV2/package-lock.json
+++ b/Tasks/AzureIoTEdgeV2/package-lock.json
@@ -16,7 +16,7 @@
         "azure-pipelines-task-lib": "^4.4.0",
         "azure-pipelines-tasks-artifacts-common": "^2.225.0",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
-        "azure-pipelines-tasks-utility-common": "^3.210.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "minimatch": "^3.1.2"
       },
       "devDependencies": {
@@ -68,12 +68,14 @@
     "node_modules/@types/semver": {
       "version": "5.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
+      "integrity": "sha1-FGwqKe59O65L8vyydGNuJkyBPEU=",
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
+      "version": "3.4.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-3.4.13.tgz",
+      "integrity": "sha1-/okOUX+4QGIL4oTuIT6B1wKx92s=",
+      "license": "MIT"
     },
     "node_modules/adm-zip": {
       "version": "0.5.14",
@@ -185,22 +187,6 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.0.2.tgz",
-      "integrity": "sha512-rmAQM2gZw/PQpK5+5aSs+I6ZBv4PFC2BT1o+0ADS1SgSejA+14EmbI2Lt8uXwkX7oeOMkwFmg0pHKwe8D9IT5A==",
-      "license": "MIT",
-      "dependencies": {
-        "des.js": "^1.1.0",
-        "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
-        "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
     "node_modules/azure-pipelines-task-lib": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.13.0.tgz",
@@ -288,21 +274,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.0.2.tgz",
-      "integrity": "sha512-rmAQM2gZw/PQpK5+5aSs+I6ZBv4PFC2BT1o+0ADS1SgSejA+14EmbI2Lt8uXwkX7oeOMkwFmg0pHKwe8D9IT5A==",
-      "dependencies": {
-        "des.js": "^1.1.0",
-        "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
-        "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      }
-    },
     "node_modules/azure-pipelines-tasks-docker-common": {
       "version": "2.242.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.242.0.tgz",
@@ -343,26 +314,30 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.219.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.219.1.tgz",
-      "integrity": "sha512-VyssHbJQ40aRBq1m0oSG4XCesbRPzsH3Ao8lohmsQZl+GN17TeCnKmr/OoVYsqgtG9TEw59pG4WYW++lsLeeew==",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
+      "license": "MIT",
       "dependencies": {
-        "@types/node": "^16.11.39",
-        "azure-pipelines-task-lib": "^4.0.0-preview",
-        "azure-pipelines-tool-lib": "^2.0.0-preview",
+        "@types/node": "~16.11.39",
+        "azure-pipelines-task-lib": "^4.11.0",
+        "azure-pipelines-tool-lib": "^2.0.7",
         "js-yaml": "3.13.1",
-        "semver": "^5.4.1"
+        "semver": "^5.7.2",
+        "typed-rest-client": "2.1.0"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/@types/node": {
-      "version": "16.18.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.60.tgz",
-      "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA=="
+      "version": "16.11.68",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.11.68.tgz",
+      "integrity": "sha1-MO6SP02UB5PgOA9c5hwL1LcZa2w=",
+      "license": "MIT"
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.4.tgz",
-      "integrity": "sha512-LgAelZKJe3k/t3NsKSKzjeRviphns0w0p5tgwz8uHN70I9m2TToiOKl+fogrdXcM6+jiLBk5KTqrcRBqPpv/XA==",
+      "version": "2.0.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
+      "integrity": "sha1-S9vVPAQsrcivQ6v2sNyspzUNDPk=",
+      "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
@@ -371,6 +346,17 @@
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
+      }
+    },
+    "node_modules/azure-pipelines-tool-lib/node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "node_modules/balanced-match": {
@@ -1169,7 +1155,8 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "license": "MIT"
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
@@ -1253,13 +1240,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "license": "MIT",
       "dependencies": {
-        "qs": "^6.9.1",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
         "tunnel": "0.0.6",
         "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/typescript": {

--- a/Tasks/AzureIoTEdgeV2/package.json
+++ b/Tasks/AzureIoTEdgeV2/package.json
@@ -10,7 +10,7 @@
     "azure-pipelines-task-lib": "^4.4.0",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
-    "azure-pipelines-tasks-utility-common": "^3.210.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "minimatch": "^3.1.2"
   },
   "devDependencies": {

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 247,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/PublishSymbolsV2/package-lock.json
+++ b/Tasks/PublishSymbolsV2/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-tasks-artifacts-common": "^2.245.1",
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
         "azure-pipelines-tasks-packaging-common": "^3.236.0",
-        "azure-pipelines-tasks-utility-common": "^3.225.0",
+        "azure-pipelines-tasks-utility-common": "3.258.0",
         "msal-node1": "npm:@azure/msal-node@^1.18.4",
         "msal-node2": "npm:@azure/msal-node@^2.9.2",
         "semver": "^6.3.1",
@@ -437,9 +437,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
-      "version": "3.246.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.246.0.tgz",
-      "integrity": "sha1-+AfA6GAxHX81X9Y4YhTuuacwa2A=",
+      "version": "3.258.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-utility-common/-/azure-pipelines-tasks-utility-common-3.258.0.tgz",
+      "integrity": "sha1-Vl6Igsb1o2q4ts6fEc3RDbRfp+I=",
       "license": "MIT",
       "dependencies": {
         "@types/node": "~16.11.39",

--- a/Tasks/PublishSymbolsV2/package.json
+++ b/Tasks/PublishSymbolsV2/package.json
@@ -23,7 +23,7 @@
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tasks-artifacts-common": "^2.245.1",
     "azure-pipelines-tasks-packaging-common": "^3.236.0",
-    "azure-pipelines-tasks-utility-common": "^3.225.0",
+    "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
     "agent-base": "^6.0.2",
     "msal-node1": "npm:@azure/msal-node@^1.18.4",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 260,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 260,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
### **Context**
[AB#2273409](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2273409)

---

### **Task Name**
AzureIoTEdgeV2,
PublishSymbolsV2

---

### **Description**
Update azure-pipelines-tasks-utility-common to 3.258.0 to utilize new version of 7zip.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
N/A

---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
