### PR TITLE
AzureIoTEdgeV2: add Node24 handler and migrate to Node 24

### DIFF
--- a/Tasks/AzureIoTEdgeV2/package-lock.json
+++ b/Tasks/AzureIoTEdgeV2/package-lock.json
@@ -9,18 +9,18 @@
       "version": "1.1.2",
       "dependencies": {
         "@types/mocha": "^5.2.7",
-        "@types/node": "^20.3.1",
+        "@types/node": "^24.10.0",
         "@types/q": "^1.5.4",
         "agent-base": "^6.0.2",
         "applicationinsights": "^1.0.2",
-        "azure-pipelines-task-lib": "^4.4.0",
+        "azure-pipelines-task-lib": "^5.2.6",
         "azure-pipelines-tasks-artifacts-common": "^2.273.0",
         "azure-pipelines-tasks-docker-common": "^2.268.0",
-        "azure-pipelines-tasks-utility-common": "3.272.0",
+        "azure-pipelines-tasks-utility-common": "^3.270.0",
         "minimatch": "3.1.5"
       },
       "devDependencies": {
-        "typescript": "5.1.6"
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -238,11 +238,12 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "24.12.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha1-Jwl0VWmBHcvcV8CX+v3Th8YzA4I=",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/q": {
@@ -411,17 +412,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha1-/VMnGollIKefO6iDOcwLNiv51bk=",
+      "version": "5.2.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
+      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
+        "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
       }
     },
@@ -446,30 +447,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.60.tgz",
       "integrity": "sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA=="
     },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/azure-pipelines-task-lib/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-6.3.1.tgz",
@@ -477,19 +454,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-artifacts-common/node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
@@ -528,34 +492,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "license": "MIT"
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
       "version": "2.3.1",
@@ -604,32 +540,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/uuid/-/uuid-8.3.4.tgz",
       "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
-    "node_modules/azure-pipelines-tasks-docker-common/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-docker-common/node_modules/azure-pipelines-task-lib/node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
-    },
     "node_modules/azure-pipelines-tasks-docker-common/node_modules/q": {
       "version": "1.4.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.4.1.tgz",
@@ -637,19 +547,6 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-docker-common/node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/azure-pipelines-tasks-utility-common": {
@@ -671,34 +568,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha1-J4dfqikmwPR1s5qLseVGwBdvjUs=",
       "license": "MIT"
-    },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/azure-pipelines-tasks-utility-common/node_modules/typed-rest-client": {
       "version": "2.2.0",
@@ -729,34 +598,6 @@
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "^3.1.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/typed-rest-client": {
@@ -1389,30 +1230,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha1-PgdFCoCA684/vwysSU9NKrMk4II=",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-docker": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
@@ -1986,12 +1803,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "license": "MIT"
-    },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
@@ -2074,38 +1885,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha1-9bKmgIl8acI4oTzRaxVnH4tzVJ8=",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -2238,20 +2017,16 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
+      "version": "0.10.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
+      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.2"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
       }
     },
     "node_modules/shimmer": {
@@ -2357,18 +2132,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2425,10 +2188,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.9.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2444,9 +2208,10 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha1-/8zf82rqSITL/OmnUKBYAiT1ikY=",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/Tasks/AzureIoTEdgeV2/package-lock.json
+++ b/Tasks/AzureIoTEdgeV2/package-lock.json
@@ -16,7 +16,7 @@
         "azure-pipelines-task-lib": "^5.2.6",
         "azure-pipelines-tasks-artifacts-common": "^2.273.0",
         "azure-pipelines-tasks-docker-common": "^2.268.0",
-        "azure-pipelines-tasks-utility-common": "^3.270.0",
+        "azure-pipelines-tasks-utility-common": "^3.272.0",
         "minimatch": "3.1.5"
       },
       "devDependencies": {

--- a/Tasks/AzureIoTEdgeV2/package.json
+++ b/Tasks/AzureIoTEdgeV2/package.json
@@ -14,7 +14,7 @@
     "azure-pipelines-task-lib": "^5.2.6",
     "azure-pipelines-tasks-artifacts-common": "^2.273.0",
     "azure-pipelines-tasks-docker-common": "^2.268.0",
-    "azure-pipelines-tasks-utility-common": "^3.270.0",
+    "azure-pipelines-tasks-utility-common": "^3.272.0",
     "minimatch": "3.1.5"
   },
   "devDependencies": {

--- a/Tasks/AzureIoTEdgeV2/package.json
+++ b/Tasks/AzureIoTEdgeV2/package.json
@@ -7,20 +7,20 @@
   "version": "1.1.2",
   "dependencies": {
     "@types/mocha": "^5.2.7",
-    "@types/node": "^20.3.1",
+    "@types/node": "^24.10.0",
     "@types/q": "^1.5.4",
     "agent-base": "^6.0.2",
     "applicationinsights": "^1.0.2",
-    "azure-pipelines-task-lib": "^4.4.0",
+    "azure-pipelines-task-lib": "^5.2.6",
     "azure-pipelines-tasks-artifacts-common": "^2.273.0",
     "azure-pipelines-tasks-docker-common": "^2.268.0",
-    "azure-pipelines-tasks-utility-common": "3.272.0",
+    "azure-pipelines-tasks-utility-common": "^3.270.0",
     "minimatch": "3.1.5"
   },
   "devDependencies": {
-    "typescript": "5.1.6"
+    "typescript": "^5.7.2"
   },
   "overrides": {
-	  "minimatch": "3.1.5"
+    "minimatch": "3.1.5"
   }
 }

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 276,
+    "Minor": 275,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 274,
-    "Patch": 2
+    "Minor": 276,
+    "Patch": 0
   },
   "preview": false,
   "showEnvironmentVariables": true,
@@ -256,6 +256,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "index.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "index.js",
       "argumentFormat": ""
     }

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 276,
+    "Minor": 275,
     "Patch": 0
   },
   "preview": false,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 274,
-    "Patch": 2
+    "Minor": 276,
+    "Patch": 0
   },
   "preview": false,
   "showEnvironmentVariables": true,
@@ -256,6 +256,10 @@
       "argumentFormat": ""
     },
     "Node20_1": {
+      "target": "index.js",
+      "argumentFormat": ""
+    },
+    "Node24": {
       "target": "index.js",
       "argumentFormat": ""
     }

--- a/Tasks/AzureIoTEdgeV2/util.ts
+++ b/Tasks/AzureIoTEdgeV2/util.ts
@@ -34,7 +34,7 @@ export default class Util {
     var toSign = resourceUri + '\n' + expires;
 
     // Use crypto
-    var hmac = crypto.createHmac('sha256', new Buffer(signingKey, 'base64'));
+    var hmac = crypto.createHmac('sha256', Buffer.from(signingKey, 'base64'));
     hmac.update(toSign);
     var base64UriEncoded = encodeURIComponent(hmac.digest('base64'));
 

--- a/make-options.json
+++ b/make-options.json
@@ -257,6 +257,7 @@
     "Node24_10": [],
     "Node24_overwrite": [
         "AppCenterDistributeV3",
+        "AzureIoTEdgeV2",
         "PublishSymbolsV2"
     ],
     "wif_242": [


### PR DESCRIPTION
### **Context**
Node.js 20 reaches end-of-life in April 2026, so all maintained Azure Pipelines tasks must add a Node 24 execution handler, fix any APIs removed/deprecated between Node 20 and Node 24, and ship on the updated toolchain. This PR migrates the `AzureIoTEdgeV2` task to Node 24.

---

### **Task Name**
AzureIoTEdgeV2 (Azure IoT Edge)

---

### **Description**
Migrates `AzureIoTEdgeV2` to the Node 24 runtime (in-place / overwrite mode):
- Add the `Node24` execution handler to `task.json` and `task.loc.json`.
- Replace the deprecated `new Buffer(...)` constructor with `Buffer.from(...)` in `util.ts` (the only confirmed breaking-API hit from the scan).
- Bump the toolchain in `package.json` / `package-lock.json`: `azure-pipelines-task-lib ^5.2.4`, `@types/node ^24.10.0`, `typescript 5.7.2`.
- Register `AzureIoTEdgeV2` under `Node24_overwrite` in `make-options.json`.
- Bump task version `2.274.2` → `2.276.0`.

`tsconfig.json` is intentionally unchanged (no named capture groups; matches the pattern used by `AppCenterDistributeV3`).

---

### **Risk Assessment** (Low / Medium / High)
Low. Scope is limited to a single task. The only code change is a like-for-like `Buffer` API swap with identical behavior; the rest is handler registration, version bump, and toolchain updates. Existing `Node10`/`Node16`/`Node20_1` handlers are retained, so behavior on older agents is unchanged.

---

### **Change Behind Feature Flag** (Yes / No)
No. This uses the in-place / overwrite migration approach (single shipped version). Rollback is handled via "Override Task Version" if needed.

---

### **Tech Design / Approach**
- Followed the standard Node 24 task-migration approach (overwrite mode): add handler, fix breaking APIs, bump toolchain + version, register build config.
- Breaking-API scan run across the task source; only `new Buffer()` required a fix. Other patterns (`crypto.createCipher`/`createDecipher`, `url.parse`, `util.is*`, `fs.Stats`/`FsStats`, named regex capture groups, `NODE_OPTIONS`) came back clean.

---

### **Documentation Changes Required** (Yes/No)
No.

---

### **Unit Tests Added or Updated** (Yes / No)
No new tests required for a runtime/handler migration. Existing L0 tests were run and pass.

---

### **Additional Testing Performed**
- `node make.js build --task AzureIoTEdgeV2 --configs Node24_overwrite --bumpBaseTask` → BUILD SUCCESSFUL (built with Node 24 / TypeScript 5.7.2).
- `node make.js test --task AzureIoTEdgeV2` → L0 suites pass (task suite + common/General suite).
- **Validated on a real hosted agent:** packaged a private test extension, ran it on a classic pipeline. Run log confirms the task executes on the Node 24 handler — `Version : 2.276.1` (test build) and `Using node path: .../externals/node24/bin/node`, task loaded inputs and ran its logic on Ubuntu 24.04.

---

### **Logging Added/Updated** (Yes/No)
No.

---

### **Telemetry Added/Updated** (Yes/No)
No.
