### PR TITLE
Add BicepDeployV0 localization entry

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -226,6 +226,12 @@
           },
           {
             "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
+            "SourceFile": "Tasks\\BicepDeployV0\\Strings\\resources.resjson\\en-US\\resources.resjson",
+            "CopyOption": "LangIDOnPath",
+            "OutputPath": "Tasks\\BicepDeployV0\\Strings\\resources.resjson"
+          },
+          {
+            "Languages": "de-DE;es-ES;fr-FR;it-IT;ja-JP;ko-KR;ru-RU;zh-CN;zh-TW",
             "SourceFile": "Tasks\\CacheBetaV1\\Strings\\resources.resjson\\en-US\\resources.resjson",
             "CopyOption": "LangIDOnPath",
             "OutputPath": "Tasks\\CacheBetaV1\\Strings\\resources.resjson"


### PR DESCRIPTION
This pull request adds localization support for the `BicepDeployV0` task by including it in the localization project configuration. This ensures that the task's resource files can be properly localized for multiple languages.

**Localization support:**

* Added a new entry in `LocProject.json` to enable localization for the `BicepDeployV0` task, specifying supported languages, the source file location, copy option, and output path.