### PR TITLE
Change code owners for AzureStaticWebAppV0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -112,7 +112,7 @@ Tasks/AzureRmWebAppDeploymentV5/   @jvano @dannysongg @shilpirachna1 @microsoft/
 # DRI rotation: Azure Spring Apps/AzDMSS-Support
 Tasks/AzureSpringCloudV0    @microsoft/azure-spring-apps @menxiao
 
-Tasks/AzureStaticWebAppV0/  @microsoft/azure-static-web-apps @mkarmark @joslinmicrosoft
+Tasks/AzureStaticWebAppV0/  @microsoft/azure-static-web-apps @cjk7989 @jessieyyt @LongOddCode
 
 Tasks/AzureTestPlanV0/     @manos  @microsoft/adoautotest
 


### PR DESCRIPTION
Updated code owners for AzureStaticWebAppV0.

### **Context**
Same change as #22202 — updating CODEOWNERS for AzureStaticWebAppV0.

### **Task Name**
AzureStaticWebAppV0

### **Description**
Updated code owners for AzureStaticWebAppV0: replaced @mkarmark and @joslinmicrosoft with @cjk7989, @jessieyyt, and @LongOddCode.

### **Risk Assessment** (Low)
CODEOWNERS-only change, no task code affected.

### **Unit Tests Added or Updated** (No)
Not applicable — no code changes.