### PR TITLE
Dependency update and version bump in JenkinsDownloadArtifactsV1 Task

### DIFF
--- a/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package-lock.json
@@ -1131,15 +1131,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha1-pfY2Stfk5n6VtKB+LYxvcRx09iQ=",
+      "version": "2.5.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha1-7zmz2Z4vyfJUIMDbeWL+Nsr80kQ=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -1298,9 +1298,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/Tasks/JenkinsDownloadArtifactsV1/package.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/package.json
@@ -31,6 +31,6 @@
     "typescript": "^5.7.2"
   },
   "overrides": {
-    "form-data": "^2.5.4"
+    "form-data": "^2.5.6"
   }
 }

--- a/Tasks/JenkinsDownloadArtifactsV1/task.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "groups": [

--- a/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
+++ b/Tasks/JenkinsDownloadArtifactsV1/task.loc.json
@@ -18,7 +18,7 @@
   "demands": [],
   "version": {
     "Major": 1,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "groups": [


### PR DESCRIPTION
Associated Work Item:
[AB#2436681](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2436681)


### **Description**
Security vulnerabilities were found in form-data across the listed work items.
To resolve them, the dependencies were upgraded to secure versions and the lockfiles were regenerated.

---

### **Task Name**
1 JenkinsDownloadArtifactsV1

---

Changes:

   JenkinsDownloadArtifactsV1
- Task version bumped: 1.276.0 -> 1.277.0
- form-data: ^2.5.4 -> ^2.5.6


---

### **Risk Assessment** (Low)
Low- As we are updating the version

---

### **Change Behind Feature Flag** (No)
NA

---

### **Tech Design / Approach**
- The vulnerable dependency paths, both direct and transitive, were upgraded.
- Tasks were rebuilt to keep the outputs and lockfiles aligned.

---

### **Documentation Changes Required** (No)
No documentation changes needed.

---

### **Unit Tests Added or Updated** (No)
NA

---

### **Additional Testing Performed**
- Testing done only through CI checks no further testing done.
- Build validation completed successfully: node make.js build --task JenkinsDownloadArtifactsV1--BypassNpmAudit
- Confirmed with npm audit.

---

### **Logging Added/Updated** (No)
NA

---

### **Telemetry Added/Updated** (No)
NA

---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected