### PR TITLE
The feature flag for enabling the new OpenSSL version has been renamed

### DIFF
--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
+++ b/Tasks/AzureCloudPowerShellDeploymentV2/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV1/task.json
+++ b/Tasks/AzureFileCopyV1/task.json
@@ -13,8 +13,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzureFileCopyV1/task.loc.json
+++ b/Tasks/AzureFileCopyV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.json
+++ b/Tasks/AzureFileCopyV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV2/task.loc.json
+++ b/Tasks/AzureFileCopyV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.json
+++ b/Tasks/AzureFileCopyV3/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV3/task.loc.json
+++ b/Tasks/AzureFileCopyV3/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.json
+++ b/Tasks/AzureFileCopyV4/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV4/task.loc.json
+++ b/Tasks/AzureFileCopyV4/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.json
+++ b/Tasks/AzureFileCopyV5/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV5/task.loc.json
+++ b/Tasks/AzureFileCopyV5/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/task.json
+++ b/Tasks/AzureFileCopyV6/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzureFileCopyV6/task.loc.json
+++ b/Tasks/AzureFileCopyV6/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 6,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV2/task.json
+++ b/Tasks/AzurePowerShellV2/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 2,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "demands": [
         "azureps"

--- a/Tasks/AzurePowerShellV2/task.loc.json
+++ b/Tasks/AzurePowerShellV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "azureps"

--- a/Tasks/AzurePowerShellV3/task.json
+++ b/Tasks/AzurePowerShellV3/task.json
@@ -17,8 +17,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 3,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "releaseNotes": "Added support for Fail on standard error and ErrorActionPreference",
     "demands": [

--- a/Tasks/AzurePowerShellV3/task.loc.json
+++ b/Tasks/AzurePowerShellV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "demands": [

--- a/Tasks/AzurePowerShellV4/task.json
+++ b/Tasks/AzurePowerShellV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV4/task.loc.json
+++ b/Tasks/AzurePowerShellV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.json
+++ b/Tasks/AzurePowerShellV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "releaseNotes": "Added support for Az Module and cross platform agents.",
   "groups": [

--- a/Tasks/AzurePowerShellV5/task.loc.json
+++ b/Tasks/AzurePowerShellV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 269,
-    "Patch": 2
+    "Minor": 270,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "groups": [

--- a/Tasks/Common/VstsAzureRestHelpers_/VstsAzureRestHelpers_.psm1
+++ b/Tasks/Common/VstsAzureRestHelpers_/VstsAzureRestHelpers_.psm1
@@ -1350,7 +1350,7 @@ function ConvertTo-Pfx {
     $pfxFilePassword = [System.Guid]::NewGuid().ToString()
     Set-Content -Path $pfxPasswordFilePath -Value $pfxFilePassword -NoNewline
 
-    $useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2_in_VstsAzureRestHelpers'
+    $useOpenssLatestVersion = Get-VstsPipelineFeature -FeatureName 'UseOpensslv3.4.2VstsAzureRestHelpers'
     if(-not $useOpenssLatestVersion) {
         $openSSLExePath = "$PSScriptRoot\openssl\openssl.exe"
         $openSSLArgs = "pkcs12 -export -in $pemFilePath -out $pfxFilePath -password file:`"$pfxPasswordFilePath`""

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 269,
+    "Minor": 270,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -13,7 +13,7 @@
   "preview": false,
   "version": {
     "Major": 2,
-    "Minor": 269,
+    "Minor": 270,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.json
@@ -16,8 +16,8 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 269,
-        "Patch": 1
+        "Minor": 270,
+        "Patch": 0
     },
     "demands": [
         "sqlpackage"

--- a/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
+++ b/Tasks/SqlAzureDacpacDeploymentV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 269,
-    "Patch": 1
+    "Minor": 270,
+    "Patch": 0
   },
   "demands": [
     "sqlpackage"


### PR DESCRIPTION
### **Context**
The name of the FF used to enable the 3.4.2 OpenSSL version in _VstsAzureRestHelpers_ has been changed
[AB#2349925](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2349925)

---

### **Task Name**
AzureCloudPowerShellDeploymentV1, AzureCloudPowerShellDeploymentV2, AzureFileCopyV1, AzureFileCopyV2, AzureFileCopyV3, AzureFileCopyV4, AzureFileCopyV5, AzureFileCopyV6, AzurePowerShellV2, AzurePowerShellV3, AzurePowerShellV4, AzurePowerShellV5, SqlAzureDacpacDeploymentV1, PublishSymbolsV2

---

### **Description**
The feature flag for enabling the new OpenSSL version has been renamed

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Yes (UseOpensslv3.4.2VstsAzureRestHelpers)

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
