### PR TITLE
Fix error message formatting in AzureCLIV3 task

### DIFF
--- a/Tasks/AzureCLIV3/azureclitask.ts
+++ b/Tasks/AzureCLIV3/azureclitask.ts
@@ -235,6 +235,25 @@ export class azureclitask {
     private static tenantId: string = null;
     private static isSupportCertificateParameter: boolean = false;
 
+    private static formatExecError(err: any): string {
+        if (!err) return 'Unknown error';
+        
+        const code = err.code ?? err.exitCode;
+        const stderr = typeof err.stderr === 'string' ? err.stderr.trim() : '';
+        const stdout = typeof err.stdout === 'string' ? err.stdout.trim() : '';
+        
+        if (stderr || stdout || code !== undefined) {
+            const parts = [];
+            if (code !== undefined) parts.push(`code=${code}`);
+            if (stderr) parts.push(`stderr=${stderr}`);
+            if (stdout) parts.push(`stdout=${stdout}`);
+            return parts.join(' | ');
+        }
+        
+        if (err instanceof Error) return err.message;
+        return JSON.stringify(err, Object.getOwnPropertyNames(err));
+    }
+
     private static isAzVersionGreaterOrEqual(azVersionResultOutput, versionToCompare) {
         try {
             let versionMatch = [];
@@ -414,8 +433,7 @@ export class azureclitask {
                 throw tl.loc('AuthSchemeNotSupportedForAzureDevOps', authScheme);
             }
         } catch (error) {
-            const errorMessage = error?.message || error?.toString() || String(error);
-            throw new Error(`Failed to setup Azure DevOps CLI: ${errorMessage}`);
+            throw new Error(`Failed to setup Azure DevOps CLI: ${this.formatExecError(error)}`);
         }
     }
 

--- a/Tasks/AzureCLIV3/task.json
+++ b/Tasks/AzureCLIV3/task.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 3,
     "Minor": 270,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "Azure CLI $(scriptPath)",

--- a/Tasks/AzureCLIV3/task.loc.json
+++ b/Tasks/AzureCLIV3/task.loc.json
@@ -20,7 +20,7 @@
   "version": {
     "Major": 3,
     "Minor": 270,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.0.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
The AzureCLIV3 task was displaying "[object Object]" error messages when Azure DevOps CLI setup failed.

---

### **Task Name**
AzureCLIV3

---

### **Description**
Fixed an issue where execution errors displayed "[object Object]" instead of the actual error message.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
