### PR TITLE
fix for Az.accounts backward compatibility

### DIFF
--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 6,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 6,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
### **Context**
fix for az.accounts backward compatibility
📌[Bug 2292694](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2292694): fix for Azure File Copy Task Version 6.258.2 Causing Breaks in Pipelines.

---

### **Task Name**
AzureFileCopyV6

---

### **Description**
fix for Azure File Copy Task Version 6.258.2 Causing Breaks in Pipelines.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
Yes

---

### **Additional Testing Performed**


---

### **Documentation Changes Required** (Yes / No)  
No

---

### **Checklist**
- [X] Related issue linked (if applicable)
- [X] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [X] Verified the task behaves as expected
