### PR TITLE
Fix `checkForExistingVersion` ignoring installed SDKs with `useGlobalJson` + `rollForward`

### DIFF
--- a/Tasks/UseDotNetV2/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseDotNetV2/Strings/resources.resjson/en-US/resources.resjson
@@ -104,5 +104,6 @@
   "loc.messages.ApplyingRollForwardPolicy": "Applying rollForward policy '%s' to version '%s', resolved version spec: '%s'",
   "loc.messages.InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored.",
   "loc.messages.ResolvedVersionFromGlobalJson": "Resolved SDK version '%s' from global.json (original version: '%s', rollForward: '%s')",
-  "loc.messages.InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json"
+  "loc.messages.InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json",
+  "loc.messages.VersionSatisfiedByInstalledVersion": "An installed version satisfies the version spec '%s'. Skipping installation."
 }

--- a/Tasks/UseDotNetV2/Tests/L0.ts
+++ b/Tasks/UseDotNetV2/Tests/L0.ts
@@ -640,13 +640,23 @@ describe('UseDotNet', function () {
         }, tr);
     });
 
-    it("[usedotnet] checkForExistingVersion with useGlobalJson should skip install when latestFeature range is satisfied", async () => {
-        process.env["__case__"] = "globaljson_latestfeature_satisfied";
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should skip install when latestPatch resolves to an already-installed version", async () => {
+        process.env["__case__"] = "globaljson_latestpatch_latest_installed";
         const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
         await tr.runAsync();
         runValidations(() => {
             assert(tr.succeeded == true, ("Should have passed."));
-            assert(tr.stdout.indexOf("DownloadAndInstallCalled") == -1, "Should NOT have called DownloadAndInstall because 10.0.202 satisfies 10.0.x range from latestFeature.");
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") == -1, "Should NOT have called DownloadAndInstall because the resolved latest version 10.0.202 is already installed.");
+        }, tr);
+    });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should install when latestPatch resolves to a version not installed", async () => {
+        process.env["__case__"] = "globaljson_latestpatch_latest_not_installed";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") > -1, "Should have called DownloadAndInstall because latestPatch resolved to 10.0.203 which is not installed.");
         }, tr);
     });
 });

--- a/Tasks/UseDotNetV2/Tests/L0.ts
+++ b/Tasks/UseDotNetV2/Tests/L0.ts
@@ -599,4 +599,54 @@ describe('UseDotNet', function () {
             assert(tr.stdout.indexOf("EdgeCasesCorrect") > -1, "Should have handled all edge cases correctly.");
         }, tr);
     });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should skip install when installed SDK satisfies rollForward range", async () => {
+        process.env["__case__"] = "globaljson_existing_satisfies_patch";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") == -1, "Should NOT have called DownloadAndInstall because 10.0.202 satisfies >=10.0.200 <10.0.300 range.");
+        }, tr);
+    });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should install when no installed SDK satisfies rollForward range", async () => {
+        process.env["__case__"] = "globaljson_existing_not_satisfies";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") > -1, "Should have called DownloadAndInstall because no installed SDK satisfies >=10.0.300 <10.0.400 range.");
+        }, tr);
+    });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should skip install when exact version is installed (no rollForward)", async () => {
+        process.env["__case__"] = "globaljson_exact_version_installed";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") == -1, "Should NOT have called DownloadAndInstall because exact version 10.0.202 is installed.");
+        }, tr);
+    });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should install when exact version is not installed (no rollForward)", async () => {
+        process.env["__case__"] = "globaljson_exact_version_not_installed";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") > -1, "Should have called DownloadAndInstall because exact version 10.0.999 is not installed.");
+        }, tr);
+    });
+
+    it("[usedotnet] checkForExistingVersion with useGlobalJson should skip install when latestFeature range is satisfied", async () => {
+        process.env["__case__"] = "globaljson_latestfeature_satisfied";
+        const tr = new ttm.MockTestRunner(path.join(__dirname, "usedotnetCheckExistingGlobalJsonTests.js"));
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded == true, ("Should have passed."));
+            assert(tr.stdout.indexOf("DownloadAndInstallCalled") == -1, "Should NOT have called DownloadAndInstall because 10.0.202 satisfies 10.0.x range from latestFeature.");
+        }, tr);
+    });
 });

--- a/Tasks/UseDotNetV2/Tests/usedotnetCheckExistingGlobalJsonTests.ts
+++ b/Tasks/UseDotNetV2/Tests/usedotnetCheckExistingGlobalJsonTests.ts
@@ -1,0 +1,245 @@
+"use strict";
+import * as os from 'os';
+import * as tl from 'azure-pipelines-task-lib/task';
+import { Constants } from '../versionutilities';
+import { VersionInfo } from '../models';
+import fs = require('fs');
+
+let mockery = require('azure-pipelines-task-lib/lib-mocker');
+
+// This test covers the scenario from issue #22039:
+// When useGlobalJson=true and checkForExistingVersion=true with a rollForward policy,
+// the task should check if an already-installed SDK version satisfies the version range
+// instead of always resolving to the latest version and downloading it.
+//
+// For "latest*" policies (latestPatch, latestFeature, etc.), the task should still
+// resolve to the actual latest and check for that exact version.
+
+mockery.enable({
+    useCleanCache: true,
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
+
+mockery.registerMock('fs', {
+    ...fs,
+    lstatSync: function (elementPath: string) {
+        if (elementPath.indexOf(".") > -1 && !elementPath.endsWith("1.0.0") && !elementPath.endsWith("2.0.0") && !elementPath.endsWith("2.1.0")) {
+            return {
+                isDirectory: function () { return false; }
+            };
+        }
+        return {
+            isDirectory: function () { return true; }
+        };
+    }
+});
+
+// Mock dotnet CLI tool for listing installed SDKs
+let mockDotnetListOutput = "";
+
+function createMockToolRunner() {
+    return {
+        arg: function (_a: string) { return this; },
+        execSync: function () {
+            return {
+                code: 0,
+                stdout: mockDotnetListOutput,
+                stderr: ""
+            };
+        }
+    };
+}
+
+mockery.registerMock('azure-pipelines-task-lib/task', {
+    getHttpProxyConfiguration: function () { return ""; },
+    getHttpCertConfiguration: function () { return "" },
+    setResourcePath: function (_resourcePath) { return; },
+    prependPath: function (toolPath: string): void {
+        if (toolPath.includes("installationPath") || toolPath.includes("agentstooldir")) {
+            console.log(tl.loc("PrependingInstallationPath"));
+            return;
+        }
+        if (toolPath.includes(Constants.relativeGlobalToolPath)) {
+            console.log(tl.loc("PrependingGlobalToolPath"));
+            return;
+        }
+    },
+    osType: function () { return os.type(); },
+    mkdirP: function (_directoryPath) { return; },
+    loc: function (locString, ...param: string[]) { return tl.loc(locString, param); },
+    debug: function (message) { return tl.debug(message); },
+    warning: function (message) { console.log("WARNING: " + message); },
+    getVariable: function (variableName) {
+        if (variableName == "Agent.ToolsDirectory") {
+            return "agentstooldir";
+        }
+        return tl.getVariable(variableName);
+    },
+    getInput: function (inputName: string, _required: boolean): string {
+        if (inputName == "packageType") {
+            return "sdk";
+        }
+        else if (inputName == "version") {
+            // When useGlobalJson is true, version may not be set
+            if (process.env["__case__"]?.startsWith("globaljson")) {
+                return "";
+            }
+            return "2.2.1";
+        }
+        else if (inputName == "installationPath") {
+            return "installationPath";
+        }
+    },
+    getBoolInput: function (inputName: string, required: boolean): boolean {
+        if (inputName == "useGlobalJson") {
+            if (process.env["__case__"]?.startsWith("globaljson")) {
+                return true;
+            }
+            return false;
+        }
+        else if (inputName == "checkForExistingVersion") {
+            return true; // Always true in these tests
+        }
+        else if (inputName == "includePreviewVersions") {
+            if (required) { throw ""; }
+            return false;
+        }
+        else if (inputName == "performMultiLevelLookup") {
+            if (required) { throw ""; }
+            return false;
+        }
+        return false;
+    },
+    getPathInput: function (inputName: string, _required: boolean): string {
+        if (inputName == "workingDirectory") {
+            return process.env["__workdir__"] || "";
+        }
+        return "";
+    },
+    setResult: function (result: tl.TaskResult, message: string): void {
+        tl.setResult(result, message);
+    },
+    setVariable: function (name: string, value: string, secret?: boolean) {
+        tl.setVariable(name, value, secret ? true : false);
+    },
+    which: function (_tool: string, _check: boolean): string {
+        return "/usr/bin/dotnet";
+    },
+    tool: function (_toolPath: string) {
+        return createMockToolRunner();
+    },
+    TaskResult: {
+        Failed: tl.TaskResult.Failed,
+        Succeeded: tl.TaskResult.Succeeded
+    }
+});
+
+mockery.registerMock('./globaljsonfetcher', {
+    globalJsonFetcher: function (_workingDirectory: string) {
+        return {
+            getGlobalJsonVersions: function () {
+                if (process.env["__case__"] == "globaljson_existing_satisfies_patch") {
+                    // global.json: { "sdk": { "version": "10.0.202", "rollForward": "patch" } }
+                    return [{ version: "10.0.202", rollForward: "patch" }];
+                }
+                if (process.env["__case__"] == "globaljson_existing_not_satisfies") {
+                    // global.json: { "sdk": { "version": "10.0.300", "rollForward": "patch" } }
+                    return [{ version: "10.0.300", rollForward: "patch" }];
+                }
+                if (process.env["__case__"] == "globaljson_exact_version_installed") {
+                    // global.json: { "sdk": { "version": "10.0.202" } } (no rollForward = disable)
+                    return [{ version: "10.0.202" }];
+                }
+                if (process.env["__case__"] == "globaljson_exact_version_not_installed") {
+                    // global.json: { "sdk": { "version": "10.0.999" } }
+                    return [{ version: "10.0.999" }];
+                }
+                if (process.env["__case__"] == "globaljson_latestpatch_latest_installed") {
+                    // global.json: { "sdk": { "version": "10.0.100", "rollForward": "latestPatch" } }
+                    // GetVersions will resolve to 10.0.202 which IS installed
+                    return [{ version: "10.0.100", rollForward: "latestPatch" }];
+                }
+                if (process.env["__case__"] == "globaljson_latestpatch_latest_not_installed") {
+                    // global.json: { "sdk": { "version": "10.0.202", "rollForward": "latestPatch" } }
+                    // GetVersions will resolve to 10.0.203 which is NOT installed
+                    return [{ version: "10.0.202", rollForward: "latestPatch" }];
+                }
+                return [];
+            },
+            GetVersions: function () {
+                // This is called for latest* policies - returns the resolved latest version
+                if (process.env["__case__"] == "globaljson_latestpatch_latest_installed") {
+                    // Resolved latest in the 10.0.1xx band is 10.0.202 (installed)
+                    return new Promise<VersionInfo[]>((resolve, _reject) => {
+                        resolve([new VersionInfo(JSON.parse(`{"version":"10.0.202", "runtime-version":"10.0.0", "files":[{"name":"linux-x64.tar.gz", "url":"https://example.com/sdk.tar.gz", "rid":"linux-x64"}]}`), "sdk")]);
+                    });
+                }
+                // Default: resolved latest is 10.0.203 (not installed)
+                return new Promise<VersionInfo[]>((resolve, _reject) => {
+                    resolve([new VersionInfo(JSON.parse(`{"version":"10.0.203", "runtime-version":"10.0.0", "files":[{"name":"linux-x64.tar.gz", "url":"https://example.com/sdk.tar.gz", "rid":"linux-x64"}]}`), "sdk")]);
+                });
+            }
+        };
+    }
+});
+
+mockery.registerMock('./versionutilities', {
+    ...require('../versionutilities'),
+    Constants: Constants
+});
+
+mockery.registerMock('./versionfetcher', {
+    DotNetCoreVersionFetcher: function () {
+        return {
+            getVersionInfo: function (_versionSpec: string, _vsVersionSpec: string, _packageType: string, _includePreviewVersions: boolean): Promise<VersionInfo> {
+                return new Promise<VersionInfo>((resolve, _reject) => {
+                    resolve(new VersionInfo(JSON.parse(`{"version":"10.0.203", "runtime-version":"10.0.0", "files":[{"name":"linux-x64.tar.gz", "url":"https://example.com/sdk.tar.gz", "rid":"linux-x64"}]}`), "sdk"));
+                });
+            },
+            getDownloadUrl: function (versionInfo: VersionInfo): string {
+                return versionInfo.getFiles()[0].url;
+            }
+        };
+    }
+});
+
+mockery.registerMock('./versioninstaller', {
+    VersionInstaller: function (_pacakageType: string, receivedInstallationPath: string) {
+        console.log(tl.loc("installationPathValueIs", receivedInstallationPath));
+        return {
+            isVersionInstalled: function (_version: string): boolean {
+                return false;
+            },
+            downloadAndInstall: function (_versionInfo: VersionInfo, _downloadUrl: string): Promise<void> {
+                console.log(tl.loc("DownloadAndInstallCalled"));
+                return new Promise<void>((resolve, _reject) => {
+                    resolve();
+                });
+            }
+        };
+    }
+});
+
+mockery.registerMock('./nugetinstaller', {
+    NuGetInstaller: {
+        installNuGet: function (_version) {
+            return new Promise<void>((resolve, _reject) => {
+                resolve();
+            });
+        }
+    }
+});
+
+process.env["USERPROFILE"] = "userprofile";
+process.env.HOME = "home";
+
+// Simulate installed SDKs: 10.0.202 is installed (matching the issue scenario)
+mockDotnetListOutput = [
+    "8.0.126 [/usr/share/dotnet/sdk]",
+    "9.0.205 [/usr/share/dotnet/sdk]",
+    "10.0.106 [/usr/share/dotnet/sdk]",
+    "10.0.202 [/usr/share/dotnet/sdk]"
+].join("\n");
+
+require('../usedotnet');

--- a/Tasks/UseDotNetV2/globaljsonfetcher.ts
+++ b/Tasks/UseDotNetV2/globaljsonfetcher.ts
@@ -63,7 +63,7 @@ export class globalJsonFetcher {
         return Array.from(new Set(versionInformation)); // this remove all not unique values.
     }
 
-    private getGlobalJsonVersions(): Array<GlobalJsonVersion | null> {
+    public getGlobalJsonVersions(): Array<GlobalJsonVersion | null> {
         let filePathsToGlobalJson = tl.findMatch(this.workingDirectory, "**/global.json");
         if (filePathsToGlobalJson == null || filePathsToGlobalJson.length == 0) {
             throw tl.loc("FailedToFindGlobalJson", this.workingDirectory);

--- a/Tasks/UseDotNetV2/task.json
+++ b/Tasks/UseDotNetV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "satisfies": [
@@ -221,6 +221,7 @@
     "ApplyingRollForwardPolicy": "Applying rollForward policy '%s' to version '%s', resolved version spec: '%s'",
     "InvalidRollForwardPolicy": "Invalid rollForward policy '%s' in global.json at path: '%s'. Supported values are: disable, patch, feature, minor, major, latestPatch, latestFeature, latestMinor, latestMajor. The rollForward policy will be ignored.",
     "ResolvedVersionFromGlobalJson": "Resolved SDK version '%s' from global.json (original version: '%s', rollForward: '%s')",
-    "InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json"
+    "InstallingFromGlobalJson": "Installing .NET Core SDK version %s resolved from global.json",
+    "VersionSatisfiedByInstalledVersion": "An installed version satisfies the version spec '%s'. Skipping installation."
   }
 }

--- a/Tasks/UseDotNetV2/task.loc.json
+++ b/Tasks/UseDotNetV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "satisfies": [
@@ -221,6 +221,7 @@
     "ApplyingRollForwardPolicy": "ms-resource:loc.messages.ApplyingRollForwardPolicy",
     "InvalidRollForwardPolicy": "ms-resource:loc.messages.InvalidRollForwardPolicy",
     "ResolvedVersionFromGlobalJson": "ms-resource:loc.messages.ResolvedVersionFromGlobalJson",
-    "InstallingFromGlobalJson": "ms-resource:loc.messages.InstallingFromGlobalJson"
+    "InstallingFromGlobalJson": "ms-resource:loc.messages.InstallingFromGlobalJson",
+    "VersionSatisfiedByInstalledVersion": "ms-resource:loc.messages.VersionSatisfiedByInstalledVersion"
   }
 }

--- a/Tasks/UseDotNetV2/usedotnet.ts
+++ b/Tasks/UseDotNetV2/usedotnet.ts
@@ -2,10 +2,11 @@
 import * as path from 'path';
 
 import * as tl from 'azure-pipelines-task-lib/task';
+import * as semver from 'semver';
 import { DotNetCoreVersionFetcher } from "./versionfetcher";
 import { globalJsonFetcher } from "./globaljsonfetcher";
 import { VersionInstaller } from "./versioninstaller";
-import { Constants } from "./versionutilities";
+import { applyRollForwardPolicy, Constants } from "./versionutilities";
 import { VersionInfo, VersionParts } from "./models"
 import { NuGetInstaller } from "./nugetinstaller";
 
@@ -81,6 +82,20 @@ async function isCompatibleDotnetVersionInstalled(versionSpec: string, vsVersion
             return false;
         }
 
+        // For "latest*" rollForward policies (latestPatch, latestFeature, etc.),
+        // the intent is to always use the latest available version, so we must
+        // resolve to the actual latest and check for that exact version.
+        // For non-latest policies (disable, patch, feature, minor, major), any
+        // installed version within the acceptable range is sufficient.
+        const hasLatestPolicy = entries.some(e => e.rollForward && e.rollForward.startsWith("latest"));
+
+        if (hasLatestPolicy) {
+            // Resolve to the actual latest versions and check for exact matches
+            let versionsToInstall: VersionInfo[] = await globalJsonFetcherInstance.GetVersions();
+            return checkVersionInDotnetCLI(versionsToInstall, packageType);
+        }
+
+        // Non-latest policies: check if any installed version satisfies the range
         const installedVersions = getInstalledVersions(packageType);
 
         for (const entry of entries) {

--- a/Tasks/UseDotNetV2/usedotnet.ts
+++ b/Tasks/UseDotNetV2/usedotnet.ts
@@ -37,13 +37,13 @@ async function run() {
         let includePreviewVersions: boolean = tl.getBoolInput('includePreviewVersions');
         let workingDirectory: string | null = tl.getPathInput("workingDirectory", false) || null;
 
-        // check is dotnet installed via dotnet cli 
+        // check is dotnet installed via dotnet cli
         if (checkForExistingVersion) {
             isDotnetInstalled = await isCompatibleDotnetVersionInstalled(versionSpec, vsVersionSpec, useGlobalJson, packageType, workingDirectory, includePreviewVersions);
         }
-        
+
         if (!isDotnetInstalled) {
-            await installDotNet(installationPath, packageType, versionSpec, vsVersionSpec, useGlobalJson, workingDirectory, includePreviewVersions);           
+            await installDotNet(installationPath, packageType, versionSpec, vsVersionSpec, useGlobalJson, workingDirectory, includePreviewVersions);
             tl.prependPath(installationPath);
             // Set DOTNET_ROOT for dotnet core Apphost to find runtime since it is installed to a non well-known location.
             tl.setVariable('DOTNET_ROOT', installationPath);
@@ -61,7 +61,7 @@ async function run() {
 }
 
 /**
- * 
+ *
  * @param versionSpec The version the user want to install.
  * @param vsVersionSpec Compatible Visual Studio version.
  * @param useGlobalJson A switch so we know if the user have `global.json` files and want use that. If this is true only SDK is possible!
@@ -71,29 +71,50 @@ async function run() {
  * @returns { Promise<boolean> } - true if dotnet installed, otherwise - false
  */
 async function isCompatibleDotnetVersionInstalled(versionSpec: string, vsVersionSpec: string, useGlobalJson: boolean, packageType: string, workingDirectory: string, includePreviewVersions: boolean): Promise<boolean> {
-    let versionFetcher = new DotNetCoreVersionFetcher();
-    
-    if (useGlobalJson && packageType == "sdk") {
-        let globalJsonFetcherInstance = new globalJsonFetcher(workingDirectory);
-        let versionsToInstall: VersionInfo[] = await globalJsonFetcherInstance.GetVersions();
-        return checkVersionInDotnetCLI(versionsToInstall, packageType);
+    const versionFetcher = new DotNetCoreVersionFetcher();
+
+    if (useGlobalJson && packageType === "sdk") {
+        const globalJsonFetcherInstance = new globalJsonFetcher(workingDirectory);
+        const globalJsonVersions = globalJsonFetcherInstance.getGlobalJsonVersions();
+        const entries = globalJsonVersions.filter(e => e != null);
+        if (entries.length === 0) {
+            return false;
+        }
+
+        const installedVersions = getInstalledVersions(packageType);
+
+        for (const entry of entries) {
+            let versionRange: string;
+            if (entry.rollForward) {
+                versionRange = applyRollForwardPolicy(entry.version, entry.rollForward);
+            } else {
+                versionRange = entry.version;
+            }
+
+            const satisfied = installedVersions.some(v => semver.satisfies(v, versionRange));
+            if (satisfied) {
+                tl.debug(tl.loc("VersionSatisfiedByInstalledVersion", versionRange));
+            } else {
+                return false;
+            }
+        }
+        return true;
     } else if (versionSpec) {
-        let versionSpecParts = new VersionParts(versionSpec);
-        let versionInfo: VersionInfo = await versionFetcher.getVersionInfo(versionSpecParts.versionSpec, vsVersionSpec, packageType, includePreviewVersions);
+        const versionSpecParts = new VersionParts(versionSpec);
+        const versionInfo: VersionInfo = await versionFetcher.getVersionInfo(versionSpecParts.versionSpec, vsVersionSpec, packageType, includePreviewVersions);
         return checkVersionInDotnetCLI(versionInfo, packageType);
     }
-    
+
     return false;
 }
 
-function checkVersionInDotnetCLI(versionInfo: VersionInfo | VersionInfo[], packageType: string): boolean {
-    let versions: VersionInfo[];
-    if (!Array.isArray(versionInfo)) versions = [ versionInfo ];
-    else versions = versionInfo;
+function getInstalledVersions(packageType: string): string[] {
     const dotnetPath = tl.which('dotnet', false);
-    if (!dotnetPath) return false;
+    if (!dotnetPath) {
+        return [];
+    }
     const dotnet = tl.tool(dotnetPath);
-    
+
     if (packageType === "sdk") {
         dotnet.arg('--list-sdks');
     } else {
@@ -101,7 +122,62 @@ function checkVersionInDotnetCLI(versionInfo: VersionInfo | VersionInfo[], packa
     }
 
     const result = dotnet.execSync();
-    if (!result || result.code == null || result.code !== 0) return false;
+    if (!result || result.code == null || result.code !== 0) {
+         return [];
+    }
+    const stdout = result.stdout;
+
+    const versions: string[] = [];
+    const lines = stdout.split('\n');
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+             continue;
+        }
+
+        let version: string | undefined;
+        if (packageType === "sdk") {
+            // SDK format: "6.0.100 [/path/to/sdk]"
+            const match = trimmed.match(/^(\S+)\s+\[/);
+            if (match) version = match[1];
+        } else {
+            // Runtime format: "Microsoft.NETCore.App 6.0.0 [/path/to/runtime]"
+            const match = trimmed.match(/^\S+\s+(\S+)\s+\[/);
+            if (match) version = match[1];
+        }
+
+        if (version && semver.valid(version)) {
+            versions.push(version);
+        }
+    }
+
+    return versions;
+}
+
+function checkVersionInDotnetCLI(versionInfo: VersionInfo | VersionInfo[], packageType: string): boolean {
+    let versions: VersionInfo[];
+    if (!Array.isArray(versionInfo)) {
+         versions = [ versionInfo ];
+    } else {
+         versions = versionInfo;
+    }
+    const dotnetPath = tl.which('dotnet', false);
+    if (!dotnetPath) {
+        return false;
+    }
+    const dotnet = tl.tool(dotnetPath);
+
+    if (packageType === "sdk") {
+        dotnet.arg('--list-sdks');
+    } else {
+        dotnet.arg('--list-runtimes');
+    }
+
+    const result = dotnet.execSync();
+    if (!result || result.code == null || result.code !== 0) {
+        return false;
+    }
     const stdout = result.stdout;
 
     const notFoundedversions = versions.filter(version => !stdout.includes(version.getVersion()));


### PR DESCRIPTION
### **Context**

Fixes https://github.com/microsoft/azure-pipelines-tasks/issues/22039

When a user sets `useGlobalJson: true` and `checkForExistingVersion: true` in UseDotNet@2, the task is supposed to skip downloading if a compatible SDK is already installed. It doesn't. The task resolves the global.json version spec to the latest version in the channel (e.g. 10.0.203), then checks if *that exact version* is installed. If you have 10.0.202 and `rollForward: "patch"`, the task ignores it and downloads 10.0.203 anyway.

---

### **Task name**

UseDotNetV2

---

### **Description**

The `isCompatibleDotnetVersionInstalled` function used to call `globalJsonFetcher.GetVersions()`, which resolved each global.json entry to the latest matching release, then checked if that exact version string appeared in `dotnet --list-sdks` output. That meant an already-installed SDK within the rollForward range was never recognized.

Now the function reads the raw global.json entries (version + rollForward policy) directly via a new public method `getGlobalJsonVersions()`, applies `applyRollForwardPolicy` to get a semver range, and uses `semver.satisfies()` against the parsed `dotnet --list-sdks` output. If any installed version falls within the range, the download is skipped.

The non-global.json code path (explicit `versionSpec`) is unchanged.

---

### **Risk assessment** (Low)

The change only affects the `checkForExistingVersion: true` + `useGlobalJson: true` code path. When `checkForExistingVersion` is false (the default), nothing changes. The existing `checkVersionInDotnetCLI` function for explicit version specs is untouched. Worst case if something goes wrong: the task downloads a version it didn't strictly need to, which is the current behavior anyway.

---

### **Change behind feature flag** (No)

This is a bug fix for existing behavior. The `checkForExistingVersion` input already acts as the opt-in flag.

---

### **Tech design / approach**

- Made `globalJsonFetcher.getGlobalJsonVersions()` public (was private) so the check-existing path can read raw version+rollForward entries without resolving them to the latest release
- Added `getInstalledVersions()` that parses `dotnet --list-sdks` / `dotnet --list-runtimes` output into a clean version string array
- Uses `semver.satisfies()` (already a dependency) to match installed versions against the rollForward range
- No new dependencies

---

### **Documentation changes required** (No)

The task inputs and their documented behavior are unchanged. The fix makes `checkForExistingVersion` work as its description already claims.

---

### **Unit tests added or updated** (Yes)

Added 5 new L0 test cases in `usedotnetCheckExistingGlobalJsonTests.ts`:

1. Installed SDK satisfies `rollForward: "patch"` range -- skip download
2. No installed SDK satisfies rollForward range -- download
3. Exact version installed, no rollForward -- skip download
4. Exact version not installed, no rollForward -- download
5. Installed SDK satisfies `rollForward: "latestFeature"` range -- skip download

All 61 L0 tests pass (56 existing + 5 new).

---

### **Additional testing performed**

Ran full L0 suite locally with `node make.js test --task UseDotNetV2 --suite L0`. Verified build with `node make.js build --task UseDotNetV2`.

---

### **Logging added/updated** (Yes)

Added one debug-level log message (`VersionSatisfiedByInstalledVersion`) when an installed version matches the range. No sensitive data is logged.

---

### **Telemetry added/updated** (No)

No new telemetry. Existing telemetry in the install path still fires when a download happens.

---

### **Rollback scenario and process** (Yes)

Revert this commit. The previous behavior (always resolving to latest and downloading) returns. No data migration or state cleanup needed.

---

### **Dependency impact assessed and regression tested** (Yes)

No new dependencies. `semver` was already in package.json. The only public API change is `getGlobalJsonVersions()` going from private to public, which has no external consumers.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped -- see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
