### PR TITLE
feat: :sparkles: added arm64 support

### DIFF
--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK-Version",
   "loc.input.help.versionSpec": "Eine Zahl, welche die JDK-Version angibt, die im Pfad zur Verfügung gestellt werden soll. Verwenden einer Ganzzahlversion, z. B. 10",
   "loc.input.label.jdkArchitectureOption": "JDK-Architektur",
-  "loc.input.help.jdkArchitectureOption": "Die Architektur (x86, x64) des JDK.",
+  "loc.input.help.jdkArchitectureOption": "Die Architektur (x86, x64, ARM64) des JDK.",
   "loc.input.label.jdkSourceOption": "JDK-Quelle",
   "loc.input.help.jdkSourceOption": "Quelle für das komprimierte JDK.",
   "loc.input.label.jdkFile": "JDK-Datei",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/en-US/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK version",
   "loc.input.help.versionSpec": "A number that specifies the JDK version to make available on the path. Use a whole number version, such as 10",
   "loc.input.label.jdkArchitectureOption": "JDK architecture",
-  "loc.input.help.jdkArchitectureOption": "The architecture (x86, x64) of the JDK.",
+  "loc.input.help.jdkArchitectureOption": "The architecture (x86, x64, ARM64) of the JDK.",
   "loc.input.label.jdkSourceOption": "JDK source",
   "loc.input.help.jdkSourceOption": "Source for the compressed JDK.",
   "loc.input.label.jdkFile": "JDK file",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "Versión de JDK",
   "loc.input.help.versionSpec": "Número que especifica la versión de JDK que se va a poner a disposición en la ruta de acceso. Usar una versión de número entero, como 10",
   "loc.input.label.jdkArchitectureOption": "Arquitectura JDK",
-  "loc.input.help.jdkArchitectureOption": "La arquitectura (x86, x64) del JDK.",
+  "loc.input.help.jdkArchitectureOption": "La arquitectura (x86, x64, ARM64) del JDK.",
   "loc.input.label.jdkSourceOption": "Origen de JDK",
   "loc.input.help.jdkSourceOption": "Origen del JDK comprimido.",
   "loc.input.label.jdkFile": "Archivo JDK",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "Version du kit JDK",
   "loc.input.help.versionSpec": "Nombre qui spécifie la version du JDK à rendre disponible sur le chemin d’accès. Utiliser une version de nombre entier, telle que 10",
   "loc.input.label.jdkArchitectureOption": "Architecture du kit JDK",
-  "loc.input.help.jdkArchitectureOption": "Architecture (x86, x64) du kit JDK.",
+  "loc.input.help.jdkArchitectureOption": "Architecture (x86, x64, ARM64) du kit JDK.",
   "loc.input.label.jdkSourceOption": "Source du kit JDK",
   "loc.input.help.jdkSourceOption": "Source du kit JDK compressé.",
   "loc.input.label.jdkFile": "Fichier du kit JDK",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "Versione JDK",
   "loc.input.help.versionSpec": "Numero che specifica la versione JDK da rendere disponibile nel percorso. Usa una versione numero intero, ad esempio 10",
   "loc.input.label.jdkArchitectureOption": "Architettura del JDK",
-  "loc.input.help.jdkArchitectureOption": "Architettura (x86, x64) del JDK.",
+  "loc.input.help.jdkArchitectureOption": "Architettura (x86, x64, ARM64) del JDK.",
   "loc.input.label.jdkSourceOption": "Origine del JDK",
   "loc.input.help.jdkSourceOption": "Origine del JDK compresso.",
   "loc.input.label.jdkFile": "File del JDK",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK バージョン",
   "loc.input.help.versionSpec": "パスで使用可能にする JDK バージョンを指定する数値です。整数バージョン (10 など) を使用する",
   "loc.input.label.jdkArchitectureOption": "JDK アーキテクチャ",
-  "loc.input.help.jdkArchitectureOption": "JDK のアーキテクチャ (x86、x64)。",
+  "loc.input.help.jdkArchitectureOption": "JDK のアーキテクチャ (x86、x64, ARM64)。",
   "loc.input.label.jdkSourceOption": "JDK ソース",
   "loc.input.help.jdkSourceOption": "圧縮された JDK のソース。",
   "loc.input.label.jdkFile": "JDK ファイル",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK 버전",
   "loc.input.help.versionSpec": "경로에서 사용할 수 있도록 JDK 버전을 지정하는 숫자입니다. 10과 같은 정수 버전 사용",
   "loc.input.label.jdkArchitectureOption": "JDK 아키텍처",
-  "loc.input.help.jdkArchitectureOption": "JDK의 아키텍처(x86, x64)입니다.",
+  "loc.input.help.jdkArchitectureOption": "JDK의 아키텍처(x86, x64, ARM64)입니다.",
   "loc.input.label.jdkSourceOption": "JDK 소스",
   "loc.input.help.jdkSourceOption": "압축된 JDK의 소스입니다.",
   "loc.input.label.jdkFile": "JDK 파일",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "Версия JDK",
   "loc.input.help.versionSpec": "Число, определяющее версию JDK, которая должна быть доступна по пути. Используйте целочисленный номер версии, например 10",
   "loc.input.label.jdkArchitectureOption": "Архитектура JDK",
-  "loc.input.help.jdkArchitectureOption": "Архитектура JDK (x86, x64).",
+  "loc.input.help.jdkArchitectureOption": "Архитектура JDK (x86, x64, ARM64).",
   "loc.input.label.jdkSourceOption": "Источник JDK",
   "loc.input.help.jdkSourceOption": "Источник сжатого пакета JDK.",
   "loc.input.label.jdkFile": "Файл JDK",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK 版本",
   "loc.input.help.versionSpec": "指定要在路径上提供的 JDK 版本的数字。使用整数版本，例如 10",
   "loc.input.label.jdkArchitectureOption": "JDK 体系结构",
-  "loc.input.help.jdkArchitectureOption": "JDK 的体系结构(x86、x64)。",
+  "loc.input.help.jdkArchitectureOption": "JDK 的体系结构(x86、x64, ARM64)。",
   "loc.input.label.jdkSourceOption": "JDK 源",
   "loc.input.help.jdkSourceOption": "压缩 JDK 的源。",
   "loc.input.label.jdkFile": "JDK 文件",

--- a/Tasks/JavaToolInstallerV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/JavaToolInstallerV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.versionSpec": "JDK 版本",
   "loc.input.help.versionSpec": "指定可在路徑上使用之 JDK 版本的數字。使用整數版本，例如 10",
   "loc.input.label.jdkArchitectureOption": "JDK 架構",
-  "loc.input.help.jdkArchitectureOption": "JDK 的架構 (x86、x64)。",
+  "loc.input.help.jdkArchitectureOption": "JDK 的架構 (x86、x64, ARM64)。",
   "loc.input.label.jdkSourceOption": "JDK 來源",
   "loc.input.help.jdkSourceOption": "壓縮的 JDK 來源。",
   "loc.input.label.jdkFile": "JDK 檔案",

--- a/Tasks/JavaToolInstallerV1/task.json
+++ b/Tasks/JavaToolInstallerV1/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 259,
+    "Minor": 260,
     "Patch": 0
   },
   "satisfies": [
@@ -45,10 +45,11 @@
       "label": "JDK architecture",
       "options": {
         "x64": "X64",
-        "x86": "X86"
+        "x86": "X86",
+        "ARM64": "ARM64"
       },
       "required": true,
-      "helpMarkDown": "The architecture (x86, x64) of the JDK."
+      "helpMarkDown": "The architecture (x86, x64, ARM64) of the JDK."
     },
     {
       "name": "jdkSourceOption",

--- a/Tasks/JavaToolInstallerV1/task.loc.json
+++ b/Tasks/JavaToolInstallerV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 259,
+    "Minor": 260,
     "Patch": 0
   },
   "satisfies": [
@@ -45,7 +45,8 @@
       "label": "ms-resource:loc.input.label.jdkArchitectureOption",
       "options": {
         "x64": "X64",
-        "x86": "X86"
+        "x86": "X86",
+        "ARM64": "ARM64"
       },
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.jdkArchitectureOption"


### PR DESCRIPTION
### **Context**
Adds ARM64 support to Java Installer
#21201

---

### **Task Name**
JavaToolInstaller@1

---

### **Description**
Adds ARM64 support for ARM64 based machines (ie. MacOS ARM64)

---

### **Risk Assessment** (Low / Medium / High)  
Low
No code changes, only allowing an additional value on the parameters

---

### **Change Behind Feature Flag** (Yes / No)
No, not a breaking change

---

### **Tech Design / Approach**
Existing design, new parameter only

---

### **Documentation Changes Required** (Yes/No)
Documentation (task.json descriptions) has been updated to reflect

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes, no existing consumers are affected by this change

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
