### PR TITLE
Enable weekly schedule for Triage report - Release/RM workflow

### DIFF
--- a/.github/workflows/triage-report-release-rm.yml
+++ b/.github/workflows/triage-report-release-rm.yml
@@ -25,8 +25,8 @@ name: Triage report - Release/RM
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: '0 8 * * 1'  # every Monday at 08:00 UTC
+  schedule:
+    - cron: '0 8 * * 1'  # every Monday at 08:00 UTC
 
 permissions:
   issues: read


### PR DESCRIPTION
### **Context**

The `Triage report - Release/RM` workflow (`.github/workflows/triage-report-release-rm.yml`) documents in its own header that it "Runs every Monday at 08:00 UTC and on manual dispatch," but the `schedule:` trigger was left commented out — so it only ever ran on manual dispatch. This enables the intended weekly cadence.

---

### **Task Name**

N/A — no pipeline task is created or modified. Only `.github/workflows/` automation.

---

### **Description**

Uncomments the `schedule` trigger in `triage-report-release-rm.yml` so the reusable triage-report engine runs automatically every Monday at 08:00 UTC (`cron: '0 8 * * 1'`), in addition to the existing `workflow_dispatch`. No other change.

Email delivery still degrades gracefully until the `RELEASE_RM_*` mail secrets are configured (the workflow skips email and writes the report to the run's job summary), so enabling the schedule is safe before the secrets are wired up.

---

### **Risk Assessment** (Low / Medium / High)

**Low.** One-line trigger change to a single workflow. The job is read-only (`issues: read`, `contents: read`) and produces a report; it makes no repository mutations. Manual dispatch remains available. Fully reversible by re-commenting the trigger.

---

### **Change Behind Feature Flag** (Yes / No)

No — workflow trigger configuration.

---

### **Tech Design / Approach**

Enable the already-authored, already-documented schedule that was left commented. No logic change to the reusable engine.

---

### **Documentation Changes Required** (Yes/No)

No — the file header already documents the Monday 08:00 UTC cadence.

---

### **Unit Tests Added or Updated** (Yes / No)

No — workflow trigger configuration.

---

### **Additional Testing Performed**

Verified the diff only uncomments the `schedule`/`cron` lines; `workflow_dispatch` and permissions are unchanged. `workflow_dispatch` continues to allow on-demand runs for validation.

---

### **Logging Added/Updated** (Yes/No)

No.

---

### **Telemetry Added/Updated** (Yes/No)

No.

---

### **Rollback Scenario and Process** (Yes/No)

Yes — re-comment the `schedule` trigger to disable the weekly run.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

Yes — no new dependencies; no product modules affected.

---

### **Checklist**
- [ ] Related issue linked (if applicable) — N/A
- [ ] Task version was bumped — N/A (no task changed)
- [x] Verified the task behaves as expected — diff limited to enabling the documented schedule; manual dispatch preserved
