### PR TITLE
Bump azure-pipelines-task-lib and form-data versions in AzureSpringCloudV0 Task

### DIFF
--- a/Tasks/AzureSpringCloudV0/package-lock.json
+++ b/Tasks/AzureSpringCloudV0/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "1.0.7",
         "agent-base": "6.0.2",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.2.11",
         "azure-pipelines-tasks-azure-arm-rest": "^3.267.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.274.0",
         "jsonpath-plus": "^10.4.0",
@@ -656,15 +656,15 @@
       }
     },
     "node_modules/@azure/storage-file-share/node_modules/form-data": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-3.0.4.tgz",
-      "integrity": "sha1-k4JzFx0/mZKGpFV1KM4CLcLJjfE=",
+      "version": "3.0.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha1-LqPsJPDct+AmKhHvtzIDEkDqjp8=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35"
       },
       "engines": {
@@ -1025,9 +1025,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.2.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
+      "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -1852,16 +1852,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha1-tJ5IhYBF/0y/awPhgFzrytNnkFM=",
+      "version": "4.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2046,9 +2046,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3407,9 +3407,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha1-DSFO1WeBom7cMTWBwOLZKc7rhm0=",
+      "version": "7.5.16",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha1-8R4GOv7UVU91gEnQgpCeN9a1PO0=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/Tasks/AzureSpringCloudV0/package.json
+++ b/Tasks/AzureSpringCloudV0/package.json
@@ -30,7 +30,7 @@
     "jsonpath-plus": "^10.4.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.267.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.274.0",
-    "azure-pipelines-task-lib": "^5.2.10",
+    "azure-pipelines-task-lib": "^5.2.11",
     "moment": "^2.29.4",
     "nock": "^10.0.6",
     "q": "1.4.1",

--- a/Tasks/AzureSpringCloudV0/task.json
+++ b/Tasks/AzureSpringCloudV0/task.json
@@ -18,8 +18,8 @@
   "preview": false,
   "version": {
     "Major": 0,
-    "Minor": 275,
-    "Patch": 3
+    "Minor": 276,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureSpringCloudV0/task.loc.json
+++ b/Tasks/AzureSpringCloudV0/task.loc.json
@@ -18,8 +18,8 @@
   "preview": false,
   "version": {
     "Major": 0,
-    "Minor": 275,
-    "Patch": 3
+    "Minor": 276,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [


### PR DESCRIPTION
Associated Work Item:
[AB#2432246](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2432246)


### **Description**
Vulnerabilities were identified in form-data in the listed work items.
To address this, dependencies were updated to secure versions and lockfiles were regenerated.

---

### **Task Name**
1 AzureSpringCloudV0

---

Changes:

   AzureSpringCloudV0
- Task version bumped: 0.275.3 -> 0.276.0
- azure-pipelines-task-lib: ^5.2.10 -> ^5.2.11


---

### **Risk Assessment** (Low)
Low- As we are updating the version

---

### **Change Behind Feature Flag** (No)
NA

---

### **Tech Design / Approach**
- Upgraded vulnerable dependency paths (direct/transitive).
- Rebuilt tasks to keep outputs and lockfiles consistent.

---

### **Documentation Changes Required** (No)
No documentation changes needed.

---

### **Unit Tests Added or Updated** (No)
NA

---

### **Additional Testing Performed**
- Testing done only through CI checks no further testing done.
- Build validation passed: node make.js build --task AzureSpringCloudV0--BypassNpmAudit
- Verified through npm audit.

---

### **Logging Added/Updated** (No)
NA

---

### **Telemetry Added/Updated** (No)
NA

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected