### PR TITLE
 Localization pipeline: fail-fast on merge conflicts + fix CRLF/LF divergence

### DIFF
--- a/Localize/localize-pipeline.yml
+++ b/Localize/localize-pipeline.yml
@@ -46,7 +46,22 @@ stages:
         git config --global user.email "$(github_email)"
         git config --global user.name "$(username)"
         git checkout -b Localization origin/Localization
+
+        # OneLocBuild commits .resjson files with Windows CRLF endings, while the repo
+        # standard (.gitattributes) is LF. Enable merge.renormalize so the 3-way merge
+        # canonicalizes line endings and does not raise spurious CRLF-vs-LF conflicts on
+        # every shared localized file.
+        git config merge.renormalize true
+
+        # Fail fast on a failed merge. Previously "git merge" was followed by "git push",
+        # and a merge failure was masked because only the last command's exit code set the
+        # step result - leaving master and Localization silently diverged.
         git merge origin/master
+        if ($LASTEXITCODE -ne 0) {
+          git merge --abort
+          throw "Sync with master failed due to merge conflicts. Resolve them on the Localization branch and re-run."
+        }
+
         git push origin Localization
       displayName: "Sync with master branch"
       condition: and(succeeded(), in(variables['build.reason'], 'Schedule', 'Manual'))


### PR DESCRIPTION
### **Context**
The localization pipeline has a "_Sync with master branch"_ step that runs git merge origin/master followed by git push. Because only the last command's exit code sets the step status, a failed merge is masked by the git push and the step reports success. As a result master is never merged into Localization and the two branches have silently diverged (~558 ahead / ~50 behind). `The conflicts are mostly CRLF-vs-LF: OneLocBuild writes CRLF .resjson files on the Localization branch while the repo standard (.gitattributes) is LF.`

[AB#2432914](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2432914)

---

### **Task Name**
N/A — this is a change to the localization pipeline (Localize/localize-pipeline.yml), not to a pipeline task

---

### **Description**
 Hardens the "Sync with master branch" step:

   - git config merge.renormalize true — the 3-way merge canonicalizes line endings so CRLF/LF differences no longer raise spurious conflicts on shared localized files.
   - Exit-code check after git merge — on failure it runs git merge --abort and throws, so the step fails instead of silently continuing to git push.

  Single file changed (Localize/localize-pipeline.yml, +15 lines); the original three git commands are preserved.

---

### **Risk Assessment** (Low / Medium / High)  
Low. Scoped to one step in an internal scheduled pipeline
---

### **Change Behind Feature Flag** (Yes / No)
 No. It is a pipeline YAML fix to a single internal step; a feature flag is not applicable to declarative pipeline definitions. Rollback is a simple revert.

---

### **Tech Design / Approach**
 Root-caused from build logs across 6 recent runs (all show CONFLICT/Automatic merge failed yet step = succeeded) and branch divergence analysis.
 - Chose merge.renormalize + explicit $LASTEXITCODE guard over alternatives (e.g. failOnStderr, splitting into separate steps) as the smallest, most targeted fix.

---

### **Documentation Changes Required** (Yes/No)
No. No user-facing guides, API specs, or runbooks are affected.

---

### **Unit Tests Added or Updated** (Yes / No)  
 No. Pipeline YAML step logic is not covered by unit tests; behavior is validated via pipeline runs (see below).

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Logging Added/Updated** (Yes/No)
Yes (minimal). Added a descriptive throw message on merge failure so the step's error clearly states the conflict and remediation. No sensitive data exposed; severity is appropriate (terminating error on a real failure).


--- 


### **Rollback Scenario and Process** (Yes/No)
 Yes. Revert this commit to restore the prior step. No state migration or cleanup required since the change only affects how the step evaluates the merge result.

---


### **Checklist**
- [x] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
