### PR TITLE
Fix EndpointAuthorization object property name that fetch its token value

### DIFF
--- a/Tasks/KubeloginInstallerV0/task.json
+++ b/Tasks/KubeloginInstallerV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 267,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/task.loc.json
+++ b/Tasks/KubeloginInstallerV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 267,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/utils.ts
+++ b/Tasks/KubeloginInstallerV0/utils.ts
@@ -178,13 +178,13 @@ function getGithubEndPointToken(): string {
 
   switch (githubEndpointObject.scheme) {
     case 'PersonalAccessToken':
-      githubEndpointToken = githubEndpointObject.parameters.accessToken;
+      githubEndpointToken = githubEndpointObject.parameters.AccessToken;
       break;
     case 'OAuth':
-      githubEndpointToken = githubEndpointObject.parameters.accessToken;
+      githubEndpointToken = githubEndpointObject.parameters.AccessToken;
       break;
     case 'Token':
-      githubEndpointToken = githubEndpointObject.parameters.accessToken;
+      githubEndpointToken = githubEndpointObject.parameters.AccessToken;
       break;
     default:
       throw new GitHubEndpointSchemeError(


### PR DESCRIPTION
Fix EndpointAuthorization object property name that fetch its token value

---

### **Task Name**
KubeloginInstallerV0

---

### **Description**
Fix EndpointAuthorization object property name that fetch its token value

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

### **Additional Testing Performed**
Tested on private organization with different agent flavors (windows, ubuntu, mac)

---

### **Logging Added/Updated** (Yes/No)
No
--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No

---

### **Checklist**
- [X ] Related issue linked (if applicable)
- [X ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [X ] Verified the task behaves as expected
