### PR TITLE
Fix GoToolV0 to conditionally set GOROOT only for Go < 1.9 (#20796)

### DIFF
--- a/Tasks/GoToolV0/Tests/L0GorootBoundaryVersion.ts
+++ b/Tasks/GoToolV0/Tests/L0GorootBoundaryVersion.ts
@@ -1,0 +1,37 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'gotool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Test Go 1.9.0 exactly (boundary version) - GOROOT should NOT be set
+tmr.setInput('version', '1.9.0');
+
+// Mock environment variables
+process.env['Agent.TempDirectory'] = path.join(__dirname, 'temp');
+
+// Mock tool lib functions
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: function(toolName: string, version: string) {
+        console.log('Found cached Go version');
+        return '/mock/cache/go/1.9.0';
+    },
+    prependPath: function(toolPath: string) {
+        console.log(`Adding to PATH: ${toolPath}`);
+    }
+});
+
+// Mock os module
+tmr.registerMock('os', {
+    platform: () => 'linux',
+    arch: () => 'x64'
+});
+
+// Mock telemetry
+tmr.registerMock('azure-pipelines-tasks-utility-common/telemetry', {
+    emitTelemetry: function(area: string, feature: string, properties: any) {
+        console.log(`Telemetry: ${area}.${feature}`);
+    }
+});
+
+tmr.run();

--- a/Tasks/GoToolV0/Tests/L0GorootLegacyVersion.ts
+++ b/Tasks/GoToolV0/Tests/L0GorootLegacyVersion.ts
@@ -1,0 +1,37 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'gotool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Test legacy Go version (< 1.9) - GOROOT SHOULD be set
+tmr.setInput('version', '1.8.7');
+
+// Mock environment variables
+process.env['Agent.TempDirectory'] = path.join(__dirname, 'temp');
+
+// Mock tool lib functions
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: function(toolName: string, version: string) {
+        console.log('Found cached Go version');
+        return '/mock/cache/go/1.8.7';
+    },
+    prependPath: function(toolPath: string) {
+        console.log(`Adding to PATH: ${toolPath}`);
+    }
+});
+
+// Mock os module
+tmr.registerMock('os', {
+    platform: () => 'linux',
+    arch: () => 'x64'
+});
+
+// Mock telemetry
+tmr.registerMock('azure-pipelines-tasks-utility-common/telemetry', {
+    emitTelemetry: function(area: string, feature: string, properties: any) {
+        console.log(`Telemetry: ${area}.${feature}`);
+    }
+});
+
+tmr.run();

--- a/Tasks/GoToolV0/Tests/L0GorootModernVersion.ts
+++ b/Tasks/GoToolV0/Tests/L0GorootModernVersion.ts
@@ -1,0 +1,37 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'gotool.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Test modern Go version (>= 1.9) - GOROOT should NOT be set
+tmr.setInput('version', '1.23.3');
+
+// Mock environment variables
+process.env['Agent.TempDirectory'] = path.join(__dirname, 'temp');
+
+// Mock tool lib functions
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    findLocalTool: function(toolName: string, version: string) {
+        console.log('Found cached Go version');
+        return '/mock/cache/go/1.23.3';
+    },
+    prependPath: function(toolPath: string) {
+        console.log(`Adding to PATH: ${toolPath}`);
+    }
+});
+
+// Mock os module
+tmr.registerMock('os', {
+    platform: () => 'linux',
+    arch: () => 'x64'
+});
+
+// Mock telemetry
+tmr.registerMock('azure-pipelines-tasks-utility-common/telemetry', {
+    emitTelemetry: function(area: string, feature: string, properties: any) {
+        console.log(`Telemetry: ${area}.${feature}`);
+    }
+});
+
+tmr.run();

--- a/Tasks/GoToolV0/task.json
+++ b/Tasks/GoToolV0/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 265,
+    "Minor": 268,
     "Patch": 0
   },
   "satisfies": [

--- a/Tasks/GoToolV0/task.loc.json
+++ b/Tasks/GoToolV0/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 265,
+    "Minor": 268,
     "Patch": 0
   },
   "satisfies": [


### PR DESCRIPTION
### **Context**
Fix GoToolV0 to conditionally set GOROOT only for Go < 1.9
Fixes: #20796

---

### **Task Name**
GoToolV0

---

### **Description**
The GoToolV0 task was unconditionally setting the GOROOT environment variable for all Go versions. This is problematic because:


1. Go versions >= 1.9 auto-detect GOROOT from the binary location and don't need it set explicitly
2. Setting GOROOT explicitly causes issues when users compile custom Go versions (e.g., Go tip) because:
    - The environment variable overrides the auto-detected GOROOT
    - This creates a mismatch between the go binary and GOROOT
    - Results in errors like "dist doesn't exist" when running `go tool dist test`

This behavior differs from the GitHub Actions setup-go task, which correctly only sets GOROOT for Go versions < 1.9.

Solution:
Updated the setGoEnvironmentVariables function to:

- Parse the Go version
- Only set GOROOT when the version is < 1.9
- Log debug messages indicating whether GOROOT is being set or skipped
- Continue setting GOPATH and GOBIN as before

---

### **Risk Assessment** (Low / Medium / High)  
Low.

---

### **Change Behind Feature Flag** (Yes / No)
No.

---

### **Tech Design / Approach**
Simple change in GOROOT configuration. Conditionally skipped.

---

### **Documentation Changes Required** (Yes/No)
No.

---

### **Unit Tests Added or Updated** (Yes / No)  
Yes. Added unit tests.

---

### **Additional Testing Performed**
No.

---

### **Logging Added/Updated** (Yes/No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (Yes/No) 
No.

---

### **Rollback Scenario and Process** (Yes/No)
Downgrade task version when using the task.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
