### PR TITLE
Handle dotnet publish logging the same way as dotnet build.

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -208,6 +208,17 @@ describe('DotNetCoreExe Suite', function () {
         assert(tr.failed, 'task should have failed');
     });
 
+    it('build passes when zero match found with empty string', async () => {
+        process.env["__projects__"] = "";
+        process.env["__command__"] = "build";
+        let tp = path.join(__dirname, 'validInputs.js')
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+
+        assert(tr.invokedToolCount == 1, 'should have invoked tool');
+        assert(tr.succeeded, 'task should have succeeded');
+    });
+
     it('test throws warning when zero match found', async () => {
         process.env["__projects__"] = "*fail*/project.json";
         process.env["__command__"] = "test";

--- a/Tasks/DotNetCoreCLIV2/Tests/publishInputs.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/publishInputs.ts
@@ -11,6 +11,11 @@ tmr.setInput('publishWebProjects', process.env["__publishWebProjects__"] && proc
 tmr.setInput('arguments', process.env["__arguments__"] ? process.env["__arguments__"] : "");
 tmr.setInput('modifyOutputPath', process.env["modifyOutput"] == "false" ? "false" : "true");
 
+// Get out of the Tests folder to the task root folder. This will match the path used in the task.
+// We normalize the string to use forward slashes as that is what the mock answer does and makes this test cross platform.
+var loggerAssembly = path.join(__dirname, '..', 'dotnet-build-helpers/Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll').replace(/\\/g, "/");
+var loggerString = `-dl:CentralLogger,"${loggerAssembly}"*ForwardingLogger,"${loggerAssembly}"`
+
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": { "dotnet": "dotnet" },
     "checkPath": { "dotnet": true },
@@ -18,78 +23,7 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "web/web.config": true,
         "web2/wwwroot": true,
     },
-    "exec": {
-        "dotnet publish web/project.json": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish web/project.csproj": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish web2/project.json": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish web.tests/project.json": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish lib/project.json": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish web3/project.json --configuration release --output /usr/out/web3": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish lib2/project.json --configuration release --output /usr/out/lib2": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-         "dotnet publish web3/project.json --configuration release --output /usr/out": {
-            "code": 0,
-            "stdout": "published web3 without adding project name to path\n",
-            "stderr": ""
-        },
-        "dotnet publish lib2/project.json --configuration release --output /usr/out": {
-            "code": 0,
-            "stdout": "published lib2 without adding project name to path\n",
-            "stderr": ""
-        },
-        "dotnet publish --configuration release --output /usr/out": {
-            "code": 0,
-            "stdout": "published without adding project name to path\n",
-            "stderr": ""
-        },
-        "dotnet publish": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish web/project.csproj --configuration release --output /usr/out/web": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish lib/project.csproj --configuration release --output /usr/out": {
-            "code": 0,
-            "stdout": "published",
-            "stderr": ""
-        },
-        "dotnet publish dummy/project.json": {
-            "code": 1,
-            "stdout": "not published",
-            "stderr": ""
-        }
-    },
+    "exec": {},
     "findMatch": {
         "**/project.json": ["web/project.json", "web2/project.json", "web.tests/project.json", "lib/project.json"],
         "**/project.json;**/*.csproj": ["web/project.json", "web2/project.json", "web.tests/project.json", "lib/project.json"],
@@ -98,8 +32,81 @@ let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
         "*fail*/project.json": [],
         "*customoutput/project.json": ["web3/project.json", "lib2/project.json"],
         "dummy/project.json": ["dummy/project.json"],
-        "" : []
+        "": []
     }
+};
+
+// Refactored exec values using bracket notation to allow dynamic keys
+// This accounts for different paths on different developer machines
+a["exec"][`dotnet publish web/project.json ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web/project.csproj ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web2/project.json ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web.tests/project.json ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish lib/project.json ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web3/project.json ${loggerString} --configuration release --output /usr/out/web3`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish lib2/project.json ${loggerString} --configuration release --output /usr/out/lib2`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web3/project.json ${loggerString} --configuration release --output /usr/out`] = {
+    "code": 0,
+    "stdout": "published web3 without adding project name to path\n",
+    "stderr": ""
+};
+a["exec"][`dotnet publish lib2/project.json ${loggerString} --configuration release --output /usr/out`] = {
+    "code": 0,
+    "stdout": "published lib2 without adding project name to path\n",
+    "stderr": ""
+};
+a["exec"][`dotnet publish ${loggerString} --configuration release --output /usr/out`] = {
+    "code": 0,
+    "stdout": "published without adding project name to path\n",
+    "stderr": ""
+};
+a["exec"][`dotnet publish ${loggerString}`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish web/project.csproj ${loggerString} --configuration release --output /usr/out/web`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish lib/project.csproj ${loggerString} --configuration release --output /usr/out`] = {
+    "code": 0,
+    "stdout": "published",
+    "stderr": ""
+};
+a["exec"][`dotnet publish dummy/project.json ${loggerString}`] = {
+    "code": 1,
+    "stdout": "not published",
+    "stderr": ""
 };
 
 process.env["MOCK_NORMALIZE_SLASHES"] = "true";

--- a/Tasks/DotNetCoreCLIV2/Tests/validateWebProject.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/validateWebProject.ts
@@ -16,7 +16,12 @@ tmr.setInput('workingDirectory', process.env["workingDirectory"] ? process.env["
 process.env['TASK_TEST_TRACE'] = "true";
 
 var projectFile = path.join(__dirname, process.env["__projects__"]);
-var execCommand = "dotnet publish " + projectFile
+
+// Get out of the Tests folder to the task root folder. This will match the path used in the task.
+var loggerAssembly = path.join(__dirname, '..', 'dotnet-build-helpers/Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll');
+var loggerString = `-dl:CentralLogger,"${loggerAssembly}"*ForwardingLogger,"${loggerAssembly}"`
+
+var execCommand = `dotnet publish ${projectFile} ${loggerString}`;
 
 let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
     "which": {

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -118,7 +118,7 @@ export class dotNetExe {
             } else {
                 dotnet.arg(projectFile);
             }
-            if (this.isBuildCommand()) {
+            if (this.isBuildCommand() || this.isPublishCommand()) {
                 var loggerAssembly = path.join(__dirname, 'dotnet-build-helpers/Microsoft.TeamFoundation.DistributedTask.MSBuild.Logger.dll');
                 dotnet.arg(`-dl:CentralLogger,\"${loggerAssembly}\"*ForwardingLogger,\"${loggerAssembly}\"`);
             }

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "dotnet $(command)",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 2,
     "Minor": 263,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
This addresses #7749 which was only resolved for the `dotnet build` command and `dotnet publish` still is not handled appropriately. In Azure DevOps when a publish is run, errors and logs are not picked up properly. This is applying the same fix that was done for the build command.

---

### **Task Name**
DotNetCoreCLI v2

---

### **Description**
This expands the check from just build to publish as well.

---

### **Risk Assessment** (Low / Medium / High)  
Low. I don't see how this change introduces any new risk since this is all existing code, just adding an OR check. Most of the changes in this PR are in tests.

---

### **Change Behind Feature Flag** (Yes / No)
We can add a feature flag if desired, but I think this is pretty much universally beneficial.

---

### **Tech Design / Approach**
No real design/approach to the code change itself since it is so small. On the test side I took extra steps to make sure this  was cross platform and machine agnostic.

---

### **Documentation Changes Required** (Yes/No)
Not aware of any doc changes that need to happen.

---

### **Unit Tests Added or Updated** (Yes / No)  
Updated mocks to handle the new argument for the logger. This required changing some stuff such as normalizing paths with a forward slash like the test framework does so that the correct mock key would match.

Added back the `build passes when zero match found with empty string` test that was removed as part of build fix PR #12358

I was able to handle the auto-generated path in the tests properly, so the test works now.

---

### **Additional Testing Performed**
Ran unit tests locally on a Windows 11 machine and Ubuntu. Worked properly on both with a fresh clone.

---

### **Logging Added/Updated** (Yes/No)
N/A

--- 

### **Telemetry Added/Updated** (Yes/No) 
N/A

---

### **Rollback Scenario and Process** (Yes/No)
Rolling this back should be just a simple revert.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
N/A

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
