### PR TITLE
tar-fs version update v3.1.1 for DownloadPackageV1

### DIFF
--- a/Tasks/DownloadPackageV1/package-lock.json
+++ b/Tasks/DownloadPackageV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-tasks-utility-common": "3.258.0",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1",
-        "tar-fs": "3.1.0"
+        "tar-fs": "^3.1.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha1-RnXiJU2BQQ5gnZFYGnYmCN6ZnSU=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha1-TxZOWftg8QPUcjYHMejGu0p/6e8=",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/Tasks/DownloadPackageV1/package.json
+++ b/Tasks/DownloadPackageV1/package.json
@@ -26,7 +26,7 @@
     "azure-pipelines-tasks-packaging-common": "^3.246.1",
     "azure-pipelines-tasks-utility-common": "3.258.0",
     "decompress-zip": "0.3.3",
-    "tar-fs": "3.1.0",
+    "tar-fs": "^3.1.1",
     "extract-zip": "2.0.1"
   },
   "devDependencies": {

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 262,
+    "Minor": 264,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "ms-vscs-rm",
   "version": {
     "Major": 1,
-    "Minor": 262,
+    "Minor": 264,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
### **Context**
This PR is intended to resolve the issues mentioned in the bugs attached below -
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2320889
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2320857

---

### **Task Name**
DownloadPackageV1
---

### **Description**
This PR is intended to resolve the issues mentioned in the bugs attached below -
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2320889
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2320857

The resolution was to update the existing tar-fs package version from 3.1.0 to 3.1.1 for task named DownloadPackageV1.
---

### **Risk Assessment** (Low / Medium / High)  
Low
---


### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---


### **Rollback Scenario and Process** (Yes/No)
Revert the PR for reverting the changes.

---


### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
