### PR TITLE
Update VSTSTaskSDK version for updated FS attribute

### DIFF
--- a/Tasks/PublishSymbolsV2/make.json
+++ b/Tasks/PublishSymbolsV2/make.json
@@ -83,7 +83,7 @@
       },
       {
         "name": "VstsTaskSdk",
-        "version": "0.9.0",
+        "version": "0.21.0",
         "repository": "https://www.powershellgallery.com/api/v2/",
         "cp": [
           {

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 264,
+    "Minor": 265,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 265,
-    "Patch": 2
+    "Minor": 266,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 265,
-    "Patch": 0
+    "Patch": 2
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 264,
+    "Minor": 265,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,8 +13,8 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 265,
-    "Patch": 2
+    "Minor": 266,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 265,
-    "Patch": 0
+    "Patch": 2
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [


### PR DESCRIPTION
### **Context**
To resolve customer issue for "Cannot convert value "4195872" to type "VstsTaskSdk.FS.Attributes" due to enumeration values that are not valid. ", we are updating vststasksdk
---

### **Task Name**
PublishSymbolV2
---

### **Description**
Update VstsTaskSdk version
---

### **Risk Assessment** (Low / Medium / High)  
Low
---

### **Change Behind Feature Flag** (Yes / No)
N/A
---

### **Tech Design / Approach**
N/A
---

### **Documentation Changes Required** (Yes/No)
N/A
---

### **Unit Tests Added or Updated** (Yes / No)  
Already have test to verify task
---

### **Additional Testing Performed**
N/A
---

### **Logging Added/Updated** (Yes/No)
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
Version rollback

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
