### PR TITLE
Updating the version of NuGetAuthenticateV1 task and PowerShellV2 task

### DIFF
--- a/Tasks/NuGetAuthenticateV1/task.json
+++ b/Tasks/NuGetAuthenticateV1/task.json
@@ -13,8 +13,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 247,
-    "Patch": 4
+    "Minor": 259,
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "NuGet Authenticate",

--- a/Tasks/NuGetAuthenticateV1/task.loc.json
+++ b/Tasks/NuGetAuthenticateV1/task.loc.json
@@ -13,8 +13,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 247,
-    "Patch": 4
+    "Minor": 259,
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 0
+    "Minor": 260,
+    "Patch": 3
   },
   "releaseNotes": "Script task consistency. Added support for macOS and Linux.",
   "minimumAgentVersion": "2.115.0",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 0
+    "Minor": 260,
+    "Patch": 3
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.115.0",


### PR DESCRIPTION
### **Context**
Updating the version of tasks in task.json and task.loc.json files:
- NuGetAuthenticateV1 task from 1.247.4 to 1.259.1
- PowerShellV2 task from 2.259.0 to 2.260.3

---

### **Task Name**
NuGetAuthenticateV1 and PowerShellV2

---

### **Description**
This task versions are updated to keep them consistent with the versions in the Distributed Task feed.

NuGetAuthenticateV1: https://dev.azure.com/mseng/PipelineTools/_artifacts/feed/DistributedTasks/NuGet/Mseng.MS.TF.DistributedTask.Tasks.NuGetAuthenticateV1/versions/1.259.1

PowerShellV2: https://dev.azure.com/mseng/PipelineTools/_artifacts/feed/DistributedTasks/NuGet/Mseng.MS.TF.DistributedTask.Tasks.PowerShellV2/versions/2.260.3


---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No, we are just updating the versions of the tasks

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
Yes. 

---

### **Unit Tests Added or Updated** (Yes / No)  
No, since this is just a version update.

---

### **Additional Testing Performed**
No, since this is just a version update.
---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA

---

### **Checklist**
NA
