### PR TITLE
Fix indent ping-pong: bump-versions.js writes 2-space JSON

### DIFF
--- a/Localize/bump-versions.js
+++ b/Localize/bump-versions.js
@@ -77,7 +77,7 @@ function bumpTaskVersion(taskPath, minor) {
         taskLocJson.version.Minor = minor;
     }
 
-    fs.writeFileSync(taskJsonPath, JSON.stringify(taskJson, null, 4));
+    fs.writeFileSync(taskJsonPath, JSON.stringify(taskJson, null, 2));
     fs.writeFileSync(taskLocJsonPath, JSON.stringify(taskLocJson, null, 2));
 }
 
@@ -104,7 +104,7 @@ function bumpPackageVersion(packPath, minor) {
     packageJson.version = version.format();
     packageLocJson.version = version.format();
 
-    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4));
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
     fs.writeFileSync(packageLocJsonPath, JSON.stringify(packageLocJson, null, 2));
 }
 


### PR DESCRIPTION
## Summary

**`Localize/bump-versions.js`** wrote `task.json` and `package.json` with **4-space** indent (`JSON.stringify(..., null, 4)`), while every other tool (`BuildConfigGen`, `npm install`) uses **2-space**. This caused an indent ping-pong every sprint and finally broke CI on `master` when `PublishSymbolsV2` was added to the `Node24_overwrite` bucket.

**This PR aligns the loc script to 2-space — a 2-line fix.**

---

## Why was it 4-space originally?

When `bump-versions.js` was written (~2018), **4-space was the common JavaScript convention** for `JSON.stringify` pretty-printing. Around 2009–2010 when ES5 introduced the `space` parameter, `JSON.stringify(obj, null, 4)` became the go-to pattern for human-readable JSON — it matched languages like Python and C# that favoured 4-space indent.

**But the ecosystem moved to 2-space:**

| Era | Tool / Editor | Default indent | Proof |
|---|---|:---:|---|
| Pre-2011 | npm (pre-1.0) | 4 | Early npm followed the 4-space JS convention |
| 2011+ | **npm ≥ 1.0** | **2** | npm standardized `package.json` at 2-space ([npm v5+ confirmed](https://docs.npmjs.com/cli/v10/configuring-npm/package-json)) |
| Early VS Code | General editor default | 4 | `editor.tabSize = 4` for most languages |
| Current VS Code | **JSON language-specific** | **2** | Built-in `[json].editor.tabSize: 2` ([vscode/extensions/json](https://github.com/microsoft/vscode/blob/main/extensions/json/package.json)) |
| 2017+ | **Prettier** | **2** | Default since v1.0 ([prettier.io/docs](https://prettier.io/docs/en/options.html#tab-width)) |
| .NET | **`System.Text.Json`** | **2** | Hardcoded `WriteIndented` uses 2-space until .NET 9 |

The original `bump-versions.js` author used `null, 4` — correct for 2018 conventions — but never updated when all tooling converged on 2-space. Since the `*.loc.json` writes in the same function already used `null, 2`, the mismatch was likely a copy-paste oversight that went unnoticed.

---

## Current state of indent drift

| File type | Total files | Currently 4-space | Currently 2-space | Notes |
|---|:---:|:---:|:---:|---|
| `task.json` | 223 | **54** (24%) | 169 | All 54 have a 2-space `task.loc.json` beside them — exact bug fingerprint |
| `package.json` | 170 | **24** (14%) | 146 | `npm install` re-canonicalizes on dependency changes, so drift is smaller |

**Were the 2-space files ever 4-space?** Yes — many were. Every loc rollup rewrote touched files to 4-space, then the next code-change PR (via `BuildConfigGen`) or `npm install` flipped them back to 2-space. Example for `PublishSymbolsV2/task.json`:

| Commit | PR / Date | Indent | Writer |
|---|---|:---:|---|
| `fb191d119b` | 2018-05-17 | 4 | initial human author |
| `023b877114` | [#18549](https://github.com/microsoft/azure-pipelines-tasks/pull/18549) (Node16 migration) | 2 | BuildConfigGen |
| `a6a6a01b73` | [#20321](https://github.com/microsoft/azure-pipelines-tasks/pull/20321) (loc rollup, 2024-08-20) | 4 | `bump-versions.js` |
| `e11f7f3730` | [#20107](https://github.com/microsoft/azure-pipelines-tasks/pull/20107) | 2 | BuildConfigGen |
| `6cd05fd344` | [#22128](https://github.com/microsoft/azure-pipelines-tasks/pull/22128) | 4 | `bump-versions.js` |
| `d108571f19` | [#22132](https://github.com/microsoft/azure-pipelines-tasks/pull/22132) | 2 | revert |

Five flips on a single file — the same pattern exists across all 54 currently-4-space files.

---

## Root Cause

The `Node24_overwrite` verifier does a **byte-compare** of source `task.json` against BuildConfigGen's 2-space output. The last loc rollup ([#22128](https://github.com/microsoft/azure-pipelines-tasks/pull/22128)) rewrote `PublishSymbolsV2/task.json` at 4-space, causing every PR to fail with:

```
Content doesn't match for Tasks/PublishSymbolsV2/task.json (overwrite=true).
==> Updates needed, please run node make.js --task PublishSymbolsV2
```

`master` was unblocked by [#22132](https://github.com/microsoft/azure-pipelines-tasks/pull/22132) (revert) and [#22120](https://github.com/microsoft/azure-pipelines-tasks/pull/22120) (re-canonicalize). **This PR fixes the source of the drift so it doesn't recur.**

---

## Why 2-space is correct (today)

| Tool | Indent | Reference |
|---|:---:|---|
| `BuildConfigGen` (`System.Text.Json`, `WriteIndented`) | **2** | Hardcoded until .NET 9 |
| `npm install` / `npm version` | **2** | npm default since v1.0 (2011) |
| VS Code JSON language default | **2** | `[json].editor.tabSize: 2` |
| Prettier | **2** | Default `tabWidth: 2` since v1.0 (2017) |
| Repo root `package.json` / `package-lock.json` | **2** | — |
| `*.loc.json` writes in this same script | **2** | Already correct |
| `bump-versions.js` `task.json` / `package.json` | **4** | ← the only outlier (fixed here) |

**The ecosystem consensus shifted from 4→2 for JSON between 2011–2017.** This script is the last holdout.

---

## What this PR does NOT do

- Does **not** rewrite existing 4-space files (they'll self-heal on next touch)
- Does **not** change versioning logic or `_generated/` sync
- Does **not** affect `master` directly — takes effect on next loc rollup

---

## Risk

**Low.** Two-character change (`4` → `2`) on two lines. Next loc rollup will produce 2-space files matching what BuildConfigGen and the verifier already expect.

---

## Related PRs

| PR | Context |
|---|---|
| [#22097](https://github.com/microsoft/azure-pipelines-tasks/pull/22097) | Added `PublishSymbolsV2` to `Node24_overwrite` (made bug fatal) |
| [#22128](https://github.com/microsoft/azure-pipelines-tasks/pull/22128) | Loc rollup that flipped indent (caused master failure) |
| [#22132](https://github.com/microsoft/azure-pipelines-tasks/pull/22132) | Revert of #22128 (master hotfix) |
| [#22120](https://github.com/microsoft/azure-pipelines-tasks/pull/22120) | Re-canonicalize `PublishSymbolsV2/task.json` (master hotfix) |
