### PR TITLE
Update azure-pipelines-task-lib to version 5.2.6 and add k8s package dependency

### DIFF
--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -49,7 +49,7 @@ namespace BuildConfigGen
             public static readonly Dictionary<string, string> Node24PackageOverrides = new Dictionary<string, string>
             {
                 ["typescript"] = "^5.7.2",
-                ["azure-pipelines-task-lib"] = "^5.2.4",
+                ["azure-pipelines-task-lib"] = "^5.2.6",
                 ["azure-devops-node-api"] = "^15.1.3",
                 ["azure-pipelines-tasks-artifacts-common"] = "^2.270.0",
                 ["azure-pipelines-tasks-azure-arm-rest"] = "^3.270.0",
@@ -222,7 +222,7 @@ namespace BuildConfigGen
 
             Console.WriteLine($"Current sprint: {currentSprint}");
 
-            if (bumpBaseTask) 
+            if (bumpBaseTask)
             {
                 // Split the task string and bump each task individually
                 var taskList = task!.Split(',', '|');
@@ -673,7 +673,7 @@ namespace BuildConfigGen
 
                 if (targetConfigs.Any(x => x.isNode))
                 {
-                    // Task may not have nodejs or packages.json (example: AutomatedAnalysisV0) 
+                    // Task may not have nodejs or packages.json (example: AutomatedAnalysisV0)
                     if (!HasNodeHandler(taskHandlerContents))
                     {
                         Console.WriteLine($"Skipping {task} because task doesn't have node handler does not exist");
@@ -798,7 +798,7 @@ namespace BuildConfigGen
                                         {
                                             throw new Exception($"There is no default config for task {task}");
                                         }
-                                        
+
                                         WriteTaskJson(taskOutput, taskVersionState, config, "task.json", existingLocalPackageVersion, useSemverBuildConfig: true, defaultConfig: defaultConfig);
                                         WriteTaskJson(taskOutput, taskVersionState, config, "task.loc.json", existingLocalPackageVersion, useSemverBuildConfig: true, defaultConfig: defaultConfig);
                                     }
@@ -1135,7 +1135,7 @@ namespace BuildConfigGen
 
         /// <summary>
         /// Writes task.json with version information and build config mapping.
-        /// When useSemverBuildConfig is true, uses the same major.minor.patch for all build configuration tasks, 
+        /// When useSemverBuildConfig is true, uses the same major.minor.patch for all build configuration tasks,
         /// but the "build" suffix of semver is different and directly corresponds to the config name.
         /// </summary>
         private static void WriteTaskJson(string taskPath, TaskStateStruct taskState, Config.ConfigRecord config, string fileName, string? existingLocalPackageVersion, bool useSemverBuildConfig = false, Config.ConfigRecord? defaultConfig = null)
@@ -1262,6 +1262,8 @@ namespace BuildConfigGen
             {
                 UpdateDependencyIfExists(outputNodePackagePathJsonNode, kvp.Key, kvp.Value);
             }
+
+            UpdateDependencyIfExists(outputNodePackagePathJsonNode, "azure-pipelines-tasks-kubernetes-common", "npm:azure-pipelines-tasks-k8s-common@^2.270.1");
 
             // We need to add newline since npm install command always add newline at the end of package.json
             // https://github.com/npm/npm/issues/18545
@@ -1686,7 +1688,7 @@ always-auth=true", false);
                 if (config.useGlobalVersion)
                 {
                     TaskVersion versionToUse = globalVersion;
-                    
+
                     if (config.abTaskReleases && useSemverBuildConfig)
                     {
                         // In the first stage of refactoring, we keep different version numbers to retain the ability to rollback.


### PR DESCRIPTION
### **Context**
The change resolves issues with updating packages in tasks while Node24 migration.

This PR produces changes that are placed in the PR: #21878

**WI**: [AB#2361742](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2361742)

---

### **Task Name**
N/A - Changing dependencies updating in BuildConfigGen

---

### **Description**
- Updated Node24 package override for azure-pipelines-task-lib from ^5.2.4 to ^5.2.6 in Program.cs.
- Added generated dependency injection for azure-pipelines-tasks-kubernetes-common via npm alias azure-pipelines-tasks-k8s-common@^2.270.1 in Program.cs.

---

### **Risk Assessment** 
Low

---

### **Change Behind Feature Flag**
N

---

### **Tech Design / Approach**
N/A

---

### **Documentation Changes Required**
N/A

---

### **Unit Tests Added or Updated**
N/A

---

### **Additional Testing Performed**
See PR that is produced by this change #21878

---

### **Logging Added/Updated** 
N/A

--- 

### **Telemetry Added/Updated**
N/A

---

### **Rollback Scenario and Process**
Revert the PR

---

### **Dependency Impact Assessed and Regression Tested**
N/A

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
