### PR TITLE
Update azure-pipelines-tasks-docker-common to v2.263.1 in DockerV1, DockerV2 tasks

### DIFF
--- a/Tasks/DockerV1/package-lock.json
+++ b/Tasks/DockerV1/package-lock.json
@@ -10,7 +10,7 @@
         "@types/q": "^1.5.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-docker-common": "2.263.0",
+        "azure-pipelines-tasks-docker-common": "2.263.1",
         "del": "2.2.0",
         "esprima": "2.7.1",
         "js-yaml": "4.1.0"
@@ -32,13 +32,13 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.0.tgz",
-      "integrity": "sha1-aNunA2CA4dnVaZxOSCFKt5b6c60=",
+      "version": "1.10.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha1-aKF/qGHr0U9v0xQFV5g1Xva+3xs=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -58,17 +58,17 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.0.tgz",
-      "integrity": "sha1-n07JyJpjUWknhArmIMYOgRoLVKM=",
+      "version": "1.10.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha1-g9ePl9ZHqyLmgRp6aLtCI+eh0Bk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.20.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -88,16 +88,16 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
-      "integrity": "sha1-duRKdQk6L0d/xUuE9GBJ3CzmWAA=",
+      "version": "1.22.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.1.tgz",
+      "integrity": "sha1-9HvAL/mnn2LmoyqjdUILG4bcvM0=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
-      "integrity": "sha1-NBFT9bKSdTnriYV3ZR7kjOmN2iU=",
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha1-6XEEXJAeqcEQYWsOHbJyUHeB1fY=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -130,12 +130,12 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.0.tgz",
-      "integrity": "sha1-/Cg0/FHh4rt0twwoS0D4JNhnQio=",
+      "version": "1.13.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha1-bf8v9tPJxkMMb007PmXeUx8Quv4=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
+        "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
@@ -274,9 +274,9 @@
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
-      "integrity": "sha1-9Qb/IXDllKJX+OeKoZYIjzpGoi0=",
+      "version": "0.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz",
+      "integrity": "sha1-L6lAUPJbTYXQvIudl4dLjTR6kXM=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -404,9 +404,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.262.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.262.1.tgz",
-      "integrity": "sha1-qpiN3BI1Zb9679YJgwFLg7kJ3lg=",
+      "version": "3.263.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
+      "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^3.4.2",
@@ -441,9 +441,9 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-docker-common": {
-      "version": "2.263.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.263.0.tgz",
-      "integrity": "sha1-Y3RmhgIYcbM00OBzMYWZlYEEZY8=",
+      "version": "2.263.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.263.1.tgz",
+      "integrity": "sha1-gLGlKg3ru22kbRFwrIUWMsGd/Bg=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
@@ -451,7 +451,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
         "del": "2.2.0",
         "q": "1.4.1"
       }

--- a/Tasks/DockerV1/package.json
+++ b/Tasks/DockerV1/package.json
@@ -9,7 +9,7 @@
     "@types/q": "^1.5.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.11.0",
-    "azure-pipelines-tasks-docker-common": "2.263.0",
+    "azure-pipelines-tasks-docker-common": "2.263.1",
     "del": "2.2.0",
     "esprima": "2.7.1",
     "js-yaml": "4.1.0"

--- a/Tasks/DockerV1/task.json
+++ b/Tasks/DockerV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "Simplified the task by:<br/>&nbsp;- Providing an option to simply select or type a command.<br/>&nbsp;- Retaining the useful input fields and providing an option to pass the rest as an argument to the command.",

--- a/Tasks/DockerV1/task.loc.json
+++ b/Tasks/DockerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/DockerV2/package-lock.json
+++ b/Tasks/DockerV2/package-lock.json
@@ -11,7 +11,7 @@
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-docker-common": "2.263.0",
+        "azure-pipelines-tasks-docker-common": "2.263.1",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "del": "2.2.0",
         "esprima": "2.7.1",
@@ -34,13 +34,13 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.0.tgz",
-      "integrity": "sha1-aNunA2CA4dnVaZxOSCFKt5b6c60=",
+      "version": "1.10.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha1-aKF/qGHr0U9v0xQFV5g1Xva+3xs=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-util": "^1.11.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -60,17 +60,17 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.0.tgz",
-      "integrity": "sha1-n07JyJpjUWknhArmIMYOgRoLVKM=",
+      "version": "1.10.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha1-g9ePl9ZHqyLmgRp6aLtCI+eh0Bk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.4.0",
-        "@azure/core-rest-pipeline": "^1.20.0",
-        "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -90,16 +90,16 @@
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.22.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.0.tgz",
-      "integrity": "sha1-duRKdQk6L0d/xUuE9GBJ3CzmWAA=",
+      "version": "1.22.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.1.tgz",
+      "integrity": "sha1-9HvAL/mnn2LmoyqjdUILG4bcvM0=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
-        "@azure/core-auth": "^1.8.0",
-        "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.11.0",
-        "@azure/logger": "^1.0.0",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.0.tgz",
-      "integrity": "sha1-NBFT9bKSdTnriYV3ZR7kjOmN2iU=",
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha1-6XEEXJAeqcEQYWsOHbJyUHeB1fY=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -132,12 +132,12 @@
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.13.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.0.tgz",
-      "integrity": "sha1-/Cg0/FHh4rt0twwoS0D4JNhnQio=",
+      "version": "1.13.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha1-bf8v9tPJxkMMb007PmXeUx8Quv4=",
       "license": "MIT",
       "dependencies": {
-        "@azure/abort-controller": "^2.0.0",
+        "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
@@ -277,9 +277,9 @@
       "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ=="
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.0.tgz",
-      "integrity": "sha1-9Qb/IXDllKJX+OeKoZYIjzpGoi0=",
+      "version": "0.3.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz",
+      "integrity": "sha1-L6lAUPJbTYXQvIudl4dLjTR6kXM=",
       "license": "MIT",
       "dependencies": {
         "http-proxy-agent": "^7.0.0",
@@ -403,9 +403,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.262.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.262.1.tgz",
-      "integrity": "sha1-qpiN3BI1Zb9679YJgwFLg7kJ3lg=",
+      "version": "3.263.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.263.0.tgz",
+      "integrity": "sha1-UOsMEorkX3/wsGmEEtjlfr85/CU=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^3.4.2",
@@ -434,9 +434,9 @@
       "license": "MIT"
     },
     "node_modules/azure-pipelines-tasks-docker-common": {
-      "version": "2.263.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.263.0.tgz",
-      "integrity": "sha1-Y3RmhgIYcbM00OBzMYWZlYEEZY8=",
+      "version": "2.263.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-docker-common/-/azure-pipelines-tasks-docker-common-2.263.1.tgz",
+      "integrity": "sha1-gLGlKg3ru22kbRFwrIUWMsGd/Bg=",
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
@@ -444,7 +444,7 @@
         "@types/q": "1.5.4",
         "@types/uuid": "^8.3.0",
         "azure-pipelines-task-lib": "^4.13.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.262.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.263.0",
         "del": "2.2.0",
         "q": "1.4.1"
       }

--- a/Tasks/DockerV2/package.json
+++ b/Tasks/DockerV2/package.json
@@ -10,7 +10,7 @@
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^4.13.0",
-    "azure-pipelines-tasks-docker-common": "2.263.0",
+    "azure-pipelines-tasks-docker-common": "2.263.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "del": "2.2.0",
     "esprima": "2.7.1",

--- a/Tasks/DockerV2/task.json
+++ b/Tasks/DockerV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.172.0",
   "demands": [],

--- a/Tasks/DockerV2/task.loc.json
+++ b/Tasks/DockerV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.172.0",
   "demands": [],


### PR DESCRIPTION
### **Context**
This PR updates **azure-pipelines-tasks-docker-common** package dependencies for **DockerV1** and **DockerV2**

Related WI: [AB#2312862](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2312862)

---

### **Task Name**
DockerV1, DockerV2

---

### **Description**
**DockerV1 Task**

- Before: azure-pipelines-tasks-docker-common: 2.245.0
- After: azure-pipelines-tasks-docker-common: 2.263.1

**DockerV2 Task**

- Before: azure-pipelines-tasks-docker-common: 2.256.1
- After: azure-pipelines-tasks-docker-common: 2.263.1

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
