### PR TITLE
Update Task AzureTestPlanV0 & PublishTestResultsV1 versions to align with repository versioning scheme

### DIFF
--- a/Tasks/AzureTestPlanV0/task.json
+++ b/Tasks/AzureTestPlanV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 274,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": true,
   "demands": [],

--- a/Tasks/AzureTestPlanV0/task.loc.json
+++ b/Tasks/AzureTestPlanV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 274,
-    "Patch": 1
+    "Patch": 2
   },
   "preview": true,
   "demands": [],

--- a/Tasks/PublishTestResultsV1/task.json
+++ b/Tasks/PublishTestResultsV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 274,
-    "Patch": 0
+    "Patch": 1
   },
   "deprecated": true,
   "deprecationMessage": "The PublishTestResults@1 task is deprecated. Please use the latest version of the PublishTestResults task (PublishTestResults@2 or later).",

--- a/Tasks/PublishTestResultsV1/task.loc.json
+++ b/Tasks/PublishTestResultsV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 274,
-    "Patch": 0
+    "Patch": 1
   },
   "deprecated": true,
   "deprecationMessage": "The PublishTestResults@1 task is deprecated. Please use the latest version of the PublishTestResults task (PublishTestResults@2 or later).",


### PR DESCRIPTION
### **Context**
https://github.com/microsoft/azure-pipelines-tasks/pull/22137
The Above PR was merged without taking latest changes from master branch. This caused a small versioning issue since the master branch was already at the version updated to in the PR.

PR updates the PublishTestResultsV1 task to version 1.274.0. However master branch was already at 1.274.0 so ideally the PR should have taken latest and updated to 1.274.1 which was missed

This makes it look like both the changes were part of 1.274.0.

---

### **Task Name**
AzureTestPlanV0, PublishTestResultsV1

---

### **Description**
Update patch version to align with repository versioning scheme

---

### **Risk Assessment** (Low / Medium / High)  
Low - only version change

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No Testing performed just version update

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
- Revert PR to rollback changes

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
