### PR TITLE
Update TestAgent.zip blob URL to build 31482278 (VsTestV3 only)

### DIFF
--- a/Tasks/VsTestV3/make.json
+++ b/Tasks/VsTestV3/make.json
@@ -6,7 +6,7 @@
               "dest": "./"
             },
             {
-              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/30558438/TestAgent.zip",
+              "url": "https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/31482278/TestAgent.zip",
               "dest": "./Modules"
             },
             {

--- a/Tasks/VsTestV3/task.json
+++ b/Tasks/VsTestV3/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 274,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"

--- a/Tasks/VsTestV3/task.loc.json
+++ b/Tasks/VsTestV3/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 3,
     "Minor": 274,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [
     "vstest"


### PR DESCRIPTION
### **Context**
Addresses [ICM 779579246](https://portal.microsofticm.com/imp/v5/incidents/details/779579246) — VsTest parallel execution introduces a centralized DTA test discovery phase that blocks execution (~15–16 min overhead for ~53K tests). Root cause: O(n²) LINQ dedup pattern in `DistributedTestsManager.RegisterNewTestCases()`.

**Agent-side PRs:**
- Performance fix: [ADO PR #915346](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/915346)
- MSAL dependency fix: [ADO PR #920861](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/920861)

---

### **Task Name**
VsTestV3

---

### **Description**
Updated `make.json` to point to the new TestAgent.zip blob (build 31482278). This blob includes two changes from the previous version:

1. **O(n²) fix in DTA discovery** — Replaces O(n²) LINQ dedup with HashSet O(1) lookup in `DistributedTestsManager.RegisterNewTestCases()`, gated behind feature flag `TestExecution.OptimizedDiscovery`. Reduces discovery time from ~13 min to ~25 sec for ~53K tests.
2. **Missing MSAL dependency** — Adds `Microsoft.Identity.Client.dll` to the TestAgent blob. This DLL was missing after VssCommon v20 introduced CAE token claims challenge support, causing DTAExecutionHost.exe to crash with `FileNotFoundException`.

---

### **Risk Assessment** (Low)
Low risk. The O(n²) fix is gated behind a feature flag (`TestExecution.OptimizedDiscovery`) — OFF by default. The MSAL DLL addition is a missing dependency fix. Only VsTestV3 is modified; VsTestV2 is unchanged.

---

### **Change Behind Feature Flag** (Yes)
The performance fix is gated behind feature flag `TestExecution.OptimizedDiscovery`. When OFF, existing behavior is preserved. The MSAL DLL addition is not behind a flag (it's a missing dependency fix).

---

### **Tech Design / Approach**
- Replaces `O(n²)` sequential LINQ `.Any()` dedup with `HashSet<string>` for `O(1)` lookups.
- Feature flag `TestExecution.OptimizedDiscovery` gates the optimized path — existing behavior is the fallback when OFF.
- MSAL DLL (`Microsoft.Identity.Client.dll`) was identified as missing from the TestAgent blob manifest; added via [ADO PR #920861](https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps/pullrequest/920861).
- No architectural trade-offs — this is a direct algorithmic improvement.

---

### **Documentation Changes Required** (No)
No documentation changes required.

---

### **Unit Tests Added or Updated** (No)
The fix is in the DTAExecutionHost agent binary (built separately). Existing L0 tests for VsTestV3 task runner are unaffected.

---

### **Additional Testing Performed**

*Performance validation (DevFabric):*
Validated with ~53K tests across 4 parallel agents. FF `TestExecution.OptimizedDiscovery` ON.

| Build | Task Version | FF | Discovery Time | Result |
|-------|-------------|-----|---------------|--------|
| Baseline | 2.269.0 | OFF | ~13m 20s | Pass |
| Validation | 2.274.0 | ON | ~24-30s | Pass |

Discovery time: **~13 min -> ~25 sec** (~30x improvement).

*Blob validation (dev.azure.com/csumana):*
Validated the new blob (build 31482278) across multiple scenarios:

| Scenario | Agent | Task | Result |
|----------|-------|------|--------|
| Single agent | Microsoft-hosted | VsTest@2 | Pass |
| Parallel (2 agents) | Microsoft-hosted | VsTest@2 | Pass |
| Single agent | Microsoft-hosted | VsTest@3 | Pass |
| Single agent | Self-hosted (Windows) | VsTest@2 | Pass |
| Single agent | Self-hosted (Windows) | VsTest@3 | Pass |

*Cross-platform verification:*
Confirmed VsTest@2 and VsTest@3 are Windows-only by design (runtime check in `runvstest.ts` L193-195). Linux/macOS tests correctly fail with `OnlyWindowsOsSupported`.

---

### **Logging Added/Updated** (No)
No logging changes in the task itself. The DTAExecutionHost already logs discovery timing.

---

### **Telemetry Added/Updated** (No)
No telemetry changes in the task. Existing DTA telemetry captures discovery and execution metrics.

---

### **Rollback Scenario and Process** (Yes)
- Rollback: Revert `make.json` blob URL to previous build ID. The task will download the old TestAgent.zip.
- Feature flag `TestExecution.OptimizedDiscovery` can be turned OFF to disable the optimized code path without a rollback.

---

### **Dependency Impact Assessed and Regression Tested** (Yes)
- Only `make.json` blob URL changed — no code changes in the VsTest task runner.
- The blob is built from the same TestAgent pipeline (22068), adding one DLL and one gated code path.
- Tested across Microsoft-hosted and self-hosted agents, single and parallel execution.

---

### **Checklist**
- [x] Related issue linked (ICM 779579246)
- [x] Task version was bumped (3.274.0) — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected

**References:**
- **Build pipeline (22068):** [Build 31482278](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31482278&view=results)
- **Blob URL:** https://testmanagementstore.z13.web.core.windows.net/testmanagementcontainer/31482278/TestAgent.zip
