### PR TITLE
UseDotNetV2: fix silent logging and add rollForward resolution output

### DIFF
--- a/Tasks/UseDotNetV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseDotNetV2/Strings/resources.resjson/en-US/resources.resjson
@@ -102,5 +102,7 @@
   "loc.messages.SupportPhaseNotPresentInChannel": "support-phase is not present in the channel with channel-version %s.",
   "loc.messages.DepricatedVersionNetCore": "NET Core version you specfied %s is out of support and will be removed from hosted agents soon. Please refer to https://aka.ms/dotnet-core-support for more information about the .NET support policy.",
   "loc.messages.ApplyingRollForwardPolicy": "Applying rollForward policy '%s' to version '%s', resolved version spec: '%s'",
-  "loc.messages.InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored."
+  "loc.messages.InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored.",
+  "loc.messages.ResolvedVersionFromGlobalJson": "Resolved SDK version '%s' from global.json (original version: '%s', rollForward: '%s')",
+  "loc.messages.InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json"
 }

--- a/Tasks/UseDotNetV2/globaljsonfetcher.ts
+++ b/Tasks/UseDotNetV2/globaljsonfetcher.ts
@@ -51,10 +51,11 @@ export class globalJsonFetcher {
                             channelSpec = resolvedSpec;
                         }
                     }
-                    tl.debug(tl.loc("ApplyingRollForwardPolicy", entry.rollForward, entry.version, matchingSpec || channelSpec));
+                    console.log(tl.loc("ApplyingRollForwardPolicy", entry.rollForward, entry.version, matchingSpec || channelSpec));
                 }
 
                 var versionInfo = await versionFetcher.getVersionInfo(channelSpec, null, "sdk", false, matchingSpec);
+                console.log(tl.loc("ResolvedVersionFromGlobalJson", versionInfo.getVersion(), entry.version, entry.rollForward || "disable"));
                 versionInformation.push(versionInfo);
             }
         }
@@ -71,7 +72,7 @@ export class globalJsonFetcher {
         return filePathsToGlobalJson.map(path => {
             var content = this.readGlobalJson(path);
             if (content != null) {
-                tl.loc("GlobalJsonSdkVersion", content.sdk.version, path);
+                console.log(tl.loc("GlobalJsonSdkVersion", content.sdk.version, path));
                 return {
                     version: content.sdk.version,
                     rollForward: content.sdk.rollForward
@@ -85,13 +86,13 @@ export class globalJsonFetcher {
 
     private readGlobalJson(path: string): GlobalJson | null {
         let globalJson: GlobalJson | null = null;
-        tl.loc("GlobalJsonFound", path);
+        console.log(tl.loc("GlobalJsonFound", path));
         try {
             let fileContent = fileSystem.readFileSync(path);
             // Since here is a buffer, we need to check length property to determine if it is empty.
             if (!fileContent.length) {
             // do not throw if globa.json is empty, task need not install any version in such case.
-                tl.loc("GlobalJsonIsEmpty", path);
+                tl.warning(tl.loc("GlobalJsonIsEmpty", path));
                 return null;
             }
 
@@ -102,7 +103,7 @@ export class globalJsonFetcher {
         }
 
         if (globalJson == null || globalJson.sdk == null || globalJson.sdk.version == null) {
-            tl.loc("FailedToReadGlobalJson", path);
+            tl.warning(tl.loc("FailedToReadGlobalJson", path));
             return null;
         }
 

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 271,
-    "Patch": 2
+    "Minor": 273,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"
@@ -219,6 +219,8 @@
     "SupportPhaseNotPresentInChannel": "support-phase is not present in the channel with channel-version %s.",
     "DepricatedVersionNetCore": "NET Core version you specfied %s is out of support and will be removed from hosted agents soon. Please refer to https://aka.ms/dotnet-core-support for more information about the .NET support policy.",
     "ApplyingRollForwardPolicy": "Applying rollForward policy '%s' to version '%s', resolved version spec: '%s'",
-    "InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored."
+    "InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored.",
+    "ResolvedVersionFromGlobalJson": "Resolved SDK version '%s' from global.json (original version: '%s', rollForward: '%s')",
+    "InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json"
   }
 }

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 271,
-    "Patch": 2
+    "Minor": 273,
+    "Patch": 0
   },
   "satisfies": [
     "DotNetCore"
@@ -219,6 +219,8 @@
     "SupportPhaseNotPresentInChannel": "ms-resource:loc.messages.SupportPhaseNotPresentInChannel",
     "DepricatedVersionNetCore": "ms-resource:loc.messages.DepricatedVersionNetCore",
     "ApplyingRollForwardPolicy": "ms-resource:loc.messages.ApplyingRollForwardPolicy",
-    "InvalidRollForwardPolicy": "ms-resource:loc.messages.InvalidRollForwardPolicy"
+    "InvalidRollForwardPolicy": "ms-resource:loc.messages.InvalidRollForwardPolicy",
+    "ResolvedVersionFromGlobalJson": "ms-resource:loc.messages.ResolvedVersionFromGlobalJson",
+    "InstallingFromGlobalJson": "ms-resource:loc.messages.InstallingFromGlobalJson"
   }
 }

--- a/Tasks/UseDotNetV2/usedotnet.ts
+++ b/Tasks/UseDotNetV2/usedotnet.ts
@@ -135,6 +135,7 @@ async function installDotNet(
         let versionsToInstall: VersionInfo[] = await globalJsonFetcherInstance.GetVersions();
         for (let index = 0; index < versionsToInstall.length; index++) {
             const version = versionsToInstall[index];
+            console.log(tl.loc("InstallingFromGlobalJson", version.getVersion()));
             let url = versionFetcher.getDownloadUrl(version);
             if (!dotNetCoreInstaller.isVersionInstalled(version.getVersion())) {
                 await dotNetCoreInstaller.downloadAndInstall(version, url);


### PR DESCRIPTION
### **Context**
Follow-up to #21860. Several `tl.loc()` calls in `globaljsonfetcher.ts` were silently discarded (not wrapped in any output function), and the rollForward resolution path didn't log enough for users to understand which SDK version was picked and why.

---

### **Task Name**
UseDotNetV2

---

### **Description**
- Fixed four `tl.loc()` calls in `globaljsonfetcher.ts` that produced no output because they weren't wrapped in `console.log()` or `tl.warning()`: `GlobalJsonFound`, `GlobalJsonSdkVersion`, `GlobalJsonIsEmpty`, `FailedToReadGlobalJson`.
- Promoted `ApplyingRollForwardPolicy` from `tl.debug()` to `console.log()` so users can see the policy and widened spec without enabling debug mode.
- Added two new log messages: `ResolvedVersionFromGlobalJson` (logs which SDK version was resolved, the original version, and the rollForward policy) and `InstallingFromGlobalJson` (logs each version about to be installed from the global.json path).

---

### **Risk Assessment** (Low)
Logging-only changes. No behavior change to version resolution or installation.

---

### **Change Behind Feature Flag** (No)
These are log messages. No flag needed.

---

### **Tech Design / Approach**
Wrap bare `tl.loc()` calls, promote one `tl.debug()`, add two new localized strings. No new dependencies or architectural changes.

---

### **Documentation Changes Required** (No)

---

### **Unit Tests Added or Updated** (No)
No new tests needed; these are log statements. All 56 existing tests still pass.

---

### **Additional Testing Performed**
Built with `node make.js build --task UseDotNetV2 --BypassNpmAudit`. Full test suite passes (`node make.js test --task UseDotNetV2`).

---

### **Logging Added/Updated** (Yes)
- Fixed four silent `tl.loc()` calls (bugs).
- Promoted `ApplyingRollForwardPolicy` to user-visible output.
- Added `ResolvedVersionFromGlobalJson` and `InstallingFromGlobalJson`.
- No sensitive data exposed. Uses `console.log()` (info) and `tl.warning()` correctly.

---

### **Telemetry Added/Updated** (No)
Existing telemetry in `versionfetcher.ts` already emits `userVersion` and `resolvedVersion`.

---

### **Rollback Scenario and Process** (Yes)
Revert the commit or pin task version to 2.271.x.

---

### **Dependency Impact Assessed and Regression Tested** (Yes)
No new dependencies. All 56 tests pass.

---

### **Checklist**
- [x] Task version was bumped (2.271.2 → 2.273.0)
- [x] Verified the task behaves as expected