### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 10899: Build ID 30904515

### DIFF
--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/de-DE/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/de-DE/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "Unerwarteter Fehler beim Abrufen von Tags.",
   "loc.messages.GetReleasesError": "Unerwarteter Fehler beim Abrufen von Releases.",
   "loc.messages.CreateReleaseError": "Unerwarteter Fehler beim Erstellen der Release.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "Fehler beim Erstellen des Release aufgrund von: %s",
   "loc.messages.EditReleaseError": "Unerwarteter Fehler beim Bearbeiten des Release.",
   "loc.messages.DeleteReleaseError": "Unerwarteter Fehler beim Löschen des Release.",
   "loc.messages.CreatingRelease": "Release für Tag wird erstellt: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/es-ES/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/es-ES/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "Error inesperado al aplicar \"fetch\" para recuperar cambios en las etiquetas.",
   "loc.messages.GetReleasesError": "Error inesperado al aplicar \"fetch\" para recuperar cambios en las versiones.",
   "loc.messages.CreateReleaseError": "Error inesperado al crear la versión.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "No se pudo crear la versión debido a: %s",
   "loc.messages.EditReleaseError": "Error inesperado al editar la versión.",
   "loc.messages.DeleteReleaseError": "Error inesperado al eliminar la versión.",
   "loc.messages.CreatingRelease": "Creando una versión para la etiqueta: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/fr-FR/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/fr-FR/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "Une erreur inattendue s'est produite durant la récupération (fetch) des étiquettes.",
   "loc.messages.GetReleasesError": "Une erreur inattendue s'est produite durant la récupération (fetch) des mises en production.",
   "loc.messages.CreateReleaseError": "Une erreur inattendue s'est produite durant la création de la mise en production.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "Échec de la création de la version en raison de : %s",
   "loc.messages.EditReleaseError": "Une erreur inattendue s'est produite durant la modification de la mise en production.",
   "loc.messages.DeleteReleaseError": "Une erreur inattendue s'est produite durant la suppression de la mise en production.",
   "loc.messages.CreatingRelease": "Création d'une mise en production pour l'étiquette : %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/it-IT/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/it-IT/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "Si è verificato un errore imprevisto durante il recupero dei tag.",
   "loc.messages.GetReleasesError": "Si è verificato un errore imprevisto durante il recupero delle versioni.",
   "loc.messages.CreateReleaseError": "Si è verificato un errore imprevisto durante la creazione della versione.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "Non è possibile creare la versione perché: %s",
   "loc.messages.EditReleaseError": "Si è verificato un errore imprevisto durante la modifica della versione.",
   "loc.messages.DeleteReleaseError": "Si è verificato un errore imprevisto durante l'eliminazione della versione.",
   "loc.messages.CreatingRelease": "Creazione di una versione per il tag: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/ja-JP/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/ja-JP/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "タグのフェッチ中に予期しないエラーが発生しました。",
   "loc.messages.GetReleasesError": "リリースのフェッチ中に予期しないエラーが発生しました。",
   "loc.messages.CreateReleaseError": "リリースの作成中に予期しないエラーが発生しました。",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "次の理由でリリースを作成できませんでした: %s",
   "loc.messages.EditReleaseError": "リリースの編集中に予期しないエラーが発生しました。",
   "loc.messages.DeleteReleaseError": "リリースの削除中に予期しないエラーが発生しました。",
   "loc.messages.CreatingRelease": "タグのリリースを作成しています: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/ko-KR/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "태그를 페치하는 중 예기치 않은 오류가 발생했습니다.",
   "loc.messages.GetReleasesError": "릴리스를 페치하는 중 예기치 않은 오류가 발생했습니다.",
   "loc.messages.CreateReleaseError": "릴리스를 만드는 중 예기치 않은 오류가 발생했습니다.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "다음으로 인해 릴리스를 만들지 못했습니다. %s",
   "loc.messages.EditReleaseError": "릴리스를 편집하는 중 예기치 않은 오류가 발생했습니다.",
   "loc.messages.DeleteReleaseError": "릴리스를 삭제하는 중 예기치 않은 오류가 발생했습니다.",
   "loc.messages.CreatingRelease": "%s 태그의 릴리스를 만드는 중",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/ru-RU/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "При получении тегов произошла непредвиденная ошибка.",
   "loc.messages.GetReleasesError": "При получении выпусков произошла непредвиденная ошибка.",
   "loc.messages.CreateReleaseError": "При создании выпуска произошла непредвиденная ошибка.",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "Не удалось создать выпуск по следующей причине: %s",
   "loc.messages.EditReleaseError": "При изменении выпуска произошла непредвиденная ошибка.",
   "loc.messages.DeleteReleaseError": "При удалении выпуска произошла непредвиденная ошибка.",
   "loc.messages.CreatingRelease": "Создание выпуска для тега: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/zh-CN/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "提取标记时出现意外错误。",
   "loc.messages.GetReleasesError": "提取发布时出现意外错误。",
   "loc.messages.CreateReleaseError": "创建发布时出现意外错误。",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "创建发布失败，原因是: %s",
   "loc.messages.EditReleaseError": "编辑发布时出现意外错误。",
   "loc.messages.DeleteReleaseError": "删除发布时出现意外错误。",
   "loc.messages.CreatingRelease": "正在创建标记的发布: %s",

--- a/Tasks/GitHubReleaseV1/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/Tasks/GitHubReleaseV1/Strings/resources.resjson/zh-TW/resources.resjson
@@ -50,7 +50,7 @@
   "loc.messages.GetTagsError": "擷取標籤時發生未預期的錯誤。",
   "loc.messages.GetReleasesError": "擷取版本時發生未預期的錯誤。",
   "loc.messages.CreateReleaseError": "建立版本時發生未預期的錯誤。",
-  "loc.messages.CreateReleaseFailed": "Failed to create the release due to: %s",
+  "loc.messages.CreateReleaseFailed": "無法建立發行版本，原因: %s",
   "loc.messages.EditReleaseError": "編輯版本時發生未預期的錯誤。",
   "loc.messages.DeleteReleaseError": "刪除版本時發生未預期的錯誤。",
   "loc.messages.CreatingRelease": "正在建立標籤 %s 的版本",


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.