### PR TITLE
Add versionFilePath to UseNode@1

### DIFF
--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -22,5 +22,6 @@
   "loc.messages.NodeVersionNotFound": "Unable to find Node version %s for platform %s and architecture %s.",
   "loc.messages.UnexpectedOS": "Unexpected OS %s",
   "loc.messages.AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
-  "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'"
+  "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
+  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
 }

--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -5,6 +5,8 @@
   "loc.instanceNameFormat": "Use Node $(versionSpec)",
   "loc.input.label.version": "Version",
   "loc.input.help.version": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0",
+  "loc.input.label.versionFilePath": "Version File Path",
+  "loc.input.help.versionFilePath": "File path to get version.  Example: src/.nvmrc",
   "loc.input.label.checkLatest": "Check for Latest Version",
   "loc.input.help.checkLatest": "Always checks online for the latest available version that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
   "loc.input.label.force32bit": "Use 32 bit version on x64 agents",

--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -23,5 +23,6 @@
   "loc.messages.UnexpectedOS": "Unexpected OS %s",
   "loc.messages.AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
   "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
+  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+  "loc.messages.InvalidVersionSpecification": "Version specification '%s' is invalid."
 }

--- a/Tasks/UseNodeV1/Tests/L0.ts
+++ b/Tasks/UseNodeV1/Tests/L0.ts
@@ -114,4 +114,16 @@ describe('NodeTool Suite', function () {
         assert(tr.stdout.indexOf('DOWNLOAD https://mymirror.example.com/node/v10.15.1/') > -1, 'Should download from the custom mirror base');
       }, tr);
     });
+
+    it('Fails when version and versionFilePath are both specified', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidConfiguration.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_CannotSpecifyVersionAndVersionFilePath'), "Descriptive message should be output");
+      }, tr);
+    });
 });

--- a/Tasks/UseNodeV1/Tests/L0.ts
+++ b/Tasks/UseNodeV1/Tests/L0.ts
@@ -126,4 +126,28 @@ describe('NodeTool Suite', function () {
         assert(tr.stdOutContained('loc_mock_CannotSpecifyVersionAndVersionFilePath'), "Descriptive message should be output");
       }, tr);
     });
+
+    it('Fails when specified version is invalid', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidVersionSpec.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_InvalidVersionSpecification InvalidFromVersion'), "Descriptive message should be output");
+      }, tr);
+    });
+
+    it('Fails when version in specified versionSpecFile is invalid', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidVersionSpecInFile.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_InvalidVersionSpecification InvalidFromFile'), "Descriptive message should be output");
+      }, tr);
+    });
 });

--- a/Tasks/UseNodeV1/Tests/L0InvalidConfiguration.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidConfiguration.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('version', '26.x');
+tmr.setInput('versionFilePath', '.node-version');
+
+tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
@@ -1,0 +1,9 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('version', 'InvalidFromVersion');
+
+tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0InvalidVersionSpecInFile.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidVersionSpecInFile.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionFilePath', '.node-version');
+
+tmr.registerMock('fs', {
+  readFileSync: function (filePath) {
+    if (filePath === '.node-version') {
+      return 'InvalidFromFile';
+    }
+
+    return 'Unexpected file path: ' + filePath;
+  }
+});
+
+tmr.run();

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -111,6 +111,7 @@
     "UnexpectedOS": "Unexpected OS %s",
     "AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
     "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
+    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+    "InvalidVersionSpecification": "Version specification '%s' is invalid."
   }
 }

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -110,6 +110,7 @@
     "NodeVersionNotFound": "Unable to find Node version %s for platform %s and architecture %s.",
     "UnexpectedOS": "Unexpected OS %s",
     "AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
-    "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'"
+    "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
+    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
   }
 }

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 277,
+    "Patch": 0
   },
   "satisfies": [
     "Node",

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -36,6 +36,13 @@
       "helpMarkDown": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0"
     },
     {
+      "name": "versionFilePath",
+      "type": "string",
+      "label": "Version File Path",
+      "required": false,
+      "helpMarkDown": "File path to get version.  Example: src/.nvmrc"
+    },
+    {
       "name": "checkLatest",
       "type": "boolean",
       "label": "Check for Latest Version",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -111,6 +111,7 @@
     "UnexpectedOS": "ms-resource:loc.messages.UnexpectedOS",
     "AgentTempDirNotSet": "ms-resource:loc.messages.AgentTempDirNotSet",
     "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror",
-    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath"
+    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath",
+    "InvalidVersionSpecification": "ms-resource:loc.messages.InvalidVersionSpecification"
   }
 }

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -110,6 +110,7 @@
     "NodeVersionNotFound": "ms-resource:loc.messages.NodeVersionNotFound",
     "UnexpectedOS": "ms-resource:loc.messages.UnexpectedOS",
     "AgentTempDirNotSet": "ms-resource:loc.messages.AgentTempDirNotSet",
-    "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror"
+    "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror",
+    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath"
   }
 }

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,8 +16,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 277,
+    "Patch": 0
   },
   "satisfies": [
     "Node",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -36,6 +36,13 @@
       "helpMarkDown": "ms-resource:loc.input.help.version"
     },
     {
+      "name": "versionFilePath",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.versionFilePath",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.versionFilePath"
+    },
+    {
       "name": "checkLatest",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.checkLatest",

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -41,6 +41,10 @@ async function run() {
 }
 
 function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) {
+    if (versionSpecInput && versionFilePathInput) {
+        throw new Error(taskLib.loc('CannotSpecifyVersionAndVersionFilePath'));
+    }
+
     if (versionFilePathInput) {
         return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
     }

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -12,6 +12,7 @@ import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as installer from './installer';
 import * as proxyutil from './proxyutil';
 import * as path from 'path';
+import * as fs from 'fs';
 
 async function run() {
     try {
@@ -20,7 +21,7 @@ async function run() {
         // If not supplied then task is still used to setup proxy, auth, etc...
         //
         taskLib.setResourcePath(path.join(__dirname, 'task.json'));
-        const version = taskLib.getInput('version', false);
+        const version = getNodeVersion(taskLib.getInput('version', false), taskLib.getInput('versionFilePath', false));
         const nodejsMirror = taskLib.getInput('nodejsMirror', false) || 'https://nodejs.org/dist/';
         const retryCountOnDownloadFails = taskLib.getInput('retryCountOnDownloadFails', false) || "5";
         const delayBetweenRetries = taskLib.getInput('delayBetweenRetries', false) || "1000";
@@ -37,6 +38,14 @@ async function run() {
     catch (error) {
         taskLib.setResult(taskLib.TaskResult.Failed, error.message);
     }
+}
+
+function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) {
+    if (versionFilePathInput) {
+        return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
+    }
+
+    return versionSpecInput;
 }
 
 run()

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -9,6 +9,7 @@
 
 import * as taskLib from 'azure-pipelines-task-lib/task';
 //import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as semver from 'semver';
 import * as installer from './installer';
 import * as proxyutil from './proxyutil';
 import * as path from 'path';
@@ -45,11 +46,15 @@ function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) 
         throw new Error(taskLib.loc('CannotSpecifyVersionAndVersionFilePath'));
     }
 
-    if (versionFilePathInput) {
-        return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
+    const version =
+        versionFilePathInput
+            ? fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' })
+            : versionSpecInput;
+    if (semver.validRange(version) === null) {
+        throw new Error(taskLib.loc('InvalidVersionSpecification', version));
     }
 
-    return versionSpecInput;
+    return version;
 }
 
 run()


### PR DESCRIPTION


### **Context**
Fixes #22131

---

### **Task Name**
UseNode@1

---

### **Description**
Adds a `versionFilePath` input to UseNode@1 so that version specs can be stored in a file (e.g. `.nvmrc` or `.node-version`), instead of duplicated in the Pipelines config.

---

### **Risk Assessment** (Low / Medium / High)  
Low. This change is backwards compatible and requires a developer to opt in to using the new input.

---

### **Change Behind Feature Flag** (Yes / No)
This adds a new input field, I don't know whether or not that can be feature flagged.

---

### **Tech Design / Approach**
This approach used the same basic idea as NodeTool@0 and UseDotnet@2

---

### **Documentation Changes Required** (Yes/No)
Yes, there is a new input field, as well as new error messages.

---

### **Unit Tests Added or Updated** (Yes / No)  
Yes, added tests for new error messages.

---

### **Additional Testing Performed**
Verified automated tests did not have additional failures.

---

### **Logging Added/Updated** (Yes/No)
Yes, new error conditions output an error message

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
No

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
