### PR TITLE
Fix AzureCLI@2 fallback when 'az version' returns empty output

### DIFF
--- a/Tasks/AzureCLIV2/azureclitask.ts
+++ b/Tasks/AzureCLIV2/azureclitask.ts
@@ -56,8 +56,8 @@ export class azureclitask {
             if (versionCommand) {
                 azVersionResult = tl.execSync("az", "version");
 
-                if (azVersionResult.code !== 0 || azVersionResult.stderr) {
-                    tl.debug("az version failed, falling back to 'az --version'");
+                if (azVersionResult.code !== 0 || azVersionResult.stderr || !azVersionResult.stdout || azVersionResult.stdout.trim() === '') {
+                    tl.debug("az version failed or returned empty output, falling back to 'az --version'");
                     azVersionResult = tl.execSync("az", "--version");
                 }
             } 


### PR DESCRIPTION
Fixes #21512

When the UseAzVersion feature flag is enabled, the AzureCLI@2 task runs 'az version' instead of 'az --version'. In some environments, 'az version' returns exit code 0 but with empty stdout, causing the version parsing to fail.

The existing fallback logic only checked for non-zero exit codes or stderr output, but didn't handle the case where stdout is empty or contains only whitespace.

This fix adds checks for empty stdout to trigger the fallback to 'az --version', ensuring the task works reliably.