### PR TITLE
add PowerShellOnTargetMachinesV1 to make-options to allow builds

### DIFF
--- a/make-options.json
+++ b/make-options.json
@@ -171,6 +171,7 @@
         "PipAuthenticateV0",
         "PipAuthenticateV1",
         "PowerShellV2",
+        "PowerShellOnTargetMachinesV1",
         "PowerShellOnTargetMachinesV2",
         "PowerShellOnTargetMachinesV3",
         "PublishBuildArtifactsV1",


### PR DESCRIPTION
### **Context**

To generate courtesy push builds for the latest sprint we need to add PowerShellOnTargetMachinesV1 since it was updated in PR: https://github.com/microsoft/azure-pipelines-tasks/pull/22282

---

### **Task Name**
NA

---

### **Description**
Update make-options.json to allow PowerShellOnTargetMachinesV1 builds

---

### **Risk Assessment** (Low / Medium / High)  
Low - no task functionality change

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
None

---

### **Logging Added/Updated** (Yes/No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
Revert PR to rollback

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
