### PR TITLE
Run Test Pipelines for multiple Node versions

### DIFF
--- a/ci/ci-test-tasks/canary-tests-v2.yml
+++ b/ci/ci-test-tasks/canary-tests-v2.yml
@@ -49,9 +49,9 @@ jobs:
     vmImage: ubuntu-latest
   steps:
   - task: NodeTool@0
-    displayName: Use Node 20.x
+    displayName: Use Node 24.x
     inputs:
-      versionSpec: 20.x
+      versionSpec: 24.x
 
   - script: |
       cd ./ci/ci-test-tasks/test-and-verify-v2

--- a/ci/ci-test-tasks/test-and-verify-v2/src/api.ts
+++ b/ci/ci-test-tasks/test-and-verify-v2/src/api.ts
@@ -52,6 +52,12 @@ class API {
         }, this.projectName);
     }
 
+    public async addBuildTags(buildId: number, tags: string[]) {
+        const api = await this.getBuildApi();
+
+        return await api.addBuildTags(tags, this.projectName, buildId);
+    }
+
     public async updateBuild(buildId: number) {
         const api = await this.getBuildApi();
 

--- a/ci/ci-test-tasks/test-and-verify-v2/src/helpers.ts
+++ b/ci/ci-test-tasks/test-and-verify-v2/src/helpers.ts
@@ -3,91 +3,151 @@ import path from 'path';
 
 const RepoRoot = path.join(__dirname, '..', '..', '..', '..');
 
+// Get test Node version from environment variable (e.g., "20" or "24")
+const TEST_NODE_VERSION = process.env.TEST_NODE_VERSION ? parseInt(process.env.TEST_NODE_VERSION) : null;
+
 export function getBuildConfigs(task: string): string[] {
     const generatedTasksPath = path.join(RepoRoot, '_generated');
 
     console.log(`checking buildconfig for ${task}`);
+    console.log(`Test Node version from TEST_NODE_VERSION: ${TEST_NODE_VERSION || 'not set'}`);
+    
     try {
         const items = fs.readdirSync(generatedTasksPath);
-        const tasksToTest: string[] = [];
+        const generatedVariants: string[] = [];
 
+        // Find all generated variants for this task
         for (const item of items) {
             const itemPath = path.join(generatedTasksPath, item);
-            const stats = fs.statSync(itemPath);
-
-            if (stats.isDirectory() && item.startsWith(task)) {
-                tasksToTest.push(item);
+            if (fs.statSync(itemPath).isDirectory() && item.startsWith(task)) {
+                generatedVariants.push(item);
             }
         }
 
-        if (tasksToTest.length === 0) {
-            tasksToTest.push(task);
+        // Find highest Node version across base task and all variants
+        const baseNodeVersion = getNodeVersionFromTaskJson(task);
+        let highestNodeVersion = baseNodeVersion;
+        let highestVariant: string | null = baseNodeVersion ? task : null;
+
+        for (const variant of generatedVariants) {
+            const variantNodeVersion = getNodeVersionFromTaskJson(task, variant);
+            if (variantNodeVersion !== null && (highestNodeVersion === null || variantNodeVersion > highestNodeVersion)) {
+                highestNodeVersion = variantNodeVersion;
+                highestVariant = variant;
+            }
         }
-        return tasksToTest;
+
+        console.log(`Latest Node version: ${highestNodeVersion} (variant: ${highestVariant})`);
+
+        // Determine test configurations
+        const configs: string[] = [];
+        const baseNodeVersions = getNodeVersionsFromTaskJson(task);
+        const needsTestNode = TEST_NODE_VERSION !== null && TEST_NODE_VERSION !== highestNodeVersion;
+        const isInPlaceUpdate = TEST_NODE_VERSION !== null && 
+                               highestNodeVersion !== null &&
+                               baseNodeVersions.includes(TEST_NODE_VERSION) && 
+                               baseNodeVersions.includes(highestNodeVersion);
+
+        // Add TEST_NODE_VERSION configuration
+        if (needsTestNode) {
+            const testNodeVariant = generatedVariants.find(v => 
+                getNodeVersionFromTaskJson(task, v) === TEST_NODE_VERSION
+            );
+
+            if (testNodeVariant) {
+                configs.push(testNodeVariant);
+            } else if (baseNodeVersions.includes(TEST_NODE_VERSION)) {
+                configs.push(isInPlaceUpdate ? `${task}@Node${TEST_NODE_VERSION}` : task);
+            }
+        }
+
+        // Add highest Node version configuration
+        if (highestVariant) {
+            const configName = (highestVariant === task && isInPlaceUpdate) 
+                ? `${task}@Node${highestNodeVersion}` 
+                : highestVariant;
+            
+            if (!configs.includes(configName)) {
+                configs.push(configName);
+            }
+        }
+
+        // Default to base task if no configs found
+        if (configs.length === 0) {
+            configs.push(task);
+        }
+
+        console.log(`Test configurations: ${configs.join(', ')}`);
+        return configs;
     } catch (error) {
         console.error(`Error reading subdirectories: ${error}`);
         return [task];
     }
 }
 
-function getNodeVersionFromTaskJson(taskName: string, buildConfig?: string): number | null {
-    let taskJsonPath: string;
-    
+function getTaskJsonPath(taskName: string, buildConfig?: string): string {
     if (buildConfig) {
-        // Check _generated folder first for build configs
-        taskJsonPath = path.join(RepoRoot, '_generated', buildConfig, 'task.json');
-        if (!fs.existsSync(taskJsonPath)) {
-            // Fall back to base task folder
-            taskJsonPath = path.join(RepoRoot, 'Tasks', taskName, 'task.json');
+        const generatedPath = path.join(RepoRoot, '_generated', buildConfig, 'task.json');
+        if (fs.existsSync(generatedPath)) {
+            return generatedPath;
         }
-    } else {
-        taskJsonPath = path.join(RepoRoot, 'Tasks', taskName, 'task.json');
     }
+    return path.join(RepoRoot, 'Tasks', taskName, 'task.json');
+}
 
-    try {
-        const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf8'));
-        const execution = taskJson.execution || {};
-        
-        // Extract all Node versions from execution handlers
-        const nodeVersions: number[] = [];
-        
-        for (const handler in execution) {
-            if (handler.startsWith('Node')) {
-                // Extract number from handler name (e.g., Node10 -> 10, Node20_1 -> 20, Node24 -> 24)
-                const match = handler.match(/Node(\d+)/);
-                if (match) {
-                    nodeVersions.push(parseInt(match[1]));
+function extractNodeVersions(execution: any): number[] {
+    const versions: number[] = [];
+    for (const handler in execution) {
+        if (handler.startsWith('Node')) {
+            const match = handler.match(/Node(\d+)/);
+            if (match) {
+                const version = parseInt(match[1]);
+                if (!versions.includes(version)) {
+                    versions.push(version);
                 }
             }
         }
+    }
+    return versions.sort((a, b) => a - b);
+}
+
+function getNodeVersionsFromTaskJson(taskName: string, buildConfig?: string): number[] {
+    try {
+        const taskJsonPath = getTaskJsonPath(taskName, buildConfig);
+        const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf8'));
+        return extractNodeVersions(taskJson.execution || {});
+    } catch (error) {
+        console.error(`Error reading task.json for ${taskName}: ${error}`);
+        return [];
+    }
+}
+
+function getNodeVersionFromTaskJson(taskName: string, buildConfig?: string): number | null {
+    try {
+        const taskJsonPath = getTaskJsonPath(taskName, buildConfig);
+        const taskJson = JSON.parse(fs.readFileSync(taskJsonPath, 'utf8'));
+        const versions = extractNodeVersions(taskJson.execution || {});
         
-        // Return highest Node version
-        if (nodeVersions.length > 0) {
-            const maxVersion = Math.max(...nodeVersions);
-            console.log(`Found Node versions for ${buildConfig || taskName}: [${nodeVersions.join(', ')}], using highest: ${maxVersion}`);
-            return maxVersion;
-        }
-        
-        console.log(`No Node execution handlers found in ${taskJsonPath}`);
-        return null;
+        return versions.length > 0 ? Math.max(...versions) : null;
     } catch (error) {
         console.error(`Error reading task.json for ${taskName}: ${error}`);
         return null;
     }
 }
 
-export function getNodeVersionForTask(taskName: string): number | null {
-    // Get all build configs for this task
-    const buildConfigs = getBuildConfigs(taskName);
-    
-    // Try to find Node version from any of the build configs
-    for (const buildConfig of buildConfigs) {
-        const nodeVersion = getNodeVersionFromTaskJson(taskName, buildConfig);
-        if (nodeVersion !== null) {
-            return nodeVersion;
+export function getNodeVersionForTask(taskName: string, buildConfig?: string): number | null {
+    // Check for @Node marker in buildConfig (for in-place updates like "UseDotNetV2@Node20")
+    if (buildConfig?.includes('@Node')) {
+        const match = buildConfig.match(/@Node(\d+)$/);
+        if (match) {
+            return parseInt(match[1]);
         }
     }
     
-    // If no build configs have Node version, try base task
-    return getNodeVersionFromTaskJson(taskName);
+    // Try to get Node version from build config, or fall back to base task
+    const nodeVersion = buildConfig 
+        ? getNodeVersionFromTaskJson(taskName, buildConfig) 
+        : getNodeVersionFromTaskJson(taskName);
+    
+    return nodeVersion;
 }


### PR DESCRIPTION
### **Context**
This PR enhances the PR check system to support multi-version Node.js testing for Azure Pipelines tasks.

This change enables the test orchestration system to automatically run tests on both the TEST_NODE_VERSION (e.g., Node 20 for backward compatibility) and the latest Node version (e.g., Node 24) configured in task.json files.
[Testing Pipleine](https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=239486&view=logs&j=aaddeca2-3d22-5290-1576-db3329e255e0&t=d194d552-d1ee-5a7f-169f-6d332d898d38)
---

### **Task Name**
NA

---

### **Description**
Enhanced the test-and-verify-v2 test orchestration system to support running PR checks on multiple Node versions:

---

### **Risk Assessment** - **Low**
- No impact on task execution, only on how PR checks are orchestrated

---

### **Change Behind Feature Flag** - **No**

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** - **Yes**

**Required Updates:**
- Internal CI/CD documentation explaining TEST_NODE_VERSION usage
- Pipeline setup guide for enabling multi-version testing
- Examples of expected behavior for different task structures
- Troubleshooting guide for common scenarios

---

### **Unit Tests Added or Updated** - **No**

NA

---

### **Additional Testing Performed**

Manual

---

### **Logging Added/Updated** - **NA**
NA
---

### **Telemetry Added/Updated** - **No**
NA

---

### **Rollback Scenario and Process** - **Yes**
NA