### PR TITLE
Fix minified test dependency installation on Windows

### DIFF
--- a/make.js
+++ b/make.js
@@ -830,9 +830,15 @@ CLI.test = async function(/** @type {{ suite: string; node: string; task: string
                     npmArgs.push('--omit=dev');
                 }
                 childProcess.execFileSync(
-                    process.platform === 'win32' ? 'npm.cmd' : 'npm',
+                    'npm',
                     npmArgs,
-                    { cwd: scratchPackagePath, stdio: 'inherit', env: process.env });
+                    {
+                        cwd: scratchPackagePath,
+                        stdio: 'inherit',
+                        env: process.env,
+                        // Windows cannot execute npm.cmd directly with execFile.
+                        shell: process.platform === 'win32'
+                    });
                 mkdir('-p', path.dirname(destinationNodeModulesPath));
                 rm('-Rf', destinationNodeModulesPath);
                 fs.renameSync(scratchNodeModulesPath, destinationNodeModulesPath);


### PR DESCRIPTION
### **Context**

Windows PR validation fails for minified tasks that restore production-pruned dependencies before L0 tests. Node 20 reports `spawnSync npm.cmd EINVAL` before npm starts because `execFileSync` cannot execute Windows command scripts directly. This was observed in the BashV3 minification canary PR.

---

### **Task Name**

N/A - shared task build and test infrastructure.

---

### **Description**

Invoke `npm` through the command shell on Windows when restoring isolated test dependencies. Unix continues to execute npm directly.

---

### **Risk Assessment** (Low / Medium / High)

**Low.** The change is limited to dependency restoration for minified task tests. Arguments are fixed by the build system, and non-Windows behavior is unchanged.

---

### **Change Behind Feature Flag** (Yes / No)

**No.** This repairs a failing build-infrastructure path and only runs when a minified task needs dependencies restored for tests.

---

### **Tech Design / Approach**

Use `execFileSync("npm", ...)` with `shell: true` only on Windows. Windows resolves `npm` to `npm.cmd` through the command shell; Unix retains direct process execution.

---

### **Documentation Changes Required** (Yes/No)

**No.**

---

### **Unit Tests Added or Updated** (Yes / No)

**No.** Existing BashV3 normal, minified, and common L0 suites exercise this restoration path.

---

### **Additional Testing Performed**

- `node --check make.js`
- `node make.js test --task BashV3 --suite L0`
- BashV3: 45 passing
- BashV3_Minified: 45 passing
- Common L0: 40 passing
- Confirmed the prior Windows failure occurred before npm launched with `spawnSync npm.cmd EINVAL`.

---

### **Logging Added/Updated** (Yes/No)

**No.**

---

### **Telemetry Added/Updated** (Yes/No)

**No.**

---

### **Rollback Scenario and Process** (Yes/No)

**Yes.** Revert this change to restore the previous invocation.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

**Yes.** No dependency versions change. Both normal and minified BashV3 test suites pass after the invocation change.

---

### **Checklist**

- [x] Related issue linked (if applicable) - N/A
- [x] Task version was bumped - N/A, no task implementation changed
- [x] Verified the task behaves as expected