### PR TITLE
Fix Resolve-Error in AzurePowerShell task

### DIFF
--- a/Tasks/AzurePowerShellV5/CoreAz.ps1
+++ b/Tasks/AzurePowerShellV5/CoreAz.ps1
@@ -35,7 +35,6 @@ try {
 }
 catch {
     Write-Host "An error occurred in Initialize-AzModule"
-    Resolve-Error $_ | ConvertTo-Json -Depth 5 | Write-Host
     throw
 }
 

--- a/Tasks/AzurePowerShellV5/package-lock.json
+++ b/Tasks/AzurePowerShellV5/package-lock.json
@@ -11,7 +11,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.259.2",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.2",
         "azure-pipelines-tasks-utility-common": "3.258.0"
       },
       "devDependencies": {

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 260,
+    "Minor": 261,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 260,
+    "Minor": 261,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
In AzurePowerShellV5 task we were getting Resolve-Error when using self-hosted agent. We observed that from Az version 13 there was breaking change. Therefore, we did fix for this.
[Breaking Change] Removed alias 'Resolve-Error' for the cmdlet 'Resolve-AzError'.
We havent replaced 'Resolve-Error' with 'Resolve-AzError' as 'Resolve-Error' was only showing the additional debug logs with stack trace details.

https://github.com/Azure/azure-powershell/releases/tag/v13.0.0-November2024 

---

### **Task Name**
AzurePowerShellV5

---

Workitem links: #20581 
                          #2226138

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
Did testing in private org : https://dev.azure.com/v-schhabra0181/Test/_releaseProgress?_a=release-environment-logs&releaseId=331&environmentId=331

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Rollback is not needed as the change will not impact the existing functionality.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
