### PR TITLE
Add support for InstallationToken in kubelogininstallerV0

### DIFF
--- a/Tasks/KubeloginInstallerV0/task.json
+++ b/Tasks/KubeloginInstallerV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 268,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/utils.ts
+++ b/Tasks/KubeloginInstallerV0/utils.ts
@@ -186,6 +186,9 @@ function getGithubEndPointToken(): string {
     case 'Token':
       githubEndpointToken = githubEndpointObject.parameters.AccessToken;
       break;
+    case 'InstallationToken':
+      githubEndpointToken = githubEndpointObject.parameters.AccessToken;
+      break;
     default:
       throw new GitHubEndpointSchemeError(
         taskLib.loc("InvalidEndpointAuthScheme", githubEndpointObject.scheme)


### PR DESCRIPTION
### **Context**

When Github Connection uses InstallationToken, the task raises error.

### **Task Name**

KubeloginInstallerV0

---

### **Description**

If the scheme of `githubEndpointObject` is `InstallationToken`, return `AccessToken` 

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility)._

---

### **Change Behind Feature Flag** (Yes / No)

No.

---

### **Tech Design / Approach**

N/A

---

### **Documentation Changes Required** (Yes/No)

No.

The document incides it supports `InstallationToken`, actually not. So no updates to documents.

```
    {
      "name": "gitHubConnection",
      "type": "connectedService:github:OAuth,OAuth2,PersonalAccessToken,InstallationToken,Token",
      "label": "GitHub Connection",
      "defaultValue": "",
      "required": false,
      "helpMarkDown": "A GitHub connection is needed to prevent anonymous requests limits to the Github API for [Azure/kubelogin](https://github.com/azure/kubelogin) from impacting the installation. Leaving this empty may cause failures if the request limit is reached. This connection does not require ANY permissions."
    }
```

---

### **Unit Tests Added or Updated** (Yes / No)  

No.

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Logging Added/Updated** (Yes/No)

No.

--- 

### **Telemetry Added/Updated** (Yes/No) 

No.

---

### **Rollback Scenario and Process** (Yes/No)

No.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

No.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
