### PR TITLE
Stop logging token

### DIFF
--- a/Tasks/PublishSymbolsV2/Auth.ps1
+++ b/Tasks/PublishSymbolsV2/Auth.ps1
@@ -15,7 +15,6 @@ function Get-AccessToken()
         Write-Host "connectedServiceName is specified. Using it to get the access token. - $ConnectedServiceName"
         $accessToken = Get-ConnectedServiceNameAccessToken -connectedServiceName $ConnectedServiceName;
         $PersonalAccessToken = $accessToken.access_token;
-        Write-Host "PersonalAccessToken - received"
     }
     elseif ($AsAccountName) {
         Write-Host "PAT access token"
@@ -35,7 +34,7 @@ function Get-AccessToken()
         }
     }
 
-    Write-Host "Received PersonalAccessToken: $PersonalAccessToken"
+    Write-Host "PersonalAccessToken - received"
     return $PersonalAccessToken;
 }
 

--- a/Tasks/PublishSymbolsV2/task.json
+++ b/Tasks/PublishSymbolsV2/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [

--- a/Tasks/PublishSymbolsV2/task.loc.json
+++ b/Tasks/PublishSymbolsV2/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 2,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "minimumAgentVersion": "2.144.0",
   "groups": [


### PR DESCRIPTION
### **Context**
Don't log tokens when it isn't needed.
---

### **Task Name**
Publish Symbols v2

---

### **Description**
Stops logging unneeded tokens when it is redacted anyway.

---

### **Risk Assessment** (Low / Medium / High)  
low

---

### **Change Behind Feature Flag** NO


---

### **Tech Design / Approach**
NA
---

### **Documentation Changes Required** (Yes/No)
NA
---

### **Unit Tests Added or Updated** (Yes / No)  
NA

---

### **Additional Testing Performed**
NA

---

### **Logging Added/Updated** (Yes/No)
YES
--- 

### **Telemetry Added/Updated** (Yes/No) 
NA
---

### **Rollback Scenario and Process** (Yes/No)
NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
NA
---

### **Checklist**
- [ NA] Related issue linked (if applicable)
- [ x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ x] Verified the task behaves as expected
Note: Minor Task version was already bumped to 277 earlier this week, so rolling this into that version.