### PR TITLE
Update the vulnerable tar-fs package to new version in DownloadPackageV1

### DIFF
--- a/Tasks/DownloadPackageV1/package-lock.json
+++ b/Tasks/DownloadPackageV1/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-tasks-utility-common": "3.265.1",
         "decompress-zip": "0.3.3",
         "extract-zip": "2.0.1",
-        "tar-fs": "3.1.0"
+        "tar-fs": "3.1.1"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -2237,9 +2237,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha1-RnXiJU2BQQ5gnZFYGnYmCN6ZnSU=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha1-TxZOWftg8QPUcjYHMejGu0p/6e8=",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",

--- a/Tasks/DownloadPackageV1/package.json
+++ b/Tasks/DownloadPackageV1/package.json
@@ -26,7 +26,7 @@
     "azure-pipelines-tasks-packaging-common": "^3.246.1",
     "azure-pipelines-tasks-utility-common": "3.265.1",
     "decompress-zip": "0.3.3",
-    "tar-fs": "3.1.0",
+    "tar-fs": "3.1.1",
     "extract-zip": "2.0.1"
   },
   "devDependencies": {

--- a/Tasks/DownloadPackageV1/task.json
+++ b/Tasks/DownloadPackageV1/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 266,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "Adds support to download Maven, Python, Universal and Npm packages.",

--- a/Tasks/DownloadPackageV1/task.loc.json
+++ b/Tasks/DownloadPackageV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 266,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
[AB#2320889](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2320889)
[AB#2320857](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2320857)

Update the vulnerable package tar-fs to patched version 3.1.1

---

### **Task Name**

DownloadPackageV1

---

### **Description**
The tar-fs package version used in task DownloadPackageV1 is marked as vulnerable and recommended to be update to atleast 3.1.1


---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Unit Tests Added or Updated** (Yes / No)  
No Test Cases added or updated

---

### **Additional Testing Performed**
Testing was done through existing canary tests
https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=222064&view=results

<img width="760" height="854" alt="image" src="https://github.com/user-attachments/assets/bb772d03-46ba-457e-b434-aec5fa7256dc" />


---

### **Rollback Scenario and Process** (Yes/No)
Revert PR to rollback the changes

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
