### PR TITLE
Override form-data package update in AzureNLBManagementV1

### DIFF
--- a/Tasks/AppCenterTestV1/package-lock.json
+++ b/Tasks/AppCenterTestV1/package-lock.json
@@ -1934,6 +1934,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es5-ext": {
       "version": "0.10.64",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -2294,13 +2309,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "2.5.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha1-pfY2Stfk5n6VtKB+LYxvcRx09iQ=",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
         "node": ">= 0.12"
@@ -2591,6 +2610,21 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },

--- a/Tasks/AppCenterTestV1/package.json
+++ b/Tasks/AppCenterTestV1/package.json
@@ -28,5 +28,8 @@
   },
   "devDependencies": {
     "typescript": "5.1.6"
+  },
+  "overrides": {
+    "form-data": "^2.5.4"
   }
 }

--- a/Tasks/AppCenterTestV1/task.json
+++ b/Tasks/AppCenterTestV1/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 261,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.206.1",
   "groups": [

--- a/Tasks/AppCenterTestV1/task.loc.json
+++ b/Tasks/AppCenterTestV1/task.loc.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": 1,
     "Minor": 261,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.206.1",
   "groups": [


### PR DESCRIPTION
### **Context**
https://dev.azure.com/mseng/PipelineTools/_componentGovernance/184?alertId=331292

---

### **Task Name**
AzureNLBManagementV1
---

### **Description**
Updated Form Data package version to resolve vulnerabilities.

---

### **Risk Assessment** (Low / Medium / High)  
Low
---

### **Additional Testing Performed**
We don't have a pipeline for this task, requesting owning team to verify the changes.

---

### **Rollback Scenario and Process** (Yes/No)
Revert the PR for reverting the changes.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
