### PR TITLE
Fix FtpUpload@2 helpUrl

### DIFF
--- a/Tasks/FtpUploadV2/task.json
+++ b/Tasks/FtpUploadV2/task.json
@@ -4,7 +4,7 @@
   "friendlyName": "FTP upload",
   "description": "Upload files using FTP",
   "author": "Microsoft Corporation",
-  "helpUrl": "https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/ftp-upload",
+  "helpUrl": "https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/ftp-upload-v2",
   "helpMarkDown": "Upload files to a remote machine using the File Transfer Protocol (FTP), or securely with FTPS.  [More Information](http://go.microsoft.com/fwlink/?LinkId=809084).",
   "category": "Utility",
   "visibility": [


### PR DESCRIPTION
### **Context**
Fix a broken `helpUrl`.

---

### **Task Name**
FtpUpload@2

---

### **Description**
Fix a broken `helpUrl`.

Broken: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/ftp-upload
Working: https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/ftp-upload-v2?view=azure-pipelines

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
n/a

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
n/a

---

### **Logging Added/Updated** (Yes/No)
No 

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
