### PR TITLE
Fix findGlobalJsonFile boundary check for custom checkout paths (#21989)

### DIFF
--- a/Tasks/DotNetCoreCLIV2/Tests/L0.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/L0.ts
@@ -629,4 +629,32 @@ describe('DotNetCoreExe Suite', function () {
         assert.strictEqual(tr.errorIssues.length, 0);
     });
 
+    it('finds global.json when workingDirectory is outside Build.SourcesDirectory but inside Agent.BuildDirectory (issue #21989)', async () => {
+        const tp = path.join(__dirname, './TestCommandTests/runTestsWithWorkingDirOutsideSourcesDir.js');
+        const tr = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        assert(tr.succeeded, 'task should succeed when global.json found via Agent.BuildDirectory fallback');
+        assert.strictEqual(tr.errorIssues.length, 0);
+
+        // Verify the fallback was used
+        assert(
+            tr.stdout.indexOf('Using Agent.BuildDirectory') >= 0,
+            'should log that Agent.BuildDirectory fallback was used'
+        );
+
+        // Verify global.json was found
+        assert(
+            tr.stdout.indexOf('Found global.json') >= 0,
+            'should discover global.json via the fallback boundary'
+        );
+
+        // Verify --solution flag was added (MTP detected)
+        assert(
+            tr.stdout.indexOf('--solution') >= 0,
+            'should add --solution flag when MTP is detected via fallback'
+        );
+    });
+
 });

--- a/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/runTestsWithWorkingDirOutsideSourcesDir.ts
+++ b/Tasks/DotNetCoreCLIV2/Tests/TestCommandTests/runTestsWithWorkingDirOutsideSourcesDir.ts
@@ -1,0 +1,81 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import util = require('../DotnetMockHelper');
+
+// Simulate multi-repo checkout scenario (issue #21989):
+//   Build.SourcesDirectory         = c:\agent\work\1\s          (default, stays in multi-repo)
+//   System.DefaultWorkingDirectory = c:\agent\work\1\s          (same in multi-repo)
+//   Agent.BuildDirectory           = c:\agent\work\1
+//   workingDirectory               = c:\agent\work\1\repository (custom checkout path)
+//
+// global.json with MTP config is at c:\agent\work\1\repository\global.json
+// The fix should find it via the Agent.BuildDirectory fallback and add --solution.
+
+const buildDir = path.join('c:\\agent', 'work', '1');
+const sourcesDir = path.join(buildDir, 's');
+const repoDir = path.join(buildDir, 'repository');
+const dotnetPath = path.join('path', 'dotnet');
+
+const projectPath = path.join(repoDir, 'MySolution.slnx');
+const globalJsonPath = path.join(repoDir, 'global.json');
+
+const taskPath = path.join(__dirname, '../..', 'dotnetcore.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const nmh: util.DotnetMockHelper = new util.DotnetMockHelper(tmr);
+
+// Override env vars to simulate multi-repo checkout
+process.env['BUILD_SOURCESDIRECTORY'] = sourcesDir;
+process.env['SYSTEM_DEFAULTWORKINGDIRECTORY'] = sourcesDir;
+process.env['AGENT_BUILDDIRECTORY'] = buildDir;
+
+nmh.setNugetVersionInputDefault();
+
+tmr.setInput('command', 'test');
+tmr.setInput('projects', projectPath);
+tmr.setInput('publishTestResults', 'false');
+tmr.setInput('workingDirectory', repoDir);
+
+const answers: ma.TaskLibAnswers = {
+    osType: {},
+    checkPath: {
+        [projectPath]: true,
+        [dotnetPath]: true
+    },
+    which: {
+        dotnet: dotnetPath
+    },
+    exec: {
+        [`${dotnetPath} test --solution ${projectPath}`]: { code: 0, stdout: '', stderr: '' },
+        [`"${dotnetPath}" test --solution "${projectPath}"`]: { code: 0, stdout: '', stderr: '' }
+    },
+    exist: {
+        [globalJsonPath]: true
+    },
+    stats: {
+        [projectPath]: { isFile: true }
+    },
+    findMatch: {
+        [projectPath]: [projectPath]
+    }
+};
+
+nmh.setAnswers(answers);
+
+nmh.registerNugetUtilityMock([projectPath]);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+
+const fs = require('fs');
+const fsClone = { ...fs };
+
+fsClone.readFileSync = function (filePath: string) {
+    if (filePath === globalJsonPath) {
+        return '{"test":{"runner":"Microsoft.Testing.Platform"}}';
+    }
+    return fs.readFileSync(filePath);
+};
+
+tmr.registerMock('fs', fsClone);
+tmr.run();

--- a/Tasks/DotNetCoreCLIV2/dotnetcore.ts
+++ b/Tasks/DotNetCoreCLIV2/dotnetcore.ts
@@ -147,7 +147,7 @@ export class dotNetExe {
     }
 
     private findGlobalJsonFile(): string | null {
-        const repoRoot =
+        let repoRoot =
             path.resolve(
                 tl.getVariable('Build.SourcesDirectory') ||
                 tl.getVariable('System.DefaultWorkingDirectory') ||
@@ -158,10 +158,34 @@ export class dotNetExe {
 
         tl.debug(`Searching for global.json starting in '${searchDir}' and ending at '${repoRoot}'.`);
 
-        const relStart = path.relative(repoRoot, searchDir);
-        if (relStart.startsWith('..') || path.isAbsolute(relStart)) {
-            tl.debug(`Working directory '${searchDir}' is outside repo root '${repoRoot}'. Skipping search.`);
-            return null;
+        const isInside = (dir: string, root: string): boolean => {
+            const rel = path.relative(root, dir);
+            return !rel.startsWith('..') && !path.isAbsolute(rel);
+        };
+
+        if (!isInside(searchDir, repoRoot)) {
+            const fallbacks: { name: string; variable: string }[] = [
+                { name: 'System.DefaultWorkingDirectory', variable: tl.getVariable('System.DefaultWorkingDirectory') || '' },
+                { name: 'Agent.BuildDirectory', variable: tl.getVariable('Agent.BuildDirectory') || '' }
+            ];
+
+            let found = false;
+            for (const fb of fallbacks) {
+                if (fb.variable) {
+                    const altRoot = path.resolve(fb.variable);
+                    if (isInside(searchDir, altRoot)) {
+                        tl.debug(`Working directory '${searchDir}' is outside Build.SourcesDirectory '${repoRoot}'. Using ${fb.name} '${altRoot}' as search boundary.`);
+                        repoRoot = altRoot;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!found) {
+                tl.debug(`Working directory '${searchDir}' is outside all known root directories. Skipping global.json search.`);
+                return null;
+            }
         }
 
         while (true) {

--- a/Tasks/DotNetCoreCLIV2/task.json
+++ b/Tasks/DotNetCoreCLIV2/task.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 271,
+    "Minor": 273,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/DotNetCoreCLIV2/task.loc.json
+++ b/Tasks/DotNetCoreCLIV2/task.loc.json
@@ -17,7 +17,7 @@
   "demands": [],
   "version": {
     "Major": 2,
-    "Minor": 271,
+    "Minor": 273,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
### **Context**
 Fixes https://github.com/microsoft/azure-pipelines-tasks/issues/21989
 
 Regression introduced in v2.271 by PR #21892 ("fix global.json lookup at repository root"). Users running `dotnet test` with 
Microsoft Testing Platform (MTP) and `.slnx` files get failures when using custom checkout paths (e.g., `checkout: self` with `path:` 
in multi-repo pipelines).
 
 ---
 
 ### **Task Name**
 DotNetCoreCLIV2
 
 ---
 
 ### **Description**
 `findGlobalJsonFile()` uses `Build.SourcesDirectory` as the upper boundary when walking up from `workingDirectory` to find 
`global.json`. With custom checkout paths (multi-repo checkout or `checkout: self` with `path:`), `workingDirectory` can resolve 
outside `Build.SourcesDirectory`, causing the function to return `null`. This makes MTP detection fail, so the `--solution` flag is 
not added to `dotnet test`, which newer .NET SDKs require for MTP projects.
 
 **Fix:** Add a fallback chain for the search boundary:
 1. `Build.SourcesDirectory` (default — works for standard checkout)
 2. `System.DefaultWorkingDirectory` (covers single-checkout with custom path)
 3. `Agent.BuildDirectory` (covers multi-repo checkout where both above stay at `/s`)
 
 ---
 
 ### **Risk Assessment** (Low)
 - The fix only changes behavior when `workingDirectory` is already outside `Build.SourcesDirectory` (currently broken — returns 
`null`). No change to existing working scenarios.
 - Fallback boundaries are progressively wider but all scoped to the pipeline's build directory.
 - All 50 existing unit tests pass unchanged.
 
 ---
 
 ### **Change Behind Feature Flag** (No)
 This is a bug fix for a regression. The current behavior (returning `null` when workingDirectory is outside SourcesDirectory) is 
always wrong — there is no scenario where the broken behavior is desirable. A feature flag would leave affected users broken.
 
 ---
 
 ### **Tech Design / Approach**
 - `findGlobalJsonFile()` boundary check now tries three well-known pipeline variables in order: `Build.SourcesDirectory` → 
`System.DefaultWorkingDirectory` → `Agent.BuildDirectory`
 - Each is progressively wider but still scoped to the current build
 - The bottom-up search logic (while loop walking up directories) is unchanged
 - `Agent.BuildDirectory` is the tightest safe boundary that covers all possible checkout locations
 
 ---
 
 ### **Documentation Changes Required** (No)
 No user-facing documentation changes needed. The fix restores expected behavior.
 
 ---
 
 ### **Unit Tests Added or Updated** (Yes)
 - **New test:** `runTestsWithWorkingDirOutsideSourcesDir.ts` — simulates the exact multi-repo checkout scenario from issue #21989 
with `Build.SourcesDirectory`, `System.DefaultWorkingDirectory`, and `Agent.BuildDirectory` all set to different values
 - **Updated:** `L0.ts` — added test case verifying `Agent.BuildDirectory` fallback is used, `global.json` is found, and `--solution` 
flag is added
 - All 50 tests pass (49 existing + 1 new)
 
 ---
 
 ### **Additional Testing Performed**
 - **Pipeline repro** with multi-repo checkout (`checkout: self` with `path: repository` + second repo) on Azure DevOps hosted agent:
   - Original DotNetCoreCLI@2 v2.271: confirmed bug — `global.json not found`, no `--solution` flag
   - Fixed task v2.273: `Agent.BuildDirectory` fallback used, `global.json` found, `--solution` added
   - Verified with user-provided debug logs matching the exact failure pattern
   - pipeline link: https://dev.azure.com/rishabhmalikOrg/Test%20Project/_build/results?buildId=2472&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=b801fef0-4998-5417-6df0-af092da60315
 
 ---
 
 ### **Logging Added/Updated** (Yes)
 - Debug messages added for each fallback step (which boundary was used and why)
 - No sensitive data exposed
 - Uses `tl.debug()` consistent with existing logging
 
 ---
 
 ### **Telemetry Added/Updated** (No)
 No new telemetry needed — this is a boundary check fix in an existing function.
 
 ---
 
 ### **Rollback Scenario and Process** (Yes)
 Rollback: revert this commit. The change is isolated to `findGlobalJsonFile()` in `dotnetcore.ts`. Version bump to 2.273.0 allows 
pinning to previous version if needed.
 
 ---
 
 ### **Dependency Impact Assessed and Regression Tested** (Yes)
 - No new dependencies added
 - All 50 unit tests pass
 - Only `dotnetcore.ts` modified (task logic), no changes to shared packages
 
 ---
 
 ### **Checklist**
 - [x] Related issue linked (https://github.com/microsoft/azure-pipelines-tasks/issues/21989)
 - [x] Task version was bumped (2.271.0 → 2.273.0)
 - [x] Verified the task behaves as expected
