### PR TITLE
Update Openssl Version

### DIFF
--- a/Tasks/AzureAppServiceManageV0/package-lock.json
+++ b/Tasks/AzureAppServiceManageV0/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
         "azure-pipelines-task-lib": "^4.11.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.259.2",
+        "azure-pipelines-tasks-azure-arm-rest": "3.259.2",
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "q": "1.4.1",
         "xml2js": "^0.5.0"

--- a/Tasks/AzureAppServiceManageV0/task.json
+++ b/Tasks/AzureAppServiceManageV0/task.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "$(Action): $(WebAppName)",

--- a/Tasks/AzureAppServiceManageV0/task.loc.json
+++ b/Tasks/AzureAppServiceManageV0/task.loc.json
@@ -18,8 +18,8 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "1.102.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 2
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
-    "Patch": 2
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 259,
-    "Patch": 2
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 259,
-    "Patch": 2
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -159,8 +159,12 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
-    $versionOutput = & $openSSLExePath version
-    Write-Verbose "OpenSSL version: $versionOutput"
+    try {
+        $versionOutput = & $openSSLExePath version
+        Write-Verbose "OpenSSL version: $versionOutput"
+    } catch {
+        Write-Host "There was an error while getting the OpenSSL version $_"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`" -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -1,6 +1,6 @@
 $featureFlags = @{
     retireAzureRM = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
+    useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2'
 }
 
 # Utility Functions used by AzureFileCopy.ps1 (other than azure calls) #
@@ -159,6 +159,8 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
+    $versionOutput = & $openSSLExePath version
+    Write-Verbose "OpenSSL version: $versionOutput"
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`" -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -1,6 +1,6 @@
 $featureFlags = @{
     retireAzureRM = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
 }
 
 # Utility Functions used by AzureFileCopy.ps1 (other than azure calls) #

--- a/Tasks/AzureFileCopyV4/Utility.ps1
+++ b/Tasks/AzureFileCopyV4/Utility.ps1
@@ -1,5 +1,6 @@
 $featureFlags = @{
     retireAzureRM = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
 }
 
 # Utility Functions used by AzureFileCopy.ps1 (other than azure calls) #
@@ -150,8 +151,14 @@ function ConvertTo-Pfx {
         [System.IO.File]::WriteAllText($pfxPasswordFilePath, $pfxFilePassword, [System.Text.Encoding]::ASCII)
     }
 
-    $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
-    $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    if (-not $featureFlags.useOpenssLatestVersion) {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    }
+    else {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`" -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/Utility.ps1
+++ b/Tasks/AzureFileCopyV5/Utility.ps1
@@ -159,8 +159,12 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
-    $versionOutput = & $openSSLExePath version
-    Write-Verbose "OpenSSL version: $versionOutput"
+    try {
+        $versionOutput = & $openSSLExePath version
+        Write-Verbose "OpenSSL version: $versionOutput"
+    } catch {
+        Write-Host "There was an error while getting the OpenSSL version $_"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV5/Utility.ps1
+++ b/Tasks/AzureFileCopyV5/Utility.ps1
@@ -6,7 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
+    useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2'
 }
 
 function Get-AzureCmdletsVersion
@@ -159,6 +159,8 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
+    $versionOutput = & $openSSLExePath version
+    Write-Verbose "OpenSSL version: $versionOutput"
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV5/Utility.ps1
+++ b/Tasks/AzureFileCopyV5/Utility.ps1
@@ -6,6 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
 }
 
 function Get-AzureCmdletsVersion
@@ -150,8 +151,14 @@ function ConvertTo-Pfx {
         [System.IO.File]::WriteAllText($pfxPasswordFilePath, $pfxFilePassword, [System.Text.Encoding]::ASCII)
     }
 
-    $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
-    $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    if (-not $featureFlags.useOpenssLatestVersion) {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    }
+    else {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV5/Utility.ps1
+++ b/Tasks/AzureFileCopyV5/Utility.ps1
@@ -6,7 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
 }
 
 function Get-AzureCmdletsVersion

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/Utility.ps1
+++ b/Tasks/AzureFileCopyV6/Utility.ps1
@@ -159,8 +159,12 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
-    $versionOutput = & $openSSLExePath version
-    Write-Verbose "OpenSSL version: $versionOutput"
+    try {
+        $versionOutput = & $openSSLExePath version
+        Write-Verbose "OpenSSL version: $versionOutput"
+    } catch {
+        Write-Host "There was an error while getting the OpenSSL version $_"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV6/Utility.ps1
+++ b/Tasks/AzureFileCopyV6/Utility.ps1
@@ -6,7 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
+    useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2'
 }
 
 function Get-AzureCmdletsVersion
@@ -159,6 +159,8 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
     }
+    $versionOutput = & $openSSLExePath version
+    Write-Verbose "OpenSSL version: $versionOutput"
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV6/Utility.ps1
+++ b/Tasks/AzureFileCopyV6/Utility.ps1
@@ -6,6 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
 }
 
 function Get-AzureCmdletsVersion
@@ -150,8 +151,14 @@ function ConvertTo-Pfx {
         [System.IO.File]::WriteAllText($pfxPasswordFilePath, $pfxFilePassword, [System.Text.Encoding]::ASCII)
     }
 
-    $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
-    $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    if (-not $featureFlags.useOpenssLatestVersion) {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv4\openssl.cnf"
+    }
+    else {
+        $openSSLExePath = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.cnf"
+    }
     $env:RANDFILE=".rnd"
 
     $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`"  -keypbe PBE-SHA1-3DES -certpbe PBE-SHA1-3DES -macalg sha1"

--- a/Tasks/AzureFileCopyV6/Utility.ps1
+++ b/Tasks/AzureFileCopyV6/Utility.ps1
@@ -6,7 +6,7 @@ $jobId = $env:SYSTEM_JOBID;
 
 $featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
 }
 
 function Get-AzureCmdletsVersion

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 260,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 260,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 259,
-    "Patch": 3
+    "Minor": 262,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -35,7 +35,21 @@ $otherVersion = "OtherVersion"
 $latestVersion = "LatestVersion"
 $versionTolerance = 3
 
+
 . (Join-Path $PSScriptRoot "Utility.ps1") 
+Write-Host "FF $(Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2')"
+# Check for opensslv4 and openssl342 executables, write their paths and versions
+if (Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2') {
+    $opensslPath = Join-Path $PSScriptRoot 'ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe'
+} else {
+    $opensslPath = Join-Path $PSScriptRoot 'ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe'
+}
+if (Test-Path $opensslPath) {
+    $v = & $opensslPath version
+    Write-Host "OpenSSL version used by task: $v ($opensslPath)"
+} else {
+    Write-Host "OpenSSL not found in expected location: $opensslPath"
+}
 if ($targetAzurePs -eq $otherVersion) {
     if ($null -eq $customTargetAzurePs) {
         throw (Get-VstsLocString -Key InvalidAzurePsVersion $customTargetAzurePs)

--- a/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
+++ b/Tasks/AzurePowerShellV5/AzurePowerShell.ps1
@@ -35,21 +35,7 @@ $otherVersion = "OtherVersion"
 $latestVersion = "LatestVersion"
 $versionTolerance = 3
 
-
 . (Join-Path $PSScriptRoot "Utility.ps1") 
-Write-Host "FF $(Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2')"
-# Check for opensslv4 and openssl342 executables, write their paths and versions
-if (Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2') {
-    $opensslPath = Join-Path $PSScriptRoot 'ps_modules\VstsAzureHelpers_\opensslv3.4.2\openssl.exe'
-} else {
-    $opensslPath = Join-Path $PSScriptRoot 'ps_modules\VstsAzureHelpers_\opensslv4\openssl.exe'
-}
-if (Test-Path $opensslPath) {
-    $v = & $opensslPath version
-    Write-Host "OpenSSL version used by task: $v ($opensslPath)"
-} else {
-    Write-Host "OpenSSL not found in expected location: $opensslPath"
-}
 if ($targetAzurePs -eq $otherVersion) {
     if ($null -eq $customTargetAzurePs) {
         throw (Get-VstsLocString -Key InvalidAzurePsVersion $customTargetAzurePs)

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 261,
+    "Minor": 262,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 261,
+    "Minor": 262,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -1,5 +1,6 @@
 ﻿$featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
 }
 
 function Add-Certificate {
@@ -362,8 +363,14 @@ function ConvertTo-Pfx {
     else {
         [System.IO.File]::WriteAllText($pfxPasswordFilePath, $pfxFilePassword, [System.Text.Encoding]::ASCII)
     }
-     $openSSLExePath = "$PSScriptRoot\opensslv4\openssl.exe"
-     $env:OPENSSL_CONF = "$PSScriptRoot\opensslv4\openssl.cnf"
+    if(-not $featureFlags.useOpenssLatestVersion) {
+        $openSSLExePath = "$PSScriptRoot\opensslv4\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\opensslv4\openssl.cnf"
+    }
+    else{
+        $openSSLExePath = "$PSScriptRoot\opensslv3.4.2\openssl.exe"
+        $env:OPENSSL_CONF = "$PSScriptRoot\opensslv3.4.2\openssl.cnf"
+     }
      $env:RANDFILE=".rnd"
      $openSSLArgs = "pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
      $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -1,6 +1,6 @@
 ﻿$featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
+    useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2'
 }
 
 function Add-Certificate {
@@ -371,9 +371,11 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\opensslv3.4.2\openssl.cnf"
      }
-     $env:RANDFILE=".rnd"
-     $openSSLArgs = "pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
-     $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero
+    $versionOutput = & $openSSLExePath version
+    Write-Verbose "OpenSSL version: $versionOutput"
+    $env:RANDFILE=".rnd"
+    $openSSLArgs = "pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
+    $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero
     return $pfxFilePath, $pfxFilePassword
 }
 

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -371,8 +371,12 @@ function ConvertTo-Pfx {
         $openSSLExePath = "$PSScriptRoot\opensslv3.4.2\openssl.exe"
         $env:OPENSSL_CONF = "$PSScriptRoot\opensslv3.4.2\openssl.cnf"
      }
-    $versionOutput = & $openSSLExePath version
-    Write-Verbose "OpenSSL version: $versionOutput"
+    try {
+        $versionOutput = & $openSSLExePath version
+        Write-Verbose "OpenSSL version: $versionOutput"
+    } catch {
+        Write-Host "There was an error while getting the OpenSSL version $_"
+    }
     $env:RANDFILE=".rnd"
     $openSSLArgs = "pkcs12 -export -certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg sha1 -in `"$pemFilePath`" -out `"$pfxFilePath`" -password file:`"$pfxPasswordFilePath`""
     $procExitCode = Invoke-VstsProcess -FileName $openSSLExePath -Arguments $openSSLArgs -RequireExitCodeZero

--- a/Tasks/Common/VstsAzureHelpers_/Utility.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/Utility.ps1
@@ -1,6 +1,6 @@
 ﻿$featureFlags = @{
     retireAzureRM  = [System.Convert]::ToBoolean($env:RETIRE_AZURERM_POWERSHELL_MODULE)
-    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_LATEST_VERSION_3_4_2)
+    useOpenssLatestVersion = [System.Convert]::ToBoolean($env:USE_OPENSSL_VERSION_3_4_2)
 }
 
 function Add-Certificate {

--- a/Tasks/Common/VstsAzureHelpers_/make.json
+++ b/Tasks/Common/VstsAzureHelpers_/make.json
@@ -130,6 +130,25 @@
                         "dest": "netstandard/"
                     }
                 ]
+            },
+            {
+                "name": "VstsTaskSdk",
+                "version": "0.21.0",
+                "repository": "https://www.powershellgallery.com/api/v2/",
+                "cp": [
+                    {
+                        "source": [
+                            "*.dll",
+                            "*.ps1",
+                            "*.psd1",
+                            "*.psm1",
+                            "lib.json",
+                            "Strings"
+                        ],
+                        "dest": "ps_modules/VstsTaskSdk/",
+                        "options": "-R"
+                    }
+                ]
             }
         ],
         "archivePackages": [

--- a/Tasks/Common/VstsAzureHelpers_/make.json
+++ b/Tasks/Common/VstsAzureHelpers_/make.json
@@ -137,6 +137,11 @@
                 "archiveName": "openssl_new3.4.0.zip",
                 "url": "https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.0/M252/openssl.zip",
                 "dest": "./opensslv4"
+            },
+            {
+                "archiveName": "openssl_new3.4.2.zip",
+                "url": "https://vstsagenttools.blob.core.windows.net/tools/openssl/3.4.2/M262/openssl.zip",
+                "dest": "./opensslv3.4.2"
             }
         ]
     }

--- a/Tasks/DockerComposeV0/package-lock.json
+++ b/Tasks/DockerComposeV0/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "DockerComposeV0_Node20",
+  "name": "DockerComposeV0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/Tasks/DockerComposeV0/task.json
+++ b/Tasks/DockerComposeV0/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/DockerComposeV0/task.loc.json
+++ b/Tasks/DockerComposeV0/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 249,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 262,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 262,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/make.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/make.json
@@ -17,7 +17,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.10.0",
+                "version": "0.21.0",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 257,
+        "Minor": 262,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 262,
+        "Minor": 263,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 262,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 257,
+    "Minor": 262,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/package-lock.json
+++ b/Tasks/VSBuildV1/package-lock.json
@@ -1,36 +1,60 @@
 {
   "name": "vsts-tasks-vsbuild",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "@types/mocha": {
+  "packages": {
+    "": {
+      "name": "vsts-tasks-vsbuild",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^10.17.0",
+        "azure-pipelines-task-lib": "^4.16.0",
+        "azure-pipelines-tasks-msbuildhelpers": "^3.259.1"
+      },
+      "devDependencies": {
+        "typescript": "4.0.2"
+      }
+    },
+    "node_modules/@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha1-MV1XDMtWxTRS/4Y4c432BybVtuo="
+      "integrity": "sha1-MV1XDMtWxTRS/4Y4c432BybVtuo=",
+      "license": "MIT"
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "10.17.60",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
+      "license": "MIT"
     },
-    "adm-zip": {
+    "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk="
+      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
-    "agent-base": {
+    "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
-    "azure-pipelines-task-lib": {
+    "node_modules/azure-pipelines-task-lib": {
       "version": "4.17.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
       "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "adm-zip": "^0.5.10",
         "minimatch": "3.0.5",
         "nodejs-file-downloader": "^4.11.1",
@@ -40,63 +64,98 @@
         "uuid": "^3.0.1"
       }
     },
-    "azure-pipelines-tasks-msbuildhelpers": {
+    "node_modules/azure-pipelines-tasks-msbuildhelpers": {
       "version": "3.259.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-msbuildhelpers/-/azure-pipelines-tasks-msbuildhelpers-3.259.1.tgz",
       "integrity": "sha1-g+mYjMHgUQY5ybxseE58Ikcb2jk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^10.17.0",
         "azure-pipelines-task-lib": "^4.17.0"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "license": "MIT"
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.0.tgz",
       "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "follow-redirects": {
+    "node_modules/follow-redirects": {
       "version": "1.15.9",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha1-pgT6EORDv5jKlCKNnuvMLoosjuE="
+      "integrity": "sha1-pgT6EORDv5jKlCKNnuvMLoosjuE=",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "license": "ISC"
     },
-    "function-bind": {
+    "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw="
+      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "requires": {
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
@@ -104,195 +163,299 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
-      "dependencies": {
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        }
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "hasown": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "https-proxy-agent": {
+    "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "agent-base": "6",
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "license": "ISC"
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
-    "is-core-module": {
+    "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A="
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
-    "nodejs-file-downloader": {
+    "node_modules/nodejs-file-downloader": {
       "version": "4.13.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
       "integrity": "sha1-2ofDAIHeX/TouGQGLJjN7APmatA=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "follow-redirects": "^1.15.6",
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "license": "MIT"
     },
-    "q": {
+    "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "resolve": {
+    "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha1-tmPoP/sJu/I4aURza6roAwKbizk=",
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "sanitize-filename": {
+    "node_modules/sanitize-filename": {
       "version": "1.6.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
       "integrity": "sha1-dV69dSBFkxl34wsgJdNA18kJA3g=",
-      "requires": {
+      "license": "WTFPL OR ISC",
+      "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg="
+      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shelljs": {
+    "node_modules/shelljs": {
       "version": "0.8.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
       "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
-      "requires": {
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "supports-preserve-symlinks-flag": {
+    "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk="
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "truncate-utf8-bytes": {
+    "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-      "requires": {
+      "license": "WTFPL",
+      "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "4.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-4.0.2.tgz",
       "integrity": "sha1-fqfIh3fHI8aB4zv3mIvl0AjQWsI=",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
-    "utf8-byte-length": {
+    "node_modules/utf8-byte-length": {
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
-      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4="
+      "integrity": "sha1-+fY5ENFVNu4rLV3UZlOJcV6sXB4=",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
     }
   }
 }

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 260,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 260,
+    "Minor": 263,
     "Patch": 0
   },
   "demands": [

--- a/Tests/lib/Initialize-Test.ps1
+++ b/Tests/lib/Initialize-Test.ps1
@@ -94,3 +94,5 @@ function Get-LocalizedString {
 
     ($Key -f $ArgumentList)
 }
+
+function global:Get-VstsPipelineFeature { return $false }


### PR DESCRIPTION
### **Context**
Currently, versions 3.4.0 and 1.0.2 of OpenSSL are in use. Due to a vulnerability issue, it is necessary to upgrade to version 3.4.2.

---

### **Task Name**
AzurePowershellv1- V5, AzureFilecopyV1- V6, PublishSymbolV2, AzureCloudPowerShellDeploymentV1,V2, SqlAzureDacpacDeploymentV1

---

### **Description**
The OpenSSL version has been updated to 3.4.2.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
FF DistributedTask.Tasks.UseOpensslv3.4.2

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
By disabling the feature flag

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
