### PR TITLE
Fix Invoke‑Expression usage in ServiceTypeHealthPolicyMap and add tests

### DIFF
--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -1,3 +1,83 @@
+function ConvertTo-ServiceTypeHealthPolicyMap
+{
+    <#
+    .SYNOPSIS
+    Safely parses a ServiceTypeHealthPolicyMap string into a hashtable without using Invoke-Expression.
+
+    .DESCRIPTION
+    Parses a string in the format @{ "ServiceTypeName" = "MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices" }
+    into a PowerShell hashtable. Only string operations are used — no code evaluation occurs.
+
+    .PARAMETER PolicyMapString
+    The string to parse. Expected format: @{ "TypeName1" = "N,N,N"; "TypeName2" = "N,N,N" }
+    #>
+
+    Param (
+        [Parameter(Mandatory = $true)]
+        [string]$PolicyMapString
+    )
+
+    $result = @{}
+
+    # Remove leading/trailing whitespace
+    $trimmed = $PolicyMapString.Trim()
+
+    # Strip the @{ } wrapper
+    if ($trimmed -match '^\s*@\s*\{(?<inner>.*)\}\s*$')
+    {
+        $inner = $Matches['inner'].Trim()
+    }
+    else
+    {
+        throw "Invalid ServiceTypeHealthPolicyMap format. Expected format: @{ `"ServiceTypeName`" = `"MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices`" }"
+    }
+
+    # Empty hashtable is valid
+    if ([string]::IsNullOrWhiteSpace($inner))
+    {
+        return $result
+    }
+
+    # Split entries by semicolons
+    $entries = $inner -split '\s*;\s*'
+
+    foreach ($entry in $entries)
+    {
+        $entry = $entry.Trim()
+        if ([string]::IsNullOrWhiteSpace($entry))
+        {
+            continue
+        }
+
+        # Match: "key" = "value" or 'key' = 'value' or key = "value" (with flexible quoting)
+        if ($entry -match '^\s*(?:"(?<key>[^"]+)"|''(?<key>[^'']+)''|(?<key>[^\s=]+))\s*=\s*(?:"(?<val>[^"]+)"|''(?<val>[^'']+)''|(?<val>[^\s;]+))\s*$')
+        {
+            $key = $Matches['key']
+            $val = $Matches['val']
+
+            # Validate the key contains only valid service type name characters
+            if ($key -notmatch '^[a-zA-Z0-9._\-]+$')
+            {
+                throw "Invalid service type name '$key'. Service type names may only contain letters, digits, dots, hyphens, and underscores."
+            }
+
+            # Validate the value is three comma-separated integers (0-100)
+            if ($val -notmatch '^\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*$')
+            {
+                throw "Invalid health policy value '$val' for service type '$key'. Expected format: MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices (e.g., '5,10,15')"
+            }
+
+            $result[$key] = $val
+        }
+        else
+        {
+            throw "Invalid entry '$entry' in ServiceTypeHealthPolicyMap. Expected format: `"ServiceTypeName`" = `"N,N,N`""
+        }
+    }
+
+    return $result
+}
+
 function Publish-UpgradedServiceFabricApplication
 {
     <#
@@ -310,7 +390,15 @@ function Publish-UpgradedServiceFabricApplication
             $serviceTypeHealthPolicyMap = $UpgradeParameters["ServiceTypeHealthPolicyMap"]
             if ($serviceTypeHealthPolicyMap -and $serviceTypeHealthPolicyMap -is [string])
             {
-                $UpgradeParameters["ServiceTypeHealthPolicyMap"] = Invoke-Expression $serviceTypeHealthPolicyMap
+                $useSafeParser = Get-VstsPipelineFeature -FeatureName 'SfSafeParser'
+                if (-not $useSafeParser)
+                {
+                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = Invoke-Expression $serviceTypeHealthPolicyMap
+                }
+                else
+                {
+                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
+                }
             }
 
             Write-Host (Get-VstsLocString -Key SFSDK_StartAppUpgrade)

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -23,7 +23,7 @@ function ConvertTo-ServiceTypeHealthPolicyMap
     $trimmed = $PolicyMapString.Trim()
 
     # Strip the @{ } wrapper
-    if ($trimmed -match '^\s*@\s*\{(?<inner>.*)\}\s*$')
+    if ($trimmed -match '^\s*@\s*\{(?<inner>[\s\S]*)\}\s*$')
     {
         $inner = $Matches['inner'].Trim()
     }
@@ -38,8 +38,8 @@ function ConvertTo-ServiceTypeHealthPolicyMap
         return $result
     }
 
-    # Split entries by semicolons
-    $entries = $inner -split '\s*;\s*'
+    # Split entries by semicolons or newlines
+    $entries = $inner -split '\s*[;\r\n]+\s*'
 
     foreach ($entry in $entries)
     {

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -412,7 +412,7 @@ function Publish-UpgradedServiceFabricApplication
                     }
                     catch
                     {
-                        Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorMessage $_.Exception.Message
+                        Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorData $_
                         throw
                     }
                 }

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -406,7 +406,15 @@ function Publish-UpgradedServiceFabricApplication
                 }
                 else
                 {
-                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
+                    try
+                    {
+                        $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
+                    }
+                    catch
+                    {
+                        Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorMessage $_.Exception.Message
+                        throw
+                    }
                 }
             }
 

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -67,6 +67,15 @@ function ConvertTo-ServiceTypeHealthPolicyMap
                 throw "Invalid health policy value '$val' for service type '$key'. Expected format: MaxPercentUnhealthyPartitionsPerService,MaxPercentUnhealthyReplicasPerPartition,MaxPercentUnhealthyServices (e.g., '5,10,15')"
             }
 
+            $nums = @([int]$Matches[1], [int]$Matches[2], [int]$Matches[3])
+            foreach ($n in $nums)
+            {
+                if ($n -lt 0 -or $n -gt 100)
+                {
+                    throw "Invalid health policy value '$val' for service type '$key'. Each percentage must be between 0 and 100."
+                }
+            }
+
             $result[$key] = $val
         }
         else

--- a/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
+++ b/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param()
+
+. $PSScriptRoot\..\..\..\Tests\lib\Initialize-Test.ps1
+. $PSScriptRoot\..\ServiceFabricSDK\Publish-UpgradedServiceFabricApplication.ps1
+
+# Test 1: Valid single entry with double quotes
+$input1 = '@{ "ServiceTypeName01" = "5,10,15" }'
+$result1 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input1
+Assert-AreEqual "5,10,15" $result1["ServiceTypeName01"] "Single entry parsing failed"
+
+# Test 2: Valid multiple entries
+$input2 = '@{ "ServiceTypeName01" = "5,10,5"; "ServiceTypeName02" = "5,5,5" }'
+$result2 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input2
+Assert-AreEqual "5,10,5" $result2["ServiceTypeName01"] "Multi-entry key1 failed"
+Assert-AreEqual "5,5,5" $result2["ServiceTypeName02"] "Multi-entry key2 failed"
+
+# Test 3: Empty hashtable
+$input3 = '@{}'
+$result3 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input3
+Assert-AreEqual 0 $result3.Count "Empty hashtable should have 0 entries"
+
+# Test 4: Empty hashtable with whitespace
+$input4 = '@{  }'
+$result4 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input4
+Assert-AreEqual 0 $result4.Count "Empty hashtable with whitespace should have 0 entries"
+
+# Test 5: Single quotes
+$input5 = "@{ 'WebFrontEnd' = '5,10,5' }"
+$result5 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input5
+Assert-AreEqual "5,10,5" $result5["WebFrontEnd"] "Single-quoted entry parsing failed"
+
+# Test 6: Bare word key
+$input6 = '@{ MyServiceType = "0,5,10" }'
+$result6 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input6
+Assert-AreEqual "0,5,10" $result6["MyServiceType"] "Bare word key parsing failed"
+
+# Test 7: Key with dots and hyphens
+$input7 = '@{ "My.Service-Type_v2" = "10,20,30" }'
+$result7 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input7
+Assert-AreEqual "10,20,30" $result7["My.Service-Type_v2"] "Key with special chars failed"
+
+# Test 8: Whitespace variations
+$input8 = '@{  "Svc1"  =  "1,2,3"  ;  "Svc2"  =  "4,5,6"  }'
+$result8 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input8
+Assert-AreEqual "1,2,3" $result8["Svc1"] "Whitespace variation key1 failed"
+Assert-AreEqual "4,5,6" $result8["Svc2"] "Whitespace variation key2 failed"
+
+# Test 9: Values with spaces around commas
+$input9 = '@{ "Svc" = "5, 10, 15" }'
+$result9 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9
+Assert-AreEqual "5, 10, 15" $result9["Svc"] "Spaces around commas should be preserved"
+
+# Test 10: Command injection attempt should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{}; Write-Host "RCE: $(whoami)"; $token = $env:SYSTEM_ACCESSTOKEN'
+} "*Invalid ServiceTypeHealthPolicyMap format*"
+
+# Test 11: Subexpression injection in key should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "$(whoami)" = "5,10,5" }'
+} "*Invalid service type name*"
+
+# Test 12: Invalid value format should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "notanumber" }'
+} "*Invalid health policy value*"
+
+# Test 13: Missing @{ } wrapper should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '"Svc" = "5,10,5"'
+} "*Invalid ServiceTypeHealthPolicyMap format*"
+
+# Test 14: Pipeline injection in value should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "5,10,5 | whoami" }'
+} "*Invalid health policy value*"
+
+# Test 15: Semicolon injection in value via quotes should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "5,10,5"; Remove-Item -Recurse C:\ }'
+} "*Invalid entry*"

--- a/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
+++ b/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
@@ -51,6 +51,30 @@ $input9 = '@{ "Svc" = "5, 10, 15" }'
 $result9 = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9
 Assert-AreEqual "5, 10, 15" $result9["Svc"] "Spaces around commas should be preserved"
 
+# Test 9a: Newline-separated entries (multi-line YAML input)
+$input9a = "@{`n`"ServiceType1`" = `"5,10,15`"`n`"ServiceType2`" = `"1,2,3`"`n}"
+$result9a = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9a
+Assert-AreEqual "5,10,15" $result9a["ServiceType1"] "Newline-separated key1 failed"
+Assert-AreEqual "1,2,3" $result9a["ServiceType2"] "Newline-separated key2 failed"
+
+# Test 9b: Newline-separated with indentation (YAML | block style)
+$input9b = "@{`n  `"WebFrontEnd`" = `"5,10,15`"`n  `"BackEnd`" = `"0,5,10`"`n}"
+$result9b = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9b
+Assert-AreEqual "5,10,15" $result9b["WebFrontEnd"] "YAML block key1 failed"
+Assert-AreEqual "0,5,10" $result9b["BackEnd"] "YAML block key2 failed"
+
+# Test 9c: Mixed semicolons and newlines
+$input9c = "@{`n`"Svc1`" = `"1,2,3`"; `"Svc2`" = `"4,5,6`"`n`"Svc3`" = `"7,8,9`"`n}"
+$result9c = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9c
+Assert-AreEqual "1,2,3" $result9c["Svc1"] "Mixed separators key1 failed"
+Assert-AreEqual "4,5,6" $result9c["Svc2"] "Mixed separators key2 failed"
+Assert-AreEqual "7,8,9" $result9c["Svc3"] "Mixed separators key3 failed"
+
+# Test 9d: Unquoted integer values (bare-word value)
+$input9d = '@{ "Svc" = 5,10,15 }'
+$result9d = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $input9d
+Assert-AreEqual "5,10,15" $result9d["Svc"] "Unquoted integer value parsing failed"
+
 # Test 10: Command injection attempt should throw
 Assert-Throws {
     ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{}; Write-Host "RCE: $(whoami)"; $token = $env:SYSTEM_ACCESSTOKEN'

--- a/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
+++ b/Tasks/ServiceFabricDeployV1/Tests/ConvertToServiceTypeHealthPolicyMap.ps1
@@ -66,6 +66,20 @@ Assert-Throws {
     ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "notanumber" }'
 } "*Invalid health policy value*"
 
+# Test 12a: Out-of-range percentage (>100) should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "5,101,15" }'
+} "*Each percentage must be between 0 and 100*"
+
+# Test 12b: Out-of-range percentage (999) should throw
+Assert-Throws {
+    ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "999,0,0" }'
+} "*Each percentage must be between 0 and 100*"
+
+# Test 12c: Boundary value 100 should succeed
+$result_boundary = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '@{ "Svc" = "0,100,50" }'
+Assert-AreEqual "0,100,50" $result_boundary["Svc"] "Boundary value 100 should be accepted"
+
 # Test 13: Missing @{ } wrapper should throw
 Assert-Throws {
     ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString '"Svc" = "5,10,5"'

--- a/Tasks/ServiceFabricDeployV1/Tests/L0.ts
+++ b/Tasks/ServiceFabricDeployV1/Tests/L0.ts
@@ -9,83 +9,86 @@ import path = require('path');
 var psr = null;
 
 describe('ServiceFabricDeploy Suite', function () {
-    this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
+  this.timeout(parseInt(process.env.TASK_TEST_TIMEOUT) || 20000);
 
-    before((done) => {
-        if (psm.testSupported()) {
-            psr = new psm.PSRunner();
-            psr.start();
-        }
-
-        done();
-    });
-
-    after(function () {
-        if (psr) {
-            psr.kill();
-        }
-    });
-
+  before(done => {
     if (psm.testSupported()) {
-        it('AAD deploy', (done) => {
-            psr.run(path.join(__dirname, 'AadDeploy.ps1'), done);
-        })
-        it('Certificate deploy', (done) => {
-            psr.run(path.join(__dirname, 'CertDeploy.ps1'), done);
-        })
-        it('No auth deploy', (done) => {
-            psr.run(path.join(__dirname, 'NoAuthDeploy.ps1'), done);
-        })
-        it('Windows auth deploy', (done) => {
-            psr.run(path.join(__dirname, 'WindowsAuthDeploy.ps1'), done);
-        })
-        it('Certificate deploy with Docker support', (done) => {
-            psr.run(path.join(__dirname, 'CertDeployWithDocker.ps1'), done);
-        })
-        it('Certificate deploy with Docker support and multiple Thumbprints', (done) => {
-            psr.run(path.join(__dirname, 'CertDeployWithDockerMultiThumbprint.ps1'), done);
-        })
-        it('Deploy with diff pkg', (done) => {
-            psr.run(path.join(__dirname, 'CreateDiffPkg.ps1'), done);
-        })
-        it('Copy application package should retry', (done) => {
-            psr.run(path.join(__dirname, 'CopyApplicationPackageShouldRetry.ps1'), done);
-        })
-        it('Copy application package should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'CopyApplicationPackageShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Get appliction type should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'GetApplicationTypeShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Register application type should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'RegisterApplicationTypeShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Register application type should retry', (done) => {
-            psr.run(path.join(__dirname, 'RegisterApplicationTypeShouldRetry.ps1'), done);
-        })
-        it('Unregister application type should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'UnregisterApplicationTypeShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Unregister application type should retry', (done) => {
-            psr.run(path.join(__dirname, 'UnregisterApplicationTypeShouldRetry.ps1'), done);
-        })
-        it('Create application type should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'CreateApplicationShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Create application type should retry', (done) => {
-            psr.run(path.join(__dirname, 'CreateApplicationShouldRetry.ps1'), done);
-        })
-        it('Remove application type should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'RemoveApplicationShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Remove application type should retry', (done) => {
-            psr.run(path.join(__dirname, 'RemoveApplicationShouldRetry.ps1'), done);
-        })
-        it('Start application upgrade should retry till success', (done) => {
-            psr.run(path.join(__dirname, 'StartApplicationUpgradeShouldRetryTillSuccess.ps1'), done);
-        })
-        it('Start application upgrade should retry', (done) => {
-            psr.run(path.join(__dirname, 'StartApplicationUpgradeShouldRetry.ps1'), done);
-        })
+      psr = new psm.PSRunner();
+      psr.start();
     }
+
+    done();
+  });
+
+  after(function () {
+    if (psr) {
+      psr.kill();
+    }
+  });
+
+  if (psm.testSupported()) {
+    it('AAD deploy', done => {
+        psr.run(path.join(__dirname, 'AadDeploy.ps1'), done);
+    });
+    it('Certificate deploy', done => {
+        psr.run(path.join(__dirname, 'CertDeploy.ps1'), done);
+    });
+    it('No auth deploy', done => {
+        psr.run(path.join(__dirname, 'NoAuthDeploy.ps1'), done);
+    });
+    it('Windows auth deploy', done => {
+        psr.run(path.join(__dirname, 'WindowsAuthDeploy.ps1'), done);
+    });
+    it('Certificate deploy with Docker support', done => {
+        psr.run(path.join(__dirname, 'CertDeployWithDocker.ps1'), done);
+    });
+    it('Certificate deploy with Docker support and multiple Thumbprints', done => {
+        psr.run(path.join(__dirname, 'CertDeployWithDockerMultiThumbprint.ps1'), done);
+    });
+    it('Deploy with diff pkg', done => {
+        psr.run(path.join(__dirname, 'CreateDiffPkg.ps1'), done);
+    });
+    it('Copy application package should retry', done => {
+        psr.run(path.join(__dirname, 'CopyApplicationPackageShouldRetry.ps1'), done);
+    });
+    it('Copy application package should retry till success', done => {
+        psr.run(path.join(__dirname, 'CopyApplicationPackageShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Get appliction type should retry till success', done => {
+        psr.run(path.join(__dirname, 'GetApplicationTypeShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Register application type should retry till success', done => {
+        psr.run(path.join(__dirname, 'RegisterApplicationTypeShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Register application type should retry', done => {
+        psr.run(path.join(__dirname, 'RegisterApplicationTypeShouldRetry.ps1'), done);
+    });
+    it('Unregister application type should retry till success', done => {
+        psr.run(path.join(__dirname, 'UnregisterApplicationTypeShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Unregister application type should retry', done => {
+        psr.run(path.join(__dirname, 'UnregisterApplicationTypeShouldRetry.ps1'), done);
+    });
+    it('Create application type should retry till success', done => {
+        psr.run(path.join(__dirname, 'CreateApplicationShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Create application type should retry', done => {
+        psr.run(path.join(__dirname, 'CreateApplicationShouldRetry.ps1'), done);
+    });
+    it('Remove application type should retry till success', done => {
+        psr.run(path.join(__dirname, 'RemoveApplicationShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Remove application type should retry', done => {
+        psr.run(path.join(__dirname, 'RemoveApplicationShouldRetry.ps1'), done);
+    });
+    it('Start application upgrade should retry till success', done => {
+        psr.run(path.join(__dirname, 'StartApplicationUpgradeShouldRetryTillSuccess.ps1'), done);
+    });
+    it('Start application upgrade should retry', done => {
+        psr.run(path.join(__dirname, 'StartApplicationUpgradeShouldRetry.ps1'), done);
+    });
+    it('ConvertTo-ServiceTypeHealthPolicyMap parsing', done => {
+        psr.run(path.join(__dirname, 'ConvertToServiceTypeHealthPolicyMap.ps1'), done);
+    });
+  }
 });

--- a/Tasks/ServiceFabricDeployV1/make.json
+++ b/Tasks/ServiceFabricDeployV1/make.json
@@ -17,7 +17,7 @@
         "nugetv2": [
             {
                 "name": "VstsTaskSdk",
-                "version": "0.11.0",
+                "version": "0.21.0",
                 "repository": "https://www.powershellgallery.com/api/v2/",
                 "cp": [
                     {

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 228,
+        "Minor": 273,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 228,
+    "Minor": 273,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
### **Context**
[AB#2378793](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2378793)

---

### **Task Name**
ServiceFabricDeployV1

---

### **Description**
Added `ConvertTo-ServiceTypeHealthPolicyMap` — a safe string-only parser that replaces `Invoke-Expression` for parsing the `ServiceTypeHealthPolicyMap` input. It validates keys (alphanumeric, dots, hyphens, underscores only) and values (three comma-separated integers, each 0–100). Supports semicolons, newlines, and mixed separators to handle multi-line YAML | block inputs.
Gated the change behind the `SfSafeParser` feature flag. When the FF is off, the old `Invoke-Expression` path is used.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Yes (DistributedTask_Tasks_SfSafeParser)

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
Added `ConvertToServiceTypeHealthPolicyMap.ps1` with 21 test cases (13 positive, 8 negative) registered in `L0.ts`. 

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
