### PR TITLE
Fix PackerBuildV1 credential Leak

### DIFF
--- a/Tasks/PackerBuildV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/PackerBuildV1/Strings/resources.resjson/en-US/resources.resjson
@@ -84,6 +84,7 @@
   "loc.messages.ExtractingPackerCompleted": "Packer extracted successfully at path: %s.",
   "loc.messages.CreatedStagingDirectory": "Created staging directory for keeping packer binary and templates: %s.",
   "loc.messages.CouldNotDeleteStagingDirectory": "Could not delete staging directory %s. Please delete manually.",
+  "loc.messages.CouldNotDeleteTempFile": "Could not delete temporary variables file %s. Please delete manually.",
   "loc.messages.InstalledPackerVersion": "Current installed packer version is %s.",
   "loc.messages.PackerToolBusy": "Packer tool seems to be busy. Retrying after 1 second...",
   "loc.messages.ResolvingDeployPackageInput": "Resolving deploy package path.",

--- a/Tasks/PackerBuildV1/Tests/L0.ts
+++ b/Tasks/PackerBuildV1/Tests/L0.ts
@@ -59,6 +59,18 @@ describe('PackerBuild Suite V1', function() {
             assert(tr.stdout.indexOf(match2) > -1, 'correctly writes contents of var file (containing template variables)');
         });
 
+        it('Deletes packer var file (containing credentials) after execution', async () => {
+            let tp = path.join(__dirname, 'L0Windows.js');
+            let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+            let deleteMatch = 'rmRF C:\\somefolder\\somevarfile.json';
+            await tr.runAsync();
+
+            runValidations(() => {
+                assert(tr.succeeded, 'task should have succeeded');
+                assert(tr.stdout.indexOf(deleteMatch) > -1, 'should delete var file containing credentials from Agent.TempDirectory after execution');
+            }, tr);
+        });
+
         it('Runs successfully for windows template with managed image', async () => {
             let tp = path.join(__dirname, 'L0WindowsManaged.js');
             let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
+++ b/Tasks/PackerBuildV1/src/azureSpnTemplateVariablesProvider.ts
@@ -33,7 +33,7 @@ export default class AzureSpnTemplateVariablesProvider implements definitions.IT
         this._spnVariables.set(constants.TemplateVariableClientIdName, tl.getEndpointAuthorizationParameter(connectedService, 'serviceprincipalid', false));
         if (endpointObject.scheme === 'WorkloadIdentityFederation') {
             const oidc_token = await endpointObject.applicationTokenCredentials.getFederatedToken();
-            // tl.setSecret(oidc_token);
+            tl.setSecret(oidc_token);
             this._spnVariables.set(constants.TemplateVariableClientjwtName, oidc_token);
         }
         else  {

--- a/Tasks/PackerBuildV1/src/operations/packerBuild.ts
+++ b/Tasks/PackerBuildV1/src/operations/packerBuild.ts
@@ -22,6 +22,7 @@ export async function run(packerHost: packerHost): Promise<any> {
         let filePath: string = utils.generateTemporaryFilePath();
         let content: string = utils.getPackerVarFileContent(variables);
         utils.writeFile(filePath, content);
+        packerHost.registerTempVarFile(filePath);
         command.arg(util.format("%s=%s", '-var-file', filePath));
     }
 

--- a/Tasks/PackerBuildV1/src/operations/packerBuild.ts
+++ b/Tasks/PackerBuildV1/src/operations/packerBuild.ts
@@ -20,9 +20,9 @@ export async function run(packerHost: packerHost): Promise<any> {
     for (var provider of variableProviders) {
         var variables = await provider.getTemplateVariables(packerHost);
         let filePath: string = utils.generateTemporaryFilePath();
+        packerHost.registerTempVarFile(filePath);
         let content: string = utils.getPackerVarFileContent(variables);
         utils.writeFile(filePath, content);
-        packerHost.registerTempVarFile(filePath);
         command.arg(util.format("%s=%s", '-var-file', filePath));
     }
 

--- a/Tasks/PackerBuildV1/src/operations/packerValidate.ts
+++ b/Tasks/PackerBuildV1/src/operations/packerValidate.ts
@@ -17,6 +17,7 @@ export async function run(packerHost: packerHost): Promise<void> {
         let filePath: string = utils.generateTemporaryFilePath();
         let content: string = utils.getPackerVarFileContent(variables);
         utils.writeFile(filePath, content);
+        packerHost.registerTempVarFile(filePath);
         command.arg(util.format("%s=%s", '-var-file', filePath));
     }
 

--- a/Tasks/PackerBuildV1/src/operations/packerValidate.ts
+++ b/Tasks/PackerBuildV1/src/operations/packerValidate.ts
@@ -15,9 +15,9 @@ export async function run(packerHost: packerHost): Promise<void> {
     for (var provider of variableProviders) {
         var variables = await provider.getTemplateVariables(packerHost);
         let filePath: string = utils.generateTemporaryFilePath();
+        packerHost.registerTempVarFile(filePath);
         let content: string = utils.getPackerVarFileContent(variables);
         utils.writeFile(filePath, content);
-        packerHost.registerTempVarFile(filePath);
         command.arg(util.format("%s=%s", '-var-file', filePath));
     }
 

--- a/Tasks/PackerBuildV1/src/packerHost.ts
+++ b/Tasks/PackerBuildV1/src/packerHost.ts
@@ -16,6 +16,7 @@ export default class PackerHost implements definitions.IPackerHost {
         this._templateFileProviders = {};
         this._templateVariablesProviders = {};
         this._taskParameters = new TaskParameters();
+        this._tempVarFiles = [];
     }
 
     public async initialize() {
@@ -88,7 +89,22 @@ export default class PackerHost implements definitions.IPackerHost {
         this._templateVariablesProviders[providerType] = provider;
     }
 
+    // registers a temporary var-file (containing SPN/WIF credentials) so it is purged during cleanup
+    public registerTempVarFile(filePath: string): void {
+        this._tempVarFiles.push(filePath);
+    }
+
     public cleanup(): void {
+        // purge var-files containing SPN/WIF credentials from Agent.TempDirectory (rmRF handles files)
+        this._tempVarFiles.forEach(filePath => {
+            try {
+                utils.deleteDirectory(filePath);
+            }
+            catch (err) {
+                tl.warning(tl.loc("CouldNotDeleteTempFile", filePath));
+            }
+        });
+
         try{
             utils.deleteDirectory(this._stagingDirectory);
         }
@@ -183,6 +199,7 @@ export default class PackerHost implements definitions.IPackerHost {
     private _packerPath: string;
     private _taskParameters: TaskParameters;
     private _stagingDirectory: string;
+    private _tempVarFiles: string[];
     private _templateFileProviders: ObjectDictionary<definitions.ITemplateFileProvider>;
     private _templateVariablesProviders: ObjectDictionary<definitions.ITemplateVariablesProvider>;
 }

--- a/Tasks/PackerBuildV1/src/packerHost.ts
+++ b/Tasks/PackerBuildV1/src/packerHost.ts
@@ -95,7 +95,6 @@ export default class PackerHost implements definitions.IPackerHost {
     }
 
     public cleanup(): void {
-        // purge var-files containing SPN/WIF credentials from Agent.TempDirectory (rmRF handles files)
         this._tempVarFiles.forEach(filePath => {
             try {
                 utils.deleteDirectory(filePath);

--- a/Tasks/PackerBuildV1/src/utilities.ts
+++ b/Tasks/PackerBuildV1/src/utilities.ts
@@ -153,9 +153,7 @@ export function deleteDirectory(dir: string): void {
 
     if(tl.exist(dir)) {
         tl.debug("Cleaning-up directory " + dir);
-        try {
-            tl.rmRF(dir);
-        } catch(error) {}
+        tl.rmRF(dir);
     }
 }
 

--- a/Tasks/PackerBuildV1/task.json
+++ b/Tasks/PackerBuildV1/task.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
+    "Minor": 277,
     "Patch": 0
   },
   "demands": [],
@@ -355,6 +355,7 @@
     "ExtractingPackerCompleted": "Packer extracted successfully at path: %s.",
     "CreatedStagingDirectory": "Created staging directory for keeping packer binary and templates: %s.",
     "CouldNotDeleteStagingDirectory": "Could not delete staging directory %s. Please delete manually.",
+    "CouldNotDeleteTempFile": "Could not delete temporary variables file %s. Please delete manually.",
     "InstalledPackerVersion": "Current installed packer version is %s.",
     "PackerToolBusy": "Packer tool seems to be busy. Retrying after 1 second...",
     "ResolvingDeployPackageInput": "Resolving deploy package path.",

--- a/Tasks/PackerBuildV1/task.loc.json
+++ b/Tasks/PackerBuildV1/task.loc.json
@@ -14,7 +14,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 274,
+    "Minor": 277,
     "Patch": 0
   },
   "demands": [],
@@ -355,6 +355,7 @@
     "ExtractingPackerCompleted": "ms-resource:loc.messages.ExtractingPackerCompleted",
     "CreatedStagingDirectory": "ms-resource:loc.messages.CreatedStagingDirectory",
     "CouldNotDeleteStagingDirectory": "ms-resource:loc.messages.CouldNotDeleteStagingDirectory",
+    "CouldNotDeleteTempFile": "ms-resource:loc.messages.CouldNotDeleteTempFile",
     "InstalledPackerVersion": "ms-resource:loc.messages.InstalledPackerVersion",
     "PackerToolBusy": "ms-resource:loc.messages.PackerToolBusy",
     "ResolvingDeployPackageInput": "ms-resource:loc.messages.ResolvingDeployPackageInput",


### PR DESCRIPTION
### **Context**
This PR fixes a security issue in the PackerBuild task where AzureRM service-connection credentials could be exposed to later steps in the same pipeline job.

Two problems were addressed:
1. The task writes a temporary Packer `-var-file` containing the service-connection credentials (`client_secret` for Service Principal connections, `client_jwt` for Workload Identity Federation connections) into the root of `$(Agent.TempDirectory)`, but never deletes it. `host.cleanup()` only removed the staging sub-folder, so the credential var-file lingered on the agent and was readable by any subsequent (potentially lower-trust) step in the same job.
2. The WIF OIDC token (`client_jwt`) was not masked because the `tl.setSecret(...)` call had been commented out, so the token could appear unmasked in logs.

---

### **Task Name**
PackerBuild (PackerBuildV1)

---

### **Description**
- **Purge credential var-files:** `packerHost` now tracks every temporary var-file it creates. `packerValidate` and `packerBuild` register their var-file via `packerHost.registerTempVarFile(filePath)` immediately after writing it, and `host.cleanup()` deletes all registered var-files (in addition to the existing staging-folder cleanup). Cleanup runs in the `finally` block of `main.ts`, so purging happens even if the build fails.
- **Mask the WIF OIDC token:** restored `tl.setSecret(oidc_token)` in the Workload Identity Federation branch of `azureSpnTemplateVariablesProvider.ts` so the token is masked in logs.
- Added a `CouldNotDeleteTempFile` localized message used if a var-file cannot be removed.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** Changes are scoped to PackerBuildV1. The cleanup is additive and runs in an existing `finally` path; the masking change only registers an existing secret with the agent. No change to the image-build behavior or task inputs/outputs.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** This is a small, self-contained security fix. The cleanup runs in the existing teardown path and does not alter the functional build flow, so a feature flag is unnecessary.

---

### **Tech Design / Approach**
- Centralized the cleanup in `packerHost` (the object that already owns lifecycle/teardown) rather than adding ad-hoc unlink calls in each operation.
- Operations only register the var-file path; the host is the single owner responsible for deleting them during `cleanup()`.
- Reused the existing `utils.deleteDirectory` (rmRF-based) primitive, which handles files as well as directories, to avoid introducing a new helper.

---

### **Documentation Changes Required** (Yes/No)
**No.** No user-facing behavior or input changes.

---

### **Unit Tests Added or Updated** (Yes / No)
**Yes.** Added an L0 regression test `Deletes packer var file (containing credentials) after execution` that asserts the credential var-file in `Agent.TempDirectory` is deleted (`rmRF <varfile>`) after the task runs. This test fails without the fix and passes with it.

---

### **Additional Testing Performed**
Validated end-to-end using the PackerBuildV1 canary pipeline with a real AzureRM (Service Principal) connection, using a post-execution scan step that enumerates `$(Agent.TempDirectory)/*.json` for `client_secret` / `client_jwt` (reporting only file name, field, length, and SHA-256 — never the raw secret).

- **Before the fix:** the scan found leftover credential var-files in `Agent.TempDirectory` and failed the step.
  Build: https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=317546&view=results
- **After the fix:** no credential var-files remained; the scan reported clean.
  Build: https://dev.azure.com/canarytest/PipelineTasks/_build/results?buildId=317726&view=results

Note: the credential var-file is written before Packer runs, and cleanup runs in `finally`, so the purge is verified even though the underlying Packer/Azure deployment can fail for unrelated environment reasons (e.g. subscription VM quota).

---

### **Logging Added/Updated** (Yes/No)
**Yes.** Added the `CouldNotDeleteTempFile` message (shown only if a var-file cannot be deleted). Logging does not expose sensitive data — the WIF token is now masked via `setSecret`, and no credential values are written to the log.

---

### **Telemetry Added/Updated** (Yes/No)
**No.**

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert this PR. The change is isolated to PackerBuildV1 and has no data/state migration, so reverting fully restores previous behavior.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** No new dependencies; the fix reuses the existing `utils.deleteDirectory` primitive. Existing PackerBuildV1 L0 tests (including the staging-folder cleanup tests) continue to pass, and the new regression test covers the credential var-file cleanup.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected