### PR TITLE
ServiceFabricDeployV1: emit SfSafeParserFailure telemetry on safe-parser errors

### DIFF
--- a/Tasks/Common/ServiceFabricHelpers/SFOperations.ps1
+++ b/Tasks/Common/ServiceFabricHelpers/SFOperations.ps1
@@ -25,5 +25,6 @@ $SF_Operations = @{
     RemoveComposeDeployment           = 'RemoveComposeDeployment';
     GetComposeDeploymentUpgradeStatus = 'GetComposeDeploymentUpgradeStatus';
     StartComposeDeploymentUpgrade     = 'StartComposeDeploymentUpgrade';
-    CreateNewComposeDeployment        = 'CreateNewComposeDeployment'
+    CreateNewComposeDeployment        = 'CreateNewComposeDeployment';
+    SfSafeParserFailure               = 'SfSafeParserFailure';
 }

--- a/Tasks/ServiceFabricComposeDeployV0/task.json
+++ b/Tasks/ServiceFabricComposeDeployV0/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 244,
+        "Minor": 273,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricComposeDeployV0/task.json
+++ b/Tasks/ServiceFabricComposeDeployV0/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 0,
-        "Minor": 273,
+        "Minor": 274,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricComposeDeployV0/task.loc.json
+++ b/Tasks/ServiceFabricComposeDeployV0/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 244,
+    "Minor": 273,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/ServiceFabricComposeDeployV0/task.loc.json
+++ b/Tasks/ServiceFabricComposeDeployV0/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -406,15 +406,8 @@ function Publish-UpgradedServiceFabricApplication
                 }
                 else
                 {
-                    try
-                    {
-                        $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
-                    }
-                    catch
-                    {
-                        Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorData $_
-                        throw
-                    }
+                    $global:operationId = $SF_Operations.SfSafeParserFailure
+                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
                 }
             }
 

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 273,
-        "Patch": 0
+        "Patch": 1
     },
     "demands": [
         "Cmd"

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -17,8 +17,8 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 273,
-        "Patch": 1
+        "Minor": 274,
+        "Patch": 0
     },
     "demands": [
         "Cmd"

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 1,
     "Minor": 273,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "Cmd"

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -17,8 +17,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 273,
-    "Patch": 1
+    "Minor": 274,
+    "Patch": 0
   },
   "demands": [
     "Cmd"

--- a/Tasks/ServiceFabricPowerShellV1/task.json
+++ b/Tasks/ServiceFabricPowerShellV1/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 228,
+        "Minor": 273,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricPowerShellV1/task.json
+++ b/Tasks/ServiceFabricPowerShellV1/task.json
@@ -17,7 +17,7 @@
     "author": "Microsoft Corporation",
     "version": {
         "Major": 1,
-        "Minor": 273,
+        "Minor": 274,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricPowerShellV1/task.loc.json
+++ b/Tasks/ServiceFabricPowerShellV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 273,
+    "Minor": 274,
     "Patch": 0
   },
   "demands": [

--- a/Tasks/ServiceFabricPowerShellV1/task.loc.json
+++ b/Tasks/ServiceFabricPowerShellV1/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 228,
+    "Minor": 273,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
### **Context**
[AB#2378793](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2378793)

---

### **Task Name**
ServiceFabricDeployV1

---

### **Description**
- Added `SfSafeParserFailure` to `Tasks/Common/ServiceFabricHelpers/SFOperations.ps1`.
- In `Publish-UpgradedServiceFabricApplication.ps1`, set `$global:operationId = $SF_Operations.SfSafeParserFailure` immediately before invoking `ConvertTo-ServiceTypeHealthPolicyMap`, so any exception thrown by the safe parser is reported via the existing `Publish-Telemetry` call in `deploy.ps1`'s catch block with a distinct `OperationId`.
- Bumped task version.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
Yes (`DistributedTask.Tasks.SfSafeParser`)

---

### **Tech Design / Approach**

---

### **Documentation Changes Required** (Yes/No)
No 

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Disable the `DistributedTask.Tasks.SfSafeParser` pipeline feature flag

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
