### PR TITLE
AppCenterDistributeV3 - Set the release ID as ADO variable

### DIFF
--- a/Tasks/AppCenterDistributeV3/appcenterdistribute.ts
+++ b/Tasks/AppCenterDistributeV3/appcenterdistribute.ts
@@ -148,6 +148,7 @@ async function loadReleaseIdUntilSuccess(apiServer: string, apiVersion: string, 
             if (response && response.upload_status === "readyToBePublished" && response.release_distinct_id) {
                 const releaseId = response.release_distinct_id;
                 tl.debug(`---- Received release id is ${releaseId}`);
+                console.log("##vso[task.setVariable variable=AppCenterReleaseId]${releaseId}")
                 clearInterval(timerId);
                 resolve(releaseId);
             } else if (!response || response.upload_status === "error") {

--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 248,
+    "Minor": 261,
     "Patch": 1
   },
   "minimumAgentVersion": "2.206.1",

--- a/Tasks/AppCenterDistributeV3/task.json
+++ b/Tasks/AppCenterDistributeV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 247,
+    "Minor": 248,
     "Patch": 1
   },
   "minimumAgentVersion": "2.206.1",


### PR DESCRIPTION
**Summary:**  
Define the release ID as an Azure DevOps variable to enable its use in subsequent steps for reporting.

### **Context**
The `AppCenterDistributeV3` task streamlines the process of uploading builds and initiating releases within our CI/CD pipeline. To enhance workflow automation, we aim to notify the test and development teams by providing direct access to the release via a shared link. Currently, this is facilitated using the `appcenter-cli`, which introduces additional overhead and complexity. By capturing the `releaseID` as an Azure DevOps (ADO) pipeline variable, we can significantly simplify this process. This approach will enable seamless integration with downstream tasks, improve traceability, and support more efficient build workflows.
---

### **Task Name**
AppCenterDistributeV3
---

### **Description**
Once the builds have been successfully uploaded and the `releaseId` is obtained, the `vso[task.setVariable]` command is used to assign the retrieved `releaseId` to a pipeline variable. 
The minor version has been bumped up to 261 for the current sprint.
---

### **Risk Assessment** (Low / Medium / High)  
Low, as this involves setting a pipeline variable.

---

### **Change Behind Feature Flag** (Yes / No)
This is very small change and will not impact users

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
No
---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
NA

---

### **Logging Added/Updated** (Yes/No)
Yes

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA
---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
