### PR TITLE
Package.json changed by removing msal-node1

### DIFF
--- a/Tasks/PublishSymbolsV2/package-lock.json
+++ b/Tasks/PublishSymbolsV2/package-lock.json
@@ -18,7 +18,6 @@
         "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
         "azure-pipelines-tasks-packaging-common": "^3.236.0",
         "azure-pipelines-tasks-utility-common": "3.258.0",
-        "msal-node1": "npm:@azure/msal-node@^1.18.4",
         "msal-node2": "npm:@azure/msal-node@^2.9.2",
         "semver": "^6.3.1",
         "uuid": "^10.0.0"
@@ -1560,35 +1559,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
-    },
-    "node_modules/msal-node1": {
-      "name": "@azure/msal-node",
-      "version": "1.18.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-node/-/msal-node-1.18.4.tgz",
-      "integrity": "sha1-ySGwRHyS+zsMsev1qadvytLsfCE=",
-      "dependencies": {
-        "@azure/msal-common": "13.3.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      }
-    },
-    "node_modules/msal-node1/node_modules/@azure/msal-common": {
-      "version": "13.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/msal-common/-/msal-common-13.3.1.tgz",
-      "integrity": "sha1-ASRlv5QNEjddxHOHt1TM+da5IYA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/msal-node1/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/msal-node2": {
       "name": "@azure/msal-node",

--- a/Tasks/PublishSymbolsV2/package.json
+++ b/Tasks/PublishSymbolsV2/package.json
@@ -26,7 +26,6 @@
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.254.0",
     "agent-base": "^6.0.2",
-    "msal-node1": "npm:@azure/msal-node@^1.18.4",
     "msal-node2": "npm:@azure/msal-node@^2.9.2",
     "uuid": "^10.0.0",
     "semver": "^6.3.1"

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 260,
+    "Minor": 262,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 260,
+    "Minor": 262,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
### **Context**
Removing msal-node1 reference for vulnerability.


📌 [How to link to ADO Work Items](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops)

---

### **Task Name**
PublishSymbolsV2

---

### **Description**
Remove msal-node1 from the package.json

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Its parameter based

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

---

### **Unit Tests Added or Updated** (Yes / No)  
Tests are already in place

---

### **Additional Testing Performed**
Local tests

---

### **Logging Added/Updated** (Yes/No)
yes

--- 

### **Telemetry Added/Updated** (Yes/No) 
yes

---

### **Rollback Scenario and Process** (Yes/No)
Change current version in production, 
revert current code changes with new version
rollout new deployment

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
PublushSymbolsV2 task

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
