### PR TITLE
Add JDK 17 and JDK21 Ant tasks

### DIFF
--- a/Tasks/ANTV1/task.json
+++ b/Tasks/ANTV1/task.json
@@ -210,6 +210,8 @@
       "visibleRule": "javaHomeSelection = JDKVersion",
       "options": {
         "default": "default",
+        "1.21": "JDK 21",
+        "1.17": "JDK 17",
         "1.11": "JDK 11",
         "1.10": "JDK 10 (out of support)",
         "1.9": "JDK 9 (out of support)",


### PR DESCRIPTION
### **Context**
Running Azure pipeline Ant tasks for JDK 17 and 21 is not possible

---

### **Task Name**
Ant

---

### **Description**
Added support for JDK 17 and JDK 21 for the Ant build task

---

### **Risk Assessment** (Low / Medium / High)  
Low impact

---

### **Change Behind Feature Flag** (Yes / No)
Yes

---

### **Tech Design / Approach**
Reviewed JDK runtimes

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
Tested running the pipeline, by manually overwriting the json file and confirmed that it worked 

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Revert this PR to rollback

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Pipeline task tested by manually overwriting the task json file

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
