### PR TITLE
Update the tooltip in the UI for "Invoke Azure Function" check

### DIFF
--- a/Tasks/AzureFunctionV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureFunctionV1/Strings/resources.resjson/en-US/resources.resjson
@@ -7,7 +7,7 @@
   "loc.input.label.function": "Azure function URL",
   "loc.input.help.function": "URL of the Azure function that needs to be invoked​. Example:- https://azurefunctionapp.azurewebsites.net/api/HttpTriggerJS1",
   "loc.input.label.key": "Function key",
-  "loc.input.help.key": "Function or Host key with which to access this function. To keep the key secure, define a secret variable and use it here. Example: - $(myFunctionKey) where myFunctionKey is a secret pipeline variable with a value of the secret key, like `ZxPXnIEODXLRzYwCw1TgZ4osMfoKs9Zn6se6X/N0FnztfDvZbdOmYw==`",
+  "loc.input.help.key": "Function or Host key with which to access this function. To keep the key secure, create a variable group, add a secret variable, and use it here. Make sure to link the variable group in the \"Control options\" section. Example: $(myFunctionKey), where myFunctionKey is the secret variable containing the key, like `ZxPXnIEODXLRzYwCw1TgZ4osMfoKs9Zn6se6X/N0FnztfDvZbdOmYw==`",
   "loc.input.label.method": "Method",
   "loc.input.help.method": "Select the HTTP method with which the function should be invoked.",
   "loc.input.label.headers": "Headers",

--- a/Tasks/AzureFunctionV1/task.json
+++ b/Tasks/AzureFunctionV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 220,
+        "Minor": 267,
         "Patch": 0
     },
     "instanceNameFormat": "Azure Function: $(function)",
@@ -43,7 +43,7 @@
             "label": "Function key",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Function or Host key with which to access this function. To keep the key secure, define a secret variable and use it here. Example: - $(myFunctionKey) where myFunctionKey is a secret pipeline variable with a value of the secret key, like `ZxPXnIEODXLRzYwCw1TgZ4osMfoKs9Zn6se6X/N0FnztfDvZbdOmYw==`"
+            "helpMarkDown": "Function or Host key with which to access this function. To keep the key secure, create a variable group, add a secret variable, and use it here. Make sure to link the variable group in the \"Control options\" section. Example: $(myFunctionKey), where myFunctionKey is the secret variable containing the key, like `ZxPXnIEODXLRzYwCw1TgZ4osMfoKs9Zn6se6X/N0FnztfDvZbdOmYw==`"
         },
         {
             "name": "method",

--- a/Tasks/AzureFunctionV1/task.loc.json
+++ b/Tasks/AzureFunctionV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 220,
+    "Minor": 267,
     "Patch": 0
   },
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
Currently the tooltip for the `Function key` field doesn't mention that a linked variable group is required to use a secret variable
📌 [AB#2254373](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2254373)

---

### **Task Name**
AzureFunctionV1

---

### **Description**
Updated the help text for the `Function key` input field in the `Azure Function` task

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**


---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
