### PR TITLE
Update Deprecation.md to mark NodeToolV0 as deprecated

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -54,6 +54,7 @@ For migration guidance and replacement tasks, please refer to the deprecation me
 | Maven V2 | [PR #20199](https://github.com/microsoft/azure-pipelines-tasks/pull/20199) | 2024-08-02 |
 | Maven V3 | [PR #20199](https://github.com/microsoft/azure-pipelines-tasks/pull/20199) | 2024-08-02 |
 | MysqlDeploymentOnMachineGroup V1 | [PR #20222](https://github.com/microsoft/azure-pipelines-tasks/pull/20222) | 2024-08-05 |
+| NodeTool V0 | [PR #21902](https://github.com/microsoft/azure-pipelines-tasks/pull/21902) | 2026-03-20 |
 | NuGet V0 | [PR #20222](https://github.com/microsoft/azure-pipelines-tasks/pull/20222) | 2024-08-05 |
 | NuGetAuthenticate V0 | [PR #20222](https://github.com/microsoft/azure-pipelines-tasks/pull/20222) | 2024-08-05 |
 | NuGetInstaller V0 | [PR #20222](https://github.com/microsoft/azure-pipelines-tasks/pull/20222) | 2024-08-05 |


### PR DESCRIPTION
### **Context**
[AB#2363038](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2363038)
PR updates the deprecation.md file to track list of deprecated tasks, their deprecation date and the PR they were deprecated in.
Related PR: https://github.com/microsoft/azure-pipelines-tasks/pull/21902

---

### **Task Name**
NA

---

### **Description**
Updated Deprecation.md to track NodeToolV0 deprecation.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
NA. 

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No - updates to markdown file no task functionality changed

---

### **Logging Added/Updated** (Yes/No)
NA

--- 

### **Telemetry Added/Updated** (Yes/No) 
NA

---

### **Rollback Scenario and Process** (Yes/No)
- Revert PR to rollback changes. However this just a documentation update please revert https://github.com/microsoft/azure-pipelines-tasks/pull/21902 to revert task changes

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
