### PR TITLE
BicepDeployV0: defer tl.loc() until after setResourcePath

### DIFF
--- a/Tasks/BicepDeployV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/BicepDeployV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Bicep Deploy (Test)",
+  "loc.friendlyName": "Bicep Deploy",
   "loc.helpMarkDown": "[Learn more about this task](https://aka.ms/bicepdeploytaskreadme)",
   "loc.description": "Deploy and Manage Azure Resources using Bicep Files",
   "loc.instanceNameFormat": "Bicep $(operation) $(name)",

--- a/Tasks/BicepDeployV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/BicepDeployV0/Strings/resources.resjson/en-US/resources.resjson
@@ -1,5 +1,5 @@
 {
-  "loc.friendlyName": "Bicep Deploy",
+  "loc.friendlyName": "Bicep Deploy (Test)",
   "loc.helpMarkDown": "[Learn more about this task](https://aka.ms/bicepdeploytaskreadme)",
   "loc.description": "Deploy and Manage Azure Resources using Bicep Files",
   "loc.instanceNameFormat": "Bicep $(operation) $(name)",
@@ -91,5 +91,10 @@
   "loc.messages.InvalidChangeType": "Invalid change type: %s",
   "loc.messages.UnknownPropertyChangeType": "Unknown property change type: %s.",
   "loc.messages.InvalidJsonValue": "Invalid JSON value: %s",
-  "loc.messages.FailedToLogout": "The following error occurred while logging out: %s"
+  "loc.messages.FailedToLogout": "The following error occurred while logging out: %s",
+  "loc.messages.SettingAzureCloud": "Setting active cloud to: %s",
+  "loc.messages.LoginFailed": "Azure login failed",
+  "loc.messages.MSILoginFailed": "Azure login failed using Managed Service Identity",
+  "loc.messages.AuthSchemeNotSupported": "Auth Scheme %s is not supported",
+  "loc.messages.ErrorInSettingUpSubscription": "Error in setting up subscription"
 }

--- a/Tasks/BicepDeployV0/Tests/L0.ts
+++ b/Tasks/BicepDeployV0/Tests/L0.ts
@@ -1,5 +1,6 @@
 import assert = require("assert");
 import path = require("path");
+import * as cp from "child_process";
 import * as ttm from "azure-pipelines-task-lib/mock-test";
 
 // Uncomment to improve traces while testing
@@ -212,5 +213,26 @@ describe("stacks tests", function() {
       { name: 'intOutput', value: '42' },
       { name: 'objectOutput', value: '{"key1":"value1","key2":"value2"}' },
     ], this.test!.title);
+  });
+});
+
+// Verifies that nothing in the task graph calls tl.loc() at module-import time
+// (before tl.setResourcePath() runs). The mock-test harness stubs both
+// setResourcePath and loc to no-ops, so this regression is invisible to the
+// MockTestRunner-based tests above. Instead, we spawn a child node process
+// that requires the real (non-mocked) task-lib via ../logging and inspect
+// stdout for task-lib's "Resource file haven't been set" warning.
+describe("resource file loading", function() {
+  this.timeout(15000);
+
+  it("does not localize at import time", function() {
+    const probe = path.join(__dirname, "resourceFileProbe.js");
+    const result = cp.spawnSync(process.execPath, [probe], { encoding: "utf8" });
+
+    assert.strictEqual(result.status, 0, `probe exited non-zero: ${result.stderr}`);
+    assert(
+      !result.stdout.includes("Resource file haven't been set"),
+      `tl.setResourcePath() must run before any tl.loc() call.\nProbe stdout:\n${result.stdout}\nProbe stderr:\n${result.stderr}`,
+    );
   });
 });

--- a/Tasks/BicepDeployV0/Tests/resourceFileProbe.ts
+++ b/Tasks/BicepDeployV0/Tests/resourceFileProbe.ts
@@ -1,0 +1,12 @@
+// Probe script invoked as a child process by L0.ts.
+//
+// This script requires the real (non-mocked) `azure-pipelines-task-lib`
+// transitively via `../logging`. If `logging` (or any of its dependents)
+// invokes `tl.loc()` at module scope -- before `tl.setResourcePath()` runs --
+// task-lib emits a "Resource file haven't been set" warning to stdout. The
+// parent test inspects stdout to detect the regression.
+//
+// The probe deliberately does NOT call `tl.setResourcePath()` so any
+// module-scope localization attempt is observable.
+
+require('../logging');

--- a/Tasks/BicepDeployV0/logging.ts
+++ b/Tasks/BicepDeployV0/logging.ts
@@ -13,13 +13,17 @@ export class TaskLogger implements Logger {
     logError = (message: string) => logErrorRaw(colorize(message, Color.Red));
 }
 
-export const loggingMessageConfig: LoggingMessageConfig = {
+// NOTE: These are factory functions (not module-scoped consts) so that tl.loc()
+// is invoked only after main.ts calls tl.setResourcePath(). Building these objects
+// at import time would resolve every key before resources are loaded, producing
+// "Resource file haven't been set, can't find loc string for key: ..." warnings.
+export const createLoggingMessageConfig = (): LoggingMessageConfig => ({
     diagnosticsReturned: tl.loc('DiagnosticsReturned'),
     bicepCacheHit: (version: string, path: string) =>
         tl.loc('BicepCacheHit', version, path),
     bicepDownloading: (version: string) =>
         tl.loc('BicepDownloading', version),
-    requestFailedCorrelation: (correlationId: string | null) => 
+    requestFailedCorrelation: (correlationId: string | null) =>
         tl.loc('RequestFailedCorrelation', correlationId),
     filesIgnoredForDelete: tl.loc('FilesIgnoredForDelete'),
     startingOperation: (type: string, operation: string, scope: string, scopedId: string, name: string) =>
@@ -28,9 +32,9 @@ export const loggingMessageConfig: LoggingMessageConfig = {
         tl.loc('UsingTemplateFile', templateFile),
     usingParametersFile: (parametersFile: string) =>
         tl.loc('UsingParametersFile', parametersFile),
-};
+});
 
-export const errorMessageConfig: ErrorMessageConfig = {
+export const createErrorMessageConfig = (): ErrorMessageConfig => ({
     // Handler errors
     createFailed: tl.loc('CreateFailed'),
     validationFailed: tl.loc('ValidationFailed'),
@@ -73,6 +77,6 @@ export const errorMessageConfig: ErrorMessageConfig = {
         tl.loc('InvalidChangeType', changeType),
     unknownPropertyChangeType: (propertyChangeType: string) => 
         tl.loc('UnknownPropertyChangeType', propertyChangeType),
-    invalidJsonValue: (value: unknown) => 
+    invalidJsonValue: (value: unknown) =>
         tl.loc('InvalidJsonValue', value),
-};
+});

--- a/Tasks/BicepDeployV0/main.ts
+++ b/Tasks/BicepDeployV0/main.ts
@@ -2,9 +2,11 @@ import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import { parseConfig, execute } from '@azure/bicep-deploy-common';
 import { TaskInputParameterNames, TaskInputReader, TaskOutputSetter } from './taskIO';
-import { TaskLogger, errorMessageConfig, loggingMessageConfig } from './logging';
+import { TaskLogger, createErrorMessageConfig, createLoggingMessageConfig } from './logging';
 import { AzureAuthenticationHelper } from './auth';
 import { TaskBicepCache } from './bicepCache';
+
+tl.setResourcePath(path.join(__dirname, 'task.json'));
 
 export async function run(): Promise<void> {
     const authHelper = new AzureAuthenticationHelper();
@@ -24,8 +26,16 @@ export async function run(): Promise<void> {
         // Login to Azure after validation passes
         await authHelper.loginAzure(connectedService);
 
-        // Execute the deployment or deployment stack operation
-        await execute(config, logger, outputSetter, bicepCache, errorMessageConfig, loggingMessageConfig);
+        // Execute the deployment or deployment stack operation. Build the message
+        // configs lazily so tl.loc() runs after tl.setResourcePath() above.
+        await execute(
+            config,
+            logger,
+            outputSetter,
+            bicepCache,
+            createErrorMessageConfig(),
+            createLoggingMessageConfig(),
+        );
         tl.setResult(tl.TaskResult.Succeeded, tl.loc('OperationSucceeded'));
     } catch (err: any) {
         const errorMessage = err instanceof Error ? err.message : String(err);
@@ -35,5 +45,4 @@ export async function run(): Promise<void> {
     }
 }
 
-tl.setResourcePath(path.join(__dirname, 'task.json'));
 run();

--- a/Tasks/BicepDeployV0/task.json
+++ b/Tasks/BicepDeployV0/task.json
@@ -395,7 +395,12 @@
     "InvalidChangeType": "Invalid change type: %s",
     "UnknownPropertyChangeType": "Unknown property change type: %s.",
     "InvalidJsonValue": "Invalid JSON value: %s",
-    "FailedToLogout": "The following error occurred while logging out: %s"
+    "FailedToLogout": "The following error occurred while logging out: %s",
+    "SettingAzureCloud": "Setting active cloud to: %s",
+    "LoginFailed": "Azure login failed",
+    "MSILoginFailed": "Azure login failed using Managed Service Identity",
+    "AuthSchemeNotSupported": "Auth Scheme %s is not supported",
+    "ErrorInSettingUpSubscription": "Error in setting up subscription"
   },
   "execution": {
     "Node24": {

--- a/Tasks/BicepDeployV0/task.json
+++ b/Tasks/BicepDeployV0/task.json
@@ -11,7 +11,7 @@
   "version": {
     "Major": 0,
     "Minor": 273,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Bicep $(operation) $(name)",

--- a/Tasks/BicepDeployV0/task.loc.json
+++ b/Tasks/BicepDeployV0/task.loc.json
@@ -398,7 +398,12 @@
     "InvalidChangeType": "ms-resource:loc.messages.InvalidChangeType",
     "UnknownPropertyChangeType": "ms-resource:loc.messages.UnknownPropertyChangeType",
     "InvalidJsonValue": "ms-resource:loc.messages.InvalidJsonValue",
-    "FailedToLogout": "ms-resource:loc.messages.FailedToLogout"
+    "FailedToLogout": "ms-resource:loc.messages.FailedToLogout",
+    "SettingAzureCloud": "ms-resource:loc.messages.SettingAzureCloud",
+    "LoginFailed": "ms-resource:loc.messages.LoginFailed",
+    "MSILoginFailed": "ms-resource:loc.messages.MSILoginFailed",
+    "AuthSchemeNotSupported": "ms-resource:loc.messages.AuthSchemeNotSupported",
+    "ErrorInSettingUpSubscription": "ms-resource:loc.messages.ErrorInSettingUpSubscription"
   },
   "execution": {
     "Node24": {

--- a/Tasks/BicepDeployV0/task.loc.json
+++ b/Tasks/BicepDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 273,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",


### PR DESCRIPTION
### **Context**
_Describe the context or motivation for this PR. Include links to any related Azure DevOps Work Items or GitHub issues._  
📌 [How to link to ADO Work Items](https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops)

logging.ts built the LoggingMessageConfig and ErrorMessageConfig objects at module-import time, calling tl.loc() before main.ts ran tl.setResourcePath(). On a real agent this caused 'Resource file haven't been set, can't find loc string for key: ...' warnings and raw-key fallback for every message.

Convert both consts to factory functions (createLoggingMessageConfig / createErrorMessageConfig) and invoke them inside run() after setResourcePath.

Add a Tests/resourceFileProbe.ts child script and a 'resource file loading' L0 test that spawns it with the real (non-mocked) task-lib and asserts no 'Resource file haven't been set' warning hits stdout. The mock-test harness stubs setResourcePath/loc to no-ops, so this regression is invisible to the existing MockTestRunner-based tests; the probe is the only guard.

BicepDeployV0 calls loginAzureRM from the shared azure-pipelines-tasks-azure-arm-rest/azCliUtility module, which issues tl.loc(...) calls for SettingAzureCloud, LoginFailed, MSILoginFailed, AuthSchemeNotSupported, and ErrorInSettingUpSubscription. Because tl.loc resolves keys against the consuming task's own resources and BicepDeployV0 never declared these keys, every run emitted ##[warning]Can't find loc string for key: ... — most visibly for LoginFailed and ErrorInSettingUpSubscription, which are passed eagerly to throwIfError(...) and therefore evaluated on every invocation regardless of whether login actually fails. This change adds the five missing keys to task.json, task.loc.json, and the en-US resources.resjson, matching the English wording already used by sibling tasks such as AzureCLIV2.

---

### **Task Name**
_Name of the updated or newly created pipeline task._

BicepDeployV0

---

### **Description**
_Summarize the changes made in this PR clearly and concisely._

Fix BicepDeployV0 "Resource file haven't been set" warnings by deferring tl.loc() until after tl.setResourcePath() — convert loggingMessageConfig/errorMessageConfig consts to factory functions invoked inside run(). Adds an L0 probe test that spawns a child process against the real (non-mocked) task-lib to guard against regression, since the mock-test harness stubs setResourcePath/loc to no-ops. Add the five loc strings (SettingAzureCloud, LoginFailed, MSILoginFailed, AuthSchemeNotSupported, ErrorInSettingUpSubscription) that BicepDeployV0 transitively uses from the shared azure-arm-rest azCliUtility module, eliminating Can't find loc string warnings at runtime.

---

### **Risk Assessment** (Low / Medium / High)  
_Assess the level of risk and provide reasoning (e.g., scope, impact, backward compatibility)._

Low

---

### **Change Behind Feature Flag** (Yes / No)
_Can this change be behine feature flag, if not why?_

No, not needed

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

Not needed

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

No doc change needed

---

### **Unit Tests Added or Updated** (Yes / No)  
_Indicate whether unit tests were added or modified to reflect these changes._

Yes

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Logging Added/Updated** (Yes/No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

Not needed

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

Not needed

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

Yes

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
