### PR TITLE
Fix multiple bindings issue on IISWebAppManagementOnmachineGroupV0

### DIFF
--- a/Tasks/IISWebAppManagementOnMachineGroupV0/make.json
+++ b/Tasks/IISWebAppManagementOnMachineGroupV0/make.json
@@ -3,7 +3,7 @@
        "nugetv2": [
             {
                 "name": "TaskModuleIISManageUtility",
-                "version": "0.1.8",
+                "version": "0.1.9",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/IISWebAppManagementOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppManagementOnMachineGroupV0/task.json
@@ -17,8 +17,8 @@
     "demands": [],
     "version": {
         "Major": 0,
-        "Minor": 241,
-        "Patch": 1
+        "Minor": 260,
+        "Patch": 0
     },
     "minimumAgentVersion": "2.111.0",
     "instanceNameFormat": "Manage $(IISDeploymentType)",

--- a/Tasks/IISWebAppManagementOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppManagementOnMachineGroupV0/task.loc.json
@@ -17,8 +17,8 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 241,
-    "Patch": 1
+    "Minor": 260,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.111.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
Fix multiple binding issue on IISWebAppManagementOnmachineGroupV0 task
📌 https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2275871

---

### **Task Name**
IISWebAppManagementOnmachineGroupV0

---

### **Description**
In the IISWebAppManagementOnMachineGroupV0 task, we encountered a failure when attempting to add multiple SSL bindings on an agent running Windows Server 2022.
The issue was due to a hardcoded value in the code, which prevented the task from retrieving the correct configuration for this OS version. We resolved the issue by updating the code to fetch the required value dynamically.

---

### **Risk Assessment** (Low / Medium / High)  
Low (As the changes we did are not breaking the code) 

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**


---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Task Override

---



### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
