### PR TITLE
Remove assign rules from issue-rules.yml (owner assignment now handled by assignOwners.yml)

### DIFF
--- a/issue-rules.yml
+++ b/issue-rules.yml
@@ -60,23 +60,19 @@ rules:
 - valueFor: '**Enter Task Name**'
   contains: 'CocoaPods'
   addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']
 - valueFor: '**Enter Task Name**'
   contains: 'PublishBuildArtifact'
   addLabels: ['Area: CrossPlatform']
 - valueFor: '**Enter Task Name**'
   contains: 'Python'
   addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']
 - valueFor: '**Enter Task Name**'
   contains: 'PyPI'
   addLabels: ['Area: CrossPlatform']
-  assign: ['leantk']  
 # Area: Release
 - valueFor: '**Enter Task Name**'
   contains: 'AzureCli'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'ACRTask'
   addLabels: ['Area: Release']
@@ -89,194 +85,147 @@ rules:
 - valueFor: '**Enter Task Name**'
   contains: 'ResourceGroup'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'Vmss'
   addLabels: ['Area: Release']
-  assign: ['bishal-pdmsft']
 - valueFor: '**Enter Task Name**'
   contains: 'DotNetCore'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'UseDotNet'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'Go'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'Packer'
   addLabels: ['Area: Release']
-  assign: ['bishal-pdmsft']
 - valueFor: '**Enter Task Name**'
   contains: 'ServiceFabric'
   addLabels: ['Area: Release']
-  assign: ['rvairavelu']
 - valueFor: '**Enter Task Name**'
   contains: 'IoTEdge'
   addLabels: ['Area: Release']
-  assign: ['marianan']
 - valueFor: '**Enter Task Name**'
   contains: 'GithubRelease'
   addLabels: ['Area: Release']
-  assign: ['prativen']
 - valueFor: '**Enter Task Name**'
   contains: 'BuildArtifacts'
   addLabels: ['Area: Release']
-  assign: ['Lovakumar']
 - valueFor: '**Enter Task Name**'
   contains: 'FileshareArtifacts'
   addLabels: ['Area: Release']
-  assign: ['Lovakumar']
 - valueFor: '**Enter Task Name**'
   contains: 'DownloadGitHub'
   addLabels: ['Area: Release']
-  assign: ['Lovakumar']
 - valueFor: '**Enter Task Name**'
   contains: 'JenkinsDownload'
   addLabels: ['Area: Release']
-  assign: ['Lovakumar']
 - valueFor: '**Enter Task Name**'
   contains: 'KeyVault'
   addLabels: ['Area: Release']
-  assign: ['prativen']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureMonitorV'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'AzurePolicy'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Docker'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Helm'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Kubectl'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Kubernetes'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Duffle'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'Delay'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'InvokeRestApi'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'QueryWorkItems'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureServiceBus'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'ManualIntervention'
   addLabels: ['Area: Release']
-  assign: ['ammohant']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureCloud'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AppService'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureRmWebApp'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Azure App Service deploy'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureWebApp'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'FileTransform'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureFunction'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureFileCopy'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzurePowerShell'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'PowerShellOnTarget'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'AzureNLB'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Sql'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Mysql'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'MonitorAlerts'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Chef'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'IISWeb'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'WindowsMachine'
   addLabels: ['Area: Release']
-  assign: ['nadesu']
 - valueFor: '**Enter Task Name**'
   contains: 'Azure'
   addLabels: ['Area: Release','environment:need-to-triage']
-  assign: ['nadesu']
 # Area: PipelineCaching
 - valueFor: '**Enter Task Name**'
   contains: 'Cache'
   addLabels: ['Area: PipelineCaching']
-  assign: ['johnterickson']
 
 # Area: Test
 - valueFor: '**Enter Task Name**'
   contains: 'VSTest'
   addLabels: ['Area: Test']
-  assign: ['phanikmmsft']
 - valueFor: '**Enter Task Name**'
   contains: 'PublishTest'
   addLabels: ['Area: TestManagement']
-  assign: ['shailesh-sk']
   
 # Area: ArtifactsPackages
 - valueFor: '**Enter Task Name**'


### PR DESCRIPTION
## What

Removes all `assign:` rules from `issue-rules.yml`.

## Why

Owner assignment is now handled by the **`assignOwners.yml`** workflow, which assigns issue owner(s) from **`.github/CODEOWNERS`** based on the issue's *Task name* field and `Task:` labels (only when the issue has no assignees yet, so it never overrides a human). That makes the hand-maintained `assign: ['<user>']` entries in `issue-rules.yml` redundant — and having two competing sources of ownership means they drift apart over time (CODEOWNERS is kept current; these inline entries were not).

## Change

- Removed **51** `assign:` lines across the `rules:` section.
- **Labeling behavior is unchanged** — every `valueFor` / `contains` / `addLabels` rule is preserved (97 rules intact). Only the owner-assignment side effect is dropped, now owned solely by CODEOWNERS + `assignOwners.yml`.

## Testing

- YAML validated after the edit (parses to the same 4 top-level keys: `rules`, `nomatches`, `tags`, `pathMappings`; 97 rules).
- No `assign:` references remain in the file.
