### PR TITLE
Update MSBuild Logger binary

### DIFF
--- a/Tasks/MSBuildV1/package-lock.json
+++ b/Tasks/MSBuildV1/package-lock.json
@@ -10,7 +10,7 @@
         "@types/mocha": "^9.1.1",
         "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "^4.16.0",
-        "azure-pipelines-tasks-msbuildhelpers": "3.256.0"
+        "azure-pipelines-tasks-msbuildhelpers": "3.259.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -63,9 +63,10 @@
       }
     },
     "node_modules/azure-pipelines-tasks-msbuildhelpers": {
-      "version": "3.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.256.0.tgz",
-      "integrity": "sha1-4t3Bgt4u1lPwrzlumJxlH9mg2WE=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.259.1.tgz",
+      "integrity": "sha1-g+mYjMHgUQY5ybxseE58Ikcb2jk=",
+      "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/MSBuildV1/package.json
+++ b/Tasks/MSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "^4.16.0",
-    "azure-pipelines-tasks-msbuildhelpers": "3.256.0"
+    "azure-pipelines-tasks-msbuildhelpers": "3.259.1"
   },
   "devDependencies": {
     "typescript": "5.1.6"

--- a/Tasks/MSBuildV1/task.json
+++ b/Tasks/MSBuildV1/task.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/MSBuildV1/task.loc.json
+++ b/Tasks/MSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/package-lock.json
+++ b/Tasks/VSBuildV1/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "azure-pipelines-tasks-msbuildhelpers": {
-      "version": "3.256.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.256.0.tgz",
-      "integrity": "sha1-4t3Bgt4u1lPwrzlumJxlH9mg2WE=",
+      "version": "3.259.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.259.1.tgz",
+      "integrity": "sha1-g+mYjMHgUQY5ybxseE58Ikcb2jk=",
       "requires": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",

--- a/Tasks/VSBuildV1/package.json
+++ b/Tasks/VSBuildV1/package.json
@@ -15,7 +15,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.0",
     "azure-pipelines-task-lib": "^4.16.0",
-    "azure-pipelines-tasks-msbuildhelpers": "^3.256.0"
+    "azure-pipelines-tasks-msbuildhelpers": "^3.259.1"
   },
   "devDependencies": {
     "typescript": "4.0.2"

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 256,
+    "Minor": 260,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
### **Context**
The binary _Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll_ has been updated with the strong name signed version, in the common packages **msbuildhelpers -> 3.259.1**
This PR updates the package **msbuildhelpers** to point to that version.
[User Story](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2283764)
PR for updating msbuildhelpers : [PR](https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/472)
  

---

### **Task Name**
MSBuildV1, VSBuildV1

---

### **Description**
Updated the package **msbuildhelpers** to use version 3.259.1 which has the strong name signed version of the binary _Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll_

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
- Unit Tests
- Validated by uploading to test org, and checking if task behaves as expected

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
