### PR TITLE
Added Compatibility for lower versions of AzureCLIV2

### DIFF
--- a/Tasks/AzureCLIV2/azureclitask.ts
+++ b/Tasks/AzureCLIV2/azureclitask.ts
@@ -49,9 +49,24 @@ export class azureclitask {
             var failOnStdErr: boolean = tl.getBoolInput("failOnStandardError", false);
             tl.mkdirP(cwd);
             tl.cd(cwd);
-            const versionCommand = tl.getPipelineFeature('UseAzVersion') ? "version" : "--version"
             const minorVersionTolerance = 5
-            const azVersionResult: IExecSyncResult = tl.execSync("az", versionCommand);
+            let azVersionResult;
+            const versionCommand = tl.getPipelineFeature('UseAzVersion');
+
+            if (versionCommand) {
+                try {
+                    if (azVersionResult.code !== 0 || azVersionResult.stderr) {
+                        throw new Error(azVersionResult.stderr);
+                    }
+
+                } catch (err) {
+                        azVersionResult = tl.execSync("az", "--version");
+                        }
+            } 
+            else {
+                    azVersionResult = tl.execSync("az", "--version");
+            }
+
             Utility.throwIfError(azVersionResult);
             this.isSupportCertificateParameter = this.isAzVersionGreaterOrEqual(azVersionResult.stdout, "2.66.0");
             await validateAzModuleVersion("azure-Cli", azVersionResult.stdout, "Azure-Cli", minorVersionTolerance)

--- a/Tasks/AzureCLIV2/task.json
+++ b/Tasks/AzureCLIV2/task.json
@@ -19,8 +19,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 1
+    "Minor": 262,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "Azure CLI $(scriptPath)",

--- a/Tasks/AzureCLIV2/task.loc.json
+++ b/Tasks/AzureCLIV2/task.loc.json
@@ -19,8 +19,8 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 1
+    "Minor": 262,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION


### **Context**
- Added try/catch for Azure CLI version check.
- When 'UseAzVersion' feature flag is enabled:
  - **First attempt**: run 'az version'
  - **On failure**: fall back to 'az --version'.
https://github.com/microsoft/azure-pipelines-tasks/pull/20986
---

### **Task Name**
AzureCLIV2

---


### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Yes

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No
---

### **Additional Testing Performed**
Built and uploaded the tasks to test org and validated if the tasks work properly.
---

### **Logging Added/Updated** (Yes/No)
Yes

--- 

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
