### PR TITLE
Add performing npm audit locally

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -100,6 +100,12 @@ npm run build
 node make.js build --task ShellScript
 ```
 
+## Build task with the bypassed auditing step
+
+```bash
+node make.js build --task ShellScript --BypassNpmAudit
+```
+
 ## Run Tests
 
 Tests for each task are located in Tests folder for each task.  To get additional debugging when you are running your tests, set the environment variable TASK_TEST_TRACE to 1.  This will cause additional logging to be printed to STDOUT.

--- a/make-util.js
+++ b/make-util.js
@@ -165,13 +165,11 @@ function performNpmAudit(taskPath) {
 
         if (auditResult.error) {
             console.log(`\x1b[A\x1b[K❌ npm audit failed because the build task at "${taskPath}" has vulnerable dependencies.`);
-            console.log(`👉 Please see details by running the command: npm audit fix --prefix ${taskPath}`);
+            console.log(`👉 Please see details by running the command: npm audit --prefix ${taskPath}`);
             process.exit(1);
         } else {
             console.log('\x1b[A\x1b[K✅ npm audit completed successfully.');
         }
-
-        console.log(auditResult);
     } catch (error) {
         console.error('\x1b[A\x1b[K❌ "performNpmAudit" failed.');
         console.error(error.message);

--- a/make-util.js
+++ b/make-util.js
@@ -1,15 +1,20 @@
-var check = require('validator').default;
-var fs = require('fs');
-var makeOptions = require('./make-options.json');
-var minimatch = require('minimatch');
-var ncp = require('child_process');
-var os = require('os');
-var path = require('path');
-var process = require('process');
-var semver = require('semver');
-var shell = require('shelljs');
-const { XMLParser } = require("fast-xml-parser");
-const Downloader = require("nodejs-file-downloader");
+const ncp = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const process = require('process');
+
+const { XMLParser } = require('fast-xml-parser');
+const minimatch = require('minimatch');
+const minimist = require('minimist');
+const Downloader = require('nodejs-file-downloader');
+const check = require('validator').default;
+const semver = require('semver');
+const shell = require('shelljs');
+
+const makeOptions = require('./make-options.json');
+
+const args = minimist(process.argv.slice(2));
 
 // global paths
 var repoPath = __dirname;
@@ -157,6 +162,16 @@ exports.getCommonPackInfo = getCommonPackInfo;
 function performNpmAudit(taskPath) {
     console.log('\n🛫 Running npm audit...');
 
+    if (process.env['TF_BUILD']) {
+        console.log(`\x1b[A\x1b[K⏭️  Skipping npm audit in build pipeline because it is not supported in the pipeline.`);
+        return;
+    }
+
+    if (args.BypassNpmAudit) {
+        console.log(`\x1b[A\x1b[K⏭️  Skipping npm audit because --BypassNpmAudit argument is set.`);
+        return;
+    }
+
     try {
         const auditResult = ncp.spawnSync('npm', ['audit', '--prefix', taskPath, '--audit-level=high'], {
             stdio: 'pipe',
@@ -165,7 +180,10 @@ function performNpmAudit(taskPath) {
 
         if (auditResult.error) {
             console.log(`\x1b[A\x1b[K❌ npm audit failed because the build task at "${taskPath}" has vulnerable dependencies.`);
-            console.log(`👉 Please see details by running the command: npm audit --prefix ${taskPath}`);
+            console.log('👉 Please see details by running the command');
+            console.log(`\tnpm audit --prefix ${taskPath}`);
+            console.log('or execute the command with --BypassNpmAudit argument to skip the auditing');
+            console.log(`\tnode make.js --build --task ${args.task} --BypassNpmAudit`);
             process.exit(1);
         } else {
             console.log('\x1b[A\x1b[K✅ npm audit completed successfully.');
@@ -213,9 +231,7 @@ var buildNodeTask = function (taskPath, outDir, isServerBuild) {
         cd(taskPath);
     }
 
-    if (!process.env['TF_BUILD']) {
-        performNpmAudit(taskPath);
-    }
+    performNpmAudit(taskPath);
 
     // Use the tsc version supplied by the task if it is available, otherwise use the global default.
     if (overrideTscPath) {

--- a/make-util.js
+++ b/make-util.js
@@ -154,6 +154,30 @@ var getCommonPackInfo = function (modOutDir) {
 }
 exports.getCommonPackInfo = getCommonPackInfo;
 
+function performNpmAudit(taskPath) {
+    console.log('\n🛫 Running npm audit...');
+
+    try {
+        const auditResult = ncp.spawnSync('npm', ['audit', '--prefix', taskPath, '--audit-level=high'], {
+            stdio: 'pipe',
+            encoding: 'utf8',
+        });
+
+        if (auditResult.error) {
+            console.log(`\x1b[A\x1b[K❌ npm audit failed because the build task at "${taskPath}" has vulnerable dependencies.`);
+            console.log(`👉 Please see details by running the command: npm audit fix --prefix ${taskPath}`);
+            process.exit(1);
+        } else {
+            console.log('\x1b[A\x1b[K✅ npm audit completed successfully.');
+        }
+
+        console.log(auditResult);
+    } catch (error) {
+        console.error('\x1b[A\x1b[K❌ "performNpmAudit" failed.');
+        console.error(error.message);
+    }
+}
+
 var buildNodeTask = function (taskPath, outDir, isServerBuild) {
     var originalDir = shell.pwd().toString();
     cd(taskPath);
@@ -189,6 +213,10 @@ var buildNodeTask = function (taskPath, outDir, isServerBuild) {
             run('npm install');
         }
         cd(taskPath);
+    }
+
+    if (!process.env['TF_BUILD']) {
+        performNpmAudit(taskPath);
     }
 
     // Use the tsc version supplied by the task if it is available, otherwise use the global default.

--- a/make-util.js
+++ b/make-util.js
@@ -191,6 +191,7 @@ function performNpmAudit(taskPath) {
     } catch (error) {
         console.error('\x1b[A\x1b[K❌ "performNpmAudit" failed.');
         console.error(error.message);
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
### **Context**
To strengthen the tasks' security posture, I introduced a new function, **performNpmAudit**.
This function runs **npm audit** with **--audit-level=high** scoped to the task directory, helping us proactively detect and address high-severity vulnerabilities during local development.

The audit step is disabled in CI environments by checking the **TF_BUILD** environment variable and a contributor can bypass the auditing step by adding the option **BypassNpmAudit** to a command:
```bash
node make.js --build --task @(TaskV1|TaskV2) --BypassNpmAudit
```

[AB#2287182](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2287182)

---

### **Task Name**
N/A

---

### **Description**
The PR introduces **npm audit** execution to help identify and localize the vulnerabilities in build tasks

---

### **Risk Assessment**
Low

---

### **Change Behind Feature Flag**
N

---

### **Tech Design / Approach**
N

---

### **Documentation Changes Required**
N

---

### **Unit Tests Added or Updated**
N

---

### **Additional Testing Performed**
N

---

### **Logging Added/Updated**
- Added logging for **npm audit** performing and possible exceptions

--- 

### **Telemetry Added/Updated**
N

---

### **Rollback Scenario and Process**
N

---

### **Dependency Impact Assessed and Regression Tested**
N

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
