### PR TITLE
AzureIoTEdgeV2: harden docker login and command invocation

### DIFF
--- a/Tasks/AzureIoTEdgeV2/buildimage.ts
+++ b/Tasks/AzureIoTEdgeV2/buildimage.ts
@@ -32,7 +32,6 @@ export async function run() {
     cwd: tl.cwd(),
     env: envList,
     outStream: outputStream as stream.Writable,
-    shell: true,
   } as IExecOptions;
   let defaultPlatform = tl.getInput('defaultPlatform', true);
   await tl.exec(`${Constants.iotedgedev}`, ["build", "--file", templateFilePath, "--platform", defaultPlatform], execOptions);

--- a/Tasks/AzureIoTEdgeV2/constant.ts
+++ b/Tasks/AzureIoTEdgeV2/constant.ts
@@ -26,7 +26,7 @@ export default class Constants {
   public static osTypeMac = "Darwin";
   public static defaultDockerHubHostname = "docker.io";
   public static variableKeyDisableTelemetry = "DISABLE_TELEMETRY";
-  public static execSyncSilentOption = { silent: true, shell: true } as IExecSyncOptions;
+  public static execSyncSilentOption = { silent: true } as IExecSyncOptions;
   public static defaultExecOption = {} as IExecSyncOptions;
   public static UTF8 = "utf8";
   public static outputVariableDeploymentPathKey = "DEPLOYMENT_FILE_PATH";

--- a/Tasks/AzureIoTEdgeV2/deployimage.ts
+++ b/Tasks/AzureIoTEdgeV2/deployimage.ts
@@ -77,7 +77,6 @@ class azureclitask {
       let outputStream: EchoStream = new EchoStream();
       let execOptions: IExecOptions = {
         errStream: outputStream as stream.Writable,
-        shell: true,
       } as IExecOptions;
 
       let result1 = tl.execSync('az', ["iot", "edge", "deployment", "delete", "--hub-name", iothub, "--deployment-id", configId], Constants.execSyncSilentOption);
@@ -188,9 +187,9 @@ class imagevalidationtask {
       if (credentials) {
         Object.keys(credentials).forEach((key: string) => {
           let credential = credentials[key];
-          let loginResult = tl.execSync("docker", ["login", credential.address, "-u", credential.username, "-p", credential.password], Constants.execSyncSilentOption);
-          tl.debug(JSON.stringify(loginResult));
-          if (loginResult.code != 0) {
+          let loginResult = util.dockerLogin(credential.address, credential.username, credential.password);
+          tl.debug(JSON.stringify({ status: loginResult.status }));
+          if (loginResult.status != 0) {
             tl.warning(tl.loc("InvalidRegistryCredentialWarning", credential.address, loginResult.stderr));
           } else {
             tl.loc("LoginRegistrySucess", credential.address);

--- a/Tasks/AzureIoTEdgeV2/genconfig.ts
+++ b/Tasks/AzureIoTEdgeV2/genconfig.ts
@@ -33,7 +33,6 @@ export async function run() {
   let execOptions: IExecOptions = {
     cwd: tl.cwd(),
     env: envList,
-    shell: true,
   } as IExecOptions;
   let defaultPlatform = tl.getInput('defaultPlatform', true);
   let genConfigCommand = ["genconfig", "--file", templateFilePath, "--platform", defaultPlatform];

--- a/Tasks/AzureIoTEdgeV2/pushimage.ts
+++ b/Tasks/AzureIoTEdgeV2/pushimage.ts
@@ -60,7 +60,14 @@ export async function run() {
    * However, "michaeljqzq" is not in the scope of a credential.
    * So here is a work around to login in advanced call to `iotedgedev push` and then logout after everything done.
    */
-  util.dockerLogin(authenticationToken.getLoginServerUrl(), authenticationToken.getUsername(), authenticationToken.getPassword());
+  const loginServerUrl = authenticationToken.getLoginServerUrl();
+  const loginResult = util.dockerLogin(loginServerUrl, authenticationToken.getUsername(), authenticationToken.getPassword());
+  // spawnSync does not throw on a non-zero exit code, so explicitly fail fast here.
+  // Unlike the deploy task (which validates multiple registries and warns-and-continues),
+  // push depends on this single login succeeding before `iotedgedev push` runs.
+  if (loginResult.status !== 0) {
+    throw new TaskError('Failed to login to container registry', tl.loc('InvalidRegistryCredentialWarning', loginServerUrl, loginResult.stderr));
+  }
 
   let envList = process.env;
   // Set bypass modules

--- a/Tasks/AzureIoTEdgeV2/pushimage.ts
+++ b/Tasks/AzureIoTEdgeV2/pushimage.ts
@@ -60,7 +60,7 @@ export async function run() {
    * However, "michaeljqzq" is not in the scope of a credential.
    * So here is a work around to login in advanced call to `iotedgedev push` and then logout after everything done.
    */
-  tl.execSync(`docker`, ["login", "-u", authenticationToken.getUsername(), "-p", authenticationToken.getPassword(), authenticationToken.getLoginServerUrl()], Constants.execSyncSilentOption)
+  util.dockerLogin(authenticationToken.getLoginServerUrl(), authenticationToken.getUsername(), authenticationToken.getPassword());
 
   let envList = process.env;
   // Set bypass modules
@@ -79,7 +79,6 @@ export async function run() {
     let execOptions: IExecOptions = {
       cwd: tl.cwd(),
       env: envList,
-      shell: true,
     } as IExecOptions;
     let defaultPlatform = tl.getInput('defaultPlatform', true);
     await tl.exec(`${Constants.iotedgedev}`, ["push", "--no-build", "--file", templateFilePath, "--platform", defaultPlatform], execOptions);

--- a/Tasks/AzureIoTEdgeV2/task.json
+++ b/Tasks/AzureIoTEdgeV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 274,
-    "Patch": 2
+    "Patch": 3
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/task.loc.json
+++ b/Tasks/AzureIoTEdgeV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 274,
-    "Patch": 2
+    "Patch": 3
   },
   "preview": false,
   "showEnvironmentVariables": true,

--- a/Tasks/AzureIoTEdgeV2/util.ts
+++ b/Tasks/AzureIoTEdgeV2/util.ts
@@ -1,6 +1,7 @@
 import Constants from "./constant";
 import * as tl from "azure-pipelines-task-lib/task";
 import * as crypto from "crypto";
+import * as child from "child_process";
 import { IExecSyncOptions } from 'azure-pipelines-task-lib/toolrunner';
 import { Writable } from "stream";
 import { RegistryCredential } from './registrycredentialfactory';
@@ -13,6 +14,19 @@ interface Cmd {
 }
 
 export default class Util {
+  /**
+   * Run `docker login` while passing the password through stdin (`--password-stdin`)
+   * instead of as a command-line argument. This keeps the registry password out of
+   * the process argument list and out of any shell interpretation.
+   */
+  public static dockerLogin(server: string, username: string, password: string): child.SpawnSyncReturns<string> {
+    const docker: string = tl.which("docker", true);
+    return child.spawnSync(docker, ["login", "-u", username, "--password-stdin", server], {
+      input: password,
+      encoding: "utf-8",
+    });
+  }
+
   public static expandEnv(input: string, ...exceptKeys: string[]): string {
     const pattern: RegExp = new RegExp(/\$([a-zA-Z0-9_]+)|\${([a-zA-Z0-9_]+)}/g);
     const exceptSet: Set<string> = new Set(exceptKeys);


### PR DESCRIPTION
This change hardens how the AzureIoTEdgeV2 task invokes external commands and handles registry credentials:

- `docker login` now receives the registry password via stdin (`--password-stdin`) rather than on the command line.
- Child processes are invoked with explicit argument arrays instead of being routed through a shell, which makes argument handling more predictable across Linux and Windows agents.

Behavior for normal usage is unchanged; legitimate logins, builds, and deployments continue to work. Verified on hosted Linux and Windows agents.

Task ID: 38013954