### PR TITLE
Fix symlink regression: bump webdeployment-common to ^4.274.1 in AzureFunctionAppV1 and V2

### DIFF
--- a/Tasks/AzureFunctionAppV1/package-lock.json
+++ b/Tasks/AzureFunctionAppV1/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.272.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.274.1",
         "azure-storage": "2.10.7",
         "moment": "^2.29.3",
         "q": "1.4.1",
@@ -212,23 +212,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -262,16 +245,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@types/events": {
@@ -364,18 +337,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
@@ -413,114 +374,40 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha1-ydkcNQNiBAuJJzeceqacBlUSL2E=",
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-1.2.0.tgz",
+      "integrity": "sha1-+1xq9UQ7P6akJjRHU7rSp7REqt0=",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.1.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha1-Y7xxnZUYA+/HLPlhpW74EHYN0U0=",
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "license": "MIT",
       "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/asn1": {
@@ -542,10 +429,13 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-3.2.6.tgz",
-      "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4=",
-      "license": "MIT"
+      "version": "2.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-2.6.4.tgz",
+      "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
@@ -696,16 +586,16 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.274.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.274.0.tgz",
-      "integrity": "sha1-NcgswFMEW5d5TjxUcaDXTfAVFZo=",
+      "version": "4.274.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.274.1.tgz",
+      "integrity": "sha1-43V9u+zNyBQ+ZU7TAAWEtRxFjIM=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",
         "@types/node": "^16.11.39",
         "@xmldom/xmldom": "^0.8.13",
-        "archiver": "7.0.1",
+        "archiver": "1.2.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "ltx": "2.8.0",
         "node-stream-zip": "^1.15.0",
@@ -771,116 +661,11 @@
         "sax": "0.5.x"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha1-HKO6DtyUaaqr71ZH52moPVAYCxo=",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha1-ez4QvY4fyA2vOLtRaSFnj1ZquJ8=",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.6.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-fs/-/bare-fs-4.6.0.tgz",
-      "integrity": "sha1-/y8QyCONP/lPJwTwxYGxl7R+8RI=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.8.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-os/-/bare-os-3.8.7.tgz",
-      "integrity": "sha1-CcfE6MgX3nULC2m2XJKVE/ae3mU=",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha1-tZ0YEwulKmr5J22z6WouPT6lIXg=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-stream/-/bare-stream-2.12.0.tgz",
-      "integrity": "sha1-8baBh2gRN5C7v96Q9HAD83DId44=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha1-FUbWMFeRcYnKubJGKelG4ej3rzE=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -911,6 +696,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -939,9 +734,9 @@
       "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
+      "version": "5.7.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
       "funding": [
         {
           "type": "github",
@@ -959,16 +754,32 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "license": "MIT"
+    },
     "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha1-oQmTuQVQgdVTBL2f60oHLeF59AU=",
+      "version": "0.2.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -976,6 +787,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -1045,24 +862,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "license": "Apache-2.0"
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "license": "MIT"
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1076,44 +875,18 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha1-JtMSUaZrnWuiOoQGTs06anHSYJ4=",
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/compress-commons/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/concat-map": {
@@ -1128,54 +901,26 @@
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "license": "MIT"
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha1-PK01qTS4v3HyXKUkttpR+36s4v8=",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha1-hSmjho+LJ6u5FfbDYXwPre2/lDA=",
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1311,12 +1056,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
-      "license": "MIT"
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1336,11 +1075,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "license": "MIT"
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1387,33 +1129,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events/-/events-3.3.0.tgz",
-      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha1-tWqE/WEbZhDgotDwn4D9+THi3+Y=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
@@ -1456,12 +1171,6 @@
       "version": "3.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha1-KG4x3pbrltOKl4mYFXQLoqTzZAw=",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1542,34 +1251,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1594,6 +1275,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1663,20 +1356,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1692,30 +1386,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1913,6 +1583,17 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
@@ -1953,15 +1634,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2068,21 +1740,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "license": "MIT"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/js-md4": {
       "version": "0.3.2",
@@ -2262,12 +1919,6 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
-      "license": "ISC"
-    },
     "node_modules/ltx": {
       "version": "2.8.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ltx/-/ltx-2.8.0.tgz",
@@ -2371,15 +2022,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/moment": {
@@ -2547,10 +2189,13 @@
       }
     },
     "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2588,6 +2233,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -2621,11 +2275,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
-      "license": "BlueOak-1.0.0"
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2634,22 +2291,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/performance-now": {
@@ -2677,15 +2318,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2782,35 +2414,11 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha1-w9gx9R9ee/pi+i/75LUIxkDwlYQ=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "license": "ISC"
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -3101,17 +2709,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha1-zJZ+mTkP2ouRix7q87xDdjfIx68=",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3127,102 +2724,6 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -3233,33 +2734,21 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha1-om9bJsNN/Uk2pPip5pSo9RAq8T0=",
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
       "license": "MIT",
       "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha1-uPpyRe+Ojv+oB4KBlGyFq3gKCxI=",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha1-XQc6mnS5wKnSjfrcq5a2BK9X2Lo=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/to-buffer": {
@@ -3529,96 +3018,11 @@
       "integrity": "sha1-hQmvo7ccW70RCm18YkfsZ3NsWY8=",
       "license": "BSD-2-Clause"
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -3666,43 +3070,28 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha1-4UG5MO1gzK9df6nIJg4NF0iiu/s=",
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/zip-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/Tasks/AzureFunctionAppV1/package.json
+++ b/Tasks/AzureFunctionAppV1/package.json
@@ -26,7 +26,7 @@
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.272.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.274.1",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 2
+    "Minor": 275,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 2
+    "Minor": 275,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV2/package-lock.json
+++ b/Tasks/AzureFunctionAppV2/package-lock.json
@@ -16,7 +16,7 @@
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
-        "azure-pipelines-tasks-webdeployment-common": "^4.272.1",
+        "azure-pipelines-tasks-webdeployment-common": "^4.274.1",
         "azure-storage": "2.10.7",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -212,23 +212,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -262,16 +245,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@types/events": {
@@ -364,18 +337,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha1-6vVNU7YrrkE46AnKIlyEOabvs5I=",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
@@ -413,114 +374,40 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha1-ydkcNQNiBAuJJzeceqacBlUSL2E=",
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver/-/archiver-1.2.0.tgz",
+      "integrity": "sha1-+1xq9UQ7P6akJjRHU7rSp7REqt0=",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.1.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha1-Y7xxnZUYA+/HLPlhpW74EHYN0U0=",
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "license": "MIT",
       "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/asn1": {
@@ -542,10 +429,13 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-3.2.6.tgz",
-      "integrity": "sha1-Gwco4Ukp1RuFtEm38G4nwRReOM4=",
-      "license": "MIT"
+      "version": "2.6.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/async/-/async-2.6.4.tgz",
+      "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
@@ -696,16 +586,16 @@
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
-      "version": "4.274.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.274.0.tgz",
-      "integrity": "sha1-NcgswFMEW5d5TjxUcaDXTfAVFZo=",
+      "version": "4.274.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-webdeployment-common/-/azure-pipelines-tasks-webdeployment-common-4.274.1.tgz",
+      "integrity": "sha1-43V9u+zNyBQ+ZU7TAAWEtRxFjIM=",
       "license": "MIT",
       "dependencies": {
         "@types/ltx": "3.0.6",
         "@types/mocha": "^5.2.7",
         "@types/node": "^16.11.39",
         "@xmldom/xmldom": "^0.8.13",
-        "archiver": "7.0.1",
+        "archiver": "1.2.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "ltx": "2.8.0",
         "node-stream-zip": "^1.15.0",
@@ -771,116 +661,11 @@
         "sax": "0.5.x"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/b4a/-/b4a-1.8.0.tgz",
-      "integrity": "sha1-HKO6DtyUaaqr71ZH52moPVAYCxo=",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha1-ez4QvY4fyA2vOLtRaSFnj1ZquJ8=",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.6.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-fs/-/bare-fs-4.6.0.tgz",
-      "integrity": "sha1-/y8QyCONP/lPJwTwxYGxl7R+8RI=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.8.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-os/-/bare-os-3.8.7.tgz",
-      "integrity": "sha1-CcfE6MgX3nULC2m2XJKVE/ae3mU=",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha1-tZ0YEwulKmr5J22z6WouPT6lIXg=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-stream/-/bare-stream-2.12.0.tgz",
-      "integrity": "sha1-8baBh2gRN5C7v96Q9HAD83DId44=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bare-url/-/bare-url-2.4.0.tgz",
-      "integrity": "sha1-FUbWMFeRcYnKubJGKelG4ej3rzE=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -911,6 +696,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -939,9 +734,9 @@
       "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
     },
     "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
+      "version": "5.7.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
       "funding": [
         {
           "type": "github",
@@ -959,16 +754,32 @@
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
+      "license": "MIT"
+    },
     "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha1-oQmTuQVQgdVTBL2f60oHLeF59AU=",
+      "version": "0.2.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "license": "MIT",
       "engines": {
-        "node": ">=8.0.0"
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -976,6 +787,12 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -1045,24 +862,6 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "license": "Apache-2.0"
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "license": "MIT"
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1076,44 +875,18 @@
       }
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha1-JtMSUaZrnWuiOoQGTs06anHSYJ4=",
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/compress-commons/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/concat-map": {
@@ -1128,54 +901,26 @@
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "license": "MIT"
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha1-PK01qTS4v3HyXKUkttpR+36s4v8=",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha1-hSmjho+LJ6u5FfbDYXwPre2/lDA=",
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1311,12 +1056,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
-      "license": "MIT"
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1336,11 +1075,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "license": "MIT"
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1387,33 +1129,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha1-XU0+vflYPWOlMzzi3rdICrKwV4k=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events/-/events-3.3.0.tgz",
-      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha1-tWqE/WEbZhDgotDwn4D9+THi3+Y=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
@@ -1456,12 +1171,6 @@
       "version": "3.1.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha1-KG4x3pbrltOKl4mYFXQLoqTzZAw=",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -1542,34 +1251,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1594,6 +1275,18 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
+      "license": "MIT"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1663,20 +1356,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha1-jsA1WRnNMzjChCiiPU8k7MX+c4w=",
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1692,30 +1386,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -1913,6 +1583,17 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
@@ -1953,15 +1634,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2068,21 +1740,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "license": "MIT"
-    },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
     },
     "node_modules/js-md4": {
       "version": "0.3.2",
@@ -2262,12 +1919,6 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "license": "MIT"
     },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
-      "license": "ISC"
-    },
     "node_modules/ltx": {
       "version": "2.8.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ltx/-/ltx-2.8.0.tgz",
@@ -2371,15 +2022,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/moment": {
@@ -2547,10 +2189,13 @@
       }
     },
     "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2588,6 +2233,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
@@ -2621,11 +2275,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
-      "license": "BlueOak-1.0.0"
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2634,22 +2291,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/performance-now": {
@@ -2677,15 +2318,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2782,35 +2414,11 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha1-w9gx9R9ee/pi+i/75LUIxkDwlYQ=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "license": "ISC"
     },
     "node_modules/request": {
       "version": "2.88.2",
@@ -3101,17 +2709,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha1-zJZ+mTkP2ouRix7q87xDdjfIx68=",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3127,102 +2724,6 @@
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -3233,33 +2734,21 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-3.1.8.tgz",
-      "integrity": "sha1-om9bJsNN/Uk2pPip5pSo9RAq8T0=",
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
       "license": "MIT",
       "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha1-uPpyRe+Ojv+oB4KBlGyFq3gKCxI=",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha1-XQc6mnS5wKnSjfrcq5a2BK9X2Lo=",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/to-buffer": {
@@ -3529,96 +3018,11 @@
       "integrity": "sha1-hQmvo7ccW70RCm18YkfsZ3NsWY8=",
       "license": "BSD-2-Clause"
     },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -3666,43 +3070,28 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha1-4UG5MO1gzK9df6nIJg4NF0iiu/s=",
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha1-ztvYoRRsE9//jasUBoAo1YwVrJE=",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/zip-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/Tasks/AzureFunctionAppV2/package.json
+++ b/Tasks/AzureFunctionAppV2/package.json
@@ -26,7 +26,7 @@
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
-    "azure-pipelines-tasks-webdeployment-common": "^4.272.1",
+    "azure-pipelines-tasks-webdeployment-common": "^4.274.1",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppV2/task.json
+++ b/Tasks/AzureFunctionAppV2/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 275,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 2.* <br /> Removed WAR Deploy Support, setting Web.Config options, and the option for the Startup command for Linux Azure Function Apps.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV2/task.loc.json
+++ b/Tasks/AzureFunctionAppV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 275,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",


### PR DESCRIPTION
### Summary

Updates `azure-pipelines-tasks-webdeployment-common` from `^4.272.1` to `^4.274.1` in both AzureFunctionAppV1 and AzureFunctionAppV2 to fix a symlink handling regression in `archiveFolder()`.

### Problem

In `webdeployment-common@4.272.1`, the `archiver` dependency was accidentally bumped from `1.2.0` to `7.0.1` as collateral from an `npm audit fix` (the actual CVE fix was for `@xmldom/xmldom`, not archiver).

Archiver 7.0.1 uses `fs.lstatSync` internally, which does **not** follow symlinks. This causes symlinked directories in node_modules (e.g., from `npm install` with  dependencies) to be stored as small text files containing the symlink target path instead of the actual file contents. On Linux agents, this results in broken deployments where symlinked modules are missing their code.

### Root Cause

| Package version | archiver | Symlink behavior |
|---|---|---|
| webdeployment-common 4.272.0 | 1.2.0 | Follows symlinks (working) |
| webdeployment-common 4.272.1 | 7.0.1 | Stores symlinks as text files (broken) |
| **webdeployment-common 4.274.1** | **1.2.0** | **Follows symlinks (fixed)** |

### Fix

`webdeployment-common@4.274.1` reverts `archiver` back to `1.2.0`, which uses `fs.statSync` and correctly follows symlinks. This restores the behavior that existed prior to 4.272.1.

### Changes

- package.json — `webdeployment-common` → `^4.274.1`
- package.json — `webdeployment-common` → `^4.274.1`
- task.json + task.loc.json — version bump to `1.275.0`
- task.json + task.loc.json — version bump to `2.275.0`
- Updated package-lock.json for both tasks

### Testing

- AzureFunctionAppV1 and AzureFunctionAppV2 builds successfully (no existing L0 tests)
- Verified `archiveFolder()` correctly follows symlinks with the updated package
- L0 test coverage (including symlink regression test) will be added in a follow-up PR (#22125)