### PR TITLE
Bump azure-pipelines-task-lib to ^5.2.10 for 8 Kubernetes tasks

### DIFF
--- a/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package-lock.json
@@ -13,7 +13,7 @@
         "@types/q": "^1.5.0",
         "@types/uuid": "^9.0.0",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tasks-docker-common": "^2.273.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/AzureFunctionOnKubernetesV1/package.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/package.json
@@ -24,7 +24,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^9.0.0",
     "agent-base": "^6.0.2",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tasks-docker-common": "^2.273.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/AzureFunctionOnKubernetesV1/task.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
+++ b/Tasks/AzureFunctionOnKubernetesV1/task.loc.json
@@ -15,7 +15,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV0/package-lock.json
+++ b/Tasks/HelmDeployV0/package-lock.json
@@ -10,7 +10,7 @@
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
         "agent-base": "6.0.2",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tasks-docker-common": "^2.271.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/HelmDeployV0/package.json
+++ b/Tasks/HelmDeployV0/package.json
@@ -9,7 +9,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "agent-base": "6.0.2",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tasks-docker-common": "^2.271.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/HelmDeployV0/task.json
+++ b/Tasks/HelmDeployV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV0/task.loc.json
+++ b/Tasks/HelmDeployV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV1/package-lock.json
+++ b/Tasks/HelmDeployV1/package-lock.json
@@ -10,7 +10,7 @@
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
         "agent-base": "6.0.2",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tasks-docker-common": "^2.271.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/HelmDeployV1/package.json
+++ b/Tasks/HelmDeployV1/package.json
@@ -9,7 +9,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "agent-base": "6.0.2",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tasks-docker-common": "^2.271.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/HelmDeployV1/task.json
+++ b/Tasks/HelmDeployV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmDeployV1/task.loc.json
+++ b/Tasks/HelmDeployV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [

--- a/Tasks/HelmInstallerV1/package-lock.json
+++ b/Tasks/HelmInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "^5.2.6",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
         "azure-pipelines-tool-lib": "^2.0.10"
       },

--- a/Tasks/HelmInstallerV1/package.json
+++ b/Tasks/HelmInstallerV1/package.json
@@ -8,7 +8,7 @@
     "@types/node": "^24.10.0",
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
     "azure-pipelines-tool-lib": "^2.0.10"
   },

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "preview": true,
   "demands": [],

--- a/Tasks/KubectlInstallerV0/package-lock.json
+++ b/Tasks/KubectlInstallerV0/package-lock.json
@@ -8,7 +8,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "^5.2.6",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
         "azure-pipelines-tool-lib": "^2.0.10"
       },

--- a/Tasks/KubectlInstallerV0/package.json
+++ b/Tasks/KubectlInstallerV0/package.json
@@ -7,7 +7,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^24.10.0",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
     "azure-pipelines-tool-lib": "^2.0.10"
   },

--- a/Tasks/KubectlInstallerV0/task.json
+++ b/Tasks/KubectlInstallerV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubectlInstallerV0/task.loc.json
+++ b/Tasks/KubectlInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/package-lock.json
+++ b/Tasks/KubeloginInstallerV0/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "^1.0.7",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tool-lib": "^2.0.10"
       },

--- a/Tasks/KubeloginInstallerV0/package.json
+++ b/Tasks/KubeloginInstallerV0/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^24.10.0",
     "@types/q": "^1.0.7",
     "agent-base": "^6.0.2",
-    "azure-pipelines-task-lib": "^5.2.8",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tool-lib": "^2.0.10"
   },

--- a/Tasks/KubeloginInstallerV0/task.json
+++ b/Tasks/KubeloginInstallerV0/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubeloginInstallerV0/task.loc.json
+++ b/Tasks/KubeloginInstallerV0/task.loc.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": 0,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV1/package-lock.json
+++ b/Tasks/KubernetesManifestV1/package-lock.json
@@ -12,7 +12,7 @@
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.6",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tasks-docker-common": "^2.268.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/KubernetesManifestV1/package.json
+++ b/Tasks/KubernetesManifestV1/package.json
@@ -11,7 +11,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tasks-docker-common": "^2.268.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/KubernetesManifestV1/task.json
+++ b/Tasks/KubernetesManifestV1/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV1/task.loc.json
+++ b/Tasks/KubernetesManifestV1/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 1,
     "Minor": 275,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV1/package-lock.json
+++ b/Tasks/KubernetesV1/package-lock.json
@@ -12,7 +12,7 @@
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.6",
+        "azure-pipelines-task-lib": "^5.2.10",
         "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
         "azure-pipelines-tasks-docker-common": "2.268.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
@@ -456,9 +456,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.8.tgz",
-      "integrity": "sha1-GTBOm8FZy35Zx6kShvq/0qgqPFA=",
+      "version": "5.2.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+      "integrity": "sha512-6Wak5UB+Bs693LkPoE4gZTDNkNL5DDn2buQKMtvqIWh2ZCIJk+tc1nSzroGWntJa7USs8X3cYvdl0RiSsp4/5A==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/Tasks/KubernetesV1/package.json
+++ b/Tasks/KubernetesV1/package.json
@@ -11,7 +11,7 @@
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
     "agent-base": "^6.0.2",
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "^5.2.10",
     "azure-pipelines-tasks-azure-arm-rest": "^3.274.0",
     "azure-pipelines-tasks-docker-common": "2.268.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",

--- a/Tasks/KubernetesV1/task.json
+++ b/Tasks/KubernetesV1/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 275,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "What's new in Version 1.0:<br/>&nbsp;Added new service connection type input for easy selection of Azure AKS cluster.<br/>&nbsp;Replaced output variable input with output variables section that we had added in all tasks.",

--- a/Tasks/KubernetesV1/task.loc.json
+++ b/Tasks/KubernetesV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
-    "Patch": 1
+    "Minor": 275,
+    "Patch": 0
   },
   "demands": [],
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
## Summary

Updates `azure-pipelines-task-lib` to `^5.2.10` for 8 Kubernetes-related tasks to fix a bug where `cp()` treats `@` in filenames as a glob pattern, causing infinite recursion and stack overflow.

## Changes

| Task | Previous Version | New Version | Previous task-lib | New task-lib |
|------|-----------------|-------------|-------------------|--------------|
| AzureFunctionOnKubernetesV1 | 1.275.0 | 1.275.1 | ^5.2.8 | ^5.2.10 |
| HelmDeployV0 | 0.275.0 | 0.275.1 | ^5.2.8 | ^5.2.10 |
| HelmDeployV1 | 1.275.0 | 1.275.1 | ^5.2.8 | ^5.2.10 |
| HelmInstallerV1 | 1.275.0 | 1.275.1 | ^5.2.6 | ^5.2.10 |
| KubectlInstallerV0 | 0.275.0 | 0.275.1 | ^5.2.6 | ^5.2.10 |
| KubeloginInstallerV0 | 0.275.0 | 0.275.1 | ^5.2.8 | ^5.2.10 |
| KubernetesManifestV1 | 1.275.0 | 1.275.1 | ^5.2.6 | ^5.2.10 |
| KubernetesV1 | 1.274.1 | 1.275.0 | ^5.2.6 | ^5.2.10 |

## Testing

- All 8 tasks build successfully
- All L0 test suites pass