### PR TITLE
Adding deployment group to PCCRV2 version

### DIFF
--- a/Tasks/PublishCodeCoverageResultsV2/task.json
+++ b/Tasks/PublishCodeCoverageResultsV2/task.json
@@ -10,12 +10,13 @@
     "Build"
   ],
   "runsOn": [
-    "Agent"
+    "Agent",
+    "DeploymentGroup"
   ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
+    "Minor": 264,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/PublishCodeCoverageResultsV2/task.loc.json
+++ b/Tasks/PublishCodeCoverageResultsV2/task.loc.json
@@ -10,12 +10,13 @@
     "Build"
   ],
   "runsOn": [
-    "Agent"
+    "Agent",
+    "DeploymentGroup"
   ],
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 259,
+    "Minor": 264,
     "Patch": 0
   },
   "demands": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
       "integrity": "sha1-EqVQuHlEUt9MiwhPlQA7zhdC1JY=",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -611,6 +612,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",


### PR DESCRIPTION
We have got one ticket from the customer for PublishCodeCoverageResult task issue. Incident-656029979 Details - IcM

Repro steps:

The issue can be reproduced with the following steps.

1) Start creating a classic build pipeline.

2) Add "Publish Code Coverage Results" task.

3) Right click of the task and select [Create task group]. Then, specify [Name] and then click [Create] button to save.

4) Go to [Trask groups] page and select the saved task group.

5) Add "Publish Test Results" task.

6) Change the version of "Publish Code Coverage Results" task to 1.

7) Click [Save] button.

8) Go to [Trask groups] page and select the saved task group.

9) Change the version of "Publish Code Coverage Results" task to 2.

10) Click [Save] button. ---> The error occurs.


'Meta task <Task group name>' RunsOn value: 'Agent, DeploymentGroup', doesn't match with child task 'PublishCodeCoverageResults' RunsOn value: 'Agent'. Provide valid value and try again.'

I think the problem is here.

azure-pipelines-tasks/Tasks/PublishCodeCoverageResultsV2/task.json at master · microsoft/azure-pipelines-tasks

 "runsOn": [
    "Agent"
  ],

It does not have DeploymentGroups runs on option as other tasks (even the V1 of this task has this).

### **Context**
_Describe the context or motivation for this PR. Include links to any related Azure DevOps Work Items or GitHub issues._  
📌 [How to link to ADO Work Items](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops)

---

### **Task Name**
PublishCodeCoverageResultsV2

---

### **Description**
The incident involved a failure when saving task groups that include the PublishCodeCoverageResults task due to an incorrect 'RunsOn' value. Specifically, the meta task's 'RunsOn' value included 'Agent, DeploymentGroup', which did not match the child task's 'RunsOn' value of 'Agent', causing persistent errors until the problematic task was removed and re-added. This issue was identified as a new bug and tracked under Bug 2299479.
Saving task groups fails with an error indicating a mismatch in the 'RunsOn' value between the meta task and the PublishCodeCoverageResults child task.
The root cause was identified as a new bug where the 'RunsOn' value of the meta task did not correctly align with the child PublishCodeCoverageResults task, leading to save failures in task groups.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No


---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
