### PR TITLE
Add node24 support for FileTransformV2 and update dependencies

### DIFF
--- a/Tasks/FileTransformV2/package-lock.json
+++ b/Tasks/FileTransformV2/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.3.1",
+        "@types/node": "^24.10.0",
         "@types/q": "1.0.7",
         "azure-pipelines-tasks-webdeployment-common": "4.260.0",
         "q": "1.4.1"
       },
       "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@types/events": {
@@ -38,11 +38,12 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.14.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.14.9.tgz",
-      "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+      "version": "24.10.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.10.8.tgz",
+      "integrity": "sha1-m1KdMuflrbdLE9H8m4NhXpoSpwE=",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/q": {
@@ -763,10 +764,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.9.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -776,9 +778,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
+      "license": "MIT"
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",

--- a/Tasks/FileTransformV2/package.json
+++ b/Tasks/FileTransformV2/package.json
@@ -20,12 +20,12 @@
   "homepage": "https://github.com/Microsoft/vsts-tasks#readme",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^20.3.1",
+    "@types/node": "^24.10.0",
     "@types/q": "1.0.7",
     "azure-pipelines-tasks-webdeployment-common": "4.260.0",
     "q": "1.4.1"
   },
   "devDependencies": {
-    "typescript": "5.1.6"
+    "typescript": "^5.7.2"
   }
 }

--- a/Tasks/FileTransformV2/task.json
+++ b/Tasks/FileTransformV2/task.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 266,
+    "Minor": 269,
     "Patch": 0
   },
   "releaseNotes": "More optimized task fields that allow users to enable any/all of the transformation (XML), variable substitution (JSON and XML) features in a single task instance.</br>Task fails when any of the configured transformation/substitution is NOT applied or when the task is no-op.",
@@ -92,6 +92,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "filetransform.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "filetransform.js",
       "argumentFormat": ""
     }

--- a/Tasks/FileTransformV2/task.loc.json
+++ b/Tasks/FileTransformV2/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 2,
-    "Minor": 266,
+    "Minor": 269,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
@@ -92,6 +92,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "filetransform.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "filetransform.js",
       "argumentFormat": ""
     }


### PR DESCRIPTION
### **Context**
This PR upgrades the FileTranformV2 task to support Node.js 24 runtime

Associated WI: [AB#2347899](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2347899)

---

### **Task Name**
FileTransformV2

---

### **Description**

This PR includes below changes:

Node.js 24 Runtime Support: Added Node24 execution handler to task.json and task.loc.json

Dependency updates:
- Updated @types/node from ^20.3.1 to ^24.10.0
- Updated typescript from ^5.1.6 to ^5.7.2 


---

### **Risk Assessment** (Low / Medium / High)  

Medium

**Reasoning**:

- Scope: Changes affect core dependencies including Node.js types
- Impact: The task is updated up to Node 24
- Backward Compatibility: Full backward compatibility maintained through override

The risk is mitigated by:

- Maintaining Node20_1 support alongside Node24 (with override process)
- No changes to task logic or functionality

---

### **Change Behind Feature Flag** (Yes / No)
No

This change cannot be behind a feature flag because the Node24 handler is additive and can't be covered with a feature flag

---

### **Tech Design / Approach**
No 

---

### **Documentation Changes Required** (Yes/No)
No 

---

No 

---

### **Additional Testing Performed**

 - Build and test verification: Verified task builds successfully and L0 tests succeed with updated dependencies
 - Backward compatibility: Confirm task still works with Node20_1 handler

---

### **Logging Added/Updated** (Yes/No)
No 

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Yes

**Rollback Plan:**

Revert commits on this branch
Deploy a task fix
or

**Mitigation**:

Override a task version

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes

**Impact Assessment:**

✅ @types/node v24.10.4 provides accurate type definitions for Node.js 24
✅ typescript v5.7.2 is the latest stable version with Node.js 24 support

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
