### PR TITLE
Upgrade VSBuildV1 to TypeScript 5.7.2

### DIFF
--- a/Tasks/VSBuildV1/package-lock.json
+++ b/Tasks/VSBuildV1/package-lock.json
@@ -8,12 +8,12 @@
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^10.17.0",
+        "@types/node": "^20.3.1",
         "azure-pipelines-task-lib": "^4.16.0",
         "azure-pipelines-tasks-msbuildhelpers": "3.266.0"
       },
       "devDependencies": {
-        "typescript": "4.0.2"
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@types/mocha": {
@@ -23,10 +23,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
-      "license": "MIT"
+      "version": "20.19.30",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.19.30.tgz",
+      "integrity": "sha1-hPqHSYreXNK2uo+O7AHTsTjKYNA=",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/adm-zip": {
       "version": "0.5.16",
@@ -74,6 +77,12 @@
         "@types/node": "^10.17.0",
         "azure-pipelines-task-lib": "^4.17.0"
       }
+    },
+    "node_modules/azure-pipelines-tasks-msbuildhelpers/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -422,9 +431,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha1-fqfIh3fHI8aB4zv3mIvl0AjQWsI=",
+      "version": "5.9.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -432,8 +441,14 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha1-aR0ArzkJvpOn+qE75hs6W1DvEss=",
+      "license": "MIT"
     },
     "node_modules/utf8-byte-length": {
       "version": "1.0.5",

--- a/Tasks/VSBuildV1/package.json
+++ b/Tasks/VSBuildV1/package.json
@@ -17,11 +17,11 @@
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks#readme",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^10.17.0",
+    "@types/node": "^20.3.1",
     "azure-pipelines-task-lib": "^4.16.0",
     "azure-pipelines-tasks-msbuildhelpers": "3.266.0"
   },
   "devDependencies": {
-    "typescript": "4.0.2"
+    "typescript": "^5.7.2"
   }
 }

--- a/Tasks/VSBuildV1/task.json
+++ b/Tasks/VSBuildV1/task.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 267,
+    "Minor": 271,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/VSBuildV1/task.loc.json
+++ b/Tasks/VSBuildV1/task.loc.json
@@ -12,7 +12,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 267,
+    "Minor": 271,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
## Summary
- Upgrades TypeScript from 4.0.2 to ^5.7.2 for VSBuildV1 task
- Updates @types/node from ^10.17.0 to ^20.3.1 for compatibility with newer TypeScript

## Testing
- Task builds successfully with the new TypeScript version

---

_Replaces #21723 (moved from fork to upstream branch)._