### PR TITLE
[AzureContainerAppsV0][AzureContainerAppsV1] Harden appSourcePath handling to prevent command injection

### DIFF
--- a/Tasks/AzureContainerAppsV0/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureContainerAppsV0/Strings/resources.resjson/en-US/resources.resjson
@@ -75,6 +75,7 @@
   "loc.messages.ErrorMessageFormat": "Error: %s",
   "loc.messages.ExistingContainerAppEnvironmentMessage": "Discovered existing Container App Environment, '%s', to use with the Container App.",
   "loc.messages.FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+  "loc.messages.InvalidAppSourcePathMessage": "The provided appSourcePath '%s' contains invalid characters. It must be a valid filesystem path and must not contain shell metacharacters.",
   "loc.messages.LoginFailed": "Azure login failed",
   "loc.messages.MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
   "loc.messages.MissingRequiredArgumentMessage": "One of the following arguments must be provided: appSourcePath, imageToDeploy, yamlConfigPath",

--- a/Tasks/AzureContainerAppsV0/Tests/L0.ts
+++ b/Tasks/AzureContainerAppsV0/Tests/L0.ts
@@ -66,6 +66,31 @@ describe('AzureContainerAppsV0 Suite', function () {
         }, tr);
     });
 
+    it('Fails for appSourcePath containing shell metacharacters', async () => {
+        this.timeout(5000);
+
+        const tp: string = path.join(__dirname, 'L0FailsForAppSourcePathWithMetacharacters.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            // Validate the task failed
+            assert(tr.failed, 'AzureContainerAppsV0 task should have failed when appSourcePath contains shell metacharacters.');
+
+            // Validate the correct error message was thrown
+            assert(tr.stdout.includes('InvalidAppSourcePathMessage'), 'AzureContainerAppsV0 task should reject an appSourcePath that contains shell metacharacters to prevent command injection.');
+
+            // Validate the correct result was logged to telemetry
+            assert(tr.stdout.includes('[MOCK] setFailedResult called'), 'AzureContainerAppsV0 task should signal to telemetry that the task failed.');
+
+            // Validate that the end-of-test scenarios are hit
+            assert(tr.stdout.includes('[MOCK] logoutAzure called'), 'AzureContainerAppsV0 task should try to logout of Azure at the end of the task.');
+            assert(tr.stdout.includes('[MOCK] logoutAcr called'), 'AzureContainerAppsV0 task should log Docker out of ACR at the end of the task to avoid leaving registry credentials on the agent.');
+            assert(tr.stdout.includes('[MOCK] sendLogs called'), 'AzureContainerAppsV0 task should send telemetry logs at the end of the task.');
+        }, tr);
+    });
+
     it('Fails for no service connection argument', async () => {
         this.timeout(5000);
 

--- a/Tasks/AzureContainerAppsV0/Tests/L0FailsForAppSourcePathWithMetacharacters.ts
+++ b/Tasks/AzureContainerAppsV0/Tests/L0FailsForAppSourcePathWithMetacharacters.ts
@@ -1,0 +1,125 @@
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import * as path from 'path';
+
+const taskPath = path.join(__dirname, '..', 'azurecontainerapps.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Set required arguments for the test, using an appSourcePath that contains shell metacharacters
+// to verify that the task rejects it (command-injection guard, CWE-78).
+tmr.setInput('cwd', '/fakecwd');
+tmr.setInput('acrName', 'sampletestacr');
+tmr.setInput('appSourcePath', '/samplepath;whoami');
+tmr.setInput('disableTelemetry', 'true');
+
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+
+// Assign dummy values for build variables
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() === 'build.buildid') {
+        return 'test-build-id';
+    } else if (variable.toLowerCase() === 'build.buildnumber') {
+        return 'test-build-number';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+/**
+ * ----------------------------------
+ * Mock out the common helper classes
+ * ----------------------------------
+ */
+
+// Mock out function calls for the AzureAuthenticationHelper class
+tmr.registerMock('./src/AzureAuthenticationHelper', {
+    AzureAuthenticationHelper: function() {
+        return {
+            loginAzure: function() {
+                console.log('[MOCK] loginAzure called');
+                return;
+            },
+            logoutAzure: function() {
+                console.log('[MOCK] logoutAzure called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the ContainerRegistryHelper class
+tmr.registerMock('./src/ContainerRegistryHelper', {
+    ContainerRegistryHelper: function() {
+        return {
+            loginAcrWithUsernamePassword: function(acrName: string, acrUsername: string, acrPassword: string) {
+                console.log('[MOCK] loginAcrWithUsernamePassword called');
+                return;
+            },
+            loginAcrWithAccessTokenAsync: async function() {
+                console.log('[MOCK] loginAcrWithAccessTokenAsync called');
+                return;
+            },
+            pushImageToAcr: function() {
+                console.log('[MOCK] pushImageToAcr called');
+                return;
+            },
+            logoutAcr: function() {
+                console.log('[MOCK] logoutAcr called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the TelemetryHelper class
+tmr.registerMock('./src/TelemetryHelper', {
+    TelemetryHelper: function() {
+        return {
+            setSuccessfulResult: function() {
+                console.log('[MOCK] setSuccessfulResult called');
+                return;
+            },
+            setFailedResult: function(errorMessage: string) {
+                console.log('[MOCK] setFailedResult called');
+                return;
+            },
+            setBuilderScenario: function() {
+                console.log('[MOCK] setBuilderScenario called');
+                return;
+            },
+            setDockerfileScenario: function() {
+                console.log('[MOCK] setDockerfileScenario called');
+                return;
+            },
+            setImageScenario: function() {
+                console.log('[MOCK] setImageScenario called');
+                return;
+            },
+            sendLogs: function() {
+                console.log('[MOCK] sendLogs called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the Utility class
+tmr.registerMock('./src/Utility', {
+    Utility: function() {
+        return {
+            setAzureCliDynamicInstall: function() {
+                console.log('[MOCK] setAzureCliDynamicInstall called');
+                return;
+            },
+            isNullOrEmpty(str: string): boolean {
+                return str === null || str === undefined || str === "";
+            }
+        };
+    }
+});
+
+// Run the mocked task test
+tmr.run();

--- a/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
@@ -9,6 +9,12 @@ import { Utility } from './src/Utility';
 
 const util = new Utility();
 
+// appSourcePath is documented as a filesystem path. As defense-in-depth against command injection
+// (CWE-78), reject values containing shell metacharacters; the primary fix reads and deletes the
+// runtime-stack file via the filesystem instead of a shell (see determineRuntimeStackAsync).
+// Backslash is intentionally allowed as the Windows path separator.
+const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|$`()<>\r\n]/;
+
 export class azurecontainerapps {
 
     public static async runMain(): Promise<void> {
@@ -137,6 +143,13 @@ export class azurecontainerapps {
 
         // Get the path to the application source to build and run, if provided
         this.appSourcePath = tl.getInput('appSourcePath', false);
+
+        // Reject appSourcePath values that contain shell metacharacters, as defense-in-depth against
+        // command injection (CWE-78).
+        if (!util.isNullOrEmpty(this.appSourcePath) && APP_SOURCE_PATH_INVALID_CHARS.test(this.appSourcePath)) {
+            tl.error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
+            throw Error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
+        }
 
         // Get the name of the ACR instance to push images to, if provided
         this.acrName = tl.getInput('acrName', false);

--- a/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
@@ -10,10 +10,12 @@ import { Utility } from './src/Utility';
 const util = new Utility();
 
 // appSourcePath is documented as a filesystem path. As defense-in-depth against command injection
-// (CWE-78), reject values containing shell metacharacters; the primary fix reads and deletes the
-// runtime-stack file via the filesystem instead of a shell (see determineRuntimeStackAsync).
-// Backslash is intentionally allowed as the Windows path separator.
-const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|$`()<>\r\n]/;
+// (CWE-78), reject values containing shell metacharacters that are highly unlikely to occur in a
+// legitimate path; the primary fix reads and deletes the runtime-stack file via the filesystem
+// instead of a shell (see determineRuntimeStackAsync). Characters that commonly appear in real
+// paths -- '$', '(', ')', and backslash (the Windows path separator) -- are intentionally allowed
+// (e.g. "C:\Program Files (x86)\app").
+const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|`<>\r\n]/;
 
 export class azurecontainerapps {
 

--- a/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV0/azurecontainerapps.ts
@@ -149,7 +149,6 @@ export class azurecontainerapps {
         // Reject appSourcePath values that contain shell metacharacters, as defense-in-depth against
         // command injection (CWE-78).
         if (!util.isNullOrEmpty(this.appSourcePath) && APP_SOURCE_PATH_INVALID_CHARS.test(this.appSourcePath)) {
-            tl.error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
             throw Error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
         }
 

--- a/Tasks/AzureContainerAppsV0/src/ContainerAppHelper.ts
+++ b/Tasks/AzureContainerAppsV0/src/ContainerAppHelper.ts
@@ -1,6 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 import { CommandHelper } from './CommandHelper';
 import { Utility } from './Utility';
 
@@ -404,22 +405,17 @@ export class ContainerAppHelper {
                 tl.loc('DetermineRuntimeStackFailed', appSourcePath)
             );
 
-            // Read the temp file to get the runtime stack into a variable
-            const oryxRuntimeTxtPath = path.join(appSourcePath, 'oryx-runtime.txt');
-            let command: string = `head -n 1 ${oryxRuntimeTxtPath}`;
-            if (IS_WINDOWS_AGENT) {
-                command = `Get-Content -Path ${oryxRuntimeTxtPath} -Head 1`;
-            }
+            // Read the temp file to get the runtime stack into a variable. The file is read directly
+            // from the filesystem instead of through a shell command ('head'/'Get-Content' executed via
+            // 'bash -c'/'pwsh -command') so that a user-controlled appSourcePath cannot inject shell
+            // metacharacters and execute arbitrary commands on the agent (CWE-78).
+            const oryxRuntimeTxtPath: string = path.join(appSourcePath, 'oryx-runtime.txt');
+            const oryxRuntimeText: string = fs.readFileSync(oryxRuntimeTxtPath, 'utf8');
+            const runtimeStack: string = oryxRuntimeText.split(/\r?\n/)[0].trim();
 
-            const runtimeStack = await new CommandHelper().execCommandAsync(command);
-
-            // Delete the temp file
-            command = `rm ${oryxRuntimeTxtPath}`;
-            if (IS_WINDOWS_AGENT) {
-                command = `Remove-Item -Path ${oryxRuntimeTxtPath}`;
-            }
-
-            await new CommandHelper().execCommandAsync(command);
+            // Delete the temp file using the task-lib helper rather than a shell 'rm'/'Remove-Item'
+            // command, for the same command-injection reason described above.
+            tl.rmRF(oryxRuntimeTxtPath);
 
             return runtimeStack;
         } catch (err) {

--- a/Tasks/AzureContainerAppsV0/src/ContainerRegistryHelper.ts
+++ b/Tasks/AzureContainerAppsV0/src/ContainerRegistryHelper.ts
@@ -1,6 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as child from 'child_process';
-import { CommandHelper } from './CommandHelper';
 import { Utility } from './Utility';
 
 export class ContainerRegistryHelper {

--- a/Tasks/AzureContainerAppsV0/src/ContainerRegistryHelper.ts
+++ b/Tasks/AzureContainerAppsV0/src/ContainerRegistryHelper.ts
@@ -39,8 +39,21 @@ export class ContainerRegistryHelper {
         tl.debug(`Attempting to log in to ACR instance "${acrName}" with access token`);
         const registry = `${acrName}.azurecr.io`;
         try {
-            const command: string = `CA_ADO_TASK_ACR_ACCESS_TOKEN=$(az acr login --name ${acrName} --output json --expose-token --only-show-errors | jq -r '.accessToken'); docker login ${acrName}.azurecr.io -u 00000000-0000-0000-0000-000000000000 -p $CA_ADO_TASK_ACR_ACCESS_TOKEN > /dev/null 2>&1`;
-            await new CommandHelper().execCommandAsync(command);
+            const tokenJson = child.execFileSync('az', [
+                'acr', 'login',
+                '--name', acrName,
+                '--output', 'json',
+                '--expose-token',
+                '--only-show-errors'
+            ], { encoding: 'utf8' });
+
+            const accessToken = JSON.parse(tokenJson).accessToken;
+
+            child.execFileSync('docker', [
+                'login', '--password-stdin',
+                '--username', '00000000-0000-0000-0000-000000000000',
+                registry
+            ], { input: accessToken, stdio: 'pipe' });
             this.authenticatedRegistries.add(registry);
         } catch (err) {
             tl.error(tl.loc('AcrAccessTokenAuthFailed', acrName));

--- a/Tasks/AzureContainerAppsV0/task.json
+++ b/Tasks/AzureContainerAppsV0/task.json
@@ -18,8 +18,8 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 277,
-    "Patch": 4
+    "Minor": 279,
+    "Patch": 0
   },
   "preview": true,
   "minimumAgentVersion": "2.144.0",
@@ -42,7 +42,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "string",
+      "type": "filePath",
       "label": "Application source path",
       "required": false,
       "helpMarkDown": "Absolute path on the runner of the source application code to be built. If not provided, the 'imageToDeploy' argument must be provided to ensure the Container App has an image to reference."
@@ -219,6 +219,7 @@
     "ErrorMessageFormat": "Error: %s",
     "ExistingContainerAppEnvironmentMessage": "Discovered existing Container App Environment, '%s', to use with the Container App.",
     "FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+    "InvalidAppSourcePathMessage": "The provided appSourcePath '%s' contains invalid characters. It must be a valid filesystem path and must not contain shell metacharacters.",
     "LoginFailed": "Azure login failed",
     "MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
     "MissingRequiredArgumentMessage": "One of the following arguments must be provided: appSourcePath, imageToDeploy, yamlConfigPath",

--- a/Tasks/AzureContainerAppsV0/task.json
+++ b/Tasks/AzureContainerAppsV0/task.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "filePath",
+      "type": "string",
       "label": "Application source path",
       "required": false,
       "helpMarkDown": "Absolute path on the runner of the source application code to be built. If not provided, the 'imageToDeploy' argument must be provided to ensure the Container App has an image to reference."

--- a/Tasks/AzureContainerAppsV0/task.json
+++ b/Tasks/AzureContainerAppsV0/task.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 279,
+    "Minor": 278,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/AzureContainerAppsV0/task.loc.json
+++ b/Tasks/AzureContainerAppsV0/task.loc.json
@@ -18,8 +18,8 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 277,
-    "Patch": 4
+    "Minor": 279,
+    "Patch": 0
   },
   "preview": true,
   "minimumAgentVersion": "2.144.0",
@@ -42,7 +42,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "string",
+      "type": "filePath",
       "label": "ms-resource:loc.input.label.appSourcePath",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.appSourcePath"
@@ -219,6 +219,7 @@
     "ErrorMessageFormat": "ms-resource:loc.messages.ErrorMessageFormat",
     "ExistingContainerAppEnvironmentMessage": "ms-resource:loc.messages.ExistingContainerAppEnvironmentMessage",
     "FoundAppSourceDockerfileMessage": "ms-resource:loc.messages.FoundAppSourceDockerfileMessage",
+    "InvalidAppSourcePathMessage": "ms-resource:loc.messages.InvalidAppSourcePathMessage",
     "LoginFailed": "ms-resource:loc.messages.LoginFailed",
     "MissingAcrNameMessage": "ms-resource:loc.messages.MissingAcrNameMessage",
     "MissingRequiredArgumentMessage": "ms-resource:loc.messages.MissingRequiredArgumentMessage",

--- a/Tasks/AzureContainerAppsV0/task.loc.json
+++ b/Tasks/AzureContainerAppsV0/task.loc.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "filePath",
+      "type": "string",
       "label": "ms-resource:loc.input.label.appSourcePath",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.appSourcePath"

--- a/Tasks/AzureContainerAppsV0/task.loc.json
+++ b/Tasks/AzureContainerAppsV0/task.loc.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 0,
-    "Minor": 279,
+    "Minor": 278,
     "Patch": 0
   },
   "preview": true,

--- a/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureContainerAppsV1/Strings/resources.resjson/en-US/resources.resjson
@@ -77,6 +77,7 @@
   "loc.messages.ErrorMessageFormat": "Error: %s",
   "loc.messages.ExistingContainerAppEnvironmentMessage": "Discovered existing Container App Environment, '%s', to use with the Container App.",
   "loc.messages.FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+  "loc.messages.InvalidAppSourcePathMessage": "The provided appSourcePath '%s' contains invalid characters. It must be a valid filesystem path and must not contain shell metacharacters.",
   "loc.messages.LoginFailed": "Azure login failed",
   "loc.messages.MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
   "loc.messages.MissingRequiredArgumentMessage": "One of the following arguments must be provided: appSourcePath, imageToDeploy, yamlConfigPath",

--- a/Tasks/AzureContainerAppsV1/Tests/L0.ts
+++ b/Tasks/AzureContainerAppsV1/Tests/L0.ts
@@ -66,6 +66,31 @@ describe('AzureContainerAppsV1 Suite', function () {
         }, tr);
     });
 
+    it('Fails for appSourcePath containing shell metacharacters', async () => {
+        this.timeout(5000);
+
+        const tp: string = path.join(__dirname, 'L0FailsForAppSourcePathWithMetacharacters.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+
+        runValidations(() => {
+            // Validate the task failed
+            assert(tr.failed, 'AzureContainerAppsV1 task should have failed when appSourcePath contains shell metacharacters.');
+
+            // Validate the correct error message was thrown
+            assert(tr.stdout.includes('InvalidAppSourcePathMessage'), 'AzureContainerAppsV1 task should reject an appSourcePath that contains shell metacharacters to prevent command injection.');
+
+            // Validate the correct result was logged to telemetry
+            assert(tr.stdout.includes('[MOCK] setFailedResult called'), 'AzureContainerAppsV1 task should signal to telemetry that the task failed.');
+
+            // Validate that the end-of-test scenarios are hit
+            assert(tr.stdout.includes('[MOCK] logoutAzure called'), 'AzureContainerAppsV1 task should try to logout of Azure at the end of the task.');
+            assert(tr.stdout.includes('[MOCK] logoutAcr called'), 'AzureContainerAppsV1 task should log Docker out of ACR at the end of the task to avoid leaving registry credentials on the agent.');
+            assert(tr.stdout.includes('[MOCK] sendLogs called'), 'AzureContainerAppsV1 task should send telemetry logs at the end of the task.');
+        }, tr);
+    });
+
     it('Fails for no service connection argument', async () => {
         this.timeout(5000);
 

--- a/Tasks/AzureContainerAppsV1/Tests/L0FailsForAppSourcePathWithMetacharacters.ts
+++ b/Tasks/AzureContainerAppsV1/Tests/L0FailsForAppSourcePathWithMetacharacters.ts
@@ -1,0 +1,125 @@
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+import * as path from 'path';
+
+const taskPath = path.join(__dirname, '..', 'azurecontainerapps.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// Set required arguments for the test, using an appSourcePath that contains shell metacharacters
+// to verify that the task rejects it (command-injection guard, CWE-78).
+tmr.setInput('cwd', '/fakecwd');
+tmr.setInput('acrName', 'sampletestacr');
+tmr.setInput('appSourcePath', '/samplepath;whoami');
+tmr.setInput('disableTelemetry', 'true');
+
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+
+// Assign dummy values for build variables
+tlClone.getVariable = function(variable: string) {
+    if (variable.toLowerCase() === 'build.buildid') {
+        return 'test-build-id';
+    } else if (variable.toLowerCase() === 'build.buildnumber') {
+        return 'test-build-number';
+    }
+    return null;
+};
+tlClone.assertAgent = function(variable: string) {
+    return;
+};
+tmr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+/**
+ * ----------------------------------
+ * Mock out the common helper classes
+ * ----------------------------------
+ */
+
+// Mock out function calls for the AzureAuthenticationHelper class
+tmr.registerMock('./src/AzureAuthenticationHelper', {
+    AzureAuthenticationHelper: function() {
+        return {
+            loginAzure: function() {
+                console.log('[MOCK] loginAzure called');
+                return;
+            },
+            logoutAzure: function() {
+                console.log('[MOCK] logoutAzure called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the ContainerRegistryHelper class
+tmr.registerMock('./src/ContainerRegistryHelper', {
+    ContainerRegistryHelper: function() {
+        return {
+            loginAcrWithUsernamePassword: function(acrName: string, acrUsername: string, acrPassword: string) {
+                console.log('[MOCK] loginAcrWithUsernamePassword called');
+                return;
+            },
+            loginAcrWithAccessTokenAsync: async function() {
+                console.log('[MOCK] loginAcrWithAccessTokenAsync called');
+                return;
+            },
+            pushImageToAcr: function() {
+                console.log('[MOCK] pushImageToAcr called');
+                return;
+            },
+            logoutAcr: function() {
+                console.log('[MOCK] logoutAcr called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the TelemetryHelper class
+tmr.registerMock('./src/TelemetryHelper', {
+    TelemetryHelper: function() {
+        return {
+            setSuccessfulResult: function() {
+                console.log('[MOCK] setSuccessfulResult called');
+                return;
+            },
+            setFailedResult: function(errorMessage: string) {
+                console.log('[MOCK] setFailedResult called');
+                return;
+            },
+            setBuilderScenario: function() {
+                console.log('[MOCK] setBuilderScenario called');
+                return;
+            },
+            setDockerfileScenario: function() {
+                console.log('[MOCK] setDockerfileScenario called');
+                return;
+            },
+            setImageScenario: function() {
+                console.log('[MOCK] setImageScenario called');
+                return;
+            },
+            sendLogs: function() {
+                console.log('[MOCK] sendLogs called');
+                return;
+            }
+        };
+    }
+});
+
+// Mock out function calls for the Utility class
+tmr.registerMock('./src/Utility', {
+    Utility: function() {
+        return {
+            setAzureCliDynamicInstall: function() {
+                console.log('[MOCK] setAzureCliDynamicInstall called');
+                return;
+            },
+            isNullOrEmpty(str: string): boolean {
+                return str === null || str === undefined || str === "";
+            }
+        };
+    }
+});
+
+// Run the mocked task test
+tmr.run();

--- a/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
@@ -10,6 +10,12 @@ import { Utility } from './src/Utility';
 
 const util = new Utility();
 
+// appSourcePath is documented as a filesystem path. As defense-in-depth against command injection
+// (CWE-78), reject values containing shell metacharacters; the primary fix reads and deletes the
+// runtime-stack file via the filesystem instead of a shell (see determineRuntimeStackAsync).
+// Backslash is intentionally allowed as the Windows path separator.
+const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|$`()<>\r\n]/;
+
 export class azurecontainerapps {
 
     public static async runMain(): Promise<void> {
@@ -142,6 +148,13 @@ export class azurecontainerapps {
 
         // Emit arg-injection risk telemetry (metadata only) for the user-controlled appSourcePath.
         emitArgInjectionRiskTelemetry('appSourcePath', this.appSourcePath);
+
+        // Reject appSourcePath values that contain shell metacharacters, as defense-in-depth against
+        // command injection (CWE-78).
+        if (!util.isNullOrEmpty(this.appSourcePath) && APP_SOURCE_PATH_INVALID_CHARS.test(this.appSourcePath)) {
+            tl.error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
+            throw Error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
+        }
 
         // Get the name of the ACR instance to push images to, if provided
         this.acrName = tl.getInput('acrName', false);

--- a/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
@@ -11,10 +11,12 @@ import { Utility } from './src/Utility';
 const util = new Utility();
 
 // appSourcePath is documented as a filesystem path. As defense-in-depth against command injection
-// (CWE-78), reject values containing shell metacharacters; the primary fix reads and deletes the
-// runtime-stack file via the filesystem instead of a shell (see determineRuntimeStackAsync).
-// Backslash is intentionally allowed as the Windows path separator.
-const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|$`()<>\r\n]/;
+// (CWE-78), reject values containing shell metacharacters that are highly unlikely to occur in a
+// legitimate path; the primary fix reads and deletes the runtime-stack file via the filesystem
+// instead of a shell (see determineRuntimeStackAsync). Characters that commonly appear in real
+// paths -- '$', '(', ')', and backslash (the Windows path separator) -- are intentionally allowed
+// (e.g. "C:\Program Files (x86)\app").
+const APP_SOURCE_PATH_INVALID_CHARS: RegExp = /[;&|`<>\r\n]/;
 
 export class azurecontainerapps {
 

--- a/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
+++ b/Tasks/AzureContainerAppsV1/azurecontainerapps.ts
@@ -154,7 +154,6 @@ export class azurecontainerapps {
         // Reject appSourcePath values that contain shell metacharacters, as defense-in-depth against
         // command injection (CWE-78).
         if (!util.isNullOrEmpty(this.appSourcePath) && APP_SOURCE_PATH_INVALID_CHARS.test(this.appSourcePath)) {
-            tl.error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
             throw Error(tl.loc('InvalidAppSourcePathMessage', this.appSourcePath));
         }
 

--- a/Tasks/AzureContainerAppsV1/src/ContainerAppHelper.ts
+++ b/Tasks/AzureContainerAppsV1/src/ContainerAppHelper.ts
@@ -1,6 +1,7 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 import { CommandHelper } from './CommandHelper';
 import { Utility } from './Utility';
 
@@ -434,22 +435,17 @@ export class ContainerAppHelper {
                 );
             }
 
-            // Read the temp file to get the runtime stack into a variable
-            const oryxRuntimeTxtPath = path.join(appSourcePath, 'oryx-runtime.txt');
-            let command: string = `head -n 1 ${oryxRuntimeTxtPath}`;
-            if (IS_WINDOWS_AGENT) {
-                command = `Get-Content -Path ${oryxRuntimeTxtPath} -Head 1`;
-            }
+            // Read the temp file to get the runtime stack into a variable. The file is read directly
+            // from the filesystem instead of through a shell command ('head'/'Get-Content' executed via
+            // 'bash -c'/'pwsh -command') so that a user-controlled appSourcePath cannot inject shell
+            // metacharacters and execute arbitrary commands on the agent (CWE-78).
+            const oryxRuntimeTxtPath: string = path.join(appSourcePath, 'oryx-runtime.txt');
+            const oryxRuntimeText: string = fs.readFileSync(oryxRuntimeTxtPath, 'utf8');
+            const runtimeStack: string = oryxRuntimeText.split(/\r?\n/)[0].trim();
 
-            const runtimeStack = await new CommandHelper().execCommandAsync(command);
-
-            // Delete the temp file
-            command = `rm ${oryxRuntimeTxtPath}`;
-            if (IS_WINDOWS_AGENT) {
-                command = `Remove-Item -Path ${oryxRuntimeTxtPath}`;
-            }
-
-            await new CommandHelper().execCommandAsync(command);
+            // Delete the temp file using the task-lib helper rather than a shell 'rm'/'Remove-Item'
+            // command, for the same command-injection reason described above.
+            tl.rmRF(oryxRuntimeTxtPath);
 
             return runtimeStack;
         } catch (err) {

--- a/Tasks/AzureContainerAppsV1/src/ContainerRegistryHelper.ts
+++ b/Tasks/AzureContainerAppsV1/src/ContainerRegistryHelper.ts
@@ -1,6 +1,5 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as child from 'child_process';
-import { CommandHelper } from './CommandHelper';
 import { Utility } from './Utility';
 
 export class ContainerRegistryHelper {

--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -18,8 +18,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 277,
-    "Patch": 5
+    "Minor": 279,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "Azure Container Apps Deploy",
@@ -39,7 +39,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "string",
+      "type": "filePath",
       "label": "Application source path",
       "required": false,
       "helpMarkDown": "Absolute path on the runner of the source application code to be built. If not provided, the 'imageToDeploy' argument must be provided to ensure the Container App has an image to reference."
@@ -227,6 +227,7 @@
     "ErrorMessageFormat": "Error: %s",
     "ExistingContainerAppEnvironmentMessage": "Discovered existing Container App Environment, '%s', to use with the Container App.",
     "FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+    "InvalidAppSourcePathMessage": "The provided appSourcePath '%s' contains invalid characters. It must be a valid filesystem path and must not contain shell metacharacters.",
     "LoginFailed": "Azure login failed",
     "MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
     "MissingRequiredArgumentMessage": "One of the following arguments must be provided: appSourcePath, imageToDeploy, yamlConfigPath",

--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 278,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureContainerAppsV1/task.json
+++ b/Tasks/AzureContainerAppsV1/task.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "filePath",
+      "type": "string",
       "label": "Application source path",
       "required": false,
       "helpMarkDown": "Absolute path on the runner of the source application code to be built. If not provided, the 'imageToDeploy' argument must be provided to ensure the Container App has an image to reference."

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -18,8 +18,8 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 277,
-    "Patch": 5
+    "Minor": 279,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -39,7 +39,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "string",
+      "type": "filePath",
       "label": "ms-resource:loc.input.label.appSourcePath",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.appSourcePath"
@@ -227,6 +227,7 @@
     "ErrorMessageFormat": "ms-resource:loc.messages.ErrorMessageFormat",
     "ExistingContainerAppEnvironmentMessage": "ms-resource:loc.messages.ExistingContainerAppEnvironmentMessage",
     "FoundAppSourceDockerfileMessage": "ms-resource:loc.messages.FoundAppSourceDockerfileMessage",
+    "InvalidAppSourcePathMessage": "ms-resource:loc.messages.InvalidAppSourcePathMessage",
     "LoginFailed": "ms-resource:loc.messages.LoginFailed",
     "MissingAcrNameMessage": "ms-resource:loc.messages.MissingAcrNameMessage",
     "MissingRequiredArgumentMessage": "ms-resource:loc.messages.MissingRequiredArgumentMessage",

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -18,7 +18,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 278,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/AzureContainerAppsV1/task.loc.json
+++ b/Tasks/AzureContainerAppsV1/task.loc.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "appSourcePath",
-      "type": "filePath",
+      "type": "string",
       "label": "ms-resource:loc.input.label.appSourcePath",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.appSourcePath"


### PR DESCRIPTION
### **Context**
Security hardening of the user-controlled `appSourcePath` input in the AzureContainerApps tasks. In `ContainerAppHelper.determineRuntimeStackAsync`, `appSourcePath` was interpolated **unescaped** into shell command strings executed via `bash -c` / `pwsh -command` (reading and deleting the Oryx runtime-stack temp file), allowing its contents to be interpreted as shell commands on the agent (CWE-78).

Related work item: [AB#2445463](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2445463)

---

### **Task Name**
AzureContainerApps (V1 and V0)

---

### **Description**
- Read the runtime-stack temp file with `fs.readFileSync` and delete it with `tl.rmRF` instead of shelling out to `head`/`Get-Content` and `rm`/`Remove-Item` — this removes the shell entirely for these operations and is the core fix.
- Reject `appSourcePath` values containing shell metacharacters (`; & | < >` backtick, CR/LF) during input validation, as defense-in-depth. Characters that legitimately appear in filesystem paths — `$`, `(`, `)`, and backslash — are intentionally allowed (e.g. `C:\Program Files (x86)\app`).
- Change the `appSourcePath` input `type` from `string` to `filePath`.
- Add L0 tests asserting the task fails when `appSourcePath` contains shell metacharacters (V0 and V1).
- Bump `AzureContainerAppsV1` to `1.278.0` and `AzureContainerAppsV0` to `0.278.0`.

Note: argument-boundary safety for the `docker` / `pack` build invocations is provided separately by the existing `UseArgArrayForFilePath` feature flag and is out of scope for this change.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** The runtime-stack file read/delete are replaced with behavior-equivalent filesystem APIs. The input validation is defense-in-depth (the shell sinks are removed regardless) and rejects only a small set of shell control characters that are highly unlikely to appear in a legitimate path; characters common in real paths (`$`, `(`, `)`, backslash) are allowed. No change to the docker/pack build flow.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** This is a security fix that should apply unconditionally, and the change is behavior-preserving for valid filesystem paths.

---

### **Tech Design / Approach**
- Replace shell-string execution of the temp-file read/delete with `fs.readFileSync` / `tl.rmRF` (no shell involved).
- Add blocking input validation as defense-in-depth.
- The `filePath` input type signals intent and enables path validation in the UI.

---

### **Documentation Changes Required** (Yes/No)
**No.**

---

### **Unit Tests Added or Updated** (Yes / No)
**Yes.** Added `Tests/L0FailsForAppSourcePathWithMetacharacters.ts` and wired a suite case in `Tests/L0.ts` for both V0 and V1.

---

### **Additional Testing Performed**
- `node make.js build --task AzureContainerAppsV1 --BypassNpmAudit` and `--task AzureContainerAppsV0` — both compile clean.
- `node make.js test --task AzureContainerAppsV1` (15 passing) and `--task AzureContainerAppsV0` (13 passing), plus the repo General Suite validators (40 passing, including task.json / task.loc.json / resources string-consistency checks).

---

### **Logging Added/Updated** (Yes/No)
**No** new logging beyond an error message on invalid input (`InvalidAppSourcePathMessage`) via the existing `tl.error` / `tl.loc` pattern. No sensitive data is logged.

---

### **Telemetry Added/Updated** (Yes/No)
**No.** V1 retains the pre-existing `emitArgInjectionRiskTelemetry` call (metadata only).

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert this PR; the task version can be rolled back to the previously published version.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** No new dependencies — uses the built-in `fs` module and the existing `azure-pipelines-task-lib` `tl.rmRF`. Existing L0 suites (including the `UseArgArrayForFilePath` argument-handling tests) pass unchanged.

---

### **Checklist**
- [x] Related issue linked ([AB#2445463](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2445463))
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
