### PR TITLE
Springframework patch version update v5.3.45 for AppCenterTestV1

### DIFF
--- a/Tasks/AppCenterTestV1/patches/appcenter-cli+3.0.3.patch
+++ b/Tasks/AppCenterTestV1/patches/appcenter-cli+3.0.3.patch
@@ -1,26 +1,56 @@
 diff --git a/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/android/pom.xml b/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/android/pom.xml
-index af2f6c9..a9a7833 100644
+index af2f6c9..7ca17f2 100644
 --- a/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/android/pom.xml
 +++ b/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/android/pom.xml
-@@ -11,7 +11,7 @@
+@@ -28,7 +28,7 @@
      <dependency>
-       <groupId>io.appium</groupId>
-       <artifactId>java-client</artifactId>
--      <version>7.6.0</version>
-+      <version>9.4.0</version>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-beans</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
      </dependency>
      <dependency>
-       <groupId>junit</groupId>
+       <groupId>com.google.code.gson</groupId>
+@@ -38,12 +38,12 @@
+     <dependency>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-expression</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
+     </dependency>
+     <dependency>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-context</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
+     </dependency>
+     <dependency>
+       <groupId>commons-io</groupId>
 diff --git a/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/ios/pom.xml b/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/ios/pom.xml
-index af2f6c9..a9a7833 100644
+index af2f6c9..7ca17f2 100644
 --- a/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/ios/pom.xml
 +++ b/node_modules/appcenter-cli/dist/commands/test/lib/templates/appium/ios/pom.xml
-@@ -11,7 +11,7 @@
+@@ -28,7 +28,7 @@
      <dependency>
-       <groupId>io.appium</groupId>
-       <artifactId>java-client</artifactId>
--      <version>7.6.0</version>
-+      <version>9.4.0</version>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-beans</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
      </dependency>
      <dependency>
-       <groupId>junit</groupId>
+       <groupId>com.google.code.gson</groupId>
+@@ -38,12 +38,12 @@
+     <dependency>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-expression</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
+     </dependency>
+     <dependency>
+       <groupId>org.springframework</groupId>
+       <artifactId>spring-context</artifactId>
+-      <version>5.3.39</version>
++      <version>5.3.45</version>
+     </dependency>
+     <dependency>
+       <groupId>commons-io</groupId>

--- a/Tasks/AppCenterTestV1/task.json
+++ b/Tasks/AppCenterTestV1/task.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 261,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.206.1",
   "groups": [

--- a/Tasks/AppCenterTestV1/task.loc.json
+++ b/Tasks/AppCenterTestV1/task.loc.json
@@ -12,8 +12,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 261,
-    "Patch": 1
+    "Minor": 263,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.206.1",
   "groups": [


### PR DESCRIPTION
### **Context**
This PR is intended to resolve the issues mentioned in the bugs attached below - 
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2318389
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2318392

---

### **Task Name**
AppCenterTestV1
---

### **Description**
This PR is intended to resolve the issues mentioned in the bugs attached below - 
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2318389
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2318392

The resolution was to update the Springframework patch version from 5.3.39 to 5.3.45 for task named AppCenterTestV1.

---

### **Risk Assessment** (Low / Medium / High)  
Low
---

### **Additional Testing Performed**
We don't have pipeline tests running for this task. Request the owning team to verify the changes.

---


### **Rollback Scenario and Process** (Yes/No)
Revert the PR for reverting the changes.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
