### PR TITLE
Remove task signing and disable CI

### DIFF
--- a/.azure-pipelines/.vsts.release.yml
+++ b/.azure-pipelines/.vsts.release.yml
@@ -140,6 +140,7 @@ extends:
           parameters:
             os: Windows_NT
             useSemverBuildConfig: ${{ parameters.useSemverBuildConfig }}
+            signTasks: true
 
       # Courtesy Push
       - job: courtesy_push

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,6 @@ extends:
         - template: /ci/build-all-steps.yml@self
           parameters:
             os: Windows_NT
-            signTasks: false
 
       # All tasks on Linux
       - job: build_all_linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,7 @@
 # This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
 # This pipeline will be extended to the OneESPT template
 
-trigger:
-- master
-- releases/*
+trigger: none
 
 resources:
   repositories:
@@ -88,6 +86,7 @@ extends:
         - template: /ci/build-all-steps.yml@self
           parameters:
             os: Windows_NT
+            signTasks: false
 
       # All tasks on Linux
       - job: build_all_linux

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -170,7 +170,7 @@ steps:
       )
 
   # Sign all task zips as nuget packages
-  - ${{ if parameters.signTasks }}:
+  - ${{ if eq(parameters.signTasks, true) }}:
     - template: /ci/sign-all-tasks.yml@self
       parameters:
         layoutRoot: $(Build.SourcesDirectory)\_package\tasks-layout

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -1,8 +1,16 @@
 parameters:
-  os: ''
-  useSemverBuildConfig: false
-  generateReleaseNotes: true
-  signTasks: true
+- name: os
+  type: string
+  default: ''
+- name: useSemverBuildConfig
+  type: boolean
+  default: false
+- name: generateReleaseNotes
+  type: boolean
+  default: true
+- name: signTasks
+  type: boolean
+  default: false
 
 steps:
 
@@ -170,7 +178,7 @@ steps:
       )
 
   # Sign all task zips as nuget packages
-  - ${{ if eq(parameters.signTasks, true) }}:
+  - ${{ if parameters.signTasks }}:
     - template: /ci/sign-all-tasks.yml@self
       parameters:
         layoutRoot: $(Build.SourcesDirectory)\_package\tasks-layout

--- a/ci/build-all-steps.yml
+++ b/ci/build-all-steps.yml
@@ -2,6 +2,7 @@ parameters:
   os: ''
   useSemverBuildConfig: false
   generateReleaseNotes: true
+  signTasks: true
 
 steps:
 
@@ -169,9 +170,10 @@ steps:
       )
 
   # Sign all task zips as nuget packages
-  - template: /ci/sign-all-tasks.yml@self
-    parameters:
-      layoutRoot: $(Build.SourcesDirectory)\_package\tasks-layout
+  - ${{ if parameters.signTasks }}:
+    - template: /ci/sign-all-tasks.yml@self
+      parameters:
+        layoutRoot: $(Build.SourcesDirectory)\_package\tasks-layout
 
   # Stage all the tasks into a single zip for upload
   - script: node ./ci/stage-package.js


### PR DESCRIPTION
This PR disables the automatic CI trigger for the `azure-pipelines.yml` pipeline and makes ESRP task signing opt-in via a template parameter, so that CI builds no longer sign task packages while the release pipeline continues to sign. Signing is parameterized (not deleted) so the shared `ci/build-all-steps.yml` template still supports signing for callers that need it.

**Trigger change**
* `azure-pipelines.yml`: changed the trigger from `master` + `releases/*` to `trigger: none`, so this pipeline no longer runs automatically on branch pushes. Manual / scheduled / API runs still work, and PR validation is unaffected (there is no `pr:` block).

**Signing parameterization (opt-in)**
* `ci/build-all-steps.yml`: converted the parameter block to typed list syntax and added a `signTasks` parameter of `type: boolean` with `default: false`. The `sign-all-tasks.yml` call is now gated behind `${{ if parameters.signTasks }}`, so signing is excluded at compile time unless a caller opts in.
* `azure-pipelines.yml`: the CI pipeline does not pass `signTasks`, so it uses the default `false` — signing is off for CI.
* `.azure-pipelines/.vsts.release.yml`: explicitly passes `signTasks: true`, so the release pipeline continues to sign task packages.

### **Context**
Disable the automatic CI trigger and ESRP task signing for the `azure-pipelines.yml` CI pipeline. Signing was made a template parameter (rather than removed) because `ci/build-all-steps.yml` is shared with the release pipeline (`.azure-pipelines/.vsts.release.yml`), which still needs signed, Microsoft-trusted task packages for production. The default (`signTasks: false`) turns signing off for CI, and the release pipeline opts back in with `signTasks: true`.

_No linked ADO Work Item / GitHub issue — add here if applicable._

---

### **Task Name**
N/A — no pipeline task was created or modified. This PR changes only CI YAML (`azure-pipelines.yml`, `ci/build-all-steps.yml`, `.azure-pipelines/.vsts.release.yml`).

---

### **Description**
- `azure-pipelines.yml`: `trigger:` (`master`, `releases/*`) → `trigger: none`.
- `ci/build-all-steps.yml`: parameter block converted to typed list syntax; added `signTasks` (`type: boolean`, `default: false`); wrapped the `sign-all-tasks.yml` template call in `${{ if parameters.signTasks }}`.
- `.azure-pipelines/.vsts.release.yml`: passes `signTasks: true` to `build-all-steps.yml`.

Net effect: the CI pipeline (`azure-pipelines.yml`) no longer auto-triggers on push and no longer signs task packages (default `signTasks: false`). The release pipeline explicitly opts in (`signTasks: true`) and continues to sign.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** Changes are limited to three CI YAML files and are scoped to trigger + signing behavior.
- Signing is now opt-in; the release pipeline explicitly passes `signTasks: true`, so it still produces signed packages. CI produces **unsigned** packages, which must not be used for production/Marketplace release (that path uses the release pipeline).
- Because signing is in-place, no downstream step depends on it, so the build stays green.
- `signTasks` is a typed `boolean`, so `${{ if parameters.signTasks }}` evaluates correctly (a typed `false` is falsy and removes the step at compile time — avoiding the string-truthiness pitfall of untyped dictionary parameters).

---

### **Change Behind Feature Flag** (Yes / No)
**No.** These are pipeline configuration changes (trigger + template parameter), not runtime product code. Signing behavior is instead controlled by the new `signTasks` template parameter.

---

### **Tech Design / Approach**
- Signing was **parameterized, not removed**, to avoid affecting the release pipeline that shares `ci/build-all-steps.yml`.
- The parameter block was converted to **typed list syntax** so `signTasks` is a real `boolean`. This lets the gate use a simple `${{ if parameters.signTasks }}` and avoids the untyped-dictionary bug where a string `"false"` is truthy and would fail to remove the step.
- Default `signTasks: false` makes signing **opt-in**; only the release pipeline passes `signTasks: true`.
- The signing step is already scoped to `${{ if eq(parameters.os, 'Windows_NT') }}`, so Linux/macOS jobs never sign regardless of the parameter.
- Alternative considered: unconditionally deleting the signing step from the shared template — rejected because it would also disable signing for the release pipeline.

---

### **Documentation Changes Required** (Yes/No)
**No.** No user-facing docs, API specs, or runbooks are affected by these CI-only changes.

---

### **Unit Tests Added or Updated** (Yes / No)
**No.** Pipeline YAML configuration changes are not covered by task unit tests.

---

### **Additional Testing Performed**
- Verified template resolution: `azure-pipelines.yml` and `.azure-pipelines/.vsts.release.yml` both consume `ci/build-all-steps.yml`; only the release pipeline passes `signTasks: true`, so CI defaults to `false` (no signing) and release signs.
- Confirmed the other typed parameters remain compatible: `useSemverBuildConfig` is only used in `eq(..., true/false)` comparisons (which coerce correctly), and `os` remains a string used in `eq(parameters.os, 'Windows_NT')`.
- Confirmed the signing step is inside the Windows-only block, so no Linux/macOS behavior changes.

---

### **Logging Added/Updated** (Yes/No)
**No.**

---

### **Telemetry Added/Updated** (Yes/No)
**No.**

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Fully revertible by reverting this PR:
- Restore `trigger:` to `master` + `releases/*` to re-enable CI.
- Restore the original parameter block and the unconditional `sign-all-tasks.yml` call (and remove `signTasks: true` from the release pipeline) to return to always-on signing.
No state migration or data changes are involved.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** The only shared dependency is the `ci/build-all-steps.yml` template. The release pipeline explicitly opts in with `signTasks: true`, preserving its signed output; only the CI pipeline changes to unsigned. No product modules, APIs, or third-party libraries are affected.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — N/A, no task changed
- [x] Verified the task behaves as expected — verified pipeline/template resolution and per-pipeline signing behavior
