### PR TITLE
User Story 2299663: Regression on AzurePowershellV5

### DIFF
--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -41,7 +41,6 @@ if ($targetAzurePs -eq $otherVersion) {
         throw (Get-VstsLocString -Key InvalidAzurePsVersion $customTargetAzurePs)
     } else {
         $targetAzurePs = $customTargetAzurePs.Trim()
-        Initialize-ModuleVersionValidation -moduleName "azure-powershell" -targetAzurePs $targetAzurePs -displayModuleName "Az" -versionsToReduce $versionTolerance  
     }
 }
 
@@ -50,14 +49,14 @@ $regex = New-Object -TypeName System.Text.RegularExpressions.Regex -ArgumentList
 
 if ($targetAzurePs -eq $latestVersion) {
     $targetAzurePs = ""
-    $installedVersion = Get-InstalledMajorRelease "Az"
-    Initialize-ModuleVersionValidation -moduleName "azure-powershell" -targetAzurePs $installedVersion -displayModuleName "Az" -versionsToReduce $versionTolerance 
       
 } elseif (-not($regex.IsMatch($targetAzurePs))) {
     throw (Get-VstsLocString -Key InvalidAzurePsVersion -ArgumentList $targetAzurePs)
 }
 
 . $PSScriptRoot\TryMakingModuleAvailable.ps1 -targetVersion "$targetAzurePs" -platform Windows
+
+Initialize-ModuleVersionValidation -moduleName "azure-powershell" -targetAzurePs $targetAzurePs -displayModuleName "Az" -versionsToReduce $versionTolerance 
 
 if ($validateScriptSignature) {
     try {

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 259,
-    "Patch": 4
+    "Minor": 260,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 259,
-    "Patch": 4
+    "Minor": 260,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [


### PR DESCRIPTION
### **Context**
 Due to the commit https://github.com/microsoft/azure-pipelines-tasks/blame/ec77cd364bff7fcd8b21f3f5ba1c83168c505511/Tasks/AzurePowerShellV5/Utility.ps1#L233 caused a regression. now it was handle with try catch and also tried with multiple steps to get the installed Az module 

AB#https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2299663

---

### **Task Name**
AzurePowershellV5

---

### **Description**
Now  we made the get installed version of Az module under FF. Addition to that we now checking  Az module in multiple ways if the agent is hosted we used to get from the installation path. If not present we used to run Get-installedModule and GetModule to support powershell & Pwsh
---

### **Risk Assessment** (Low / Medium / High)  
Low 

---

### **Change Behind Feature Flag** (Yes / No)
Yes

---

### **Tech Design / Approach**
N/A

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
N/A

---

### **Additional Testing Performed**
Validated with Hosted agents. self-hosted, Linux based agent & Linux based self hosted agents

---

### **Logging Added/Updated** (Yes/No)
Yes 

--- 

### **Telemetry Added/Updated** (Yes/No) 
N/A

---

### **Rollback Scenario and Process** (Yes/No)
- By Turning off the FF 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes

---

### **Checklist**
- [X] Related issue linked (if applicable)
- [X] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [X] Verified the task behaves as expected
