### PR TITLE
Remove DeployVisualStudioTestAgentV2 from make-options.json

### DIFF
--- a/make-options.json
+++ b/make-options.json
@@ -77,7 +77,6 @@
         "DecryptFileV1",
         "DelayV1",
         "DeleteFilesV1",
-        "DeployVisualStudioTestAgentV2",
         "DockerV0",
         "DockerV1",
         "DockerV2",


### PR DESCRIPTION
### **Context**
Remove DeployVisualStudioTestAgentV2 from build for now due to build break

---

### **Task Name**
DeployVisualStudioTestAgentV2 

---

### **Description**
Remove DeployVisualStudioTestAgentV2 from build for now due to build break

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
N/A

---

### **Tech Design / Approach**
N/A

---

### **Documentation Changes Required** (Yes/No)
N/A
---

### **Unit Tests Added or Updated** (Yes / No)  
N/A

---

### **Additional Testing Performed**
N/A

---

### **Logging Added/Updated** (Yes/No)
N/A

--- 

### **Telemetry Added/Updated** (Yes/No) 
N/A

---

### **Rollback Scenario and Process** (Yes/No)
N/A

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
