### PR TITLE
Vulnerability fix for GradleAuthenticateV0 task

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -268,6 +268,8 @@ Tasks/GoV0/    @microsoft/release-management-task-team @manolerazvan
 
 Tasks/GoToolV0/    @microsoft/release-management-task-team @manolerazvan 
 
+Tasks/GradleAuthenticateV0/    @microsoft/azure-artifacts-packages
+
 Tasks/GradleV2/    @microsoft/azure-pipelines-tasks-and-agent @tarunramsinghani
 
 Tasks/GradleV3/    @microsoft/azure-pipelines-tasks-and-agent @tarunramsinghani

--- a/Tasks/GradleAuthenticateV0/package-lock.json
+++ b/Tasks/GradleAuthenticateV0/package-lock.json
@@ -1364,15 +1364,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
@@ -1427,26 +1418,6 @@
                 "queue-microtask": "^1.2.2"
             }
         },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
-        },
         "node_modules/sanitize-filename": {
             "version": "1.6.4",
             "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
@@ -1466,12 +1437,12 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha1-3voeBVyDv21Z6oBdjahiJU62psI=",
+            "version": "7.0.5",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha1-x5jMBVL/uwiYGRSkKodW4znQ1bE=",
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/shebang-command": {

--- a/Tasks/GradleAuthenticateV0/package.json
+++ b/Tasks/GradleAuthenticateV0/package.json
@@ -27,5 +27,8 @@
     },
     "devDependencies": {
         "typescript": "^5.7.2"
+    },
+    "overrides": {
+        "serialize-javascript": "7.0.5"
     }
 }

--- a/Tasks/GradleAuthenticateV0/task.json
+++ b/Tasks/GradleAuthenticateV0/task.json
@@ -10,7 +10,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 276,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/GradleAuthenticateV0/task.loc.json
+++ b/Tasks/GradleAuthenticateV0/task.loc.json
@@ -10,7 +10,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 276,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
### **Context**

[AB#2362576](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362576)

See comment: https://mseng.visualstudio.com/AzureDevOps/_workitems/edit/2362576#8023445

---

### **Task Name**
GradleAuthenticateV0

---

### **Description**

Mocha v12 and below package a vulnerable serialize-javascript package
V12 of Mocha is still in beta so temporarily we are adding overrides to a patched version of serialize-javascript
Once V12 of Mocha is available this override will be removed and the mocha package will be updated

---

### **Risk Assessment** (Low / Medium / High)  
Low - Mocha is an internal testing dependency.

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
NA

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
CI checks only. No additional testing done

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Revert PR to rollback changes and override the task if required

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
