### PR TITLE
Remove USE_FIXED_AZ_CONFIG_INIT

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 263,
+        "Minor": 267,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 263,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,7 +16,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 263,
+        "Minor": 267,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 263,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,7 +13,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 263,
+        "Minor": 267,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 263,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 264,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 265,
+        "Minor": 267,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 265,
+    "Minor": 267,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 265,
+        "Minor": 267,
         "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 265,
+    "Minor": 267,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 266,
+    "Minor": 267,
     "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 266,
+    "Minor": 267,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 267,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 267,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
+++ b/Tasks/Common/VstsAzureHelpers_/InitializeAzModuleFunctions.ps1
@@ -67,36 +67,6 @@ function Initialize-AzModule {
 }
 
 function Initialize-AzConfig {
-    if ([System.Convert]::ToBoolean($env:USE_FIXED_AZ_CONFIG_INIT)) {
-        Initialize-AzConfigNew
-    } else {
-        Initialize-AzConfigOld
-    }
-}
-
-function Initialize-AzConfigOld {
-    if (Get-Command Get-AzConfig -ErrorAction SilentlyContinue) {
-
-        $configValue = Get-AzConfig -AppliesTo Az -Scope CurrentUser | Where-Object { $_.Key -eq "DisplayBreakingChangeWarning" }  
-        if ($null -ne $configValue -and $configValue.Value -eq $true) {
-            # Update-AzConfig is a part of Az.Accounts
-            if (Get-Command Update-AzConfig -ErrorAction SilentlyContinue) {
-                Write-Verbose "Supressing breaking changes warnings of Az module."
-                Write-Host "##[command]Update-AzConfig -DisplayBreakingChangeWarning $false -AppliesTo Az"
-                Update-AzConfig -DisplayBreakingChangeWarning $false -AppliesTo Az -Scope Process
-            } else {
-                Write-Verbose "Update-AzConfig cmdlet is not available."
-            }                            
-        } else {
-            Write-Verbose "No need to update the config." 
-        } 
-         
-    } else {
-         Write-Verbose "Get-AzConfig cmdlet is not available."
-    }  
-}
-
-function Initialize-AzConfigNew {
     Write-Verbose "Initializing Az Config."
 
     if (![bool](Get-Command Update-AzConfig -ErrorAction SilentlyContinue)) {

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -17,7 +17,7 @@
     "version": {
         "Major": 1,
         "Minor": 267,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 267,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
### **Context**
Removed the conditional logic and functions related to the USE_FIXED_AZ_CONFIG_INIT environment variable
📌 [#AB2308645](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2308645)

---

### **Task Name**
AzureCloudPowerShellDeploymentV1
AzureCloudPowerShellDeploymentV2
AzureFileCopyV1
AzureFileCopyV2
AzureFileCopyV3
AzureFileCopyV4
AzureFileCopyV5
AzureFileCopyV6
AzurePowerShellV2
AzurePowerShellV3
AzurePowerShellV4
AzurePowerShellV5
SqlAzureDacpacDeploymentV1

---

### **Description**
Removed the conditional logic and functions related to the USE_FIXED_AZ_CONFIG_INIT environment variable

---

### **Risk Assessment** Low 

---

### **Change Behind Feature Flag** No

---

### **Tech Design / Approach**
---

### **Documentation Changes Required** No

---

### **Unit Tests Added or Updated** No

---

### **Additional Testing Performed** No

---

### **Logging Added/Updated** No

--- 

### **Telemetry Added/Updated** No

---

### **Rollback Scenario and Process** 

---

### **Dependency Impact Assessed and Regression Tested** 

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
