### PR TITLE
Add external dependency support to task minifier

### DIFF
--- a/Tests/L0Minify.ts
+++ b/Tests/L0Minify.ts
@@ -300,6 +300,164 @@ describe('Minify build helpers (minify-util)', function () {
         });
     });
 
+    describe('external package retention', function () {
+        var os = require('os');
+        var anyFs: any = fs;
+
+        function writePackage(root: string, packageJson: any): void {
+            anyFs.mkdirSync(root, { recursive: true });
+            anyFs.writeFileSync(path.join(root, 'package.json'), JSON.stringify(packageJson));
+            anyFs.writeFileSync(path.join(root, 'index.js'), 'module.exports = true;\n');
+        }
+
+        it('accepts unique top-level package names and rejects subpaths', () => {
+            assert.strictEqual(
+                JSON.stringify(minifyUtil.normalizeExternalPackages(['plain', '@scope/pkg', 'plain'])),
+                JSON.stringify(['plain', '@scope/pkg']));
+            assert.throws(
+                () => minifyUtil.normalizeExternalPackages(['plain/subpath']),
+                /invalid external package/);
+            assert.throws(
+                () => minifyUtil.normalizeExternalPackages('plain'),
+                /must be an array/);
+        });
+
+        it('retains the installed dependency closure and prunes unrelated packages', () => {
+            var outDir = anyFs.mkdtempSync(path.join(os.tmpdir(), 'minify-ext-'));
+            var nodeModules = path.join(outDir, 'node_modules');
+            var externalRoot = path.join(nodeModules, 'external-root');
+            try {
+                writePackage(externalRoot, {
+                    name: 'external-root',
+                    version: '1.0.0',
+                    dependencies: { hoisted: '1.0.0', nested: '2.0.0' },
+                    optionalDependencies: { 'missing-optional': '1.0.0' },
+                    bin: { rootbin: 'cli.js', 'tool.cmd': 'tool.js' }
+                });
+                writePackage(path.join(nodeModules, 'hoisted'), {
+                    name: 'hoisted',
+                    version: '1.0.0'
+                });
+                writePackage(path.join(externalRoot, 'node_modules', 'nested'), {
+                    name: 'nested',
+                    version: '2.0.0',
+                    bin: 'cli.js'
+                });
+                writePackage(path.join(nodeModules, 'unrelated'), {
+                    name: 'unrelated',
+                    version: '1.0.0'
+                });
+
+                var rootBin = path.join(nodeModules, '.bin');
+                anyFs.mkdirSync(rootBin, { recursive: true });
+                anyFs.writeFileSync(path.join(rootBin, 'rootbin'), '');
+                anyFs.writeFileSync(path.join(rootBin, 'rootbin.cmd'), '');
+                anyFs.writeFileSync(path.join(rootBin, 'tool.cmd'), '');
+                anyFs.writeFileSync(path.join(rootBin, 'tool.cmd.cmd'), '');
+                anyFs.writeFileSync(path.join(rootBin, 'unrelated'), '');
+                var nestedBin = path.join(externalRoot, 'node_modules', '.bin');
+                anyFs.mkdirSync(nestedBin, { recursive: true });
+                anyFs.writeFileSync(path.join(nestedBin, 'nested'), '');
+                anyFs.writeFileSync(path.join(nodeModules, '.package-lock.json'), '{}');
+
+                var closure = minifyUtil.collectExternalPackageClosure(outDir, ['external-root']);
+                assert.strictEqual(closure.retainedRoots.size, 3);
+                assert.strictEqual(
+                    JSON.stringify(minifyUtil.findRetainedPackageOverlaps(
+                        { inputs: { 'node_modules/hoisted/index.js': {} } },
+                        outDir,
+                        closure.retainedRoots).map((pkg: any) => pkg.name)),
+                    JSON.stringify(['hoisted']));
+
+                minifyUtil.pruneNodeModules(
+                    closure.nodeModulesPath,
+                    closure.retainedRoots,
+                    closure.retainedBins);
+
+                assert.ok(anyFs.existsSync(path.join(externalRoot, 'package.json')));
+                assert.ok(anyFs.existsSync(path.join(nodeModules, 'hoisted', 'package.json')));
+                assert.ok(anyFs.existsSync(path.join(externalRoot, 'node_modules', 'nested', 'package.json')));
+                assert.strictEqual(anyFs.existsSync(path.join(nodeModules, 'unrelated')), false);
+                assert.strictEqual(anyFs.existsSync(path.join(nodeModules, '.package-lock.json')), false);
+                assert.ok(anyFs.existsSync(path.join(rootBin, 'rootbin')));
+                assert.ok(anyFs.existsSync(path.join(rootBin, 'rootbin.cmd')));
+                assert.ok(anyFs.existsSync(path.join(rootBin, 'tool.cmd')));
+                assert.ok(anyFs.existsSync(path.join(rootBin, 'tool.cmd.cmd')));
+                assert.strictEqual(anyFs.existsSync(path.join(rootBin, 'unrelated')), false);
+                assert.ok(anyFs.existsSync(path.join(nestedBin, 'nested')));
+
+                assert.strictEqual(
+                    minifyUtil.collectExternalPackageClosure(outDir, ['external-root']).retainedRoots.size,
+                    3);
+            } finally {
+                anyFs.rmSync(outDir, { recursive: true, force: true });
+            }
+        });
+
+        it('fails when a required dependency is missing', () => {
+            var outDir = anyFs.mkdtempSync(path.join(os.tmpdir(), 'minify-ext-'));
+            try {
+                writePackage(path.join(outDir, 'node_modules', 'external-root'), {
+                    name: 'external-root',
+                    version: '1.0.0',
+                    dependencies: { missing: '1.0.0' }
+                });
+                assert.throws(
+                    () => minifyUtil.collectExternalPackageClosure(outDir, ['external-root']),
+                    /requires "missing", but it is not installed/);
+            } finally {
+                anyFs.rmSync(outDir, { recursive: true, force: true });
+            }
+        });
+
+        it('fails when an external package has multiple physical roots', () => {
+            var outDir = anyFs.mkdtempSync(path.join(os.tmpdir(), 'minify-ext-'));
+            try {
+                var nodeModules = path.join(outDir, 'node_modules');
+                writePackage(path.join(nodeModules, 'external-root'), {
+                    name: 'external-root',
+                    version: '1.0.0'
+                });
+                writePackage(path.join(nodeModules, 'holder'), {
+                    name: 'holder',
+                    version: '1.0.0'
+                });
+                writePackage(path.join(nodeModules, 'holder', 'node_modules', 'external-root'), {
+                    name: 'external-root',
+                    version: '2.0.0'
+                });
+                assert.throws(
+                    () => minifyUtil.collectExternalPackageClosure(outDir, ['external-root']),
+                    /installed at 2 physical roots/);
+            } finally {
+                anyFs.rmSync(outDir, { recursive: true, force: true });
+            }
+        });
+
+        it('restores published outputs when a staged replacement fails', () => {
+            var tmp = anyFs.mkdtempSync(path.join(os.tmpdir(), 'minify-publish-'));
+            try {
+                var firstDest = path.join(tmp, 'first.js');
+                var secondDest = path.join(tmp, 'second.js');
+                var firstSource = path.join(tmp, 'first.new.js');
+                anyFs.writeFileSync(firstDest, 'first-old');
+                anyFs.writeFileSync(secondDest, 'second-old');
+                anyFs.writeFileSync(firstSource, 'first-new');
+
+                assert.throws(() => minifyUtil.replaceOutputPaths([
+                    { source: firstSource, destination: firstDest },
+                    { source: path.join(tmp, 'missing.js'), destination: secondDest }
+                ], path.join(tmp, 'backup')));
+
+                assert.strictEqual(anyFs.readFileSync(firstDest, 'utf8'), 'first-old');
+                assert.strictEqual(anyFs.readFileSync(secondDest, 'utf8'), 'second-old');
+            } finally {
+                anyFs.rmSync(tmp, { recursive: true, force: true });
+            }
+        });
+
+    });
+
     describe('missing declared entry (B3)', function () {
         var os = require('os');
         var anyFs: any = fs;

--- a/docs/minify-tasks.md
+++ b/docs/minify-tasks.md
@@ -47,6 +47,38 @@ Inspect `_build/Tasks/<Task>` afterward: confirm the bundle is present, `node_mo
 gone, stack traces resolve (with `--sourcemap`), and the build didn't fail on a duplicate
 package. Once you're happy, opt the task in permanently.
 
+### Try minification with external packages
+
+There is no `--external` command-line option. For an experiment, temporarily add the package
+policy to the task's existing `make.json` while leaving permanent minification disabled:
+
+```jsonc
+{
+  "minify": {
+    "enabled": false,
+    "external": [
+      "package-with-runtime-assets"
+    ],
+    "allowBundledAndRetained": [
+      "reviewed-stateless-package"
+    ]
+  }
+}
+```
+
+Preserve any other task-specific settings already present in `make.json`, then force minification
+for that build:
+
+```bash
+node make.js build --task <Task> --minify --BypassNpmAudit
+```
+
+`--minify` overrides only whether minification is enabled. The build still reads `external`,
+`allowDuplicates`, and `allowBundledAndRetained` from `make.json`. Inspect the final
+`_build/Tasks/<Task>/node_modules` closure and run both loader-based tests and final-bundle
+black-box tests. Remove the temporary `minify` block afterward, or set `enabled: true` only when
+the task is ready to opt in permanently.
+
 ## Opt in (make.json - the real switch)
 
 To make minification a permanent property of the task, add a `minify` block to the task's

--- a/docs/minify-tasks.md
+++ b/docs/minify-tasks.md
@@ -4,8 +4,9 @@
 Node-based tasks can optionally be **bundled and minified** at build time. Instead of
 shipping the compiled JavaScript plus a full `node_modules` tree (often thousands of
 files, tens of MB), each Node execution target is bundled with [esbuild](https://esbuild.github.io/)
-into a single minified file and `node_modules` is dropped from the output. This can
-reduce a task's deployable size by ~90% or more.
+into a single minified file and bundled dependencies are dropped from `node_modules`. Packages
+listed under `minify.external` keep their runtime closures on disk. Fully bundled tasks can reduce
+their deployable size by ~90% or more; external closures reduce that saving.
 
 Minification is **off by default** and **opt-in per task**. Nothing is minified unless
 the task opts in via `make.json`. The command-line flags exist only for **experimentation** -
@@ -19,6 +20,7 @@ to try minification on a task and inspect the result before you commit to opting
 - [Source maps and debugging](#source-maps-and-debugging)
 - [Duplicate packages (split module state)](#duplicate-packages-split-module-state)
 - [Known caveats (validate before opting in)](#known-caveats-validate-before-opting-in)
+- [Partial bundling with external packages](#partial-bundling-with-external-packages)
 - [Test and canary coverage (required before opting in)](#test-and-canary-coverage-required-before-opting-in)
 - [Dependency hygiene best practices](#dependency-hygiene-best-practices)
 - [Future work / deferred](#future-work--deferred)
@@ -55,7 +57,8 @@ build (including generated tasks) - no flag required:
 {
   "minify": {
     "enabled": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "external": ["package-with-runtime-assets"]
   }
 }
 ```
@@ -68,9 +71,11 @@ per-task `make.json` setting decides.
 
 | Field | Type | Default | Description |
 | ----- | ---- | ------- | ----------- |
-| `enabled` | boolean | `false` | Bundle + minify this task's Node execution targets and drop `node_modules`. |
+| `enabled` | boolean | `false` | Bundle + minify this task's Node execution targets and drop bundled packages from `node_modules`. |
 | `sourceMap` | boolean | `false` | Also emit a TypeScript source map so runtime stack traces resolve back to `.ts` files. Only applied when `enabled` is true. |
 | `allowDuplicates` | string[] | `[]` | Package names allowed to be bundled from more than one `node_modules` root (see below). There is no global default - every entry is an explicit per-task decision. |
+| `allowBundledAndRetained` | string[] | `[]` | Reviewed stateless packages allowed to be inlined while the same installed package is also retained as part of an external package's closure. Stateful packages must instead be listed under `external`. |
+| `external` | string[] | `[]` | Top-level package names esbuild must leave as runtime `require()` calls. Their complete installed runtime dependency closures and assets are retained in `node_modules`; unrelated packages are deleted. |
 
 ## Source maps and debugging
 
@@ -212,10 +217,11 @@ package instead.
 
 ## Known caveats (validate before opting in)
 
-Bundling collapses many files into one and drops `node_modules`, which breaks a few
-assumptions that only hold when files stay separate on disk. Always trial a task with
-`--minify` (and run its tests against the minified output) **before** adding a permanent
-`make.json` opt-in. The two things most likely to bite:
+Bundling collapses many files into one and drops all non-external packages from `node_modules`,
+which breaks assumptions that only hold when files stay separate on disk. Always trial a task with
+`--minify`, run its loader-based suites through `make.js test`, and separately launch the production
+bundle in black-box tests **before** adding a permanent `make.json` opt-in. The two things most
+likely to bite:
 
 ### Dynamic `require()`
 
@@ -248,18 +254,20 @@ type, a platform check, an error handler), so it can pass a quick smoke test and
    ```
 
    Look for `require(` followed by a variable, `+` concatenation, or a `` ` `` template.
-3. **Run the task's L0/L2 tests against the minified build** - the most reliable check,
-   because an unresolved require only throws when its branch actually executes. Exercise
-   optional/rare paths (specific inputs, platform branches, error handling) where dynamic
-   loading tends to hide.
+3. **Run black-box tests against `_build/Tasks/<Task>`** - the most reliable check, because an
+   unresolved require only throws when its branch actually executes. `make.js test` uses the
+   pre-bundle mock artifact and cannot prove final packaging closure. Exercise optional/rare paths
+   (specific inputs, platform branches, error handling) where dynamic loading tends to hide.
 
 **How to fix it:**
 
 - Rewrite the computed require as a static `switch`/map of literal `require()` calls so
   esbuild can see every target.
-- Or leave the task un-minified (don't add the `make.json` opt-in) if it relies on dynamic
-  loading that can't be made static. Minify is **all-or-nothing** today - see
-  [Not currently supported](#not-currently-supported-partial-bundling--external) below.
+- If the dynamic loading is contained inside a top-level dependency, list that package under
+  [`minify.external`](#partial-bundling-with-external-packages). Its runtime closure remains
+  on disk.
+- Leave the task un-minified if the dynamic loading crosses package boundaries or cannot be
+  covered and tested safely by an external package closure.
 
 ### Manually finding hard-to-detect dynamic requires
 
@@ -317,47 +325,106 @@ Where to search the dependencies:
 - Searching the compiled JS (not just `.ts`) matters, because some deps ship only JS and the
   dynamic pattern may be introduced by a package's own build step.
 
-Because you often can't rewrite third-party code, the practical fix for a dependency-side
-dynamic require today is to **not opt the task in** (leave it un-minified). Retaining a single
-package in `node_modules` while bundling the rest is **not currently supported** - see
-[Not currently supported](#not-currently-supported-partial-bundling--external) below. Confirm
-the outcome by running the task's L0/L2 tests against the minified build.
+Because you often can't rewrite third-party code, use `minify.external` when the unsupported
+behavior is contained in a top-level package and its runtime closure can remain on disk. Confirm
+the task logic through `make.js test`, then confirm the retained closure by launching the final
+production entry in black-box tests.
 
-### Not currently supported: partial bundling / `external`
+### Partial bundling with external packages
 
-Minify is **all-or-nothing**: every declared entry is bundled and the task's entire
-`node_modules` is deleted. There is **no** `external` / partial-bundling option, so a task that
-depends on something esbuild cannot inline **cannot be minified today** - opt it out instead.
-Packages that fall in this bucket:
+List top-level package names under `minify.external` when they cannot safely be inlined:
 
 - **Native addons** (`.node` binaries) - esbuild can't inline a compiled binary.
 - **Runtime assets loaded from disk** - a package that reads its own non-JS files relative to
   `__dirname` (templates, `.wasm`, data files, worker scripts).
 - **Unavoidable dynamic `require()`/`import()`** in a dependency you can't rewrite.
 
-A future enhancement could add an `external: string[]` field to the `make.json` `minify` block
-that (a) marks those packages `external` in the esbuild options and (b) preserves them - **plus
-their full transitive dependency tree and assets** - in `node_modules` instead of deleting
-them. That transitive-closure retention is the reason it is not implemented yet: keeping only
-the top-level package would still fail at runtime the moment it requires one of its own deps.
-Until then, treat "can't be bundled" as "don't opt in".
+```jsonc
+{
+  "minify": {
+    "enabled": true,
+    "external": [
+      "azure-pipelines-task-lib",
+      "@scope/package-with-assets"
+    ]
+  }
+}
+```
+
+The minifier:
+
+1. Requires every configured name to be installed directly under the task's root
+   `node_modules`. Package subpaths are not accepted.
+2. Fails when an external package name is installed at multiple physical roots. esbuild's
+   external matching is name-based, so nested versions must be aligned first.
+3. Traverses installed `dependencies`, `optionalDependencies`, peer dependencies, and bundled
+   dependencies from each external root.
+4. Preserves every resolved package at its existing root, including nested versions, package
+   assets, and matching `.bin` launchers.
+5. Deletes every package and launcher outside the retained closure.
+6. Traverses the pruned closure again and fails if a required dependency no longer resolves.
+7. Rejects symlinked package roots or symlinked retained `node_modules` trees. Task builds must
+   materialize packages with npm so pruning cannot follow a link outside the task output.
+
+Pruning and closure validation occur in staging. Bundles and the prepared `node_modules` tree are
+published with backups and rollback so a failed prune or replacement does not leave a partially
+rewritten task output.
+
+Externalization is not tree shaking. If an external package declares build-only or unused modules
+under runtime `dependencies`, they are retained because the minifier cannot safely prove they are
+unneeded. Fix the package manifest to reduce that closure.
+
+Do not externalize only a wrapper while bundling another stateful package from its retained
+closure. Loading one physical package both from disk and from the bundle creates two module
+singletons. The build detects that overlap and fails unless the package is explicitly listed in
+`allowBundledAndRetained` as a reviewed stateless exception. Prefer adding the shared stateful
+package to `external` so every import remains a runtime import.
+
+### Testing a minified task
+
+The build preserves compiled pre-bundle code under `_build/TestArtifacts/<Task>` without copying
+its `node_modules`. This artifact exists only for loader-based L0 tests; it is not shipped.
+
+When `node make.js test` sees dependencies missing from that artifact, it:
+
+1. Copies the task package into an isolated `_build/TestDependencies/<Task>` scratch directory,
+   excluding any existing `node_modules`, and runs `npm ci --omit=dev` there. The source task's
+   dependency tree is never renamed or modified.
+2. When `Tests/package.json` and `Tests/package-lock.json` exist, creates a second scratch package
+   and runs `npm ci` there including test development dependencies.
+3. Moves only the resulting modules into the pre-bundle artifact's normal
+   `<Task>/node_modules` and `<Task>/Tests/node_modules` locations.
+4. Removes duplicate copies of configured external packages so tests use the production
+   artifact's retained singleton.
+5. Runs Mocha with normal nested Node resolution; `NODE_PATH` contains only the production
+   `node_modules` needed for configured external packages.
+6. Deletes the temporary test dependency tree.
+
+This permits production dependencies such as utility-common and uuid to remain bundled while
+existing L0 loader mocks operate on pre-bundle JavaScript. L0 therefore validates task logic and
+mock contracts, not the final bundle. Every opted-in task still needs black-box tests that launch
+the production entry from `_build/Tasks/<Task>`.
+
+The complete retained closure must be tested on every supported platform. Optional dependencies,
+native binaries, install-time outputs, and package-owned scripts can differ by OS and architecture.
 
 ### Third-party license attribution
 
-Bundling deletes `node_modules`, which also removes the standalone `LICENSE`/`NOTICE` files that
-ship inside each dependency. esbuild is configured with `legalComments: 'eof'`, so any license or
-legal comment embedded **in a dependency's source** (the `/*! … */`, `//! …`, `@license`, or
-`@preserve` banners) is preserved and collected at the end of the bundle. Standalone license
-*files* are **not** carried over — only in-source legal comments are. If a task (or a compliance
-process) depends on shipping the original `LICENSE` files alongside the code, account for this
-before opting in.
+For bundled dependencies, minification deletes their package directories and therefore their
+standalone `LICENSE`/`NOTICE` files. esbuild is configured with `legalComments: 'eof'`, so legal
+comments embedded **in dependency source** (the `/*! … */`, `//! …`, `@license`, or `@preserve`
+banners) are preserved and collected at the end of the bundle. Standalone license files are not.
+
+External package closures preserve their original package license files. A mixed bundle still needs
+complete attribution for the dependencies that were inlined and removed.
 
 ### Source map / `tsconfig` interactions
 
 The source map produced for minified tasks chains esbuild's bundle map through tsc's
 per-file maps. To keep that chain unambiguous the build emits **external** maps and deletes
-the now-redundant intermediate tsc `*.js.map` files, keeping only the final `<entry>.js.map`
-that ships next to the bundled entry. Avoid configuring a task's `tsconfig.json` with
+the now-redundant intermediate task tsc `*.js.map` files outside retained `node_modules`, keeping
+only the final `<entry>.js.map` that ships next to the bundled entry. Avoid configuring a task's
+`tsconfig.json` with
 `inlineSourceMap` when minifying - mixing inline tsc maps with the external bundle map
 produces conflicting `sourceMappingURL` directives and frames that resolve to the wrong line
 (or not at all). Stick with the default `sourceMap` behavior and let the minify step manage
@@ -376,9 +443,10 @@ the minified build.**
 
 Before adding a `make.json` `minify` block:
 
-- **Run the task's full test suite against the minified output, not just the normal build.** A
-  green run on the non-minified build proves nothing about the bundle. Build with `--minify`
-  (and `--minify --sourcemap`) and run the `L0`, `L1`, and any `L2` suites against that output.
+- **Run both test surfaces.** `make.js test` runs `L0`, `L1`, and `L2` suites against the preserved
+  pre-bundle artifact so loader mocks remain valid. That proves task logic but not packaging.
+  Separately launch `_build/Tasks/<Task>` in black-box tests for both `--minify` and
+  `--minify --sourcemap`; a green pre-bundle suite alone proves nothing about bundle closure.
 - **Exercise every runtime code path, not just the happy path.** The caveats bite on branches —
   each authentication type, each platform (Windows / Linux / macOS), each optional feature, each
   error/fallback handler, and any dynamically selected provider or handler. If a path isn't
@@ -421,14 +489,7 @@ habits for task authors:
 
 ## Future work / deferred
 
-- **Partial bundling / `external` opt-in — deliberately deferred.** We evaluated adding an
-  `external: string[]` field to the `make.json` `minify` block (mark listed packages `external`
-  in esbuild **and** keep them in `node_modules` instead of deleting them) so a task could bundle
-  everything except the one dependency it can't inline. It is **not** implemented for now because
-  correctly preserving a package means preserving its **entire transitive dependency tree and
-  runtime assets**, not just the top-level folder — otherwise the task still fails at runtime the
-  moment the kept package requires one of its own deps. See
-  [Not currently supported: partial bundling / `external`](#not-currently-supported-partial-bundling--external)
-  for the full rationale. Until a genuine need appears, the guidance stays "if a task can't be
-  fully bundled, opt it out." This can be revisited as a TODO if a real task hits a case where
-  opting out entirely is unacceptable.
+- **Package-level runtime manifests.** External closure retention trusts npm dependency metadata
+  and preserves complete package directories. Explicit package manifests for runtime assets,
+  platform selectors, and generated third-party notices would permit narrower retained outputs
+  without guessing which declared files are safe to remove.

--- a/make.js
+++ b/make.js
@@ -9,6 +9,7 @@ if (process.env.IncludeLocalPackagesBuildConfigTest === "1") {
 var fs = require('fs');
 var os = require('os');
 var path = require('path');
+var childProcess = require('child_process');
 var semver = require('semver');
 var util = require('./make-util');
 var minifyUtil = require('./minify-util');
@@ -48,6 +49,7 @@ var writeUpdatedsFromGenTasks = false;
 var buildPath = path.join(__dirname, '_build');
 var buildTasksPath = path.join(__dirname, '_build', 'Tasks');
 var buildTestsPath = path.join(__dirname, '_build', 'Tests');
+var buildTestArtifactsPath = path.join(__dirname, '_build', 'TestArtifacts');
 var buildTasksCommonPath = path.join(__dirname, '_build', 'Tasks', 'Common');
 var testsLegacyPath = path.join(__dirname, 'Tests-Legacy');
 var tasksPath = path.join(__dirname, 'Tasks');
@@ -67,6 +69,7 @@ var genTaskCommonPath = path.join(__dirname, '_generated', 'Common');
 var genTaskCommonPathLocal = path.join(__dirname, '_generated_local', 'Common');
 var taskLibPath = path.join(__dirname, 'task-lib/node');
 var tasksCommonPath = path.join(__dirname, 'tasks-common');
+var testDependenciesPath = path.join(buildPath, 'TestDependencies');
 
 var CLI = {};
 
@@ -505,7 +508,7 @@ async function buildTaskAsync(taskName, nodeVersion, isServerBuild = false) {
     //--------------------------------
     // Resolve minify opt-in.
     // The permanent opt-in lives in the task's make.json "minify" block, e.g.:
-    //   "minify": { "enabled": true, "sourceMap": true }
+    //   "minify": { "enabled": true, "sourceMap": true, "external": ["package-name"] }
     // The CLI flags (--minify / --no-minify, --sourcemap / --no-sourcemap) are for
     // experimentation only: they let you try minification on a build and always win
     // over make.json so you can force it on or off regardless of the task's setting.
@@ -533,6 +536,10 @@ async function buildTaskAsync(taskName, nodeVersion, isServerBuild = false) {
     var minifyOptions = {
         sourceMap: withSourceMap,
         allowDuplicates: Array.isArray(taskMinify.allowDuplicates) ? taskMinify.allowDuplicates : [],
+        allowBundledAndRetained: Array.isArray(taskMinify.allowBundledAndRetained)
+            ? taskMinify.allowBundledAndRetained
+            : [],
+        external: taskMinify.external,
         failOnDuplicates: !argv['allow-duplicates']
     };
 
@@ -697,7 +704,18 @@ async function buildTaskAsync(taskName, nodeVersion, isServerBuild = false) {
     // Optionally minify the compiled Node task into a single bundle per entry
     // point and drop node_modules. Enabled globally via the --minify build flag
     // or per-task via a "minify" block in the task's make.json.
+    var testArtifactPath = path.join(buildTestArtifactsPath, taskName);
+    rm('-Rf', testArtifactPath);
     if (doMinify && shouldBuildNode) {
+        // Loader-based L0 mocks cannot replace modules after esbuild inlines them.
+        // Preserve compiled pre-bundle code (without production dependencies) as a
+        // test-only artifact; CLI.test restores its exact lockfile dependencies.
+        fs.cpSync(outDir, testArtifactPath, {
+            recursive: true,
+            filter: function (source) {
+                return path.basename(source) !== 'node_modules';
+            }
+        });
         banner('Minifying task ' + taskName + (withSourceMap ? ' (with TS source map)' : ' (no source map)'), true);
         await minifyNodeTask(taskPath, outDir, minifyOptions);
     }
@@ -727,14 +745,157 @@ CLI.test = async function(/** @type {{ suite: string; node: string; task: string
     matchCopy(path.join('**', '@(*.ps1|*.psm1)'), path.join(testsPath, 'lib'), path.join(buildTestsPath, 'lib'));
 
     var suiteType = argv.suite || 'L0';
+
+    function getTaskSourcePath(taskName) {
+        var candidates = [
+            path.join(genTaskPath, taskName)
+        ];
+        if (argv.includeLocalPackagesBuildConfig) {
+            candidates.push(path.join(genTaskPathLocal, taskName));
+        }
+        candidates.push(path.join(tasksPath, taskName));
+        return candidates.find(function (candidate) {
+            return fs.existsSync(path.join(candidate, 'package.json'));
+        });
+    }
+
+    function getMissingBuiltRuntimeDependencies(taskBuildPath) {
+        var packageJsonPath = path.join(taskBuildPath, 'package.json');
+        if (!fs.existsSync(packageJsonPath)) {
+            return [];
+        }
+        var packageJson = fileToJson(packageJsonPath);
+        var runtimeDependencies = Object.assign(
+            {},
+            packageJson.dependencies || {},
+            packageJson.optionalDependencies || {});
+        return Object.keys(runtimeDependencies).filter(function (packageName) {
+            return !fs.existsSync(path.join(
+                taskBuildPath,
+                'node_modules',
+                ...packageName.split('/'),
+                'package.json'));
+        });
+    }
+
+    function prepareTaskTestDependencies(taskName, taskBuildPath) {
+        var missing = getMissingBuiltRuntimeDependencies(taskBuildPath);
+        if (!missing.length) {
+            return null;
+        }
+
+        var sourceTaskPath = getTaskSourcePath(taskName);
+        if (!sourceTaskPath || !fs.existsSync(path.join(sourceTaskPath, 'package-lock.json'))) {
+            throw new Error('Tests for minified task ' + taskName +
+                ' require dependencies removed from the production artifact (' + missing.join(', ') +
+                '), but its source package.json/package-lock.json could not be found.');
+        }
+
+        var taskTestDependenciesPath = path.join(testDependenciesPath, taskName);
+        var testNodeModulesPath = path.join(taskBuildPath, 'node_modules');
+        rm('-Rf', taskTestDependenciesPath);
+        mkdir('-p', taskTestDependenciesPath);
+
+        var taskMakePath = path.join(sourceTaskPath, 'make.json');
+        var taskMake = fs.existsSync(taskMakePath) ? fileToJson(taskMakePath) : {};
+        var externalPackages = minifyUtil.normalizeExternalPackages(
+            taskMake.minify && taskMake.minify.external);
+
+        function removeExternalPackageCopies(nodeModulesPath) {
+            var duplicateExternalRoots = [];
+            minifyUtil.walkInstalledPackages(nodeModulesPath, function (packageRoot) {
+                var packageJson = fileToJson(path.join(packageRoot, 'package.json'));
+                if (externalPackages.includes(packageJson.name)) {
+                    duplicateExternalRoots.push(packageRoot);
+                }
+            });
+            duplicateExternalRoots
+                .sort(function (left, right) { return right.length - left.length; })
+                .forEach(function (packageRoot) { rm('-Rf', packageRoot); });
+        }
+
+        function installTestDependencySet(sourcePackagePath, destinationNodeModulesPath, omitDev, scratchName) {
+            var scratchPackagePath = path.join(taskTestDependenciesPath, scratchName);
+            var scratchNodeModulesPath = path.join(scratchPackagePath, 'node_modules');
+            rm('-Rf', scratchPackagePath);
+            fs.cpSync(sourcePackagePath, scratchPackagePath, {
+                recursive: true,
+                filter: function (sourcePath) {
+                    return sourcePath === sourcePackagePath || path.basename(sourcePath) !== 'node_modules';
+                }
+            });
+            try {
+                var npmArgs = ['ci', '--no-audit', '--fund=false'];
+                if (omitDev) {
+                    npmArgs.push('--omit=dev');
+                }
+                childProcess.execFileSync(
+                    process.platform === 'win32' ? 'npm.cmd' : 'npm',
+                    npmArgs,
+                    { cwd: scratchPackagePath, stdio: 'inherit', env: process.env });
+                mkdir('-p', path.dirname(destinationNodeModulesPath));
+                rm('-Rf', destinationNodeModulesPath);
+                fs.renameSync(scratchNodeModulesPath, destinationNodeModulesPath);
+                // External packages must use the production artifact's retained
+                // copy, not a second singleton from restored test dependencies.
+                removeExternalPackageCopies(destinationNodeModulesPath);
+            } catch (err) {
+                rm('-Rf', destinationNodeModulesPath);
+                throw err;
+            } finally {
+                rm('-Rf', scratchPackagePath);
+            }
+        }
+
+        var nodePaths = [];
+        try {
+            console.log('> restoring test-only dependencies for minified task ' + taskName +
+                ' (missing from production output: ' + missing.join(', ') + ')');
+            installTestDependencySet(
+                sourceTaskPath,
+                testNodeModulesPath,
+                true,
+                'task-package');
+            nodePaths.push(testNodeModulesPath);
+
+            var sourceTestsPath = path.join(sourceTaskPath, 'Tests');
+            if (fs.existsSync(path.join(sourceTestsPath, 'package.json')) &&
+                fs.existsSync(path.join(sourceTestsPath, 'package-lock.json'))) {
+                var testsNodeModulesPath = path.join(taskBuildPath, 'Tests', 'node_modules');
+                installTestDependencySet(
+                    sourceTestsPath,
+                    testsNodeModulesPath,
+                    false,
+                    'tests-package');
+                nodePaths.unshift(testsNodeModulesPath);
+            }
+        } catch (err) {
+            nodePaths.forEach(function (nodeModulesPath) { rm('-Rf', nodeModulesPath); });
+            rm('-Rf', taskTestDependenciesPath);
+            throw err;
+        }
+
+        return {
+            root: taskTestDependenciesPath,
+            installedNodeModules: nodePaths
+        };
+    }
+
     async function runTaskTests(taskName, results) {
         banner('Testing: ' + taskName);
+        var productionTaskBuildPath = path.join(buildTasksPath, taskName);
+        var preBundleTestArtifactPath = path.join(buildTestArtifactsPath, taskName);
+        var hasPreBundleTestArtifact = fs.existsSync(preBundleTestArtifactPath);
+        var taskBuildPath = hasPreBundleTestArtifact
+            ? preBundleTestArtifactPath
+            : productionTaskBuildPath;
         // find the tests
         var nodeVersions = argv.node ? new Array(argv.node) : [Math.max(...getTaskNodeVersion(buildTasksPath, taskName))];
-        var pattern1 = path.join(buildTasksPath, taskName, 'Tests', suiteType + '.js');
+        var pattern1 = path.join(taskBuildPath, 'Tests', suiteType + '.js');
         var pattern2 = path.join(buildTasksPath, 'Common', taskName, 'Tests', suiteType + '.js');
-        var taskPath = path.join('**', '_build', 'Tasks', taskName, "**", "*.js").replace(/\\/g, '/');
-        var isNodeTask = util.isNodeTask(buildTasksPath, taskName);
+        var coverageTaskPath = path.relative(__dirname, taskBuildPath);
+        var taskPath = path.join('**', coverageTaskPath, "**", "*.js").replace(/\\/g, '/');
+        var isNodeTask = util.isNodeTask(path.dirname(taskBuildPath), taskName);
 
         var isReportWasFormed = false;
         var testsSpec = [];
@@ -751,25 +912,56 @@ CLI.test = async function(/** @type {{ suite: string; node: string; task: string
             return;
         }
 
-        for (let nodeVersion of nodeVersions) {
-            try {
-                nodeVersion = String(nodeVersion);
-                banner('Run Mocha Suits for node ' + nodeVersion);
-                // setup the version of node to run the tests
-                await util.installNodeAsync(nodeVersion);
+        var restoredDependencies = hasPreBundleTestArtifact
+            ? prepareTaskTestDependencies(taskName, taskBuildPath)
+            : null;
+        var originalNodePath = process.env.NODE_PATH;
+        if (restoredDependencies) {
+            var nodePaths = [];
+            var productionNodeModules = path.join(productionTaskBuildPath, 'node_modules');
+            if (fs.existsSync(productionNodeModules)) {
+                nodePaths.push(productionNodeModules);
+            }
+            if (originalNodePath) {
+                nodePaths.push(originalNodePath);
+            }
+            if (nodePaths.length) {
+                process.env.NODE_PATH = nodePaths.join(path.delimiter);
+            }
+        }
 
+        try {
+            for (let nodeVersion of nodeVersions) {
+                try {
+                    nodeVersion = String(nodeVersion);
+                    banner('Run Mocha Suits for node ' + nodeVersion);
+                    // setup the version of node to run the tests
+                    await util.installNodeAsync(nodeVersion);
 
-                if (isNodeTask && !isReportWasFormed && nodeVersion >= 10) {
-                    run('nyc --all -n ' + taskPath + ' --report-dir ' + coverageTasksPath + ' mocha ' + testsSpec.join(' '), /*inheritStreams:*/true, /*noHeader*/ false,  /*throwOnError*/ true);
-                    util.renameCodeCoverageOutput(coverageTasksPath, taskName);
-                    isReportWasFormed = true;
+                    if (isNodeTask && !isReportWasFormed && nodeVersion >= 10) {
+                        run('nyc --all -n ' + taskPath + ' --report-dir ' + coverageTasksPath + ' mocha ' + testsSpec.join(' '), /*inheritStreams:*/true, /*noHeader*/ false,  /*throwOnError*/ true);
+                        util.renameCodeCoverageOutput(coverageTasksPath, taskName);
+                        isReportWasFormed = true;
+                    }
+                    else {
+                        run('mocha ' + testsSpec.join(' '), /*inheritStreams:*/true, /*noHeader*/ false,  /*throwOnError*/ true);
+                    }
+                } catch (e) {
+                    console.error(e);
+                    results.push({ taskName: taskName, result: `NodeVersion: ${nodeVersion} Error: ${e}` });
                 }
-                else {
-                    run('mocha ' + testsSpec.join(' '), /*inheritStreams:*/true, /*noHeader*/ false,  /*throwOnError*/ true);
-                }
-            }  catch (e) {
-                console.error(e);
-                results.push({ taskName: taskName, result: `NodeVersion: ${nodeVersion} Error: ${e}` });
+            }
+        } finally {
+            if (originalNodePath === undefined) {
+                delete process.env.NODE_PATH;
+            } else {
+                process.env.NODE_PATH = originalNodePath;
+            }
+            if (restoredDependencies) {
+                restoredDependencies.installedNodeModules.forEach(function (nodeModulesPath) {
+                    rm('-Rf', nodeModulesPath);
+                });
+                rm('-Rf', restoredDependencies.root);
             }
         }
     }

--- a/minify-util.js
+++ b/minify-util.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const Module = require('module');
 const makeUtil = require('./make-util');
 const test = makeUtil.test;
 const rm = makeUtil.rm;
@@ -195,6 +196,402 @@ var readRootVersion = function (outDir, root) {
 };
 exports.readRootVersion = readRootVersion;
 
+// Only top-level npm package names are accepted in make.json. Subpath requests
+// such as "pkg/internal" would make it ambiguous which installed package root and
+// dependency closure must be retained.
+var normalizeExternalPackages = function (external) {
+    if (external === undefined) {
+        return [];
+    }
+    if (!Array.isArray(external)) {
+        throw new Error('minify: "external" must be an array of top-level npm package names.');
+    }
+
+    var seen = new Set();
+    return external.map(function (value) {
+        if (typeof value !== 'string') {
+            throw new Error('minify: every "external" entry must be a top-level npm package name.');
+        }
+        var name = value.trim();
+        var valid = name.length > 0 &&
+            !name.startsWith('.') &&
+            !/\s|\\/.test(name) &&
+            (/^[^/@][^/]*$/.test(name) || /^@[^/]+\/[^/]+$/.test(name));
+        if (!valid) {
+            throw new Error('minify: invalid external package "' + value +
+                '". Use a top-level npm package name such as "package" or "@scope/package", not a subpath.');
+        }
+        return name;
+    }).filter(function (name) {
+        if (seen.has(name)) {
+            return false;
+        }
+        seen.add(name);
+        return true;
+    });
+};
+exports.normalizeExternalPackages = normalizeExternalPackages;
+
+var pathKey = function (value) {
+    var resolved = path.resolve(value);
+    return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+};
+
+var packagePath = function (nodeModulesPath, packageName) {
+    return path.join.apply(path, [nodeModulesPath].concat(packageName.split('/')));
+};
+
+// Visit every physical package root in an installed node_modules tree. This is
+// used to reject an external package name that exists at multiple roots: esbuild
+// externalization is name-based, so moving all requires to the bundle root would
+// otherwise silently change which version nested importers load.
+var walkInstalledPackages = function (nodeModulesPath, visitor) {
+    if (!fs.existsSync(nodeModulesPath)) {
+        return;
+    }
+    if (fs.lstatSync(nodeModulesPath).isSymbolicLink()) {
+        return;
+    }
+    fs.readdirSync(nodeModulesPath, { withFileTypes: true }).forEach(function (entry) {
+        if (entry.name === '.bin' || entry.name.startsWith('.')) {
+            return;
+        }
+        var entryPath = path.join(nodeModulesPath, entry.name);
+        if (entry.name.startsWith('@')) {
+            if (!entry.isDirectory()) {
+                return;
+            }
+            fs.readdirSync(entryPath, { withFileTypes: true }).forEach(function (scopedEntry) {
+                if (!scopedEntry.isDirectory()) {
+                    return;
+                }
+                var root = path.join(entryPath, scopedEntry.name);
+                visitor(root);
+                walkInstalledPackages(path.join(root, 'node_modules'), visitor);
+            });
+            return;
+        }
+        if (!entry.isDirectory()) {
+            return;
+        }
+        visitor(entryPath);
+        walkInstalledPackages(path.join(entryPath, 'node_modules'), visitor);
+    });
+};
+exports.walkInstalledPackages = walkInstalledPackages;
+
+var readPackageJson = function (packageRoot) {
+    var packageJsonPath = path.join(packageRoot, 'package.json');
+    if (!fs.existsSync(packageJsonPath)) {
+        throw new Error('minify: retained package is missing package.json: ' + packageRoot);
+    }
+    try {
+        return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    } catch (err) {
+        throw new Error('minify: could not read retained package metadata at ' +
+            packageJsonPath + ': ' + err.message);
+    }
+};
+
+// Resolve a dependency using Node's search paths from the installed issuer, but
+// locate its package directory directly instead of resolving "<dep>/package.json"
+// (which modern package "exports" maps may intentionally hide).
+var resolveInstalledDependency = function (issuerRoot, dependencyName) {
+    var issuerRequire = Module.createRequire(path.join(issuerRoot, 'package.json'));
+    var searchPaths = issuerRequire.resolve.paths(dependencyName) || [];
+    for (const searchPath of searchPaths) {
+        var candidate = packagePath(searchPath, dependencyName);
+        if (fs.existsSync(path.join(candidate, 'package.json'))) {
+            return candidate;
+        }
+    }
+    return null;
+};
+exports.resolveInstalledDependency = resolveInstalledDependency;
+
+var packageBinNames = function (packageJson) {
+    if (typeof packageJson.bin === 'string') {
+        return [String(packageJson.name || '').split('/').pop()].filter(Boolean);
+    }
+    if (packageJson.bin && typeof packageJson.bin === 'object') {
+        return Object.keys(packageJson.bin);
+    }
+    return [];
+};
+
+var containingNodeModules = function (packageRoot) {
+    var parent = path.dirname(packageRoot);
+    return path.basename(parent).startsWith('@') ? path.dirname(parent) : parent;
+};
+
+var assertRetainablePackageRoot = function (packageRoot, nodeModulesPath) {
+    var stat = fs.lstatSync(packageRoot);
+    if (stat.isSymbolicLink()) {
+        throw new Error('minify: external package closures do not support symlinked package roots: ' +
+            packageRoot + '. Install the task with npm so packages are materialized before minifying.');
+    }
+    if (!stat.isDirectory()) {
+        throw new Error('minify: retained package root is not a directory: ' + packageRoot);
+    }
+
+    var realNodeModules = fs.realpathSync(nodeModulesPath);
+    var realPackageRoot = fs.realpathSync(packageRoot);
+    var relative = path.relative(realNodeModules, realPackageRoot);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new Error('minify: retained package resolves outside the task node_modules tree: ' + packageRoot);
+    }
+
+    var nestedNodeModules = path.join(packageRoot, 'node_modules');
+    if (fs.existsSync(nestedNodeModules) && fs.lstatSync(nestedNodeModules).isSymbolicLink()) {
+        throw new Error('minify: retained package has a symlinked node_modules directory: ' +
+            nestedNodeModules + '. Materialize its dependency tree before minifying.');
+    }
+};
+
+// Compute the exact installed runtime closure for configured top-level external
+// packages. The existing physical layout is retained so nested dependency versions
+// continue to resolve exactly as npm installed them.
+var collectExternalPackageClosure = function (outDir, external) {
+    var externalPackages = normalizeExternalPackages(external);
+    var nodeModulesPath = path.join(outDir, 'node_modules');
+    var retainedRoots = new Map(); // canonical absolute path -> { root, name, version }
+    var retainedBins = new Map();  // canonical node_modules path -> Set<bin name>
+
+    if (!externalPackages.length) {
+        return {
+            externalPackages: externalPackages,
+            nodeModulesPath: nodeModulesPath,
+            retainedRoots: retainedRoots,
+            retainedBins: retainedBins
+        };
+    }
+    if (!fs.existsSync(nodeModulesPath)) {
+        throw new Error('minify: cannot retain external packages because node_modules is missing from ' + outDir);
+    }
+
+    var rootPackages = externalPackages.map(function (packageName) {
+        var root = packagePath(nodeModulesPath, packageName);
+        if (!fs.existsSync(path.join(root, 'package.json'))) {
+            throw new Error('minify: external package "' + packageName +
+                '" is not installed at the task node_modules root: ' + root);
+        }
+        assertRetainablePackageRoot(root, nodeModulesPath);
+        return { name: packageName, root: root };
+    });
+
+    var installedByName = new Map();
+    walkInstalledPackages(nodeModulesPath, function (root) {
+        var packageJson = readPackageJson(root);
+        if (!installedByName.has(packageJson.name)) {
+            installedByName.set(packageJson.name, []);
+        }
+        installedByName.get(packageJson.name).push(root);
+    });
+
+    var queue = [];
+    rootPackages.forEach(function (rootPackage) {
+        var occurrences = installedByName.get(rootPackage.name) || [];
+        if (occurrences.length !== 1) {
+            throw new Error('minify: external package "' + rootPackage.name + '" is installed at ' +
+                occurrences.length + ' physical roots. Align/dedupe it to one version before externalizing: ' +
+                occurrences.join(', '));
+        }
+        queue.push(rootPackage.root);
+    });
+
+    while (queue.length) {
+        var packageRoot = queue.shift();
+        var key = pathKey(packageRoot);
+        if (retainedRoots.has(key)) {
+            continue;
+        }
+        assertRetainablePackageRoot(packageRoot, nodeModulesPath);
+
+        var relative = path.relative(nodeModulesPath, packageRoot);
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            throw new Error('minify: retained package resolved outside the task node_modules tree: ' + packageRoot);
+        }
+
+        var packageJson = readPackageJson(packageRoot);
+        retainedRoots.set(key, {
+            root: packageRoot,
+            name: packageJson.name || relative.replace(/\\/g, '/'),
+            version: packageJson.version || 'unknown'
+        });
+
+        var binNames = packageBinNames(packageJson);
+        if (binNames.length) {
+            var binKey = pathKey(containingNodeModules(packageRoot));
+            var bins = retainedBins.get(binKey) || new Set();
+            binNames.forEach(function (name) { bins.add(name); });
+            retainedBins.set(binKey, bins);
+        }
+
+        var dependencies = Object.assign({}, packageJson.dependencies || {});
+        var optional = new Set(Object.keys(packageJson.optionalDependencies || {}));
+        Object.assign(dependencies, packageJson.optionalDependencies || {});
+
+        var peerMeta = packageJson.peerDependenciesMeta || {};
+        Object.keys(packageJson.peerDependencies || {}).forEach(function (name) {
+            dependencies[name] = packageJson.peerDependencies[name];
+            if (peerMeta[name] && peerMeta[name].optional) {
+                optional.add(name);
+            }
+        });
+
+        var bundled = packageJson.bundleDependencies || packageJson.bundledDependencies || [];
+        if (Array.isArray(bundled)) {
+            bundled.forEach(function (name) {
+                if (!Object.prototype.hasOwnProperty.call(dependencies, name)) {
+                    dependencies[name] = '*';
+                }
+            });
+        }
+
+        Object.keys(dependencies).forEach(function (dependencyName) {
+            var dependencyRoot = resolveInstalledDependency(packageRoot, dependencyName);
+            if (!dependencyRoot) {
+                if (optional.has(dependencyName)) {
+                    return;
+                }
+                throw new Error('minify: retained package ' + packageJson.name + '@' +
+                    (packageJson.version || 'unknown') + ' requires "' + dependencyName +
+                    '", but it is not installed/resolvable from ' + packageRoot);
+            }
+            queue.push(dependencyRoot);
+        });
+    }
+
+    return {
+        externalPackages: externalPackages,
+        nodeModulesPath: nodeModulesPath,
+        retainedRoots: retainedRoots,
+        retainedBins: retainedBins
+    };
+};
+exports.collectExternalPackageClosure = collectExternalPackageClosure;
+
+// Return retained physical package roots that esbuild also inlined. Loading the
+// same installed module once from disk and once from the bundle creates two
+// module-level singletons, even though both copies came from one npm directory.
+var findRetainedPackageOverlaps = function (metafile, outDir, retainedRoots) {
+    var overlaps = new Map();
+    Object.keys(metafile.inputs || {}).forEach(function (input) {
+        var norm = input.replace(/\\/g, '/');
+        var idx = norm.lastIndexOf('node_modules/');
+        if (idx === -1) {
+            return;
+        }
+        var rest = norm.slice(idx + 'node_modules/'.length);
+        var match = rest.match(/^((?:@[^/]+\/)?[^/]+)/);
+        if (!match) {
+            return;
+        }
+        var rootText = norm.slice(0, idx + 'node_modules/'.length) + match[1];
+        var absoluteRoot = path.isAbsolute(rootText)
+            ? rootText
+            : path.join(outDir, rootText);
+        var retained = retainedRoots.get(pathKey(absoluteRoot));
+        if (retained) {
+            overlaps.set(retained.name, retained);
+        }
+    });
+    return Array.from(overlaps.values());
+};
+exports.findRetainedPackageOverlaps = findRetainedPackageOverlaps;
+
+var enforceRetainedPackagePolicy = function (overlaps, allowlist, outDir) {
+    if (!overlaps.length) {
+        return;
+    }
+    var allowed = overlaps.filter(function (pkg) { return allowlist.has(pkg.name); });
+    var blocking = overlaps.filter(function (pkg) { return !allowlist.has(pkg.name); });
+    if (allowed.length) {
+        console.warn('> minify: NOTE - package(s) are both bundled and retained on disk ' +
+            '(allowlisted as stateless): ' + allowed.map(function (pkg) {
+                return pkg.name + '@' + pkg.version;
+            }).join(', '));
+    }
+    if (!blocking.length) {
+        return;
+    }
+    var names = blocking.map(function (pkg) { return pkg.name + '@' + pkg.version; });
+    throw new Error('minify: ' + path.basename(outDir) +
+        ' would load package(s) both from the bundle and retained node_modules, splitting module state: ' +
+        names.join(', ') + '. Add the package as a top-level minify.external entry so every import stays ' +
+        'external, align the dependency graph, or allowlist it only when it is genuinely stateless.');
+};
+
+var pruneBinDirectory = function (nodeModulesPath, retainedBins) {
+    var binPath = path.join(nodeModulesPath, '.bin');
+    if (!fs.existsSync(binPath)) {
+        return;
+    }
+    var expected = retainedBins.get(pathKey(nodeModulesPath)) || new Set();
+    var expectedEntries = new Set();
+    expected.forEach(function (name) {
+        expectedEntries.add(name);
+        expectedEntries.add(name + '.cmd');
+        expectedEntries.add(name + '.ps1');
+    });
+    fs.readdirSync(binPath).forEach(function (entry) {
+        if (!expectedEntries.has(entry)) {
+            fs.rmSync(path.join(binPath, entry), { recursive: true, force: true });
+        }
+    });
+    if (fs.readdirSync(binPath).length === 0) {
+        fs.rmSync(binPath, { recursive: true, force: true });
+    }
+};
+
+// Delete every package not present in the retained closure while preserving each
+// retained package at its original root. This keeps Node's nested-version lookup
+// semantics and package-owned runtime assets intact.
+var pruneNodeModules = function (nodeModulesPath, retainedRoots, retainedBins) {
+    if (!fs.existsSync(nodeModulesPath)) {
+        return;
+    }
+
+    fs.readdirSync(nodeModulesPath, { withFileTypes: true }).forEach(function (entry) {
+        var entryPath = path.join(nodeModulesPath, entry.name);
+        if (entry.name === '.bin') {
+            return;
+        }
+        if (entry.name.startsWith('.')) {
+            fs.rmSync(entryPath, { recursive: true, force: true });
+            return;
+        }
+
+        if (entry.name.startsWith('@')) {
+            if (!entry.isDirectory()) {
+                fs.rmSync(entryPath, { recursive: true, force: true });
+                return;
+            }
+            fs.readdirSync(entryPath, { withFileTypes: true }).forEach(function (scopedEntry) {
+                var packageRoot = path.join(entryPath, scopedEntry.name);
+                if (!retainedRoots.has(pathKey(packageRoot))) {
+                    fs.rmSync(packageRoot, { recursive: true, force: true });
+                    return;
+                }
+                pruneNodeModules(path.join(packageRoot, 'node_modules'), retainedRoots, retainedBins);
+            });
+            if (fs.readdirSync(entryPath).length === 0) {
+                fs.rmSync(entryPath, { recursive: true, force: true });
+            }
+            return;
+        }
+
+        if (!retainedRoots.has(pathKey(entryPath))) {
+            fs.rmSync(entryPath, { recursive: true, force: true });
+            return;
+        }
+        pruneNodeModules(path.join(entryPath, 'node_modules'), retainedRoots, retainedBins);
+    });
+
+    pruneBinDirectory(nodeModulesPath, retainedBins);
+};
+exports.pruneNodeModules = pruneNodeModules;
+
 // Return the declared Node execution targets that are missing from the build
 // output. A declared handler target that never got built (task.json typo, case
 // mismatch, tsc exclude, wrong path) must FAIL the build: minify deletes
@@ -248,6 +645,9 @@ var bundleEntry = async function (esbuild, opts) {
         absWorkingDir: opts.outDir,
         outfile: opts.tmpOut,
         logLevel: 'warning',
+        // External package names (and their subpaths) remain as runtime require()
+        // calls. minifyNodeTask preserves their complete installed closures below.
+        external: opts.externalPackages,
         // A source map is only emitted when requested; it chains the tsc-emitted
         // maps so task-code frames resolve back to the original .ts (dependency
         // frames resolve to their original node_modules .js). sourcesContent embeds
@@ -350,6 +750,9 @@ var removeIntermediateSourceMaps = function (outDir, keepMapAbsPaths) {
         fs.readdirSync(dir, { withFileTypes: true }).forEach(function (dirent) {
             var full = path.join(dir, dirent.name);
             if (dirent.isDirectory()) {
+                if (dirent.name === 'node_modules') {
+                    return; // retained external packages keep their complete published contents
+                }
                 walk(full);
             } else if (/\.js\.map$/i.test(dirent.name) && !keepMapAbsPaths.has(full)) {
                 rm('-f', full);
@@ -381,6 +784,40 @@ var publishSourceMap = function (tmpMapPath, destMapPath, stagingDir, outDir) {
 };
 exports.publishSourceMap = publishSourceMap;
 
+// Atomically-as-possible publish a set of staged files/directories. Every existing
+// destination is first renamed into the staging backup directory. If any later
+// rename fails, all destinations processed so far are restored before rethrowing.
+var replaceOutputPaths = function (replacements, backupDir) {
+    fs.mkdirSync(backupDir, { recursive: true });
+    var processed = [];
+    try {
+        replacements.forEach(function (replacement, index) {
+            var backup = path.join(backupDir, String(index));
+            var record = {
+                destination: replacement.destination,
+                backup: backup,
+                hadDestination: fs.existsSync(replacement.destination)
+            };
+            if (record.hadDestination) {
+                fs.renameSync(replacement.destination, backup);
+            }
+            processed.push(record);
+            if (replacement.source) {
+                fs.renameSync(replacement.source, replacement.destination);
+            }
+        });
+    } catch (err) {
+        processed.reverse().forEach(function (record) {
+            fs.rmSync(record.destination, { recursive: true, force: true });
+            if (record.hadDestination && fs.existsSync(record.backup)) {
+                fs.renameSync(record.backup, record.destination);
+            }
+        });
+        throw err;
+    }
+};
+exports.replaceOutputPaths = replaceOutputPaths;
+
 //
 // Minify a compiled Node task: bundle every Node execution entry point (and its
 // dependencies) into a single minified file using esbuild, then drop the now
@@ -394,6 +831,10 @@ exports.publishSourceMap = publishSourceMap;
 //                      When false, no map is emitted (smallest output); keepNames
 //                      still preserves fn/class names in stack frames.
 //   allowDuplicates  - per-task list of packages exempt from the duplicate check.
+//   allowBundledAndRetained - stateless packages allowed to exist both in the
+//                       bundle and an external package's retained closure.
+//   external          - top-level package names left as runtime requires; their
+//                       installed dependency closures are retained in node_modules.
 //   failOnDuplicates - when false, a non-allowlisted duplicate warns instead of
 //                      failing (the --allow-duplicates escape hatch).
 //
@@ -401,15 +842,17 @@ exports.publishSourceMap = publishSourceMap;
 // mutated once every entry bundles and the duplicate-package policy passes, so a
 // mid-build failure never leaves the task partially rewritten.
 //
-// Returns { entries, duplicates } for reporting. Async because esbuild's build
+// Returns { entries, duplicates, externalPackages } for reporting. Async because esbuild's build
 // API (used here with metafile output for duplicate detection) is promise-based.
 //
 var minifyNodeTask = async function (taskPath, outDir, options) {
     options = options || {};
     var withSourceMap = !!options.sourceMap;
     var perTaskAllow = Array.isArray(options.allowDuplicates) ? options.allowDuplicates : [];
+    var retainedOverlapAllowlist = new Set(normalizeExternalPackages(options.allowBundledAndRetained));
     var failOnDuplicates = options.failOnDuplicates !== false; // default: fail
     var duplicateAllowlist = new Set(DEFAULT_DUPLICATE_ALLOWLIST.concat(perTaskAllow));
+    var externalPackages = normalizeExternalPackages(options.external);
 
     var esbuild;
     try {
@@ -446,6 +889,11 @@ var minifyNodeTask = async function (taskPath, outDir, options) {
             'removes node_modules; fix the task.json handler "target" path(s) or the tsc output.');
     }
 
+    // Resolve the retained closure before esbuild changes any output. In addition
+    // to validating the configured root packages, this proves every required
+    // runtime dependency is installed and records the exact nested npm layout.
+    var externalClosure = collectExternalPackageClosure(outDir, externalPackages);
+
     // esbuild refuses to overwrite an input file, so every bundle is first written
     // to a unique staging dir. It lives inside outDir so renameSync into place stays
     // on one volume, and it is always removed in finally. Nothing in outDir is
@@ -455,6 +903,7 @@ var minifyNodeTask = async function (taskPath, outDir, options) {
     var bundleMapAbsPaths = new Set();
     try {
         var duplicateRoots = new Map();
+        var retainedBundleOverlaps = new Map();
         var staged = [];
 
         // Phase 1: build + validate every entry into the staging dir.
@@ -475,9 +924,12 @@ var minifyNodeTask = async function (taskPath, outDir, options) {
                 outDir: outDir,
                 tmpOut: tmpOut,
                 withSourceMap: withSourceMap,
-                nodeTarget: 'node' + entry.nodeMajor
+                nodeTarget: 'node' + entry.nodeMajor,
+                externalPackages: externalPackages
             });
             mergeDuplicateRoots(duplicateRoots, metafile);
+            findRetainedPackageOverlaps(metafile, outDir, externalClosure.retainedRoots)
+                .forEach(function (pkg) { retainedBundleOverlaps.set(pkg.name, pkg); });
 
             staged.push({
                 entryPath: entryPath,
@@ -500,34 +952,77 @@ var minifyNodeTask = async function (taskPath, outDir, options) {
             perTaskAllow: perTaskAllow,
             failOnDuplicates: failOnDuplicates
         });
+        enforceRetainedPackagePolicy(
+            Array.from(retainedBundleOverlaps.values()),
+            retainedOverlapAllowlist,
+            outDir);
 
-        // Phase 2: publish. Everything built and passed, so move bundles into place.
+        // Prepare a pruned dependency tree in staging before publishing anything.
+        // If closure copying, pruning, or validation fails, outDir remains unchanged.
+        var nodeModulesPath = path.join(outDir, 'node_modules');
+        var stagedNodeModules = null;
+        if (fs.existsSync(nodeModulesPath)) {
+            if (!externalPackages.length) {
+                console.log('> minify: removing inlined node_modules');
+            } else {
+                var stagedDependencyRoot = path.join(stagingDir, 'retained-dependencies');
+                stagedNodeModules = path.join(stagedDependencyRoot, 'node_modules');
+                fs.mkdirSync(stagedDependencyRoot, { recursive: true });
+                fs.cpSync(nodeModulesPath, stagedNodeModules, {
+                    recursive: true,
+                    dereference: false,
+                    preserveTimestamps: true
+                });
+                var stagedClosure = collectExternalPackageClosure(stagedDependencyRoot, externalPackages);
+                pruneNodeModules(
+                    stagedClosure.nodeModulesPath,
+                    stagedClosure.retainedRoots,
+                    stagedClosure.retainedBins);
+                collectExternalPackageClosure(stagedDependencyRoot, externalPackages);
+                console.log('> minify: retaining external package closure for ' +
+                    externalPackages.join(', ') + ' (' + stagedClosure.retainedRoots.size + ' package(s))');
+            }
+        }
+
+        // Rebase source maps while they are still staged so publication itself is
+        // only a set of reversible same-volume renames.
+        staged.forEach(function (s) {
+            if (s.hasMap) {
+                s.publishMap = s.tmpOut + '.publish.map';
+                publishSourceMap(s.tmpOut + '.map', s.publishMap, stagingDir, outDir);
+            }
+        });
+
+        // Phase 2: publish. Everything built, pruned, and validated, so replace
+        // bundles and node_modules with rollback if any rename fails.
         // The bundle replaces the entry in place; in sourcemap mode its <entry>.js.map
         // ships alongside and the banner shim maps frames at runtime. No bootstrap is
         // written, so require.main === module is preserved in both modes.
+        var replacements = [];
         staged.forEach(function (s) {
             var outPath = path.join(outDir, s.outName);
-            rm('-f', outPath);
-            fs.renameSync(s.tmpOut, outPath);
+            replacements.push({ source: s.tmpOut, destination: outPath });
             if (s.hasMap) {
-                rm('-f', outPath + '.map');
-                publishSourceMap(s.tmpOut + '.map', outPath + '.map', stagingDir, outDir);
+                replacements.push({ source: s.publishMap, destination: outPath + '.map' });
                 bundleMapAbsPaths.add(outPath + '.map');
+            } else if (fs.existsSync(outPath + '.map')) {
+                replacements.push({ source: null, destination: outPath + '.map' });
             }
         });
+        if (fs.existsSync(nodeModulesPath)) {
+            replacements.push({ source: stagedNodeModules, destination: nodeModulesPath });
+        }
+        replaceOutputPaths(replacements, path.join(stagingDir, 'publish-backup'));
     } finally {
         rm('-rf', stagingDir);
     }
 
-    // Dependencies are now inlined into the bundle(s); remove node_modules.
-    var nodeModulesPath = path.join(outDir, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) {
-        console.log('> minify: removing inlined node_modules');
-        rm('-rf', nodeModulesPath);
-    }
-
     removeIntermediateSourceMaps(outDir, bundleMapAbsPaths);
 
-    return { entries: entries.map(function (e) { return e.file; }), duplicates: duplicates };
+    return {
+        entries: entries.map(function (e) { return e.file; }),
+        duplicates: duplicates,
+        externalPackages: externalPackages
+    };
 }
 exports.minifyNodeTask = minifyNodeTask;


### PR DESCRIPTION
## Summary
- allow tasks to externalize selected packages from esbuild bundles
- retain and validate each external package runtime dependency closure while pruning unrelated node_modules
- preserve pre-bundle test artifacts and restore test-only dependencies in isolated scratch directories
- add generic minifier coverage and documentation

## Validation
- `node --check make.js`
- `node --check minify-util.js`
- `node make.js serverBuild --task BashV3 --skipPrebuildSteps --BypassNpmAudit`
- `node make.js test --task BashV3 --suite L0` (45 BashV3 tests and 40 common tests)

BuildConfigGen pre-validation was skipped only because it does not recognize Git worktree `.git` files; the task build and test suites passed.