### PR TITLE
Fix PowerShell env context for audit check

### DIFF
--- a/make-util.js
+++ b/make-util.js
@@ -176,6 +176,7 @@ function performNpmAudit(taskPath) {
         const auditResult = ncp.spawnSync('npm', ['audit', '--prefix', taskPath, '--audit-level=high'], {
             stdio: 'pipe',
             encoding: 'utf8',
+            shell: true
         });
 
         if (auditResult.error) {


### PR DESCRIPTION
### **Context**
PowerShell on Windows loses environment context in some cases so npm cannot be found when it is called through spawnSync

[AB#2287182](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2287182)

---

### **Task Name**
N/A

---

### **Description**
N/A

---

### **Risk Assessment**
Low

---

### **Change Behind Feature Flag**
N/A

---

### **Tech Design / Approach**
N/A

---

### **Documentation Changes Required** (Yes/No)
N/A

---

### **Unit Tests Added or Updated**
N/A

---

### **Additional Testing Performed**
N/A

---

### **Logging Added/Updated** (Yes/No)
N/A

--- 

### **Telemetry Added/Updated** (Yes/No) 
N/A

---

### **Rollback Scenario and Process** (Yes/No)
N/A 

---

### **Dependency Impact Assessed and Regression Tested**
N/A

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
