### PR TITLE
Localize: bump tasks with _generated/ mirror by +2 to avoid BuildConfigGen version collision

### DIFF
--- a/Localize/bump-versions.js
+++ b/Localize/bump-versions.js
@@ -53,9 +53,23 @@ function bumpTaskVersion(taskPath, minor) {
     if (typeof taskJson.version.Patch != 'number') {
         throw new Error(`Error processing '${taskJsonPath}'. version.Patch should be a number.`);
     }
+
+    // Tasks that have a _generated/ mirror always carry at least one variant
+    // (e.g. <Task>_Node24) whose patch sits one above the source's Default.
+    // A naive +1 bump on the source therefore collides with the variant slot
+    // and BuildConfigGen aborts with
+    //   "inputVersion ... must not be less or equal to maxVersion ...".
+    // Bumping by +2 in that case leaves room for BuildConfigGen to roll the
+    // map forward (Default -> source, variant -> source+1).
+    const taskName = taskPath.replace(/^Tasks\//, '');
+    const hasGeneratedMirror = fs.existsSync(
+        path.join(__dirname, '..', '_generated', `${taskName}.versionmap.txt`)
+    );
+    const patchIncrement = hasGeneratedMirror ? 2 : 1;
+
     if (taskJson.version.Minor === minor) {
-        taskJson.version.Patch = taskJson.version.Patch + 1;
-        taskLocJson.version.Patch = taskLocJson.version.Patch + 1;
+        taskJson.version.Patch = taskJson.version.Patch + patchIncrement;
+        taskLocJson.version.Patch = taskLocJson.version.Patch + patchIncrement;
     } else {
         taskJson.version.Patch = 0;
         taskLocJson.version.Patch = 0;


### PR DESCRIPTION
### **Context**
The internal Localization pipeline (`localize-pipeline.yml`, runs `Localize/bump-versions.js`) has been failing intermittently this sprint with:

https://dev.azure.com/mseng/PipelinesLocalization/_build/results?buildId=31451870&view=logs&j=3b94f880-87f8-584e-4049-e95fdb9e35af&t=9cd4cf5f-4f60-5f8d-e715-df2be905b50e



System.Exception: inputVersion=2.274.5 ... must not be less or equal to maxVersion=2.274.5 specified in versionMapFile [AzureCLIV2.versionmap.txt](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Error: [make.js](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) build failed with exit code 1
at syncGeneratedTasks (Localize/bump-versions.js:150:15)


Latest occurrence: AzureCLIV2 in sprint 274. Same class of failure can hit any task that has a `_generated/<task>.versionmap.txt` mirror.

Root cause: `bumpTaskVersion` blindly increments source `Patch` by +1, but `BuildConfigGen` requires `inputVersion > maxVariantVersion`. For tasks with a `_generated/` mirror, the variant patch is already one above `Default`, so a +1 bump on the source collides with the variant slot and aborts the run before BuildConfigGen can roll the map forward.

---

### **Task Name**
N/A — change is to the localization tooling (`Localize/bump-versions.js`), not to a pipeline task.

---

### **Description**
Make `bumpTaskVersion` aware of `_generated/<task>.versionmap.txt`. When a versionmap file exists for the task, increment the source `Patch` by **+2** instead of **+1**. This leaves room for `BuildConfigGen` to assign `Default = source` and `variant = source + 1` on the next `node make.js build` invocation. Tasks without a `_generated/` mirror keep the existing +1 behaviour.

---

### **Risk Assessment** — **Low**

---

### **Change Behind Feature Flag** — **No**


---

### **Tech Design / Approach**


---

### **Documentation Changes Required** — **No**
Internal localization tooling, not a public-facing task. No user-facing or task-author docs are affected.

---

### **Unit Tests Added or Updated** — **No**

---

### **Additional Testing Performed**


---

### **Logging Added/Updated** — **No**


---

### **Telemetry Added/Updated** — **No**


---

### **Rollback Scenario and Process** — **Yes**


---

### **Dependency Impact Assessed and Regression Tested** — **Yes**

---

### **Checklist**
- [x] Related issue linked (Localization pipeline failure for sprint 274 — AzureCLIV2)
- [ ] Task version was bumped — N/A (change is to tooling, not a task)
- [x] Verified the task behaves as expected (BuildConfigGen succeeds for AzureCLIV2 with the equivalent +2 bump applied manually)