### PR TITLE
Resolve issue Task: labels from real Tasks/ folders (drop hardcoded values)

### DIFF
--- a/.github/workflows/labelIssues.cjs
+++ b/.github/workflows/labelIssues.cjs
@@ -44,6 +44,135 @@ function escapeRegExp(text) {
 }
 
 /**
+ * Normalize a task-folder name or a user-typed task token to a comparable key:
+ * lower-case, drop anything from `@` on (a version like `@5`), keep only
+ * alphanumerics, then strip a trailing version segment (`v` + digits). So
+ * `AzureCLIV2`, `AzureCLI@2` and `Azure CLI` all normalize to `azurecli`.
+ *
+ * Kept in sync with the same-named helper in assignOwners.cjs, which resolves
+ * owners from CODEOWNERS the same way.
+ * @param {string} value
+ * @returns {string}
+ */
+function normalizeTaskKey(value) {
+    if (!value) {
+        return '';
+    }
+    let s = String(value).toLowerCase();
+    const at = s.indexOf('@');
+    if (at !== -1) {
+        s = s.slice(0, at);
+    }
+    s = s.replace(/[^a-z0-9]/g, '');
+    s = s.replace(/v\d+$/, '');
+    return s;
+}
+
+/**
+ * Canonical `Task:` label name for a task folder: the folder name with any
+ * trailing version segment (`V0`, `V2`, `V10`) removed, so every version of a
+ * task shares one label. e.g. `AzureCLIV2` -> `AzureCLI`.
+ * @param {string} folder
+ * @returns {string}
+ */
+function canonicalTaskName(folder) {
+    return String(folder).replace(/V\d+$/, '');
+}
+
+/**
+ * Build a lookup from normalized task key -> Set of canonical task names, from
+ * the list of `Tasks/<Folder>` directory names in the repo.
+ *
+ * This is the single source of truth for `Task:` labels: it always reflects
+ * the tasks that actually exist in the repo, so labels never drift when tasks
+ * are added, renamed, or removed. That drift (hardcoded `Task:` values in
+ * issue-rules.yml pointing at renamed/removed tasks, or vague tokens matching
+ * several tasks) is exactly the failure mode this replaces.
+ * @param {string[]} taskFolders
+ * @returns {Map<string, Set<string>>}
+ */
+function buildTaskIndex(taskFolders) {
+    const index = new Map();
+    for (const folder of taskFolders || []) {
+        if (!folder || /^Common$/i.test(folder)) {
+            continue;
+        }
+        const key = normalizeTaskKey(folder);
+        if (!key) {
+            continue;
+        }
+        if (!index.has(key)) {
+            index.set(key, new Set());
+        }
+        index.get(key).add(canonicalTaskName(folder));
+    }
+    return index;
+}
+
+/**
+ * Resolve the `Task:` label name for a free-text "Task name" field value by
+ * matching it against the real `Tasks/` folders (via `buildTaskIndex`).
+ *
+ * An exact normalized-key match wins. Otherwise a one-directional prefix match
+ * (a folder whose key *extends* the entered value, value length >= 5) is used,
+ * but only when it is unambiguous; a vague entry like "Azure" that matches many
+ * folders resolves to nothing rather than guessing. Returns the canonical task
+ * name (without the `Task: ` prefix), or '' when nothing resolves.
+ *
+ * The issue form guides users to enter the bare task name (placeholder
+ * "E.g. AzurePowerShell", with a separate Task version field), so exact/prefix
+ * matching on the whole normalized value is sufficient in practice. A verbose
+ * free-text entry that does not normalize to a known task simply yields no
+ * Task: label (the issue still gets its Area: label) rather than a wrong guess.
+ * @param {string} taskName
+ * @param {Map<string, Set<string>>} taskIndex
+ * @returns {string}
+ */
+function resolveTaskName(taskName, taskIndex) {
+    const key = normalizeTaskKey(taskName);
+    if (!key || !taskIndex) {
+        return '';
+    }
+    if (taskIndex.has(key)) {
+        const set = taskIndex.get(key);
+        return set.size === 1 ? [...set][0] : '';
+    }
+    if (key.length >= 5) {
+        const hits = new Set();
+        for (const [folderKey, set] of taskIndex) {
+            if (folderKey.startsWith(key)) {
+                for (const canonical of set) {
+                    hits.add(canonical);
+                }
+            }
+        }
+        if (hits.size === 1) {
+            return [...hits][0];
+        }
+    }
+    return '';
+}
+
+/**
+ * Read the `Tasks/<Folder>` directory names from the checked-out repo. The
+ * labeling workflow runs after actions/checkout, so the whole repo (including
+ * Tasks/) is on disk. Returns [] if the directory is missing, so labeling
+ * degrades gracefully to Area-only rather than failing.
+ * @returns {string[]}
+ */
+function loadTaskFolders() {
+    const tasksDir = path.join(process.cwd(), 'Tasks');
+    try {
+        return fs
+            .readdirSync(tasksDir, { withFileTypes: true })
+            .filter(entry => entry.isDirectory())
+            .map(entry => entry.name);
+    } catch (err) {
+        return [];
+    }
+}
+
+/**
  * Extracts the value a user entered for a given GitHub issue-form field.
  * Forms render each input as:
  *
@@ -90,9 +219,11 @@ function extractField(body, label) {
  * @param {any[]} args.rules `rules` from issue-rules.yml.
  * @param {any[]} args.nomatches `nomatches` from issue-rules.yml.
  * @param {any[]} args.tags `tags` from issue-rules.yml.
+ * @param {string[]} args.taskFolders `Tasks/<Folder>` directory names, used to
+ *   resolve the `Task:` label from the entered task name.
  * @returns {{ labels: Set<string>, assignees: Set<string>, taskName: string, matched: boolean }}
  */
-function computeLabels({ title, body, existingLabels, rules, nomatches, tags }) {
+function computeLabels({ title, body, existingLabels, rules, nomatches, tags, taskFolders }) {
     const labels = new Set();
     const assignees = new Set();
     const existing = new Set(existingLabels || []);
@@ -117,6 +248,16 @@ function computeLabels({ title, body, existingLabels, rules, nomatches, tags }) 
             (rule.addLabels || []).forEach(label => labels.add(label));
             (rule.assign || []).forEach(user => assignees.add(user));
         }
+    }
+
+    // Resolve the `Task:` label from the actual Tasks/ folders in the repo,
+    // rather than from hardcoded `Task:` values in issue-rules.yml (which drift
+    // when tasks are renamed/removed). This is independent of the Area rules
+    // above and does not affect `matched`, so the nomatches fallback below is
+    // unchanged.
+    const resolvedTask = resolveTaskName(taskName, buildTaskIndex(taskFolders));
+    if (resolvedTask) {
+        labels.add('Task: ' + resolvedTask);
     }
 
     // Fallback: if nothing matched, scan the whole issue for team hints.
@@ -181,16 +322,24 @@ async function run({ github, context, core }) {
 
     const existingLabels = (issue.labels || []).map(label => (typeof label === 'string' ? label : label.name));
 
+    const taskFolders = loadTaskFolders();
+    if (taskFolders.length === 0) {
+        // Fail safe to Area-only labeling, but make the misconfiguration visible:
+        // this normally means the repo wasn't checked out or cwd isn't the repo root.
+        core.warning(`No Tasks/ folders found under "${process.cwd()}"; Task: labels will not be applied.`);
+    }
+
     const { labels, assignees, taskName, matched } = computeLabels({
         title: issue.title || '',
         body: issue.body || '',
         existingLabels,
         rules: doc.rules || [],
         nomatches: doc.nomatches || [],
-        tags: doc.tags || []
+        tags: doc.tags || [],
+        taskFolders
     });
 
-    core.info(`Task name: "${taskName || '(none)'}" | rule match: ${matched}`);
+    core.info(`Task name: "${taskName || '(none)'}" | rule match: ${matched} | task folders: ${taskFolders.length}`);
 
     const { owner, repo } = context.repo;
     const issue_number = issue.number;
@@ -217,3 +366,7 @@ async function run({ github, context, core }) {
 module.exports = run;
 module.exports.computeLabels = computeLabels;
 module.exports.extractField = extractField;
+module.exports.normalizeTaskKey = normalizeTaskKey;
+module.exports.canonicalTaskName = canonicalTaskName;
+module.exports.buildTaskIndex = buildTaskIndex;
+module.exports.resolveTaskName = resolveTaskName;

--- a/.github/workflows/labelIssues.test.cjs
+++ b/.github/workflows/labelIssues.test.cjs
@@ -1,0 +1,135 @@
+// @ts-check
+'use strict';
+
+/**
+ * Unit tests for labelIssues.cjs decision logic. Run with:
+ *   node --test .github/workflows/labelIssues.test.cjs
+ *
+ * These cover the folder-driven `Task:` label resolution (buildTaskIndex /
+ * resolveTaskName) and its integration into computeLabels. No network or
+ * js-yaml dependency: rules are passed inline and the task folder list is a
+ * small fixture that mirrors real Tasks/ folders.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+    computeLabels,
+    resolveTaskName,
+    buildTaskIndex,
+    normalizeTaskKey,
+    canonicalTaskName
+} = require('./labelIssues.cjs');
+
+// A fixture mirroring a slice of the real Tasks/ folders, including versioned
+// folders and the ambiguous prefixes that used to break hardcoded labels.
+const TASK_FOLDERS = [
+    'AzureCLIV1',
+    'AzureCLIV2',
+    'AzureAppServiceManageV0',
+    'AzureAppServiceSettingsV1',
+    'IISWebAppDeployment',
+    'IISWebAppDeploymentOnMachineGroupV0',
+    'IISWebAppManagementOnMachineGroupV0',
+    'BashV3',
+    'DotNetCoreCLIV2',
+    'Common'
+];
+
+const INDEX = buildTaskIndex(TASK_FOLDERS);
+
+function issueBody(taskName) {
+    return `### Task name\n\n${taskName}\n\n### What happened\n\nsomething`;
+}
+
+test('normalizeTaskKey strips version, punctuation and @version', () => {
+    assert.strictEqual(normalizeTaskKey('AzureCLIV2'), 'azurecli');
+    assert.strictEqual(normalizeTaskKey('AzureCLI@2'), 'azurecli');
+    assert.strictEqual(normalizeTaskKey('Azure CLI'), 'azurecli');
+});
+
+test('canonicalTaskName drops trailing version segment', () => {
+    assert.strictEqual(canonicalTaskName('AzureCLIV2'), 'AzureCLI');
+    assert.strictEqual(canonicalTaskName('IISWebAppDeployment'), 'IISWebAppDeployment');
+});
+
+test('buildTaskIndex ignores Common and is 1:1 for the fixture', () => {
+    assert.ok(!INDEX.has('common'));
+    assert.deepStrictEqual([...INDEX.get('azurecli')], ['AzureCLI']);
+});
+
+test('resolveTaskName: version-agnostic exact match', () => {
+    assert.strictEqual(resolveTaskName('AzureCLI@2', INDEX), 'AzureCLI');
+    assert.strictEqual(resolveTaskName('AzureCLIV1', INDEX), 'AzureCLI');
+    assert.strictEqual(resolveTaskName('bash', INDEX), 'Bash');
+});
+
+test('resolveTaskName: distinct labels for AppService Manage vs Settings', () => {
+    assert.strictEqual(resolveTaskName('AzureAppServiceManage', INDEX), 'AzureAppServiceManage');
+    assert.strictEqual(resolveTaskName('AzureAppServiceSettings', INDEX), 'AzureAppServiceSettings');
+});
+
+test('resolveTaskName: ambiguous prefixes resolve to nothing (no guessing)', () => {
+    // "AzureAppService" and "IISWeb" each prefix-match several folders.
+    assert.strictEqual(resolveTaskName('AzureAppService', INDEX), '');
+    assert.strictEqual(resolveTaskName('IISWeb', INDEX), '');
+    // A vague single word matches many folders -> nothing.
+    assert.strictEqual(resolveTaskName('Azure', INDEX), '');
+});
+
+test('resolveTaskName: specific IIS names resolve exactly', () => {
+    assert.strictEqual(resolveTaskName('IISWebAppDeployment', INDEX), 'IISWebAppDeployment');
+    assert.strictEqual(
+        resolveTaskName('IISWebAppManagementOnMachineGroup', INDEX),
+        'IISWebAppManagementOnMachineGroup'
+    );
+});
+
+test('resolveTaskName: removed/unknown task resolves to nothing', () => {
+    assert.strictEqual(resolveTaskName('AzureMonitorAlerts', INDEX), '');
+    assert.strictEqual(resolveTaskName('TotallyNotATask', INDEX), '');
+});
+
+test('computeLabels adds the resolved Task: label alongside rule Area labels', () => {
+    const rules = [{ valueFor: '**Enter Task Name**', contains: 'AzureCLI', addLabels: ['Area: Release'] }];
+    const { labels } = computeLabels({
+        title: 'x',
+        body: issueBody('AzureCLI@2'),
+        existingLabels: [],
+        rules,
+        nomatches: [],
+        tags: [],
+        taskFolders: TASK_FOLDERS
+    });
+    assert.ok(labels.has('Area: Release'));
+    assert.ok(labels.has('Task: AzureCLI'));
+});
+
+test('computeLabels adds no Task: label for a removed task, keeps Area', () => {
+    const rules = [{ valueFor: '**Enter Task Name**', contains: 'MonitorAlerts', addLabels: ['Area: Release'] }];
+    const { labels } = computeLabels({
+        title: 'x',
+        body: issueBody('AzureMonitorAlerts'),
+        existingLabels: [],
+        rules,
+        nomatches: [],
+        tags: [],
+        taskFolders: TASK_FOLDERS
+    });
+    assert.ok(labels.has('Area: Release'));
+    assert.ok(![...labels].some(l => /^Task:/.test(l)));
+});
+
+test('computeLabels never re-adds a Task: label the issue already has', () => {
+    const { labels } = computeLabels({
+        title: 'x',
+        body: issueBody('AzureCLIV2'),
+        existingLabels: ['Task: AzureCLI'],
+        rules: [],
+        nomatches: [],
+        tags: [],
+        taskFolders: TASK_FOLDERS
+    });
+    assert.ok(!labels.has('Task: AzureCLI'));
+});

--- a/issue-rules.yml
+++ b/issue-rules.yml
@@ -72,12 +72,6 @@ rules:
   contains: 'PyPI'
   addLabels: ['Area: CrossPlatform']
   assign: ['leantk']  
-- valueFor: '**Enter Task Name**'
-  contains: 'XamarinAndroid'
-  addLabels: ['Task: XamarinAndroid']
-- valueFor: '**Enter Task Name**'
-  contains: 'XamariniOS'
-  addLabels: ['Task: XamariniOS']  
 # Area: Release
 - valueFor: '**Enter Task Name**'
   contains: 'AzureCli'
@@ -198,71 +192,71 @@ rules:
   assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureCloud'
-  addLabels: ['Area: Release','Task: AzureCloudPowerShellDeployment']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AppService'
-  addLabels: ['Area: Release','Task: AzureAppService']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureRmWebApp'
-  addLabels: ['Area: Release','Task: AzureRmWebAppDeployment']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Azure App Service deploy'
-  addLabels: ['Area: Release','Task: AzureRmWebAppDeployment']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureWebApp'
-  addLabels: ['Area: Release','Task: AzureWebApp']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'FileTransform'
-  addLabels: ['Area: Release','Task: FileTransform']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureFunction'
-  addLabels: ['Area: Release','Task: AzureFunction']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureFileCopy'
-  addLabels: ['Area: Release','Task: AzureFileCopy']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzurePowerShell'
-  addLabels: ['Area: Release','Task: AzurePowerShell']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'PowerShellOnTarget'
-  addLabels: ['Area: Release','Task: PowerShellOnTargetMachines']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureNLB'
-  addLabels: ['Area: Release','Task: AzureNLBManagement']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Sql'
-  addLabels: ['Area: Release','Task: SqlDacpacDeployment']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Mysql'
-  addLabels: ['Area: Release','Task: MysqlDeployment']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'MonitorAlerts'
-  addLabels: ['Area: Release','Task: AzureMonitorAlerts']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Chef'
-  addLabels: ['Area: Release','Task: Chef']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'IISWeb'
-  addLabels: ['Area: Release','Task: IISWeb']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'WindowsMachine'
-  addLabels: ['Area: Release','Task: WindowsMachineFileCopy']
+  addLabels: ['Area: Release']
   assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Azure'
@@ -313,46 +307,46 @@ rules:
 # Area: ABTT
 - valueFor: '**Enter Task Name**'
   contains: 'JavaToolInstaller'
-  addLabels: ['Area: ABTT', 'Task: JavaToolInstaller']
+  addLabels: ['Area: ABTT']
 - valueFor: '**Enter Task Name**'
   contains: 'CMake'
-  addLabels: ['Area: ABTT', 'Task: CMake', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'XCode'
-  addLabels: ['Area: ABTT', 'Task: Xcode', 'triage']     
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'Xamarin'
   addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'PowerShellV2'
-  addLabels: ['Area: ABTT', 'Task: PowerShell', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'SSH'
   addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'CopyFilesOverSSH'
-  addLabels: ['Area: ABTT', 'Task: CopyFilesOverSSH', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'InstallSSH'
-  addLabels: ['Area: ABTT', 'Task: InstallSSHKey', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'Gradle'
-  addLabels: ['Area: ABTT', 'Task: Gradle', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'Maven'
-  addLabels: ['Area: ABTT', 'Task: Maven', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'Android'
   addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'AndroidSigning'
-  addLabels: ['Area: ABTT', 'Task: AndroidSigning']
+  addLabels: ['Area: ABTT']
 - valueFor: '**Enter Task Name**'
   contains: 'Bash'
-  addLabels: ['Area: ABTT', 'Task: Bash', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'ShellScript'
-  addLabels: ['Area: ABTT', 'Task: Bash', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - valueFor: '**Enter Task Name**'
   contains: 'Batch'
   addLabels: ['Area: ABTT']
@@ -374,9 +368,9 @@ rules:
 # add likely teams to look at based on text searches
 nomatches:
 - contains: 'Xcode' 
-  addLabels: ['Area: ABTT', 'Task: Xcode', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - contains: 'Bash' 
-  addLabels: ['Area: ABTT', 'Task: Bash', 'triage']
+  addLabels: ['Area: ABTT', 'triage']
 - contains: 'Nuget' 
   addLabels: ['Area: Artifacts']
 - contains: 'Npm' 


### PR DESCRIPTION
### **Context**

The issue labeler (`labelIssues.cjs` + `issue-rules.yml`, from #22322) hardcoded `Task: X` labels via substring `contains` rules. Those values drift from the actual tasks in the repo: they referenced a removed task (`AzureMonitorAlerts`) and emitted ambiguous labels (`Task: AzureAppService` covers two real tasks; `Task: IISWeb` covers three). Ambiguous/stale `Task:` labels also weaken the CODEOWNERS-based auto-assignment being added in #22323.

This PR makes the `Task:` label reflect reality by resolving it from the real `Tasks/<Folder>` directories instead of a hand-maintained list.

### **Task Name**

N/A — this changes issue-triage automation, not a pipeline task.

### **Description**

- **`labelIssues.cjs`** — the `Task:` label is now resolved dynamically from the repo's `Tasks/` folders (available on disk after `actions/checkout`). New helpers `normalizeTaskKey`, `canonicalTaskName`, `buildTaskIndex`, `resolveTaskName`, `loadTaskFolders`. `computeLabels` takes a `taskFolders` list and adds `Task: <canonical>` when the entered "Task name" resolves.
  - Canonical label = folder name minus trailing version (`AzureCLIV2` → `Task: AzureCLI`), so all versions share one label and `AzureCLI`, `AzureCLI@2`, `AzureCLIV2`, `Azure CLI` all resolve identically.
  - Matching is conservative: exact normalized-key wins; otherwise a one-directional, **unambiguous** prefix match; vague input (e.g. `Azure`) resolves to **no** `Task:` label rather than guessing.
- **`issue-rules.yml`** — removed all 32 hardcoded `Task:` tokens and the 2 now-empty Task-only rules (Xamarin). `Area:` labels, `nomatches` team hints, and `tags` are unchanged; area labeling stays rule-driven (areas aren't derivable from folder names).
- **`labelIssues.test.cjs`** — new `node --test` unit tests for the resolver and its integration.

This automatically fixes the three drift cases: `AzureMonitorAlerts` → no label (task removed); `AzureAppServiceManage` / `AzureAppServiceSettings` and the specific IIS tasks → their own exact labels; vague `AzureAppService` / `IISWeb` → no wrong guess.

### **Risk Assessment** (Low / Medium / High)

**Low.** Only issue-triage automation (labeling of newly opened issues); no product/task runtime code. Failure mode is fail-safe: if `Tasks/` can't be read the labeler falls back to Area-only labeling and logs a warning. Validated against all 225 real `Tasks/` folders — `buildTaskIndex` produced 0 key conflicts (159 keys → 159 distinct labels) and reproduces 24 of the 28 previous `Task:` labels exactly; the 4 differences are the intended fixes above.

### **Change Behind Feature Flag** (Yes / No)

No — GitHub Actions issue-triage workflow; not gated by product feature flags. Effectively reversible by reverting the PR.

### **Tech Design / Approach**

- Single source of truth for `Task:` labels is the `Tasks/` directory listing, eliminating manual list drift.
- `computeLabels` stays a pure function (folder list passed in) so the decision logic is unit-testable without an Octokit client, matching the existing design of this module.

### **Documentation Changes Required** (Yes/No)

No.

### **Unit Tests Added or Updated** (Yes / No)

Yes — `.github/workflows/labelIssues.test.cjs` (11 cases). Run: `node --test .github/workflows/labelIssues.test.cjs`.

### **Additional Testing Performed**

- Ran `computeLabels` end-to-end against the parsed new `issue-rules.yml` and the full 225-folder list: `AzureCLI@2` → `Task: AzureCLI`; `AzureAppServiceManage`/`Settings` → distinct exact labels; `IISWebAppDeployment` → exact; `AzureMonitorAlerts`/`Azure` → Area only, no `Task:` label.
- Validated the new `issue-rules.yml` parses with `js-yaml` (97 rules, 6 nomatches, 2 tags, 0 `Task:` labels).

### **Logging Added/Updated** (Yes/No)

Yes — logs the resolved task-folder count per run and warns when no `Tasks/` folders are found (misconfiguration / missing checkout). No sensitive data.

### **Telemetry Added/Updated** (Yes/No)

No — GitHub Actions workflow; Actions run logs are the observability surface.

### **Rollback Scenario and Process** (Yes/No)

Yes — revert this PR; the labeler returns to the previous hardcoded-rule behavior.

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

Yes. No new dependencies. Downstream `assignOwners.cjs` (#22323) consumes `Task:` labels and only benefits from more accurate ones. `Area:` labeling, `nomatches`, and `tags` are unchanged.

### **Checklist**

- [x] Related issue linked (if applicable) — N/A (follow-up to #22322)
- [ ] Task version was bumped — N/A (no task changed)
- [x] Verified the task behaves as expected — unit tests + end-to-end resolution against all 225 folders
