### PR TITLE
Add Copilot hook for sprint-based task version bumping

### DIFF
--- a/.github/hooks/bump-task-version.json
+++ b/.github/hooks/bump-task-version.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": ".github/hooks/bump-task-version.sh",
+        "timeout": 10
+      }
+    ]
+  }
+}

--- a/.github/hooks/bump-task-version.sh
+++ b/.github/hooks/bump-task-version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read hook input from stdin
+INPUT=$(cat)
+
+# Extract file path from the tool input (covers various tool parameter names)
+FILE_PATH=$(echo "$INPUT" | jq -r '
+  .toolInput.filePath //
+  .toolInput.file_path //
+  .toolInput.path //
+  empty' 2>/dev/null || true)
+
+# Only act when editing task.json or task.loc.json under Tasks/
+if [[ ! "$FILE_PATH" =~ Tasks/.*task\.(loc\.)?json$ ]]; then
+  exit 0
+fi
+
+# Fetch current sprint info
+SPRINT_JSON=$(curl -sf --max-time 5 "https://whatsprintis.it/?json") || exit 0
+SPRINT=$(echo "$SPRINT_JSON" | jq -r '.sprint')
+WEEK=$(echo "$SPRINT_JSON" | jq -r '.week')
+
+if [[ -z "$SPRINT" || "$SPRINT" == "null" ]]; then
+  exit 0
+fi
+
+# Determine target minor version based on sprint week and day-of-week
+# Cutoff: Tuesday of the 3rd sprint week. After that, target next sprint.
+DAY_OF_WEEK=$(date +%u) # 1=Monday … 7=Sunday
+if [[ "$WEEK" -gt 3 ]] || { [[ "$WEEK" -eq 3 ]] && [[ "$DAY_OF_WEEK" -gt 2 ]]; }; then
+  TARGET_MINOR=$((SPRINT + 1))
+  REASON="past the Tuesday week-3 cutoff of sprint ${SPRINT}"
+else
+  TARGET_MINOR=$SPRINT
+  REASON="within sprint ${SPRINT} (week ${WEEK})"
+fi
+
+cat <<EOF
+{
+  "systemMessage": "TASK VERSION BUMPING — Sprint data (${REASON}): target Minor=${TARGET_MINOR}. Rules: if the task's current Minor already equals ${TARGET_MINOR}, increment Patch by 1. Otherwise set Minor=${TARGET_MINOR} and Patch=0. Always update BOTH task.json AND task.loc.json with the same version. For major behavioural changes, increment Major instead."
+}
+EOF

--- a/.github/instructions/task-version.instructions.md
+++ b/.github/instructions/task-version.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "Tasks/**/task.json, Tasks/**/task.loc.json"
+description: "Use when editing task.json or task.loc.json version fields in Azure Pipelines tasks. Covers sprint-based version bumping rules."
+---
+# Task Version Bumping
+
+When modifying a task's `version` in `task.json` or `task.loc.json`:
+
+1. Fetch the current sprint from https://whatsprintis.it/?json
+2. If the sprint week is past Tuesday of week 3 (i.e., week > 3, or week == 3 and today is after Tuesday), target `Minor = sprint + 1`. Otherwise target `Minor = sprint`.
+3. If the task's current `Minor` already equals the target, increment `Patch` by 1.
+4. If the task's current `Minor` differs from the target, set `Minor` to the target and reset `Patch` to 0.
+5. For major behavioural changes (no backward compatibility), increment `Major` instead.
+6. **Always update both `task.json` and `task.loc.json`** with the same version.


### PR DESCRIPTION
### **Context**

Getting the task version right when editing `task.json` is easy to forget. The rules live in `docs/taskversionbumping.md`, but you have to look up the current sprint, figure out the cutoff, and remember to update both `task.json` and `task.loc.json`. This PR makes that automatic.

---

### **Task Name**

N/A - this is developer tooling, not a pipeline task change.

---

### **Description**

Adds a Copilot `PreToolUse` hook and a file-scoped instruction so the agent gets sprint version info before editing any task definition file.

The hook (`.github/hooks/bump-task-version.sh`) runs when the agent is about to edit a file matching `Tasks/*/task.json` or `Tasks/*/task.loc.json`. It calls `https://whatsprintis.it/?json`, checks whether we're past the Tuesday week-3 cutoff, and injects a system message with the correct `Minor` and `Patch` values to use.

The instruction (`.github/instructions/task-version.instructions.md`) attaches to those same files via `applyTo`, so the bumping rules are always in context without needing to look them up.

Three files total:
- `.github/hooks/bump-task-version.json` - hook config
- `.github/hooks/bump-task-version.sh` - the script that fetches sprint data
- `.github/instructions/task-version.instructions.md` - static version rules

---

### **Risk Assessment** (Low)

No changes to any task code or pipeline behavior. This only affects the Copilot agent's behavior when editing task definition files. If the hook fails (network issues, API down), it exits 0 and the agent proceeds without the version hint.

---

### **Change Behind Feature Flag** (No)

Copilot hooks are opt-in by nature - they only fire inside agent sessions. No feature flag needed.

---

### **Tech Design / Approach**
- Hook silently exits for any file that isn't a task definition, so it won't slow down other edits.
- 10 second timeout on the hook, 5 second timeout on the curl to `whatsprintis.it`.
- Falls back gracefully: if the API is unreachable or returns bad data, the script exits 0 with no output.

---

### **Documentation Changes Required** (No)

The hook and instruction are self-documenting. They implement the rules already written in `docs/taskversionbumping.md`.

---

### **Unit Tests Added or Updated** (No)

Shell script with a single external dependency (`whatsprintis.it`). Tested manually by piping simulated hook JSON through the script.

---

### **Additional Testing Performed**

Ran the hook script with simulated `PreToolUse` JSON for both matching (`Tasks/MavenV4/task.json`) and non-matching (`src/main.ts`) file paths. Verified correct sprint output and silent exit respectively.

---

### **Logging Added/Updated** (No)

N/A.

---

### **Telemetry Added/Updated** (No)

N/A.

---

### **Rollback Scenario and Process** (Yes)

Delete the three files. No other changes to revert.

---

### **Dependency Impact Assessed and Regression Tested** (Yes)

No dependencies added. The hook uses `curl`, `jq`, and `date`, all standard on CI and dev machines.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — N/A, no task changes
- [x] Verified the task behaves as expected