### PR TITLE
Fix command execution in bump-task-version hook to use bash explicitly

### DIFF
--- a/.github/hooks/bump-task-version.json
+++ b/.github/hooks/bump-task-version.json
@@ -3,7 +3,7 @@
     "PreToolUse": [
       {
         "type": "command",
-        "command": ".github/hooks/bump-task-version.sh",
+        "command": "bash .github/hooks/bump-task-version.sh",
         "timeout": 10
       }
     ]


### PR DESCRIPTION
### **Context**
This PR fixes the skill execution to use bash explicitly.
On Windows, running the Copilot CLI tool_use every time opens the shell script in Notepad or the default editor