### PR TITLE
Update azure-arm-rest to 3.259.1 in RM tasks

### DIFF
--- a/Tasks/AzureAppServiceManageV0/package-lock.json
+++ b/Tasks/AzureAppServiceManageV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.258.1",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "q": "1.4.1",
         "xml2js": "^0.5.0"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.1.tgz",
-      "integrity": "sha1-SMeMj37RQ1VAVQQx4WqLcdR4twg=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureAppServiceManageV0/package.json
+++ b/Tasks/AzureAppServiceManageV0/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.258.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "q": "1.4.1",
     "xml2js": "^0.5.0"

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureAppServiceSettingsV1/package-lock.json
+++ b/Tasks/AzureAppServiceSettingsV1/package-lock.json
@@ -16,7 +16,7 @@
         "agent-base": "^6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "q": "1.4.1",
         "xml2js": "^0.6.2"
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureAppServiceSettingsV1/package.json
+++ b/Tasks/AzureAppServiceSettingsV1/package.json
@@ -24,7 +24,7 @@
     "agent-base": "^6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "q": "1.4.1",
     "xml2js": "^0.6.2"

--- a/Tasks/AzureAppServiceSettingsV1/task.json
+++ b/Tasks/AzureAppServiceSettingsV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureAppServiceSettingsV1/task.loc.json
+++ b/Tasks/AzureAppServiceSettingsV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureCLIV2/package-lock.json
+++ b/Tasks/AzureCLIV2/package-lock.json
@@ -15,7 +15,7 @@
         "azure-devops-node-api": "14.0.2",
         "azure-pipelines-task-lib": "^4.17.2",
         "azure-pipelines-tasks-artifacts-common": "^2.245.1",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.258.1"
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.1.tgz",
-      "integrity": "sha1-SMeMj37RQ1VAVQQx4WqLcdR4twg=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureCLIV2/package.json
+++ b/Tasks/AzureCLIV2/package.json
@@ -23,7 +23,7 @@
     "azure-devops-node-api": "14.0.2",
     "azure-pipelines-task-lib": "^4.17.2",
     "azure-pipelines-tasks-artifacts-common": "^2.245.1",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.258.1"
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/AzureCLIV2/task.json
+++ b/Tasks/AzureCLIV2/task.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "Azure CLI $(scriptPath)",
@@ -223,7 +223,7 @@
     "JS_InvalidErrorActionPreference": "Invalid ErrorActionPreference '%s'. The value must be one of: 'Stop', 'Continue', or 'SilentlyContinue'",
     "GlobalCliConfigAgentVersionWarning": "For agent version < 2.115.0, only global Azure CLI configuration can be used",
     "UnacceptedScriptLocationValue": "%s is not a valid value for task input 'Script Location' (scriptLocation in YAML). Value can either be'inlineScript' or 'scriptPath'",
-    "ExpiredServicePrincipalMessageWithLink": "Secret expired, update service connection at\u00A0%s See\u00A0https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
+    "ExpiredServicePrincipalMessageWithLink": "Secret expired, update service connection at %s See https://aka.ms/azdo-rm-workload-identity-conversion to learn more about conversion to secret-less service connections.",
     "ProxyConfig": "az tool is configured to use %s as proxy server",
     "FailedToRefreshAzSession": "The following error occurred while trying to refresh az-cli session: %s",
     "RefreshingAzSession": "Attempting to refresh az-cli session...",

--- a/Tasks/AzureCLIV2/task.loc.json
+++ b/Tasks/AzureCLIV2/task.loc.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureFileCopyV2/package-lock.json
+++ b/Tasks/AzureFileCopyV2/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "uuid": "^8.3.0"
       },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV2/package.json
+++ b/Tasks/AzureFileCopyV2/package.json
@@ -6,7 +6,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/package-lock.json
+++ b/Tasks/AzureFileCopyV3/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "uuid": "^8.3.0"
       },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV3/package.json
+++ b/Tasks/AzureFileCopyV3/package.json
@@ -6,7 +6,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/package-lock.json
+++ b/Tasks/AzureFileCopyV4/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "uuid": "^8.3.0"
       },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV4/package.json
+++ b/Tasks/AzureFileCopyV4/package.json
@@ -6,7 +6,7 @@
     "@types/q": "1.0.7",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/package-lock.json
+++ b/Tasks/AzureFileCopyV5/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "uuid": "^8.3.0"
       },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV5/package.json
+++ b/Tasks/AzureFileCopyV5/package.json
@@ -6,7 +6,7 @@
     "@types/q": "1.0.7",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/package-lock.json
+++ b/Tasks/AzureFileCopyV6/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "uuid": "^8.3.0"
       },
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFileCopyV6/package.json
+++ b/Tasks/AzureFileCopyV6/package.json
@@ -6,7 +6,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "uuid": "^8.3.0"
   },

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 6,
     "Minor": 259,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 6,
     "Minor": 259,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFunctionAppContainerV1/package-lock.json
+++ b/Tasks/AzureFunctionAppContainerV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "moment": "2.29.4",
         "q": "1.4.1",
@@ -185,9 +185,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFunctionAppContainerV1/package.json
+++ b/Tasks/AzureFunctionAppContainerV1/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "moment": "2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppContainerV1/task.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppContainerV1/task.loc.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/package-lock.json
+++ b/Tasks/AzureFunctionAppV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.3",
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFunctionAppV1/package.json
+++ b/Tasks/AzureFunctionAppV1/package.json
@@ -23,7 +23,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV2/package-lock.json
+++ b/Tasks/AzureFunctionAppV2/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.4",
@@ -235,9 +235,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFunctionAppV2/package.json
+++ b/Tasks/AzureFunctionAppV2/package.json
@@ -23,7 +23,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",

--- a/Tasks/AzureFunctionAppV2/task.json
+++ b/Tasks/AzureFunctionAppV2/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 2.* <br /> Removed WAR Deploy Support, setting Web.Config options, and the option for the Startup command for Linux Azure Function Apps.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV2/task.loc.json
+++ b/Tasks/AzureFunctionAppV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
@@ -14,7 +14,7 @@
         "@types/uuid": "^9.0.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.235.0",
         "azure-pipelines-tool-lib": "^2.0.7",
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureFunctionOnKubernetesV1/package.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package.json
@@ -21,7 +21,7 @@
     "@types/uuid": "^9.0.0",
     "azure-pipelines-task-lib": "^4.11.0",
     "agent-base": "^6.0.2",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.235.0",
     "azure-pipelines-tool-lib": "^2.0.7",

--- a/Tasks/AzureFunctionOnKubernetesV1/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/AzureKeyVaultV1/package-lock.json
+++ b/Tasks/AzureKeyVaultV1/package-lock.json
@@ -13,7 +13,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^12.1.0",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4"
       },
       "devDependencies": {
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureKeyVaultV1/package.json
+++ b/Tasks/AzureKeyVaultV1/package.json
@@ -9,7 +9,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^12.1.0",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4"
   },
   "devDependencies": {

--- a/Tasks/AzureKeyVaultV1/task.json
+++ b/Tasks/AzureKeyVaultV1/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV1/task.loc.json
+++ b/Tasks/AzureKeyVaultV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.0.0",

--- a/Tasks/AzureKeyVaultV2/package-lock.json
+++ b/Tasks/AzureKeyVaultV2/package-lock.json
@@ -13,7 +13,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^12.1.0",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4"
       },
       "devDependencies": {
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureKeyVaultV2/package.json
+++ b/Tasks/AzureKeyVaultV2/package.json
@@ -9,7 +9,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^12.1.0",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4"
   },
   "devDependencies": {

--- a/Tasks/AzureKeyVaultV2/task.json
+++ b/Tasks/AzureKeyVaultV2/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureKeyVaultV2/task.loc.json
+++ b/Tasks/AzureKeyVaultV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.182.1",

--- a/Tasks/AzureMysqlDeploymentV1/package-lock.json
+++ b/Tasks/AzureMysqlDeploymentV1/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "compress-commons": "1.1.0",
         "crc32-stream": "1.0.0",
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureMysqlDeploymentV1/package.json
+++ b/Tasks/AzureMysqlDeploymentV1/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "compress-commons": "1.1.0",
     "crc32-stream": "1.0.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzureMysqlDeploymentV1/task.loc.json
+++ b/Tasks/AzureMysqlDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "1.100.0",

--- a/Tasks/AzurePowerShellV4/package-lock.json
+++ b/Tasks/AzurePowerShellV4/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzurePowerShellV4/package.json
+++ b/Tasks/AzurePowerShellV4/package.json
@@ -9,7 +9,7 @@
     "@types/q": "1.0.7",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/package-lock.json
+++ b/Tasks/AzurePowerShellV5/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.258.1",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.1.tgz",
-      "integrity": "sha1-SMeMj37RQ1VAVQQx4WqLcdR4twg=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzurePowerShellV5/package.json
+++ b/Tasks/AzurePowerShellV5/package.json
@@ -9,7 +9,7 @@
     "@types/q": "1.0.7",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.258.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0"
   },
   "devDependencies": {

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 2
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzureResourceGroupDeploymentV2/package-lock.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/package-lock.json
@@ -9,7 +9,7 @@
         "@types/node": "^20.3.1",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "typed-rest-client": "^1.8.9"
       },
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureResourceGroupDeploymentV2/package.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/package.json
@@ -5,7 +5,7 @@
     "@types/node": "^20.3.1",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "typed-rest-client": "^1.8.9"
   },

--- a/Tasks/AzureResourceGroupDeploymentV2/task.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.json
@@ -6,7 +6,7 @@
   "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/deploy/azure-resource-group-deployment",
   "helpMarkDown": "[Learn more about this task](https://aka.ms/argtaskreadme)",
   "category": "Deploy",
-  "releaseNotes": "-Works with cross-platform agents (Linux, macOS, or Windows)\n- Supports Template JSONs located at any publicly accessible http/https URLs.\n- Enhanced UX for Override parameters which can now be viewed/edited in a grid.\n- NAT rule mapping for VMs which are backed by an Load balancer.\n- \"Resource group\" field is now renamed as \"VM details for\u00A0\u00A0WinRM\" and is included in the section\u00A0\"Advanced deployment options for virtual machines\".\n- Limitations: \n - No support for Classic subscriptions. Only for ARM subscriptions are supported.\n - No support for PowerShell syntax as the task is now node.js based. Ensure the case sensitivity of the parameter names match, when you override the template parameters. Also, remove the PowerShell cmdlets like \"ConvertTo-SecureString\" when you migrate from version 1.0 to version 2.0.",
+  "releaseNotes": "-Works with cross-platform agents (Linux, macOS, or Windows)\n- Supports Template JSONs located at any publicly accessible http/https URLs.\n- Enhanced UX for Override parameters which can now be viewed/edited in a grid.\n- NAT rule mapping for VMs which are backed by an Load balancer.\n- \"Resource group\" field is now renamed as \"VM details for  WinRM\" and is included in the section \"Advanced deployment options for virtual machines\".\n- Limitations: \n - No support for Classic subscriptions. Only for ARM subscriptions are supported.\n - No support for PowerShell syntax as the task is now node.js based. Ensure the case sensitivity of the parameter names match, when you override the template parameters. Also, remove the PowerShell cmdlets like \"ConvertTo-SecureString\" when you migrate from version 1.0 to version 2.0.",
   "visibility": [
     "Build",
     "Release"
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
+++ b/Tasks/AzureResourceGroupDeploymentV2/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/package-lock.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/package-lock.json
@@ -10,7 +10,7 @@
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.17.2",
         "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "moment": "^2.29.4",
         "typed-rest-client": "^1.8.9"
       },
@@ -162,9 +162,9 @@
       "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ=="
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/package.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/package.json
@@ -6,7 +6,7 @@
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.17.2",
     "azure-pipelines-tasks-artifacts-common": "^2.225.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "moment": "^2.29.4",
     "typed-rest-client": "^1.8.9"
   },

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",
@@ -342,6 +342,6 @@
     "ErrorInSettingUpSubscription": "Error in setting up subscription: %s",
     "BicepParamBuildFailed": "\"az bicep build-param\" failed. Error: %s",
     "IncompatibleAzureCLIVersionBicepParam": "Azure CLI version should be >= 2.47.0 to use .bicepparam file",
-    "ErrorWhileOverrideParameterUndefined": "The provided metadata file '%s'  is missing metadata of parameter '%s'"  
+    "ErrorWhileOverrideParameterUndefined": "The provided metadata file '%s'  is missing metadata of parameter '%s'"
   }
 }

--- a/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
+++ b/Tasks/AzureResourceManagerTemplateDeploymentV3/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "minimumAgentVersion": "2.119.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "decompress-zip": "^0.3.3",
         "ltx": "2.8.0",
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureRmWebAppDeploymentV3/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package.json
@@ -23,7 +23,7 @@
     "agent-base": "^6.0.2",
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureRmWebAppDeploymentV5/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package.json
@@ -22,7 +22,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureVmssDeploymentV0/package-lock.json
+++ b/Tasks/AzureVmssDeploymentV0/package-lock.json
@@ -13,7 +13,7 @@
         "artifact-engine": "^1.5.5",
         "azp-tasks-az-blobstorage-provider": "^3.246.3",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "moment": "^2.29.4"
       },
@@ -3202,9 +3202,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureVmssDeploymentV0/package.json
+++ b/Tasks/AzureVmssDeploymentV0/package.json
@@ -9,7 +9,7 @@
     "artifact-engine": "^1.5.5",
     "azp-tasks-az-blobstorage-provider": "^3.246.3",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "moment": "^2.29.4"
   },

--- a/Tasks/AzureVmssDeploymentV0/task.json
+++ b/Tasks/AzureVmssDeploymentV0/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/AzureVmssDeploymentV0/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV0/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/AzureVmssDeploymentV1/package-lock.json
+++ b/Tasks/AzureVmssDeploymentV1/package-lock.json
@@ -13,7 +13,7 @@
         "artifact-engine": "^1.5.5",
         "azp-tasks-az-blobstorage-provider": "^3.246.3",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "moment": "^2.29.4"
       },
@@ -3201,9 +3201,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureVmssDeploymentV1/package.json
+++ b/Tasks/AzureVmssDeploymentV1/package.json
@@ -9,7 +9,7 @@
     "artifact-engine": "^1.5.5",
     "azp-tasks-az-blobstorage-provider": "^3.246.3",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "moment": "^2.29.4"
   },

--- a/Tasks/AzureVmssDeploymentV1/task.json
+++ b/Tasks/AzureVmssDeploymentV1/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/AzureVmssDeploymentV1/task.loc.json
+++ b/Tasks/AzureVmssDeploymentV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "minimumAgentVersion": "2.209.0",

--- a/Tasks/AzureWebAppContainerV1/package-lock.json
+++ b/Tasks/AzureWebAppContainerV1/package-lock.json
@@ -16,7 +16,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureWebAppContainerV1/package.json
+++ b/Tasks/AzureWebAppContainerV1/package.json
@@ -24,7 +24,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-webdeployment-common": "^4.257.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureWebAppContainerV1/task.json
+++ b/Tasks/AzureWebAppContainerV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppContainerV1/task.loc.json
+++ b/Tasks/AzureWebAppContainerV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppV1/package-lock.json
+++ b/Tasks/AzureWebAppV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "azure-pipelines-tasks-webdeployment-common": "4.257.0",
         "jsonwebtoken": "^9.0.2",
@@ -204,9 +204,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/AzureWebAppV1/package.json
+++ b/Tasks/AzureWebAppV1/package.json
@@ -23,7 +23,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-tasks-webdeployment-common": "4.257.0",
     "jsonwebtoken": "^9.0.2",

--- a/Tasks/AzureWebAppV1/task.json
+++ b/Tasks/AzureWebAppV1/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "2.209.0",
   "groups": [

--- a/Tasks/AzureWebAppV1/task.loc.json
+++ b/Tasks/AzureWebAppV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "minimumAgentVersion": "2.209.0",
   "groups": [

--- a/Tasks/ContainerBuildV0/package-lock.json
+++ b/Tasks/ContainerBuildV0/package-lock.json
@@ -10,7 +10,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "2.242.0",
         "azure-pipelines-tool-lib": "2.0.7",
         "consistent-hashing": "0.3.0"
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/ContainerBuildV0/package.json
+++ b/Tasks/ContainerBuildV0/package.json
@@ -5,7 +5,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "2.242.0",
     "azure-pipelines-tool-lib": "2.0.7",
     "consistent-hashing": "0.3.0"

--- a/Tasks/ContainerBuildV0/task.json
+++ b/Tasks/ContainerBuildV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/ContainerBuildV0/task.loc.json
+++ b/Tasks/ContainerBuildV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -11,7 +11,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
         "azure-pipelines-tasks-securefiles-common": "^2.207.0",
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-securefiles-common": "^2.207.0",

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV1/package-lock.json
+++ b/Tasks/HelmDeployV1/package-lock.json
@@ -11,7 +11,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "^2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
         "azure-pipelines-tasks-securefiles-common": "^2.207.0",
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/HelmDeployV1/package.json
+++ b/Tasks/HelmDeployV1/package.json
@@ -6,7 +6,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "^2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-securefiles-common": "^2.207.0",

--- a/Tasks/HelmDeployV1/task.json
+++ b/Tasks/HelmDeployV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV1/task.loc.json
+++ b/Tasks/HelmDeployV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [

--- a/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
@@ -13,7 +13,7 @@
         "agent-base": "^6.0.2",
         "artifact-engine": "^1.5.5",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-storage": "2.10.4",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1",
@@ -2795,9 +2795,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/JenkinsDownloadArtifactsV1/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package.json
@@ -14,7 +14,7 @@
     "agent-base": "^6.0.2",
     "artifact-engine": "^1.5.5",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-storage": "2.10.4",
     "decompress-zip": "0.3.3",
     "extract-zip": "2.0.1",

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/JenkinsDownloadArtifactsV2/package-lock.json
+++ b/Tasks/JenkinsDownloadArtifactsV2/package-lock.json
@@ -14,7 +14,7 @@
         "artifact-engine": "^1.5.5",
         "azp-tasks-az-blobstorage-provider": "^3.246.3",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1",
         "fs-extra": "5.0.0",
@@ -3245,9 +3245,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/JenkinsDownloadArtifactsV2/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV2/package.json
@@ -14,7 +14,7 @@
     "agent-base": "^6.0.2",
     "artifact-engine": "^1.5.5",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azp-tasks-az-blobstorage-provider": "^3.246.3",
     "decompress-zip": "0.3.3",
     "extract-zip": "2.0.1",

--- a/Tasks/JenkinsDownloadArtifactsV2/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV2/task.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/JenkinsDownloadArtifactsV2/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV2/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 2,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/KubeloginInstallerV0/package-lock.json
+++ b/Tasks/KubeloginInstallerV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "^1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tool-lib": "^2.0.4"
       },
       "devDependencies": {
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/KubeloginInstallerV0/package.json
+++ b/Tasks/KubeloginInstallerV0/package.json
@@ -25,7 +25,7 @@
     "@types/q": "^1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tool-lib": "^2.0.4"
   },
   "devDependencies": {

--- a/Tasks/KubeloginInstallerV0/task.json
+++ b/Tasks/KubeloginInstallerV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/task.loc.json
+++ b/Tasks/KubeloginInstallerV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 259,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV1/package-lock.json
+++ b/Tasks/KubernetesManifestV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.1",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.1.tgz",
-      "integrity": "sha1-SMeMj37RQ1VAVQQx4WqLcdR4twg=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/KubernetesManifestV1/package.json
+++ b/Tasks/KubernetesManifestV1/package.json
@@ -8,7 +8,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.224.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV1/package-lock.json
+++ b/Tasks/KubernetesV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.16.0",
-        "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
         "azure-pipelines-tasks-docker-common": "2.242.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
         "azure-pipelines-tasks-utility-common": "3.258.0",
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.258.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.258.0.tgz",
-      "integrity": "sha1-8MKK5KSnZNmycYz22I0vOhkapqQ=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.259.1.tgz",
+      "integrity": "sha1-mMsaDc1lwDZwbVcqOoJbL2KVOzE=",
       "license": "MIT",
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.8",

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -8,7 +8,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.16.0",
-    "azure-pipelines-tasks-azure-arm-rest": "3.258.0",
+    "azure-pipelines-tasks-azure-arm-rest": "3.259.1",
     "azure-pipelines-tasks-docker-common": "2.242.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
     "azure-pipelines-tasks-utility-common": "3.258.0",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 259,
-    "Patch": 1
+    "Patch": 2
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
Updating azure-arm-rest dependency in tasks

[AB#2275633](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2275633)

---

### **Task Name**
AzureAppServiceManageV0,
AzureAppServiceSettingsV1,
AzureCLIV2,
AzureFileCopyV2,
AzureFileCopyV3,
AzureFileCopyV4,
AzureFileCopyV5,
AzureFileCopyV6,
AzureFunctionAppContainerV1,
AzureFunctionAppV1,
AzureFunctionAppV2,
AzureFunctionOnKubernetesV1,
AzureKeyVaultV1,
AzureKeyVaultV2,
AzureMysqlDeploymentV1,
AzurePowerShellV4,
AzurePowerShellV5,
AzureResourceGroupDeploymentV2,
AzureResourceManagerTemplateDeploymentV3,
AzureRmWebAppDeploymentV3,
AzureRmWebAppDeploymentV4,
AzureRmWebAppDeploymentV5,
AzureVmssDeploymentV0,
AzureVmssDeploymentV1,
AzureWebAppContainerV1,
AzureWebAppV1,
ContainerBuildV0,
HelmDeployV0,
HelmDeployV1,
JenkinsDownloadArtifactsV1,
JenkinsDownloadArtifactsV2,
KubeloginInstallerV0,
KubernetesManifestV1,
KubernetesV1

---

### **Description**
This PR updates **azure-pipelines-tasks-azure-arm-rest** package to version 3.259.1 in the following tasks

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
N

---

### **Additional Testing Performed**
N

---

### **Documentation Changes Required** (Yes / No)  
N

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
