### PR TITLE
Add FF to disable Az account check

### DIFF
--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 259,
-    "Patch": 4
+    "Minor": 260,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 259,
-    "Patch": 4
+    "Minor": 260,
+    "Patch": 0
   },
   "demands": [
     "azureps"


### PR DESCRIPTION
### **Context**
Add FF to disable az account check
📌(https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2300524)

---

### **Task Name**
AzureFileCopyV6

---

### **Description**
Add FF to disable Az account module version check to download azcopy.exe.
Default Azcopy.exe keep older (10.25.1)

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Yes

---

### **Tech Design / Approach**
Yes

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
Yes
---

### **Additional Testing Performed**
Yes

---

### **Logging Added/Updated** (Yes/No)
Yes

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
task override

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [X] Related issue linked (if applicable)
- [X] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [X] Verified the task behaves as expected
