### PR TITLE
Fix warning emitted in TwineAuthenticateV1

### DIFF
--- a/Tasks/TwineAuthenticateV1/task.json
+++ b/Tasks/TwineAuthenticateV1/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 262,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV1/task.loc.json
+++ b/Tasks/TwineAuthenticateV1/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 1,
     "Minor": 262,
-    "Patch": 0
+    "Patch": 1
   },
   "runsOn": [
     "Agent",

--- a/Tasks/TwineAuthenticateV1/twineauthenticatemain.ts
+++ b/Tasks/TwineAuthenticateV1/twineauthenticatemain.ts
@@ -34,7 +34,6 @@ export class Repository
 
 async function main(): Promise<void> {
     tl.setResourcePath(path.join(__dirname, "task.json"));
-    tl.setResourcePath(path.join(__dirname, "node_modules/azure-pipelines-tasks-artifacts-common/module.json"));
 
     let internalFeedSuccessCount: number = 0;
     let externalFeedSuccessCount: number = 0;


### PR DESCRIPTION
### **Context**

Related to issue: #21798 - which this PR aims to close.

When using the `TwineAuthenticateV1` task, it will always output the following warning:
```
##[warning]Resource file has already set to: /__w/_tasks/TwineAuthenticate_e4d58330-c771-11e8-8f8f-81fbb42e2824/1.262.0/node_modules/azure-pipelines-tasks-artifacts-common/module.json
```

This fix is modeled after a similar fix applied to the `PipAuthenticateV1` task https://github.com/microsoft/azure-pipelines-tasks/commit/ff3418e27df75e2c7022cf1ca9ad34d344605b8a

 

---

### **Task Name**

`TwineAuthenticateV1`

---

### **Description**

Removed the call to
```ts
tl.setResourcePath(path.join(__dirname, "node_modules/azure-pipelines-tasks-artifacts-common/module.json"));
```

I believe this is acceptable because this already happens in the `azure-pipelines-tasks-artifacts-comment` package itself: https://github.com/microsoft/azure-pipelines-tasks-common-packages/blob/7af881598e3791fd30a0bfe9199af4ea9e5020fc/common-npm-packages/artifacts-common/webapi.ts#L6

---

### **Risk Assessment** (Low / Medium / High)  

Low

---

### **Additional Testing Performed**

I have **not** tested this end-to-end in a real environment - as it was not clear to me how I could deploy this updated task to my Azure DevOps Services environment.

Testing procedure followed:
1. Before making a fix, confirmed unit tests were already passing (they did not output the relevant Warning as far as I could see).
2. Ran `node -e "require('./twineauthenticatemain.js')` which _did_ result in the warning being logged
3. Made the changes in this PR
4. Ran `node -e "require('./twineauthenticatemain.js')` again, which now _did not_ result in the warning being logged
5. Ran tests again and confirmed they were still passing.
