### PR TITLE
Upgrade azure-pipelines-task-lib to version 5.277.0 across regressed tasks

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.277.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.276.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
         "moment": "^2.29.4",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -437,8 +437,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^24.10.0",
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
-    "azure-pipelines-task-lib": "^5.2.10",
+    "azure-pipelines-task-lib": "^5.277.0",
     "azure-pipelines-tasks-azure-arm-rest": "^3.276.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
     "moment": "^2.29.4",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
@@ -13,7 +13,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.277.0",
         "azure-pipelines-tasks-azure-arm-rest": "^3.276.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
         "moment": "^2.29.4",
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -437,8 +437,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {

--- a/Tasks/AzureRmWebAppDeploymentV5/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package.json
@@ -24,7 +24,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-tasks-azure-arm-rest": "^3.276.0",
-    "azure-pipelines-task-lib": "^5.2.10",
+    "azure-pipelines-task-lib": "^5.277.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 276,
+    "Minor": 277,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/HelmInstallerV1/package-lock.json
+++ b/Tasks/HelmInstallerV1/package-lock.json
@@ -9,7 +9,7 @@
         "@types/node": "^24.10.0",
         "@types/q": "^1.5.0",
         "@types/uuid": "^8.3.0",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.277.0",
         "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
         "azure-pipelines-tool-lib": "^2.0.10"
       },
@@ -150,9 +150,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -160,8 +160,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {

--- a/Tasks/HelmInstallerV1/package.json
+++ b/Tasks/HelmInstallerV1/package.json
@@ -8,7 +8,7 @@
     "@types/node": "^24.10.0",
     "@types/q": "^1.5.0",
     "@types/uuid": "^8.3.0",
-    "azure-pipelines-task-lib": "^5.2.10",
+    "azure-pipelines-task-lib": "^5.277.0",
     "azure-pipelines-tasks-kubernetes-common": "^2.272.0",
     "azure-pipelines-tool-lib": "^2.0.10"
   },

--- a/Tasks/HelmInstallerV1/task.json
+++ b/Tasks/HelmInstallerV1/task.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 275,
-    "Patch": 1
+    "Minor": 277,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/HelmInstallerV1/task.loc.json
+++ b/Tasks/HelmInstallerV1/task.loc.json
@@ -13,8 +13,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 275,
-    "Patch": 1
+    "Minor": 277,
+    "Patch": 0
   },
   "preview": true,
   "demands": [],

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package-lock.json
@@ -12,7 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
         "@types/q": "1.0.7",
-        "azure-pipelines-task-lib": "^5.2.10",
+        "azure-pipelines-task-lib": "^5.277.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
         "q": "1.4.1"
       },
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.277.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
+      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
@@ -186,8 +186,7 @@
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -1483,16 +1482,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/package.json
@@ -22,7 +22,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^24.10.0",
     "@types/q": "1.0.7",
-    "azure-pipelines-task-lib": "^5.2.10",
+    "azure-pipelines-task-lib": "^5.277.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.274.2",
     "q": "1.4.1"
   },

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 277,
     "Patch": 0
   },
   "demands": [],

--- a/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
+++ b/Tasks/IISWebAppDeploymentOnMachineGroupV0/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 277,
     "Patch": 0
   },
   "demands": [],


### PR DESCRIPTION
### Summary

Upgrades `azure-pipelines-task-lib` from `5.2.10` to `5.277.0` for 4 Release Management tasks that had regressions reported on the previous task-lib version. Task versions bumped to sprint 277.

### Changes per task

- package.json — updated `azure-pipelines-task-lib` to `^5.277.0`
- package-lock.json — regenerated via `npm install`
- task.json / `task.loc.json` — version minor bumped to `277`, patch set to `0`

### Tasks included

| Task | Previous Version | New Version | 
|------|-----------------|-------------|
| AzureRmWebAppDeploymentV4 | 4.276.0 | 4.277.0 |
| AzureRmWebAppDeploymentV5 | 5.276.0 | 5.277.0 |
| HelmInstallerV1 | 1.275.1 | 1.277.0 |
| IISWebAppDeploymentOnMachineGroupV0 | 0.275.0 | 0.277.0 |

### Why these 4 tasks

These tasks had regressions reported on the previous `azure-pipelines-task-lib` 5.2.x version. Upgrading to 5.277.0 picks up all accumulated fixes from the task-lib master branch 

### Testing

| Task | Build | L0 Tests |
|------|-------|----------|
| AzureRmWebAppDeploymentV4 | Pass | 8 passing (pre-existing nyc/rmRF file-locking issue on Windows — not related to upgrade) |
| AzureRmWebAppDeploymentV5 | Pass | 22 passing |
| HelmInstallerV1 | Pass | 9 passing |
| IISWebAppDeploymentOnMachineGroupV0 | Pass | 17 passing |

### Risk assessment

**Low risk.** No source code changes — only dependency version and task version metadata.