### PR TITLE
feat(GoTool): use go.mod to automatically install correct go versions

### DIFF
--- a/Tasks/GoToolV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/GoToolV0/Strings/resources.resjson/en-US/resources.resjson
@@ -4,6 +4,10 @@
   "loc.description": "Find in cache or download a specific version of Go and add it to the PATH",
   "loc.instanceNameFormat": "Use Go $(version)",
   "loc.group.displayName.advanced": "Advanced",
+  "loc.input.label.useGoMod": "Use go.mod",
+  "loc.input.help.useGoMod": "Select this option to install the Go version matching the specified go.mod file. These files are searched from system.DefaultWorkingDirectory. You can change the search root path by setting working directory input.",
+  "loc.input.label.workingDirectory": "Working Directory",
+  "loc.input.help.workingDirectory": "Specify path from where go.mod files should be searched when using `Use go.mod`. If empty, `system.DefaultWorkingDirectory` will be considered as the root path.",
   "loc.input.label.version": "Version",
   "loc.input.help.version": "The Go version to download (if necessary) and use. Example: 1.9.3",
   "loc.input.label.goPath": "GOPATH",
@@ -13,5 +17,9 @@
   "loc.input.label.goDownloadUrl": "Go download URL",
   "loc.input.help.goDownloadUrl": "URL for downloading Go binaries. Only https://go.dev/dl (official) and https://aka.ms/golang/release/latest (Microsoft build prefix) are supported. If omitted, the official Go download URL (https://go.dev/dl) will be used. You can also set the 'GOTOOL_GODOWNLOADURL' environment variable to specify the download URL. The parameter takes priority over the environment variable if both are set.",
   "loc.messages.FailedToDownload": "Failed to download Go version %s. Verify that the version is valid and resolve any other issues. Error: %s",
-  "loc.messages.TempDirNotSet": "The 'Agent.TempDirectory' environment variable was expected to be set."
+  "loc.messages.TempDirNotSet": "The 'Agent.TempDirectory' environment variable was expected to be set.",
+  "loc.messages.FailedToFindGoMod": "No go.mod file found in directory '%s'. Make sure go.mod file exists in the specified directory or its subdirectories.",
+  "loc.messages.GoModVersionDetected": "Detected Go version '%s' from go.mod file: %s",
+  "loc.messages.GoModVersionNotFound": "Could not find Go version directive in go.mod file: %s",
+  "loc.messages.FailedToReadGoMod": "Failed to read go.mod file '%s': %s"
 }

--- a/Tasks/GoToolV0/Tests/gotoolTests.ts
+++ b/Tasks/GoToolV0/Tests/gotoolTests.ts
@@ -1,0 +1,89 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+const taskPath = path.join(__dirname, '..', 'gotool.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+const testCase = process.env['__case__'];
+
+// Configure inputs depending on scenario
+switch (testCase) {
+    case 'useGoModSingle':
+        tmr.setInput('useGoMod', 'true');
+        tmr.setInput('workingDirectory', 'work');
+        break;
+    case 'useGoModMulti':
+        tmr.setInput('useGoMod', 'true');
+        tmr.setInput('workingDirectory', 'repo');
+        break;
+    case 'useGoModNotFound':
+        tmr.setInput('useGoMod', 'true');
+        tmr.setInput('workingDirectory', 'empty');
+        break;
+    case 'explicitVersion':
+        tmr.setInput('useGoMod', 'false');
+        tmr.setInput('version', '1.21.0');
+        break;
+    default:
+        throw new Error('Unknown __case__ value: ' + testCase);
+}
+
+const answers: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    'assertAgent': { '2.115.0': true }
+};
+tmr.setAnswers(answers);
+
+// Dynamic findMatch behavior based on test case
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+tlClone.findMatch = function(root: string, pattern: string) {
+    if (pattern !== '**/go.mod') return [];
+    if (testCase === 'useGoModSingle' && root === 'work') {
+        return ['work/go.mod'];
+    }
+    if (testCase === 'useGoModMulti' && root === 'repo') {
+        return ['repo/a/go.mod', 'repo/b/go.mod'];
+    }
+    if (testCase === 'useGoModNotFound') {
+        return [];
+    }
+    return [];
+};
+tlClone.getVariable = function(v: string) {
+    if (v.toLowerCase() === 'system.defaultworkingdirectory') {
+        if (testCase === 'useGoModSingle') return 'work';
+        if (testCase === 'useGoModMulti') return 'repo';
+        if (testCase === 'useGoModNotFound') return 'empty';
+    }
+    if (v.toLowerCase() === 'agent.tempdirectory') return 'temp';
+    return null;
+};
+tlClone.assertAgent = function() { return; };
+tlClone.loc = function(locString: string, ...params: any[]) { return locString + ' ' + params.join(' '); };
+tlClone.prependPath = function(p: string) { /* no-op for tests */ };
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+// fs mock
+tmr.registerMock('fs', {
+    readFileSync: function(p: string) {
+        if (p === 'work/go.mod') return Buffer.from('module example.com/single\n\n go 1.22');
+        if (p === 'repo/a/go.mod') return Buffer.from('module example.com/a\n go 1.21');
+        if (p === 'repo/b/go.mod') return Buffer.from('module example.com/b\n go 1.22');
+        return Buffer.from('');
+    }
+});
+
+// tool-lib mock
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: function(tool: string, version: string) { return false; },
+    downloadTool: function(url: string) { return 'download'; },
+    extractTar: function(downloadPath: string) { return 'ext'; },
+    extractZip: function(downloadPath: string) { return 'ext'; },
+    cacheDir: function(dir: string, tool: string, version: string) { return path.join('cache', tool, version); },
+    prependPath: function(p: string) { /* no-op */ }
+});
+
+tmr.registerMock('azure-pipelines-tasks-utility-common/telemetry', { emitTelemetry: function() {} });
+
+tmr.run();

--- a/Tasks/GoToolV0/task.json
+++ b/Tasks/GoToolV0/task.json
@@ -30,12 +30,30 @@
   ],
   "inputs": [
     {
+      "name": "useGoMod",
+      "type": "boolean",
+      "label": "Use go.mod",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "Select this option to install the Go version matching the specified go.mod file. These files are searched from system.DefaultWorkingDirectory. You can change the search root path by setting working directory input."
+    },
+    {
+      "name": "workingDirectory",
+      "type": "filePath",
+      "label": "Working Directory",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Specify path from where go.mod files should be searched when using `Use go.mod`. If empty, `system.DefaultWorkingDirectory` will be considered as the root path.",
+      "visibleRule": "useGoMod = true"
+    },
+    {
       "name": "version",
       "type": "string",
       "label": "Version",
       "defaultValue": "1.10",
       "required": true,
-      "helpMarkDown": "The Go version to download (if necessary) and use. Example: 1.9.3"
+      "helpMarkDown": "The Go version to download (if necessary) and use. Example: 1.9.3",
+      "visibleRule": "useGoMod = false"
     },
     {
       "name": "goPath",
@@ -81,6 +99,10 @@
   },
   "messages": {
     "FailedToDownload": "Failed to download Go version %s. Verify that the version is valid and resolve any other issues. Error: %s",
-    "TempDirNotSet": "The 'Agent.TempDirectory' environment variable was expected to be set."
+    "TempDirNotSet": "The 'Agent.TempDirectory' environment variable was expected to be set.",
+    "FailedToFindGoMod": "No go.mod file found in directory '%s'. Make sure go.mod file exists in the specified directory or its subdirectories.",
+    "GoModVersionDetected": "Detected Go version '%s' from go.mod file: %s",
+    "GoModVersionNotFound": "Could not find Go version directive in go.mod file: %s",
+    "FailedToReadGoMod": "Failed to read go.mod file '%s': %s"
   }
 }

--- a/Tasks/GoToolV0/task.loc.json
+++ b/Tasks/GoToolV0/task.loc.json
@@ -30,12 +30,30 @@
   ],
   "inputs": [
     {
+      "name": "useGoMod",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.useGoMod",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.useGoMod"
+    },
+    {
+      "name": "workingDirectory",
+      "type": "filePath",
+      "label": "ms-resource:loc.input.label.workingDirectory",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.workingDirectory",
+      "visibleRule": "useGoMod = true"
+    },
+    {
       "name": "version",
       "type": "string",
       "label": "ms-resource:loc.input.label.version",
       "defaultValue": "1.10",
       "required": true,
-      "helpMarkDown": "ms-resource:loc.input.help.version"
+      "helpMarkDown": "ms-resource:loc.input.help.version",
+      "visibleRule": "useGoMod = false"
     },
     {
       "name": "goPath",


### PR DESCRIPTION
### **Context**
---

Fixes #17848 

### **Task Name**
---
GoToolV0

### **Description**
---
Added an option to auto-detect the Go version to install based on the go.mod file.

### **Risk Assessment** (Low / Medium / High)  
---
Low

### **Change Behind Feature Flag** (Yes / No)
---
Yes, this is an optional parameter.

### **Tech Design / Approach**
---
N/A

### **Documentation Changes Required** (Yes/No)
---
No.

### **Unit Tests Added or Updated** (Yes / No)  
---
Yes

### **Additional Testing Performed**
---
N/A

### **Logging Added/Updated** (Yes/No)
--- 
Yes

### **Telemetry Added/Updated** (Yes/No) 
---
N/A

### **Rollback Scenario and Process** (Yes/No)
---
N/A

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
---
N/A

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
