### PR TITLE
ci: install PowerShell lint modules from Azure DevOps feed instead of PowerShell Gallery

### DIFF
--- a/ci/check-powershell-syntax.ps1
+++ b/ci/check-powershell-syntax.ps1
@@ -1,6 +1,21 @@
 # Description: Checks the PowerShell syntax of the script using PSScriptAnalyzer.
 param([String]$pathToBuiltTasks)
 
+# Install helper modules from the Azure DevOps Artifacts feed instead of the public
+# PowerShell Gallery. The feed proxies these packages and allows anonymous reads once
+# they are saved to it, so no authentication token is required here. Anonymous callers
+# only see versions already saved to the feed, so an unpinned install resolves to the
+# latest saved version.
+$AdoFeedName = "PipelineTools_PublicPackages"
+$AdoFeedSource = "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/nuget/v2"
+
+function Register-AdoFeed() {
+  if (-not (Get-PSRepository -Name $AdoFeedName -ErrorAction SilentlyContinue)) {
+    Write-Host "Registering PSRepository '$AdoFeedName'..."
+    Register-PSRepository -Name $AdoFeedName -SourceLocation $AdoFeedSource -InstallationPolicy Trusted
+  }
+}
+
 function Get-AnalyzerSettings() {
   return @{
     Severity=@('Error', 'Warning', 'Information', 'ParseError', 'ParseWarning')
@@ -36,8 +51,9 @@ function Invoke-AnalyzerToTask() {
 
   $module = Get-Module -Name "PSScriptAnalyzer";
   if ($module -eq $null) {
-    Write-Host "Installing PSScriptAnalyzer module..."
-    Install-Module -Name "PSScriptAnalyzer" -Scope CurrentUser -Force
+    Write-Host "Installing PSScriptAnalyzer module from $AdoFeedName..."
+    Register-AdoFeed
+    Install-Module -Name "PSScriptAnalyzer" -Repository $AdoFeedName -Scope CurrentUser -Force
   }
   
   Write-Host "Running PSScriptAnalyzer for $taskPath."
@@ -105,8 +121,9 @@ function main() {
   # https://github.com/PowerShell/PowerShell/issues/1755
   $module = Get-Module -Name "Newtonsoft.Json";
   if ($module -eq $null) {
-    Write-Host "Installing Newtonsoft.Json module..."
-    Install-Module -Scope CurrentUser -Name "Newtonsoft.Json" -Force
+    Write-Host "Installing Newtonsoft.Json module from $AdoFeedName..."
+    Register-AdoFeed
+    Install-Module -Scope CurrentUser -Name "Newtonsoft.Json" -Repository $AdoFeedName -Force
   }
 
   # Get the tasks which have a PowerShell handler.


### PR DESCRIPTION
### **Context**
CI builds (e.g. build 31742971) reach out to the public **PowerShell Gallery** during the "After build tasks validation" step. Root cause: the after-build PowerShell syntax check installs `PSScriptAnalyzer` and `Newtonsoft.Json` via `Install-Module` **without a `-Repository`**, so PowerShellGet defaults to `www.powershellgallery.com`. This is also why `PowerShellGallery` appears in the pipeline `networkIsolationPolicy` allow-list. This PR routes those installs through the `PipelineTools_PublicPackages` Azure DevOps Artifacts feed instead.

Work Item: [AB#2421765](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2421765)

---

### **Task Name**
N/A — CI tooling change ([ci/check-powershell-syntax.ps1](https://github.com/microsoft/azure-pipelines-tasks/blob/master/ci/check-powershell-syntax.ps1)). No pipeline task is modified.

---

### **Description**
- Added `$AdoFeedName` / `$AdoFeedSource` and an idempotent `Register-AdoFeed` helper that registers the `PipelineTools_PublicPackages` feed as a `PSRepository`.
- Updated both `Install-Module` calls (`PSScriptAnalyzer` and `Newtonsoft.Json`) to pass `-Repository $AdoFeedName`.
- No version pinning: anonymous callers only see versions already **saved** to the feed, so an unpinned install resolves to the latest saved version. No auth token (`System.AccessToken`/PAT) is required because the required packages are saved to the feed and served anonymously.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** Scoped to a CI validation script that only runs on PR builds on Windows. It does not touch any shipped task. Worst case is a build-time module install failure, which is immediately visible and reversible.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** This is a build/CI script; feature flags are not applicable.

---

### **Tech Design / Approach**
- Follows the repository's established pattern of sourcing packages from `pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages` (see `make-util.js` external NuGet handling).
- Trade-off considered: authenticated install with `System.AccessToken` vs. anonymous read of saved packages. Chose anonymous read (no token) since the packages are saved to the feed, keeping the CI step simple and avoiding cross-org token 401s.

---

### **Documentation Changes Required** (Yes/No)
**No.**

---

### **Unit Tests Added or Updated** (Yes / No)
**No** — this is a CI script; there is no unit-test harness for it.

---

### **Additional Testing Performed**
Validated locally with a test-scoped `PSRepository` pointing at the feed:
- All downloads resolved to `https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/nuget/v2` (verified via `Save-Module -Verbose`).
- **Zero** references to `powershellgallery` in the verbose output.
- Both modules installed successfully (`PSScriptAnalyzer 1.25.0`, `Newtonsoft.Json 1.0.2.201`).
- Confirmed a version-less `Find-Module` resolves anonymously to the latest saved version.
- Script parses with no syntax errors.

---

### **Logging Added/Updated** (Yes/No)
**Yes** (minor). Install messages now state the source feed (e.g. "Installing PSScriptAnalyzer module from PipelineTools_PublicPackages..."). No sensitive data logged.

---

### **Telemetry Added/Updated** (Yes/No)
**No.**

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert this single-file commit to restore the previous PowerShell Gallery-based install.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** Only the source of two build-time helper modules changes; module names/versions are unchanged. The `PSUseCompatibleSyntax` analysis behavior is unaffected.

---

### **Checklist**
- [x] Related issue linked (if applicable) — [AB#2421765](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2421765)
- [x] Task version was bumped — N/A (no task changed; CI script only)
- [x] Verified the task behaves as expected (local `Save-Module`/`Find-Module` validation against the feed)

---

### **Follow-up (not in this PR)**
Once validated in CI, `PowerShellGallery` can be dropped from the `networkIsolationPolicy` in `azure-pipelines.yml` and `.azure-pipelines/.vsts.release.yml`.