### PR TITLE
feat: sqlcmd execution for .sql files + telemetry (task4_final)

### DIFF
--- a/Tasks/MicrosoftSqlDeploymentV1/README.md
+++ b/Tasks/MicrosoftSqlDeploymentV1/README.md
@@ -1,0 +1,214 @@
+# Microsoft SQL Deployment
+
+## Overview
+
+The **Microsoft SQL Deployment** task deploys database changes to Azure SQL Database, Azure SQL Managed Instance, or SQL Server from your Azure Pipelines build or release. You can deploy from a pre-built DACPAC file, build and deploy directly from a SQL project (`.sqlproj`), or execute a T-SQL migration script — all from Windows or Linux agents without any manual tool installation.
+
+## Prerequisites
+
+### Target Database
+The target database server must already exist. The task deploys schema changes to an existing database but does not create the server itself.
+
+### Tools Required on the Agent
+The task discovers and installs the tools it needs automatically:
+- **SqlPackage** (for DACPAC and SQL project deployments) is found via the dotnet global tool, DacFramework MSI on Windows, or PATH. If you need to install it manually: `dotnet tool install -g microsoft.sqlpackage`
+- **go-sqlcmd** (for `.sql` script execution) is found on PATH or auto-installed at runtime. No manual setup needed.
+- **.NET SDK** (only when building a `.sqlproj`) is required to compile the project. Use the `UseDotNet@2` task to install it if not already present on the agent.
+
+---
+
+## Parameters
+
+### Required
+
+| Parameter | Description |
+|---|---|
+| **action** | The action to perform: `publish` (deploy schema), `script` (generate change script), `deployReport` (generate deployment report XML), or `sqlScript` (execute a `.sql` file). |
+| **path** | Path to a `.dacpac`, `.sqlproj`, or `.sql` file. The file type is detected automatically from the extension. |
+| **connectionString** | Full connection string for the target database. Store sensitive values as secret pipeline variables (e.g. `$(SqlConnectionString)`). |
+
+### Optional
+
+| Parameter | Description |
+|---|---|
+| **azureSubscription** | Azure Resource Manager service connection. Required for firewall rule management. When set with `Authentication=Active Directory Default`, the task uses the service connection identity for database authentication. |
+| **publishProfile** | Path to a SqlPackage publish profile `.xml` file. Values in `additionalArguments` take precedence. |
+| **additionalArguments** | Additional arguments passed to SqlPackage or sqlcmd. |
+| **buildArguments** | Additional arguments passed to `dotnet build` when path points to a `.sqlproj` file (e.g. `--configuration Release`). |
+| **sqlpackagePath** | Override the SqlPackage executable path. When not set, the task searches via dotnet tool, DacFramework MSI (Windows), then PATH. |
+| **sqlcmdPath** | Override the sqlcmd executable path. When not set, the task uses go-sqlcmd from PATH or auto-installs it. |
+| **firewallRuleManagement** | When `true`, temporarily adds a firewall rule for the agent IP and removes it after deployment. Defaults to `true` when `azureSubscription` is provided. Set to `false` for private VNet or on-premises deployments. |
+
+### Output Variables
+
+| Variable | Description |
+|---|---|
+| **SqlDeploymentOutputFile** | Path to the generated output file for `script` and `deployReport` actions. |
+
+---
+
+## Authentication
+
+The task authenticates to the database using the `connectionString` input. Set the `Authentication` keyword in the connection string to select the auth method:
+
+### SQL Authentication
+```
+Server=myserver.database.windows.net;Database=mydb;User ID=myuser;Password=$(SqlPassword);
+```
+
+### Active Directory Default (Managed Identity / Workload Identity)
+Connects using the agent's ambient identity (managed identity, workload identity, Azure CLI login). When `azureSubscription` is also set, the task acquires a token from the service connection and uses it for the deployment.
+```
+Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Default;
+```
+
+### Active Directory Service Principal
+```
+Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Service Principal;User ID=<clientId>;Password=$(ClientSecret);
+```
+> **Note for SQL script execution (`.sql` files)**: When using SP auth without `azureSubscription`, the `User ID` field must include the tenant ID in `clientId@tenantId` format so go-sqlcmd can resolve the tenant. When `azureSubscription` is set, the tenant is resolved automatically.
+
+### Active Directory Password
+```
+Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Password;User ID=user@domain.com;Password=$(Password);
+```
+
+### Active Directory Integrated (Kerberos)
+```
+Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Integrated;
+```
+
+### Active Directory Managed Identity
+For user-assigned managed identity, include the client ID:
+```
+Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Managed Identity;User ID=<clientId>;
+```
+
+---
+
+## Usage Examples
+
+### Deploy a DACPAC
+```yaml
+- task: MicrosoftSqlDeployment@1
+  inputs:
+    action: publish
+    path: $(Build.ArtifactStagingDirectory)/MyDatabase.dacpac
+    connectionString: $(SqlConnectionString)
+```
+
+### Deploy using Azure service connection with firewall management
+```yaml
+- task: MicrosoftSqlDeployment@1
+  inputs:
+    action: publish
+    path: $(Build.ArtifactStagingDirectory)/MyDatabase.dacpac
+    connectionString: 'Server=myserver.database.windows.net;Database=mydb;Authentication=Active Directory Default;'
+    azureSubscription: my-azure-service-connection
+```
+
+### Build and deploy a SQL project
+```yaml
+- task: UseDotNet@2
+  inputs:
+    version: '8.x'
+- task: MicrosoftSqlDeployment@1
+  inputs:
+    action: publish
+    path: $(Build.SourcesDirectory)/src/MyDatabase/MyDatabase.sqlproj
+    connectionString: $(SqlConnectionString)
+```
+
+### Execute a SQL migration script
+```yaml
+- task: MicrosoftSqlDeployment@1
+  inputs:
+    action: sqlScript
+    path: $(Build.SourcesDirectory)/migrations/V1.0__initial.sql
+    connectionString: $(SqlConnectionString)
+    firewallRuleManagement: false
+```
+
+### Generate a deployment script for review
+```yaml
+- task: MicrosoftSqlDeployment@1
+  inputs:
+    action: script
+    path: $(Build.ArtifactStagingDirectory)/MyDatabase.dacpac
+    connectionString: $(SqlConnectionString)
+    additionalArguments: '/OutputPath:$(Build.ArtifactStagingDirectory)/deploy-script.sql'
+- publish: $(Build.ArtifactStagingDirectory)/deploy-script.sql
+  artifact: deployment-script
+```
+
+---
+
+## Supported Actions
+
+| Action | File types | Description |
+|---|---|---|
+| `publish` | `.dacpac`, `.sqlproj` | Deploy schema changes to the target database |
+| `script` | `.dacpac`, `.sqlproj` | Generate a SQL change script without applying it |
+| `deployReport` | `.dacpac`, `.sqlproj` | Generate an XML report of changes that would be applied |
+| `sqlScript` | `.sql` | Execute a T-SQL script against the target database |
+
+---
+
+## Firewall Rule Management
+
+When `azureSubscription` is set and `firewallRuleManagement` is `true` (the default), the task:
+1. Detects the agent's public IP address by probing the SQL server
+2. Adds a temporary firewall rule via the Azure ARM API
+3. Removes the rule after deployment completes (always, even on failure)
+
+This requires the service connection to have `Microsoft.Sql/servers/firewallRules/write` and `Microsoft.Sql/servers/firewallRules/delete` permissions on the SQL server.
+
+Disable this for agents inside a private VNet or on-premises deployments:
+```yaml
+firewallRuleManagement: false
+```
+
+---
+
+## SqlPackage Discovery Order
+
+1. User-specified `sqlpackagePath` input
+2. Dotnet global tool (`~/.dotnet/tools/sqlpackage`)
+3. DacFramework MSI install path (Windows only, e.g. `C:\Program Files\Microsoft SQL Server\...\DAC\bin\SqlPackage.exe`)
+4. System PATH
+
+If SqlPackage is not found, install it: `dotnet tool install -g microsoft.sqlpackage`
+
+---
+
+## Known Limitations and Notes
+
+### Service Principal auth for `.sql` scripts requires a tenant ID
+When using `Authentication=Active Directory Service Principal` in the connection string for `.sql` file execution, go-sqlcmd needs the tenant ID to authenticate. If you set `azureSubscription`, the tenant ID is resolved automatically from the service connection — no extra configuration needed. If you do **not** set `azureSubscription`, you must include the tenant ID directly in the `User ID` field using the format `clientId@tenantId`:
+
+```
+User ID=11111111-2222-3333-4444-555555555555@xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx;
+```
+
+Without the tenant ID and without `azureSubscription`, the task will fail with an authentication error.
+
+### `azureSubscription` provides identity for DACPAC/sqlproj, not always for `.sql` scripts
+When using `Authentication=Active Directory Default` with `azureSubscription`, the task acquires a token from the service connection and passes it to SqlPackage via `/AccessToken`. For `.sql` script execution with go-sqlcmd, the service connection credentials are injected as environment variables so go-sqlcmd uses the same identity. Service Principal and WorkloadIdentityFederation connections are fully supported. ManagedServiceIdentity connections use the agent's own managed identity.
+
+### SQL script execution uses go-sqlcmd, not ODBC sqlcmd
+The task installs and uses [go-sqlcmd](https://github.com/microsoft/go-sqlcmd) for `.sql` file execution. If the agent has the ODBC sqlcmd (from SQL Server or mssql-tools) on PATH, the task automatically detects this and installs go-sqlcmd instead, because go-sqlcmd is required for cross-platform AAD authentication support.
+
+### `.sqlproj` builds require SDK-style projects
+Only SQL projects using `Microsoft.Build.Sql` (SDK-style) are supported for build. Legacy `.sqlproj` projects (SSDT-style) must be pre-compiled to a DACPAC outside this task.
+
+---
+
+## Troubleshooting
+
+**SqlPackage not found**: Install via `dotnet tool install -g microsoft.sqlpackage` or specify the path using the `sqlpackagePath` input.
+
+**Firewall rule management fails**: Ensure the service connection has write/delete permissions on SQL firewall rules. Alternatively, set `firewallRuleManagement: false` and manage network access separately.
+
+**DotnetNotFound when building .sqlproj**: Add the `UseDotNet@2` task before this task to install the .NET SDK.
+
+**Active Directory auth fails for SQL scripts**: Ensure `azureSubscription` is set, or include the tenant ID in the connection string `User ID` field as `clientId@tenantId` for Service Principal auth.

--- a/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -80,6 +80,7 @@
   "loc.messages.ExecutingSqlScript": "Executing SQL script: %s",
   "loc.messages.SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
   "loc.messages.SpAuthRequiresTenantId": "Service Principal auth for .sql scripts requires either an azureSubscription (tenant ID is injected automatically) or a User ID in the format clientId@tenantId in the connection string.",
+  "loc.messages.WifSqlcmdFallbackToAgentIdentity": "Could not resolve the workload identity federation credentials for the service connection. sqlcmd will authenticate using the agent's own identity, which may not have access to the database.",
   "loc.messages.DeploymentSuccessful": "Deployment completed successfully",
   "loc.messages.DeploymentFailed": "Deployment failed: %s",
   "loc.messages.InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -76,7 +76,9 @@
   "loc.messages.SqlPackageExecutionFailed": "SqlPackage execution failed with exit code: %s",
   "loc.messages.OutputFileGenerated": "Output file generated: %s",
   "loc.messages.OutputFileNotProduced": "SqlPackage succeeded but the expected output file was not produced: %s",
-  "loc.messages.InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport.",
+  "loc.messages.InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport, sqlScript.",
+  "loc.messages.ExecutingSqlScript": "Executing SQL script: %s",
+  "loc.messages.SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
   "loc.messages.DeploymentSuccessful": "Deployment completed successfully",
   "loc.messages.DeploymentFailed": "Deployment failed: %s",
   "loc.messages.InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -79,6 +79,7 @@
   "loc.messages.InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport, sqlScript.",
   "loc.messages.ExecutingSqlScript": "Executing SQL script: %s",
   "loc.messages.SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
+  "loc.messages.SpAuthRequiresTenantId": "Service Principal auth for .sql scripts requires either an azureSubscription (tenant ID is injected automatically) or a User ID in the format clientId@tenantId in the connection string.",
   "loc.messages.DeploymentSuccessful": "Deployment completed successfully",
   "loc.messages.DeploymentFailed": "Deployment failed: %s",
   "loc.messages.InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MicrosoftSqlDeploymentV1/Strings/resources.resjson/en-US/resources.resjson
@@ -59,7 +59,7 @@
   "loc.messages.FailedToGetSQLServerDetails": "Failed to get SQL Server '%s' details: %s",
   "loc.messages.ParsingConnectionString": "Parsing connection string",
   "loc.messages.InvalidConnectionString": "Invalid connection string. A valid connection string is a series of keyword/value pairs separated by semi-colons. If there are any special characters like quotes or semi-colons in the keyword value, enclose the value within quotes. Refer to https://aka.ms/sqlconnectionstring for more info.",
-  "loc.messages.UnsupportedAuthentication": "Unsupported Authentication type: '%s'. Supported values: SQL auth (no Authentication keyword), Active Directory Default, Active Directory Password, Active Directory Service Principal, Active Directory Integrated.",
+  "loc.messages.UnsupportedAuthentication": "Unsupported Authentication type: '%s'. Supported values: SQL auth (no Authentication keyword), Active Directory Default, Active Directory Password, Active Directory Service Principal, Active Directory Integrated, Active Directory Managed Identity.",
   "loc.messages.ConnectionStringMissingServer": "Invalid connection string. Please ensure 'Server' or 'Data Source' is provided in the connection string.",
   "loc.messages.ConnectionStringMissingDatabase": "Invalid connection string. Please ensure 'Database' or 'Initial Catalog' is provided in the connection string.",
   "loc.messages.ConnectionStringMissingUserId": "Invalid connection string. Please ensure 'User' or 'User ID' is provided in the connection string.",

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -524,6 +524,33 @@ describe('MicrosoftSqlDeployment Suite', function () {
             assert(tr.succeeded, 'task should succeed with AAD Service Principal auth');
         }, tr);
     });
+
+    it('should use ActiveDirectoryAzurePipelines for a Workload Identity Federation service connection', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdWifUsesAzurePipelinesAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed authenticating as the WIF service connection');
+        }, tr);
+    });
+
+    it('should take the SP tenant id from the service connection', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdSpAuthTenantFromSubscription.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with clientId@tenantId built from the service connection');
+        }, tr);
+    });
+
+    it('should use the same authentication mapping for the firewall probe as for deployment', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdFirewallProbeUsesSharedAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with the probe using --authentication-method');
+        }, tr);
+    });
 });
 
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -473,6 +473,17 @@ describe('MicrosoftSqlDeployment Suite', function () {
             assert(tr.stdout.indexOf('AccessTokenAcquired') >= 0, 'should report access token acquired');
         }, tr);
     });
+
+    it('should fail when sqlcmd execution fails with non-zero exit code', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdExecutionFailed.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.failed, 'task should fail when sqlcmd exits with non-zero code');
+            assert(tr.stdout.indexOf('SqlcmdExecutionFailed') >= 0 || tr.errorIssues.some(e => e.includes('sqlcmd execution failed')),
+                'should report sqlcmd execution failure');
+        }, tr);
+    });
 });
 
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -321,6 +321,19 @@ describe('MicrosoftSqlDeployment Suite', function () {
         }, tr);
     });
 
+    it('should auto-install go-sqlcmd when ODBC sqlcmd is on PATH', async () => {
+        // Verifies that isGoSqlcmd() correctly rejects ODBC sqlcmd (--version output
+        // does not match "sqlcmd version X.X.X") and falls through to auto-install.
+        const tp = path.join(__dirname, 'L0SqlcmdOdbcOnPathFallsToAutoInstall.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed after auto-installing go-sqlcmd');
+            assert(tr.stdout.indexOf('SqlCmdInstalling') >= 0 || tr.stdout.indexOf('sqlcmd-extracted') >= 0,
+                'should have triggered auto-install when ODBC sqlcmd was on PATH');
+        }, tr);
+    });
+
     it('should fail when sqlcmd executable is missing after auto-install extraction', async () => {
         const tp = path.join(__dirname, 'L0SqlcmdAutoInstallExeNotFound.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -484,6 +484,33 @@ describe('MicrosoftSqlDeployment Suite', function () {
                 'should report sqlcmd execution failure');
         }, tr);
     });
+
+    it('should succeed with AAD Default auth (-G, no credentials)', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdAadDefaultAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with AAD Default auth');
+        }, tr);
+    });
+
+    it('should succeed with AAD Password auth (-G + -U + SQLCMDPASSWORD)', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdAadPasswordAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with AAD Password auth');
+        }, tr);
+    });
+
+    it('should succeed with AAD Service Principal auth (--authentication-method)', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdAadServicePrincipalAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with AAD Service Principal auth');
+        }, tr);
+    });
 });
 
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadDefaultAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadDefaultAuth.ts
@@ -1,0 +1,32 @@
+// Succeeds with AAD Default auth (no credentials needed, agent ambient identity via -G).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=localhost;Database=testdb;Authentication=Active Directory Default;');
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+            // AAD Default: --authentication-method flag, no credentials needed
+            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryDefault -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadPasswordAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadPasswordAuth.ts
@@ -1,0 +1,32 @@
+// Succeeds with AAD Password auth (-G + -U + SQLCMDPASSWORD env var).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=localhost;Database=testdb;Authentication=Active Directory Password;User ID=user@tenant.com;Password=MyPassword;');
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+            // AAD Password: --authentication-method flag + -U user, password via SQLCMDPASSWORD env var
+            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryPassword -U user@tenant.com -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
@@ -1,0 +1,32 @@
+// Succeeds with AAD Service Principal auth (--authentication-method ActiveDirectoryServicePrincipal + -U clientId).
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Service Principal;User ID=my-client-id;Password=my-client-secret;');
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // SP auth: --authentication-method flag + -U clientId, secret via SQLCMDPASSWORD env var
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
@@ -8,7 +8,8 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
 tmr.setInput('action', 'sqlScript');
 tmr.setInput('path', 'test.sql');
-tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Service Principal;User ID=my-client-id;Password=my-client-secret;');
+// User ID must include @tenantId when azureSubscription is not set (required by validation).
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Service Principal;User ID=my-client-id@my-tenant-id;Password=my-client-secret;');
 
 tmr.registerMock('./src/SqlcmdHelper', {
     default: {
@@ -20,8 +21,8 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
-        // SP auth: --authentication-method flag + -U clientId, secret via SQLCMDPASSWORD env var
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id -l 30 -i test.sql': {
+        // SP auth: --authentication-method flag + -U clientId@tenantId, secret via SQLCMDPASSWORD env var
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAutoInstallSuccess.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAutoInstallSuccess.ts
@@ -1,7 +1,7 @@
 // Succeeds when sqlcmd is not on PATH and is auto-installed from go-sqlcmd releases.
+import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
-import fs = require('fs');
 
 let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
 let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
@@ -14,26 +14,23 @@ const extractedDir = '/tmp/sqlcmd-extracted';
 const executableName = process.platform === 'win32' ? 'sqlcmd.exe' : 'sqlcmd';
 const sqlcmdExePath = path.join(extractedDir, executableName);
 
-// Mock azure-pipelines-tool-lib/tool to simulate successful download and extraction
-tmr.registerMock('azure-pipelines-tool-lib/tool', {
-    downloadTool: async (_url: string) => '/tmp/sqlcmd-download',
-    extractZip: async (_file: string) => extractedDir,
-    extractTar: async (_file: string) => extractedDir
+// Mock SqlcmdHelper to simulate auto-install returning a path
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() {
+            return sqlcmdExePath;
+        }
+    }
 });
 
-const fsClone = Object.assign({}, fs);
-fsClone.existsSync = function(filePath: any): boolean {
-    const p = filePath ? filePath.toString() : '';
-    if (p === sqlcmdExePath) { return true; }   // extracted executable exists
-    if (p === 'test.sql') { return true; }
-    if (p.includes('.dotnet')) { return false; } // dotnet tool not installed
-    return false;
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, [sqlcmdExePath]: true },
+    which: { [sqlcmdExePath]: sqlcmdExePath },
+    exec: {
+        [`${sqlcmdExePath} -S localhost -d testdb -U sa -l 30 -i test.sql`]: { code: 0, stdout: 'Changed database context.' }
+    }
 };
-(fsClone as any).chmodSync = function() {};      // no-op chmod
-tmr.registerMock('fs', fsClone);
-
-// sqlcmd not on PATH — triggers auto-install
-tmr.setAnswers({ which: { 'sqlcmd': '' }, checkPath: { 'test.sql': true } });
+tmr.setAnswers(a);
 
 tmr.run();
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdExecutionFailed.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdExecutionFailed.ts
@@ -1,4 +1,4 @@
-// Succeeds with minimal valid inputs for a .sql script execution.
+// Fails when sqlcmd exits with non-zero exit code.
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
@@ -23,12 +23,11 @@ const a: ma.TaskLibAnswers = {
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
         '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': {
-            code: 0,
-            stdout: 'Changed database context to testdb.'
+            code: 1,
+            stderr: 'Msg 208, Level 16, State 1, Server localhost, Line 1\nInvalid object name \'dbo.NonExistentTable\'.'
         }
     }
 };
 tmr.setAnswers(a);
 
 tmr.run();
-

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFirewallProbeUsesSharedAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFirewallProbeUsesSharedAuth.ts
@@ -1,0 +1,62 @@
+// The firewall connectivity probe must use the same authentication mapping as the
+// deployment. It previously sent -G, which go-sqlcmd resolves to ActiveDirectoryPassword
+// when a user name and password are present — never ActiveDirectoryServicePrincipal.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Service Principal;User ID=my-client-id;Password=my-client-secret;');
+tmr.setInput('azureSubscription', 'test-service-connection-id');
+// Leave firewall management on so the real SqlUtils probe runs
+tmr.setInput('firewallRuleManagement', 'true');
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            return {
+                scheme: 'ServicePrincipal',
+                tenantID: 'my-tenant-id',
+                servicePrincipalClientID: 'sc-client-id',
+                servicePrincipalKey: 'sc-client-secret',
+                applicationTokenCredentials: {
+                    activeDirectoryResourceId: 'https://management.azure.com/',
+                    getToken: async (_force: boolean) => 'fake-sql-access-token'
+                }
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const probeQuery = `SELECT 'Validating connection from Azure Pipelines SQL Deployment Task'`;
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // Probe: master database, 15s login timeout, same auth mapping as the deployment.
+        // Succeeding here means no firewall rule is needed.
+        [`/usr/bin/sqlcmd -S myserver.database.windows.net -d master --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 15 -Q ${probeQuery}`]: {
+            code: 0,
+            stdout: 'Validating connection from Azure Pipelines SQL Deployment Task'
+        },
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromPath.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromPath.ts
@@ -1,4 +1,5 @@
 // Succeeds when sqlcmd is found on PATH.
+import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
@@ -8,25 +9,23 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('action', 'sqlScript');
 tmr.setInput('path', 'test.sql');
 tmr.setInput('connectionString', 'Server=localhost;Database=testdb;User ID=sa;Password=TestPass123!;');
-// No sqlcmdPath input - should discover from PATH
 
-// Mock fs.existsSync to return true for test.sql
-tmr.registerMock('fs', {
-    existsSync: (filePath: string) => {
-        if (filePath === 'test.sql') {
-            return true;
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() {
+            return '/usr/bin/sqlcmd';
         }
-        return false;
     }
 });
 
-// Mock tl.which to simulate sqlcmd found on PATH
-tmr.setAnswers({
-    which: {
-        'sqlcmd': '/usr/bin/sqlcmd'  // Simulate sqlcmd found on PATH
-    },
-    checkPath: { 'test.sql': true }
-});
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': { code: 0, stdout: 'Changed database context.' }
+    }
+};
+tmr.setAnswers(a);
 
 tmr.run();
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromUserPath.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromUserPath.ts
@@ -1,4 +1,5 @@
 // Succeeds when sqlcmd is found at user-specified path.
+import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
 
@@ -8,22 +9,24 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('action', 'sqlScript');
 tmr.setInput('path', 'test.sql');
 tmr.setInput('connectionString', 'Server=localhost;Database=testdb;User ID=sa;Password=TestPass123!;');
-tmr.setInput('sqlcmdPath', '/custom/path/sqlcmd.exe');
+tmr.setInput('sqlcmdPath', '/custom/path/sqlcmd');
 
-// Mock fs.existsSync to return true for user-provided sqlcmd path
-tmr.registerMock('fs', {
-    existsSync: (filePath: string) => {
-        if (filePath === '/custom/path/sqlcmd.exe') {
-            return true; // User-provided path exists - should succeed
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() {
+            return '/custom/path/sqlcmd';
         }
-        if (filePath === 'test.sql') {
-            return true;
-        }
-        return false;
     }
 });
 
-tmr.setAnswers({ checkPath: { 'test.sql': true } });
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/custom/path/sqlcmd': true },
+    which: { '/custom/path/sqlcmd': '/custom/path/sqlcmd' },
+    exec: {
+        '/custom/path/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': { code: 0, stdout: 'Changed database context.' }
+    }
+};
+tmr.setAnswers(a);
 
 tmr.run();
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdOdbcOnPathFallsToAutoInstall.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdOdbcOnPathFallsToAutoInstall.ts
@@ -1,0 +1,72 @@
+// Succeeds when ODBC sqlcmd (mssql-tools) is on PATH but the task detects it is not
+// go-sqlcmd and auto-installs go-sqlcmd instead.
+//
+// Scenario: Microsoft-hosted Linux agents ship ODBC sqlcmd on PATH.
+// SqlcmdHelper.findSqlcmd() calls `sqlcmd --version` on the PATH binary; the ODBC
+// variant does NOT print "sqlcmd version X.X.X", so isGoSqlcmd() returns false.
+// The task then auto-installs go-sqlcmd from GitHub releases and uses that instead.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=localhost;Database=testdb;User ID=sa;Password=TestPass123!;');
+
+// Do NOT mock SqlcmdHelper — we want to exercise the real variant-detection logic.
+
+const extractedDir = '/tmp/sqlcmd-extracted';
+const executableName = process.platform === 'win32' ? 'sqlcmd.exe' : 'sqlcmd';
+const goSqlcmdPath = path.join(extractedDir, executableName);
+const odbcSqlcmdPath = '/usr/bin/sqlcmd';
+
+// Mock tool-lib: simulate successful download and extraction of go-sqlcmd
+tmr.registerMock('azure-pipelines-tool-lib/tool', {
+    downloadTool: async (_url: string) => '/tmp/sqlcmd-download',
+    extractZip: async (_file: string) => extractedDir,
+    extractTar: async (_file: string) => extractedDir
+});
+
+const fsClone = Object.assign({}, fs);
+fsClone.existsSync = function(filePath: any): boolean {
+    const p = filePath ? filePath.toString() : '';
+    if (p === goSqlcmdPath) { return true; }  // auto-installed go-sqlcmd exists
+    if (p === 'test.sql')   { return true; }
+    return false;
+};
+(fsClone as any).chmodSync = function() {};
+tmr.registerMock('fs', fsClone);
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, [goSqlcmdPath]: true },
+    which: {
+        // ODBC sqlcmd is on PATH — but isGoSqlcmd() will reject it
+        'sqlcmd': odbcSqlcmdPath,
+        [goSqlcmdPath]: goSqlcmdPath
+    },
+    exec: {
+        // ODBC sqlcmd --version does NOT print "sqlcmd version X.X.X" or "Version: X"
+        // → isGoSqlcmd step 1 fails, falls through to step 2 (-?)
+        [`${odbcSqlcmdPath} --version`]: {
+            code: 0,
+            stdout: 'Microsoft (R) SQL Server Command Line Tool\nVersion 17.10.0001.1'
+        },
+        // ODBC sqlcmd -? prints the "Microsoft (R)" banner → isGoSqlcmd returns false
+        [`${odbcSqlcmdPath} -?`]: {
+            code: 0,
+            stdout: 'Microsoft (R) SQL Server Command Line Tool\nVersion 17.10.0001.1'
+        },
+        // go-sqlcmd runs the script after auto-install
+        [`${goSqlcmdPath} -S localhost -d testdb -U sa -l 30 -i test.sql`]: {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdServicePrincipalAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdServicePrincipalAuth.ts
@@ -1,0 +1,37 @@
+// Succeeds when sqlcmd is used with Active Directory Service Principal auth.
+// Verifies --authentication-method flag is passed instead of -G.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString',
+    "Server=myserver.database.windows.net;Database=testdb;" +
+    "Authentication='Active Directory Service Principal';" +
+    "User Id=my-client-id;Password=my-secret;");
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() {
+            return '/usr/bin/sqlcmd';
+        }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdSpAuthTenantFromSubscription.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdSpAuthTenantFromSubscription.ts
@@ -1,0 +1,54 @@
+// AAD Service Principal auth with an azureSubscription: go-mssqldb needs the tenant, which
+// the service connection supplies, so the user name is sent as clientId@tenantId.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+// No @tenant in User ID — it must come from the service connection
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Service Principal;User ID=my-client-id;Password=my-client-secret;');
+tmr.setInput('azureSubscription', 'test-service-connection-id');
+tmr.setInput('firewallRuleManagement', 'false');
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            return {
+                scheme: 'ServicePrincipal',
+                tenantID: 'my-tenant-id',
+                servicePrincipalClientID: 'sc-client-id',
+                servicePrincipalKey: 'sc-client-secret',
+                applicationTokenCredentials: {
+                    activeDirectoryResourceId: 'https://management.azure.com/',
+                    getToken: async (_force: boolean) => 'fake-sql-access-token'
+                }
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // Tenant appended from the service connection; secret still travels via SQLCMDPASSWORD
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdWifUsesAzurePipelinesAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdWifUsesAzurePipelinesAuth.ts
@@ -1,0 +1,58 @@
+// A Workload Identity Federation service connection must authenticate go-sqlcmd via
+// ActiveDirectoryAzurePipelines. ActiveDirectoryDefault would silently fall through the
+// DefaultAzureCredential chain to the agent's ambient identity.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'sqlScript');
+tmr.setInput('path', 'test.sql');
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Default;');
+tmr.setInput('azureSubscription', 'test-service-connection-id');
+// Skip the connectivity probe so this test isolates the deployment command
+tmr.setInput('firewallRuleManagement', 'false');
+
+// AzurePipelinesCredential exchanges the job's own access token for a service connection token
+process.env['ENDPOINT_AUTH_PARAMETER_SYSTEMVSSCONNECTION_ACCESSTOKEN'] = 'fake-system-access-token';
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            return {
+                scheme: 'WorkloadIdentityFederation',
+                tenantID: 'my-tenant-id',
+                servicePrincipalClientID: 'my-client-id',
+                applicationTokenCredentials: {
+                    activeDirectoryResourceId: 'https://management.azure.com/',
+                    getToken: async (_force: boolean) => 'fake-sql-access-token'
+                }
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // ActiveDirectoryAzurePipelines takes client/tenant/connection id from the
+        // AZURESUBSCRIPTION_* env vars, so no -U is passed on the command line.
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryAzurePipelines -l 30 -i test.sql': {
+            code: 0,
+            stdout: 'Changed database context to testdb.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -209,8 +209,11 @@ async function main(): Promise<void> {
             }
 
             console.log(tl.loc('DeploymentSuccessful'));
-
-            // Emit telemetry — actionable fields only, no PII
+        } finally {
+            if (firewallManager) {
+                await firewallManager.removeFirewallRule();
+            }
+            // Emit telemetry — actionable fields only, no PII. Always emitted regardless of outcome.
             try {
                 const telemetry = {
                     action: action,
@@ -223,10 +226,6 @@ async function main(): Promise<void> {
                 console.log('##vso[telemetry.publish area=TaskEndpointId;feature=MicrosoftSqlDeploymentV1]'
                     + JSON.stringify(telemetry));
             } catch (_) { /* telemetry is non-fatal */ }
-        } finally {
-            if (firewallManager) {
-                await firewallManager.removeFirewallRule();
-            }
         }
     }
     catch (error) {

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -112,6 +112,7 @@ async function main(): Promise<void> {
         // Firewall rule management and deployment execution
         let firewallManager: FirewallManager | undefined;
         let accessToken: string | undefined;
+        let azureEndpoint: any | undefined;
         let deployFilePath = filePath;
         let deployFileType = fileType;
 
@@ -119,7 +120,7 @@ async function main(): Promise<void> {
             // Step 1: Azure subscription — firewall + access token
             if (azureSubscription) {
                 const { AzureRMEndpoint } = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint');
-                const azureEndpoint = await new AzureRMEndpoint(azureSubscription).getEndpoint();
+                azureEndpoint = await new AzureRMEndpoint(azureSubscription).getEndpoint();
 
                 // Acquire access token for database authentication
                 if (azureEndpoint.scheme === 'ServicePrincipal' ||
@@ -195,11 +196,33 @@ async function main(): Promise<void> {
                     throw new Error(tl.loc('SqlcmdAutoInstallFailed', 'sqlcmd path is undefined'));
                 }
                 tl.debug(tl.loc('ExecutingSqlScript', deployFilePath));
+                // For token-based auth types, inject service connection credentials as env vars
+                // so go-sqlcmd's DefaultAzureCredential chain picks up the service connection identity.
+                // This ensures sqlcmd authenticates as the same identity as SqlPackage.
+                let sqlcmdEnvOverrides: { [key: string]: string } | undefined;
+                if (azureSubscription && azureEndpoint?.tenantID) {
+                    const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+                    const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated', 'activedirectorymanagedidentity'];
+
+                    // Always inject tenant ID so go-sqlcmd can resolve the tenant.
+                    sqlcmdEnvOverrides = { AZURE_TENANT_ID: azureEndpoint.tenantID };
+
+                    // For token-based auth (no creds in connection string), also inject SP client
+                    // credentials from the service connection so DefaultAzureCredential picks up
+                    // the intended identity rather than the agent's ambient identity.
+                    if (tokenBasedAuthTypes.includes(authType) && azureEndpoint.scheme === 'ServicePrincipal'
+                        && azureEndpoint.servicePrincipalClientID && azureEndpoint.servicePrincipalKey) {
+                        tl.setSecret(azureEndpoint.servicePrincipalKey);
+                        sqlcmdEnvOverrides.AZURE_CLIENT_ID = azureEndpoint.servicePrincipalClientID;
+                        sqlcmdEnvOverrides.AZURE_CLIENT_SECRET = azureEndpoint.servicePrincipalKey;
+                    }
+                }
                 await SqlcmdExecutor.executeSqlcmd(
                     sqlcmdExePath,
                     deployFilePath,
                     connectionConfig,
-                    additionalArguments || undefined
+                    additionalArguments || undefined,
+                    sqlcmdEnvOverrides
                 );
             }
 

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -8,7 +8,7 @@ import FirewallManager from './src/FirewallManager';
 import AzureSqlResourceManager from './src/AzureSqlResourceManager';
 import SqlProjectBuilder from './src/SqlProjectBuilder';
 import { SqlPackageExecutor } from './src/SqlPackageExecutor';
-import { SqlcmdExecutor } from './src/SqlcmdExecutor';
+import { SqlcmdExecutor, SqlcmdCredentials } from './src/SqlcmdExecutor';
 
 // Node version handling for DNS and network settings
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
@@ -113,14 +113,20 @@ async function main(): Promise<void> {
         let firewallManager: FirewallManager | undefined;
         let accessToken: string | undefined;
         let azureEndpoint: any | undefined;
+        let sqlcmdCredentials: SqlcmdCredentials | undefined;
         let deployFilePath = filePath;
         let deployFileType = fileType;
 
         try {
-            // Step 1: Azure subscription — firewall + access token
+            // Step 1: Azure subscription — resolve sqlcmd identity, firewall, access token
             if (azureSubscription) {
                 const { AzureRMEndpoint } = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint');
                 azureEndpoint = await new AzureRMEndpoint(azureSubscription).getEndpoint();
+
+                // Resolved before firewall management so the connectivity probe authenticates
+                // as the service connection, not the agent's ambient identity. Reads endpoint
+                // fields only — no token acquisition, so it cannot poison the ARM token cache.
+                sqlcmdCredentials = resolveSqlcmdCredentials(connectionConfig, azureSubscription, azureEndpoint);
 
                 // Acquire access token for database authentication
                 if (azureEndpoint.scheme === 'ServicePrincipal' ||
@@ -148,7 +154,7 @@ async function main(): Promise<void> {
                 }
 
                 if (firewallRuleManagement) {
-                    const ipAddress = await SqlUtils.detectIPAddress(connectionConfig, sqlcmdExePath!);
+                    const ipAddress = await SqlUtils.detectIPAddress(connectionConfig, sqlcmdExePath!, sqlcmdCredentials);
                     if (ipAddress) {
                         const resourceManager = await AzureSqlResourceManager.getResourceManager(connectionConfig.Server, azureEndpoint);
                         firewallManager = new FirewallManager(resourceManager);
@@ -197,8 +203,8 @@ async function main(): Promise<void> {
                 }
 
                 // For SP auth, go-mssqldb needs the tenant ID either in the User ID field
-                // (as clientId@tenantId) or via AZURE_TENANT_ID env var (injected when
-                // azureSubscription is set). Without either, auth will fail with a cryptic error.
+                // (as clientId@tenantId) or via the service connection. Without either, auth
+                // fails with a cryptic error, so surface a clear one up front.
                 const sqlAuthType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
                 if (sqlAuthType === 'activedirectoryserviceprincipal'
                     && !azureSubscription
@@ -207,35 +213,13 @@ async function main(): Promise<void> {
                 }
 
                 tl.debug(tl.loc('ExecutingSqlScript', deployFilePath));
-                // Inject service connection credentials as env vars so go-sqlcmd's
-                // DefaultAzureCredential chain uses the service connection identity.
-                // Only inject what's available — DefaultAzureCredential skips a provider
-                // if its required fields are missing, so no leakage across scheme types:
-                //   SP:  tenantID + clientID + clientSecret → EnvironmentCredential fires
-                //   WIF: tenantID + clientID only           → WorkloadIdentityCredential fires
-                //   MSI: tenantID only                     → ManagedIdentityCredential fires
-                let sqlcmdEnvOverrides: { [key: string]: string } | undefined;
-                if (azureSubscription && azureEndpoint?.tenantID) {
-                    const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
-                    const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated', 'activedirectorymanagedidentity'];
 
-                    if (tokenBasedAuthTypes.includes(authType)) {
-                        sqlcmdEnvOverrides = { AZURE_TENANT_ID: azureEndpoint.tenantID };
-                        if (azureEndpoint.servicePrincipalClientID) {
-                            sqlcmdEnvOverrides.AZURE_CLIENT_ID = azureEndpoint.servicePrincipalClientID;
-                        }
-                        if (azureEndpoint.servicePrincipalKey) {
-                            tl.setSecret(azureEndpoint.servicePrincipalKey);
-                            sqlcmdEnvOverrides.AZURE_CLIENT_SECRET = azureEndpoint.servicePrincipalKey;
-                        }
-                    }
-                }
                 await SqlcmdExecutor.executeSqlcmd(
                     sqlcmdExePath,
                     deployFilePath,
                     connectionConfig,
                     additionalArguments || undefined,
-                    sqlcmdEnvOverrides
+                    sqlcmdCredentials
                 );
             }
 
@@ -263,6 +247,87 @@ async function main(): Promise<void> {
         tl.debug(`Deployment failed with error: ${error}`);
         tl.setResult(tl.TaskResult.Failed, tl.loc('DeploymentFailed', error.message || error));
     }
+}
+
+/**
+ * Derive the credentials that make go-sqlcmd authenticate as the Azure service connection
+ * rather than the agent's ambient identity.
+ *
+ * Each service connection scheme is backed by a different azidentity credential, so the
+ * mechanism differs:
+ *
+ *   ServicePrincipal           → EnvironmentCredential, via AZURE_TENANT_ID + AZURE_CLIENT_ID + AZURE_CLIENT_SECRET.
+ *   WorkloadIdentityFederation → AzurePipelinesCredential, via the ActiveDirectoryAzurePipelines method.
+ *                                DefaultAzureCredential cannot be used: EnvironmentCredential needs a client
+ *                                secret and WorkloadIdentityCredential needs AZURE_FEDERATED_TOKEN_FILE, so the
+ *                                chain would silently fall through to the agent's identity.
+ *   ManagedServiceIdentity     → nothing to inject; the service connection *is* the agent's managed identity,
+ *                                which DefaultAzureCredential already resolves.
+ *
+ * Reads endpoint fields only — it acquires no tokens, so it is safe to call before ARM operations.
+ */
+function resolveSqlcmdCredentials(
+    connectionConfig: SqlConnectionConfig,
+    azureSubscription: string,
+    azureEndpoint: any
+): SqlcmdCredentials | undefined {
+    if (!azureEndpoint?.tenantID) {
+        return undefined;
+    }
+
+    const sqlAuthType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+    const scheme = (azureEndpoint.scheme ?? '').toLowerCase();
+
+    // Auth types where the connection string carries no credentials, so the identity
+    // must come from the service connection.
+    const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated', 'activedirectorymanagedidentity'];
+
+    if (tokenBasedAuthTypes.includes(sqlAuthType)) {
+        if (scheme === 'workloadidentityfederation') {
+            // AzurePipelinesCredential exchanges the pipeline's OIDC token for a service
+            // connection token, so it needs the job's own access token.
+            const systemAccessToken = tl.getEndpointAuthorizationParameter('SYSTEMVSSCONNECTION', 'ACCESSTOKEN', false);
+            if (!azureEndpoint.servicePrincipalClientID || !systemAccessToken) {
+                tl.warning(tl.loc('WifSqlcmdFallbackToAgentIdentity'));
+                return undefined;
+            }
+            tl.setSecret(systemAccessToken);
+            return {
+                tenantId: azureEndpoint.tenantID,
+                authMethodOverride: 'ActiveDirectoryAzurePipelines',
+                envOverrides: {
+                    AZURESUBSCRIPTION_SERVICE_CONNECTION_ID: azureSubscription,
+                    AZURESUBSCRIPTION_CLIENT_ID: azureEndpoint.servicePrincipalClientID,
+                    AZURESUBSCRIPTION_TENANT_ID: azureEndpoint.tenantID,
+                    SYSTEM_ACCESSTOKEN: systemAccessToken
+                }
+            };
+        }
+
+        if (scheme === 'serviceprincipal' && azureEndpoint.servicePrincipalClientID && azureEndpoint.servicePrincipalKey) {
+            tl.setSecret(azureEndpoint.servicePrincipalKey);
+            return {
+                tenantId: azureEndpoint.tenantID,
+                envOverrides: {
+                    AZURE_TENANT_ID: azureEndpoint.tenantID,
+                    AZURE_CLIENT_ID: azureEndpoint.servicePrincipalClientID,
+                    AZURE_CLIENT_SECRET: azureEndpoint.servicePrincipalKey
+                }
+            };
+        }
+
+        // ManagedServiceIdentity, or an incomplete endpoint: DefaultAzureCredential resolves
+        // the agent's managed identity, which is the service connection identity.
+        return undefined;
+    }
+
+    if (sqlAuthType === 'activedirectoryserviceprincipal') {
+        // Credentials come from the connection string, but go-mssqldb still needs a tenant.
+        // Supply the service connection's so the clientId@tenantId user name can be built.
+        return { tenantId: azureEndpoint.tenantID };
+    }
+
+    return undefined;
 }
 
 main();

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -195,26 +195,39 @@ async function main(): Promise<void> {
                     // Should not reach here — SqlcmdHelper.findSqlcmd throws if not found
                     throw new Error(tl.loc('SqlcmdAutoInstallFailed', 'sqlcmd path is undefined'));
                 }
+
+                // For SP auth, go-mssqldb needs the tenant ID either in the User ID field
+                // (as clientId@tenantId) or via AZURE_TENANT_ID env var (injected when
+                // azureSubscription is set). Without either, auth will fail with a cryptic error.
+                const sqlAuthType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+                if (sqlAuthType === 'activedirectoryserviceprincipal'
+                    && !azureSubscription
+                    && connectionConfig.UserId && !connectionConfig.UserId.includes('@')) {
+                    throw new Error(tl.loc('SpAuthRequiresTenantId'));
+                }
+
                 tl.debug(tl.loc('ExecutingSqlScript', deployFilePath));
-                // For token-based auth types, inject service connection credentials as env vars
-                // so go-sqlcmd's DefaultAzureCredential chain picks up the service connection identity.
-                // This ensures sqlcmd authenticates as the same identity as SqlPackage.
+                // Inject service connection credentials as env vars so go-sqlcmd's
+                // DefaultAzureCredential chain uses the service connection identity.
+                // Only inject what's available — DefaultAzureCredential skips a provider
+                // if its required fields are missing, so no leakage across scheme types:
+                //   SP:  tenantID + clientID + clientSecret → EnvironmentCredential fires
+                //   WIF: tenantID + clientID only           → WorkloadIdentityCredential fires
+                //   MSI: tenantID only                     → ManagedIdentityCredential fires
                 let sqlcmdEnvOverrides: { [key: string]: string } | undefined;
                 if (azureSubscription && azureEndpoint?.tenantID) {
                     const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
                     const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated', 'activedirectorymanagedidentity'];
 
-                    // Always inject tenant ID so go-sqlcmd can resolve the tenant.
-                    sqlcmdEnvOverrides = { AZURE_TENANT_ID: azureEndpoint.tenantID };
-
-                    // For token-based auth (no creds in connection string), also inject SP client
-                    // credentials from the service connection so DefaultAzureCredential picks up
-                    // the intended identity rather than the agent's ambient identity.
-                    if (tokenBasedAuthTypes.includes(authType) && azureEndpoint.scheme === 'ServicePrincipal'
-                        && azureEndpoint.servicePrincipalClientID && azureEndpoint.servicePrincipalKey) {
-                        tl.setSecret(azureEndpoint.servicePrincipalKey);
-                        sqlcmdEnvOverrides.AZURE_CLIENT_ID = azureEndpoint.servicePrincipalClientID;
-                        sqlcmdEnvOverrides.AZURE_CLIENT_SECRET = azureEndpoint.servicePrincipalKey;
+                    if (tokenBasedAuthTypes.includes(authType)) {
+                        sqlcmdEnvOverrides = { AZURE_TENANT_ID: azureEndpoint.tenantID };
+                        if (azureEndpoint.servicePrincipalClientID) {
+                            sqlcmdEnvOverrides.AZURE_CLIENT_ID = azureEndpoint.servicePrincipalClientID;
+                        }
+                        if (azureEndpoint.servicePrincipalKey) {
+                            tl.setSecret(azureEndpoint.servicePrincipalKey);
+                            sqlcmdEnvOverrides.AZURE_CLIENT_SECRET = azureEndpoint.servicePrincipalKey;
+                        }
                     }
                 }
                 await SqlcmdExecutor.executeSqlcmd(

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -8,6 +8,7 @@ import FirewallManager from './src/FirewallManager';
 import AzureSqlResourceManager from './src/AzureSqlResourceManager';
 import SqlProjectBuilder from './src/SqlProjectBuilder';
 import { SqlPackageExecutor } from './src/SqlPackageExecutor';
+import { SqlcmdExecutor } from './src/SqlcmdExecutor';
 
 // Node version handling for DNS and network settings
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
@@ -185,9 +186,43 @@ async function main(): Promise<void> {
                     tl.debug(tl.loc('OutputFileGenerated', outputFilePath));
                     tl.setVariable('SqlDeploymentOutputFile', outputFilePath);
                 }
+            } else if (deployFileType === 'SQL') {
+                if (action.toLowerCase() !== 'sqlscript') {
+                    throw new Error(tl.loc('InvalidAction', action));
+                }
+                if (!sqlcmdExePath) {
+                    // Should not reach here — SqlcmdHelper.findSqlcmd throws if not found
+                    throw new Error(tl.loc('SqlcmdAutoInstallFailed', 'sqlcmd path is undefined'));
+                }
+                tl.debug(tl.loc('ExecutingSqlScript', deployFilePath));
+                // Only use access token for token-based auth (AAD Default/Integrated)
+                const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated'];
+                const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+                const sqlcmdToken = tokenBasedAuthTypes.includes(authType) ? accessToken : undefined;
+                await SqlcmdExecutor.executeSqlcmd(
+                    sqlcmdExePath,
+                    deployFilePath,
+                    connectionConfig,
+                    additionalArguments || undefined,
+                    sqlcmdToken
+                );
             }
 
             console.log(tl.loc('DeploymentSuccessful'));
+
+            // Emit telemetry — actionable fields only, no PII
+            try {
+                const telemetry = {
+                    action: action,
+                    fileType: fileType,
+                    authMethod: connectionConfig.FormattedAuthentication ?? 'sqlauthentication',
+                    hasAzureSubscription: !!azureSubscription,
+                    sqlPackageDiscoveryMethod: needsSqlPackage ? (sqlpackagePath ? 'userSpecified' : 'discovered') : undefined,
+                    sqlcmdDiscoveryMethod: needsSqlcmd ? (sqlcmdPath ? 'userSpecified' : 'discovered') : undefined
+                };
+                console.log('##vso[telemetry.publish area=TaskEndpointId;feature=MicrosoftSqlDeploymentV1]'
+                    + JSON.stringify(telemetry));
+            } catch (_) { /* telemetry is non-fatal */ }
         } finally {
             if (firewallManager) {
                 await firewallManager.removeFirewallRule();

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -195,16 +195,11 @@ async function main(): Promise<void> {
                     throw new Error(tl.loc('SqlcmdAutoInstallFailed', 'sqlcmd path is undefined'));
                 }
                 tl.debug(tl.loc('ExecutingSqlScript', deployFilePath));
-                // Only use access token for token-based auth (AAD Default/Integrated)
-                const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated'];
-                const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
-                const sqlcmdToken = tokenBasedAuthTypes.includes(authType) ? accessToken : undefined;
                 await SqlcmdExecutor.executeSqlcmd(
                     sqlcmdExePath,
                     deployFilePath,
                     connectionConfig,
-                    additionalArguments || undefined,
-                    sqlcmdToken
+                    additionalArguments || undefined
                 );
             }
 

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -223,7 +223,7 @@ async function main(): Promise<void> {
                     sqlPackageDiscoveryMethod: needsSqlPackage ? (sqlpackagePath ? 'userSpecified' : 'discovered') : undefined,
                     sqlcmdDiscoveryMethod: needsSqlcmd ? (sqlcmdPath ? 'userSpecified' : 'discovered') : undefined
                 };
-                console.log('##vso[telemetry.publish area=TaskEndpointId;feature=MicrosoftSqlDeploymentV1]'
+                console.log('##vso[telemetry.publish area=TaskHub;feature=MicrosoftSqlDeploymentV1]'
                     + JSON.stringify(telemetry));
             } catch (_) { /* telemetry is non-fatal */ }
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlConnectionConfig.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlConnectionConfig.ts
@@ -220,13 +220,15 @@ export default class SqlConnectionConfig {
                 break;
             }
             case 'activedirectoryintegrated':
-            case 'activedirectorydefault': {
-                // These authentication types don't require user ID or password
+            case 'activedirectorydefault':
+            case 'activedirectorymanagedidentity': {
+                // These authentication types don't require user ID or password.
+                // For activedirectorymanagedidentity, UserId is optional (user-assigned MI client ID).
                 break;
             }
             default: {
-                // Unknown Authentication= value (not in the 5 supported types above).
-                // Supported methods: SQL auth (no keyword), Active Directory Default/Password/ServicePrincipal/Integrated.
+                // Unknown Authentication= value (not in the supported types).
+                // Supported: SQL auth (no keyword), Active Directory Default/Password/ServicePrincipal/Integrated/ManagedIdentity.
                 throw new Error(tl.loc('UnsupportedAuthentication', this.FormattedAuthentication));
             }
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlUtils.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlUtils.ts
@@ -1,6 +1,7 @@
 import tl = require('azure-pipelines-task-lib/task');
 import SqlConnectionConfig from './SqlConnectionConfig';
 import Constants from './Constants';
+import { SqlcmdExecutor, SqlcmdCredentials } from './SqlcmdExecutor';
 import { Writable } from 'stream';
 
 export interface ConnectionResult {
@@ -18,13 +19,19 @@ export default class SqlUtils {
      * First tries with master database, and then with user database if first one fails.
      * @param connectionConfig The connection configuration to try
      * @param sqlcmdPath Path to sqlcmd executable
+     * @param credentials Service connection identity, so the probe authenticates as the same
+     *                    identity the deployment will use rather than the agent's ambient one
      * @returns The client IP address if firewall restriction is present, or an empty string if connection succeeds
      */
-    public static async detectIPAddress(connectionConfig: SqlConnectionConfig, sqlcmdPath: string): Promise<string> {
+    public static async detectIPAddress(
+        connectionConfig: SqlConnectionConfig,
+        sqlcmdPath: string,
+        credentials?: SqlcmdCredentials
+    ): Promise<string> {
         tl.debug(tl.loc('DetectingIPAddress'));
 
         // First try connection to master
-        let result = await this.tryConnection(connectionConfig, sqlcmdPath, true);
+        let result = await this.tryConnection(connectionConfig, sqlcmdPath, true, credentials);
         if (result.success) {
             tl.debug(tl.loc('ConnectionSuccessful'));
             return '';
@@ -34,7 +41,7 @@ export default class SqlUtils {
         }
 
         // Retry connection with user database
-        result = await this.tryConnection(connectionConfig, sqlcmdPath, false);
+        result = await this.tryConnection(connectionConfig, sqlcmdPath, false, credentials);
         if (result.success) {
             tl.debug(tl.loc('ConnectionSuccessful'));
             return '';
@@ -52,12 +59,14 @@ export default class SqlUtils {
      * @param config Configuration for the connection
      * @param sqlcmdPath Path to sqlcmd executable
      * @param useMaster If true, uses "master" instead of the database specified in config
+     * @param credentials Service connection identity to authenticate the probe with
      * @returns A ConnectionResult object indicating success/failure
      */
     private static async tryConnection(
         config: SqlConnectionConfig,
         sqlcmdPath: string,
-        useMaster?: boolean
+        useMaster?: boolean,
+        credentials?: SqlcmdCredentials
     ): Promise<ConnectionResult> {
         const database = useMaster ? 'master' : config.Database;
         
@@ -67,14 +76,20 @@ export default class SqlUtils {
         let sqlcmdOutput = '';
 
         try {
-            // Build sqlcmd command with connection info
-            const sqlcmdArgs = this.buildSqlCmdArgs(config, database);
-            
+            // Reuse the deployment's argument builder so the probe and the deployment can
+            // never authenticate as different identities. 15s login timeout is enough for a
+            // connectivity probe without blocking the pipeline.
+            const sqlcmdArgs = SqlcmdExecutor.buildConnectionArguments(config, credentials, 15, database);
+
             // Add query to execute
             sqlcmdArgs.push('-Q', `SELECT 'Validating connection from Azure Pipelines SQL Deployment Task'`);
 
+            // Secrets go through a scoped env map — process.env is never mutated.
+            const sqlcmdEnv = SqlcmdExecutor.buildEnvironment(config, credentials);
+
             // Execute sqlcmd
             const result = await tl.exec(sqlcmdPath, sqlcmdArgs, {
+                env: sqlcmdEnv,
                 silent: true,
                 ignoreReturnCode: true,
                 outStream: new Writable({
@@ -126,69 +141,6 @@ export default class SqlUtils {
             return ipAddresses[0];
         }
         return undefined;
-    }
-
-    /**
-     * Builds sqlcmd arguments with connection settings
-     * @param connectionConfig The connection settings
-     * @param database The database to connect to
-     * @returns Array of sqlcmd arguments
-     */
-    private static buildSqlCmdArgs(connectionConfig: SqlConnectionConfig, database?: string): string[] {
-        const args: string[] = [];
-
-        // Server and port — sqlcmd expects "server,port" when a non-default port is used
-        const serverArg = connectionConfig.Port
-            ? `${connectionConfig.Server},${connectionConfig.Port}`
-            : connectionConfig.Server;
-        args.push('-S', serverArg);
-        args.push('-d', database || connectionConfig.Database);
-
-        // Authentication
-        const auth = connectionConfig.FormattedAuthentication;
-        
-        if (!auth || auth === 'sqlauthentication' || auth === 'sqlpassword') {
-            // SQL Authentication — pass User ID via -U; password via SQLCMDPASSWORD env var (not -P) to avoid
-            // exposing the secret in the process argument list
-            if (connectionConfig.UserId) {
-                args.push('-U', connectionConfig.UserId);
-            }
-            if (connectionConfig.Password) {
-                // Set directly on process.env — scoped to this process only, not persisted as a job variable
-                process.env[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
-            }
-        } else if (auth === 'activedirectorydefault') {
-            // AAD Default (Managed Identity)
-            args.push('-G');
-        } else if (auth === 'activedirectoryserviceprincipal') {
-            // AAD Service Principal — client secret via SQLCMDPASSWORD, client ID via -U
-            args.push('-G');
-            if (connectionConfig.UserId) {
-                args.push('-U', connectionConfig.UserId);
-            }
-            if (connectionConfig.Password) {
-                // Set directly on process.env — scoped to this process only, not persisted as a job variable
-                process.env[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
-            }
-        } else if (auth === 'activedirectorypassword') {
-            // AAD Password — password via SQLCMDPASSWORD, user via -U
-            args.push('-G');
-            if (connectionConfig.UserId) {
-                args.push('-U', connectionConfig.UserId);
-            }
-            if (connectionConfig.Password) {
-                // Set directly on process.env — scoped to this process only, not persisted as a job variable
-                process.env[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
-            }
-        } else if (auth === 'activedirectoryintegrated') {
-            // AAD Integrated
-            args.push('-G');
-        }
-
-        // -l sets the login timeout in seconds; 15s is enough for a connectivity probe without blocking the pipeline
-        args.push('-l', '15');
-
-        return args;
     }
 }
 

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -11,13 +11,14 @@ export class SqlcmdExecutor {
         sqlcmdPath: string,
         scriptPath: string,
         connectionConfig: SqlConnectionConfig,
-        additionalArguments?: string
+        additionalArguments?: string,
+        envOverrides?: { [key: string]: string }
     ): Promise<void> {
-        const args = this.buildArguments(scriptPath, connectionConfig, additionalArguments);
+        const args = this.buildArguments(scriptPath, connectionConfig, additionalArguments, envOverrides?.['AZURE_TENANT_ID']);
 
         // Pass credentials via environment variables only — never on the command line.
         // Scoped to this exec call only (not set on process.env globally).
-        const envVars: { [key: string]: string } = Object.assign({}, process.env);
+        const envVars: { [key: string]: string } = Object.assign({}, process.env, envOverrides);
 
         if (connectionConfig.Password) {
             // Pass password via SQLCMDPASSWORD env var — never on the command line.
@@ -45,7 +46,8 @@ export class SqlcmdExecutor {
     private static buildArguments(
         scriptPath: string,
         connectionConfig: SqlConnectionConfig,
-        additionalArguments?: string
+        additionalArguments?: string,
+        tenantId?: string
     ): string[] {
         const args: string[] = [];
 
@@ -93,9 +95,16 @@ export class SqlcmdExecutor {
                 break;
 
             case 'activedirectoryserviceprincipal':
-                // UserId = ClientId; ClientSecret supplied via SQLCMDPASSWORD env var
+                // UserId = ClientId; ClientSecret via SQLCMDPASSWORD env var.
+                // go-mssqldb reads the tenant from clientId@tenantId in the User ID field.
+                // When azureSubscription is set, AZURE_TENANT_ID is injected and appended here
                 addAuthenticationMethod('ActiveDirectoryServicePrincipal');
-                addUser();
+                if (connectionConfig.UserId && tenantId && !connectionConfig.UserId.includes('@')) {
+                    args.push('-U');
+                    args.push(`${connectionConfig.UserId}@${tenantId}`);
+                } else {
+                    addUser();
+                }
                 break;
 
             case 'activedirectorymanagedidentity':

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -1,0 +1,135 @@
+import tl = require('azure-pipelines-task-lib/task');
+import SqlConnectionConfig from './SqlConnectionConfig';
+import Constants from './Constants';
+
+export class SqlcmdExecutor {
+    /**
+     * Execute a .sql script file using sqlcmd.
+     * Password and access token are passed via environment variables — never on the command line.
+     */
+    public static async executeSqlcmd(
+        sqlcmdPath: string,
+        scriptPath: string,
+        connectionConfig: SqlConnectionConfig,
+        additionalArguments?: string,
+        accessToken?: string
+    ): Promise<void> {
+        const args = this.buildArguments(scriptPath, connectionConfig, additionalArguments);
+
+        // Pass credentials via environment variables only — never on the command line.
+        // Scoped to this exec call only (not set on process.env globally).
+        const envVars: { [key: string]: string } = Object.assign({}, process.env);
+
+        if (accessToken) {
+            // AAD token-based auth: use SQLCMDACCESSTOKEN, do not set password
+            envVars['SQLCMDACCESSTOKEN'] = accessToken;
+        } else if (connectionConfig.Password) {
+            // SQL / AAD password auth: pass password via SQLCMDPASSWORD env var
+            envVars[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
+        }
+
+        tl.debug(`Executing sqlcmd: ${sqlcmdPath}`);
+
+        const result = await tl.exec(sqlcmdPath, args, {
+            env: envVars,
+            failOnStdErr: false,
+            ignoreReturnCode: true
+        });
+
+        if (result !== 0) {
+            throw new Error(tl.loc('SqlcmdExecutionFailed', result));
+        }
+    }
+
+    /**
+     * Build sqlcmd command line arguments.
+     * Per spec: UTF-8 encoding is preserved by default with go-sqlcmd.
+     */
+    private static buildArguments(
+        scriptPath: string,
+        connectionConfig: SqlConnectionConfig,
+        additionalArguments?: string
+    ): string[] {
+        const args: string[] = [];
+
+        // Server (with port if specified)
+        args.push('-S');
+        args.push(connectionConfig.Port
+            ? `${connectionConfig.Server},${connectionConfig.Port}`
+            : connectionConfig.Server);
+
+        // Database
+        if (connectionConfig.Database) {
+            args.push('-d');
+            args.push(connectionConfig.Database);
+        }
+
+        // Authentication
+        const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+        if (authType.includes('activedirectory') || authType === '') {
+            if (connectionConfig.UserId) {
+                args.push('-U');
+                args.push(connectionConfig.UserId);
+                // Password passed via SQLCMDPASSWORD env var
+            } else {
+                // AAD Default / Integrated — no credentials needed
+                args.push('-G');
+            }
+        } else {
+            // SQL auth
+            args.push('-U');
+            args.push(connectionConfig.UserId!);
+            // Password passed via SQLCMDPASSWORD env var
+        }
+
+        // Login timeout (30s)
+        args.push('-l');
+        args.push('30');
+
+        // Input file
+        args.push('-i');
+        args.push(scriptPath);
+
+        // Additional arguments
+        if (additionalArguments) {
+            args.push(...this.parseAdditionalArguments(additionalArguments));
+        }
+
+        return args;
+    }
+
+    /**
+     * Parse additional arguments respecting quoted values.
+     */
+    private static parseAdditionalArguments(additionalArguments: string): string[] {
+        const args: string[] = [];
+        let current = '';
+        let inQuotes = false;
+        let quoteChar = '';
+
+        for (const char of additionalArguments) {
+            if ((char === '"' || char === "'") && !inQuotes) {
+                inQuotes = true;
+                quoteChar = char;
+                current += char;
+            } else if (char === quoteChar && inQuotes) {
+                inQuotes = false;
+                quoteChar = '';
+                current += char;
+            } else if (char === ' ' && !inQuotes) {
+                if (current.trim()) {
+                    args.push(current.trim());
+                    current = '';
+                }
+            } else {
+                current += char;
+            }
+        }
+
+        if (current.trim()) {
+            args.push(current.trim());
+        }
+
+        return args;
+    }
+}

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -66,20 +66,18 @@ export class SqlcmdExecutor {
 
         // Authentication
         const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
-        if (authType.includes('activedirectory') || authType === '') {
-            if (connectionConfig.UserId) {
-                args.push('-U');
-                args.push(connectionConfig.UserId);
-                // Password passed via SQLCMDPASSWORD env var
-            } else {
-                // AAD Default / Integrated — no credentials needed
-                args.push('-G');
-            }
-        } else {
-            // SQL auth
+        if (authType === 'activedirectorydefault' || authType === 'activedirectoryintegrated') {
+            // AAD Default / Integrated — no credentials, use -G for Entra ID
+            args.push('-G');
+        } else if (authType === 'activedirectorypassword' || authType === 'activedirectoryserviceprincipal') {
+            // AAD Password / Service Principal — UserId required, password via SQLCMDPASSWORD, -G for Entra ID
+            args.push('-G');
             args.push('-U');
             args.push(connectionConfig.UserId!);
-            // Password passed via SQLCMDPASSWORD env var
+        } else {
+            // SQL auth (no auth keyword) or AAD SQL Authentication — UserId required, password via SQLCMDPASSWORD
+            args.push('-U');
+            args.push(connectionConfig.UserId!);
         }
 
         // Login timeout (30s)

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -11,8 +11,7 @@ export class SqlcmdExecutor {
         sqlcmdPath: string,
         scriptPath: string,
         connectionConfig: SqlConnectionConfig,
-        additionalArguments?: string,
-        accessToken?: string
+        additionalArguments?: string
     ): Promise<void> {
         const args = this.buildArguments(scriptPath, connectionConfig, additionalArguments);
 
@@ -20,11 +19,9 @@ export class SqlcmdExecutor {
         // Scoped to this exec call only (not set on process.env globally).
         const envVars: { [key: string]: string } = Object.assign({}, process.env);
 
-        if (accessToken) {
-            // AAD token-based auth: use SQLCMDACCESSTOKEN, do not set password
-            envVars['SQLCMDACCESSTOKEN'] = accessToken;
-        } else if (connectionConfig.Password) {
-            // SQL / AAD password auth: pass password via SQLCMDPASSWORD env var
+        if (connectionConfig.Password) {
+            // Pass password via SQLCMDPASSWORD env var — never on the command line.
+            // go-sqlcmd reads SQLCMDPASSWORD automatically for SQL auth and AAD password/SP auth.
             envVars[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
         }
 
@@ -54,9 +51,11 @@ export class SqlcmdExecutor {
 
         // Server (with port if specified)
         args.push('-S');
-        args.push(connectionConfig.Port
-            ? `${connectionConfig.Server},${connectionConfig.Port}`
-            : connectionConfig.Server);
+        args.push(
+            connectionConfig.Port
+                ? `${connectionConfig.Server},${connectionConfig.Port}`
+                : connectionConfig.Server
+        );
 
         // Database
         if (connectionConfig.Database) {
@@ -64,20 +63,51 @@ export class SqlcmdExecutor {
             args.push(connectionConfig.Database);
         }
 
-        // Authentication
         const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
-        if (authType === 'activedirectorydefault' || authType === 'activedirectoryintegrated') {
-            // AAD Default / Integrated — no credentials, use -G for Entra ID
-            args.push('-G');
-        } else if (authType === 'activedirectorypassword' || authType === 'activedirectoryserviceprincipal') {
-            // AAD Password / Service Principal — UserId required, password via SQLCMDPASSWORD, -G for Entra ID
-            args.push('-G');
-            args.push('-U');
-            args.push(connectionConfig.UserId!);
-        } else {
-            // SQL auth (no auth keyword) or AAD SQL Authentication — UserId required, password via SQLCMDPASSWORD
-            args.push('-U');
-            args.push(connectionConfig.UserId!);
+
+        const addAuthenticationMethod = (method: string): void => {
+            args.push('--authentication-method');
+            args.push(method);
+        };
+
+        const addUser = (): void => {
+            if (connectionConfig.UserId) {
+                args.push('-U');
+                args.push(connectionConfig.UserId);
+            }
+        };
+
+        switch (authType) {
+            case 'activedirectorydefault':
+                addAuthenticationMethod('ActiveDirectoryDefault');
+                break;
+
+            case 'activedirectoryintegrated':
+                addAuthenticationMethod('ActiveDirectoryIntegrated');
+                break;
+
+            case 'activedirectorypassword':
+                // UserId required; password supplied via SQLCMDPASSWORD env var
+                addAuthenticationMethod('ActiveDirectoryPassword');
+                addUser();
+                break;
+
+            case 'activedirectoryserviceprincipal':
+                // UserId = ClientId; ClientSecret supplied via SQLCMDPASSWORD env var
+                addAuthenticationMethod('ActiveDirectoryServicePrincipal');
+                addUser();
+                break;
+
+            case 'activedirectorymanagedidentity':
+                // Optional UserId for user-assigned managed identity
+                addAuthenticationMethod('ActiveDirectoryManagedIdentity');
+                addUser();
+                break;
+
+            default:
+                // SQL Authentication — UserId required, password via SQLCMDPASSWORD
+                addUser();
+                break;
         }
 
         // Login timeout (30s)

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -2,6 +2,20 @@ import tl = require('azure-pipelines-task-lib/task');
 import SqlConnectionConfig from './SqlConnectionConfig';
 import Constants from './Constants';
 
+/**
+ * Identity material derived from the Azure service connection, used to make go-sqlcmd
+ * authenticate as the service connection rather than the agent's ambient identity.
+ * Empty when no azureSubscription is configured.
+ */
+export interface SqlcmdCredentials {
+    /** Service connection tenant ID; used to build clientId@tenantId for AAD SP auth. */
+    tenantId?: string;
+    /** Replaces the --authentication-method value (ActiveDirectoryAzurePipelines for WIF). */
+    authMethodOverride?: string;
+    /** Environment variables that carry the service connection identity to azidentity. */
+    envOverrides?: { [key: string]: string };
+}
+
 export class SqlcmdExecutor {
     /**
      * Execute a .sql script file using sqlcmd.
@@ -12,19 +26,19 @@ export class SqlcmdExecutor {
         scriptPath: string,
         connectionConfig: SqlConnectionConfig,
         additionalArguments?: string,
-        envOverrides?: { [key: string]: string }
+        credentials?: SqlcmdCredentials
     ): Promise<void> {
-        const args = this.buildArguments(scriptPath, connectionConfig, additionalArguments, envOverrides?.['AZURE_TENANT_ID']);
+        const args = this.buildConnectionArguments(connectionConfig, credentials, 30);
 
-        // Pass credentials via environment variables only — never on the command line.
-        // Scoped to this exec call only (not set on process.env globally).
-        const envVars: { [key: string]: string } = Object.assign({}, process.env, envOverrides);
+        // Input file
+        args.push('-i');
+        args.push(scriptPath);
 
-        if (connectionConfig.Password) {
-            // Pass password via SQLCMDPASSWORD env var — never on the command line.
-            // go-sqlcmd reads SQLCMDPASSWORD automatically for SQL auth and AAD password/SP auth.
-            envVars[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
+        if (additionalArguments) {
+            args.push(...this.parseAdditionalArguments(additionalArguments));
         }
+
+        const envVars = this.buildEnvironment(connectionConfig, credentials);
 
         tl.debug(`Executing sqlcmd: ${sqlcmdPath}`);
 
@@ -40,15 +54,43 @@ export class SqlcmdExecutor {
     }
 
     /**
-     * Build sqlcmd command line arguments.
-     * Per spec: UTF-8 encoding is preserved by default with go-sqlcmd.
+     * Build the environment for a sqlcmd invocation. Secrets are passed here rather than
+     * on the command line, and the map is scoped to a single exec — process.env is never mutated.
      */
-    private static buildArguments(
-        scriptPath: string,
+    public static buildEnvironment(
         connectionConfig: SqlConnectionConfig,
-        additionalArguments?: string,
-        tenantId?: string
+        credentials?: SqlcmdCredentials
+    ): { [key: string]: string } {
+        const envVars: { [key: string]: string } = Object.assign({}, process.env, credentials?.envOverrides);
+
+        if (connectionConfig.Password) {
+            // go-sqlcmd reads SQLCMDPASSWORD automatically for SQL auth and AAD password/SP auth.
+            envVars[Constants.sqlcmdPasswordEnvVarName] = connectionConfig.Password;
+        }
+
+        return envVars;
+    }
+
+    /**
+     * Build the server/database/authentication portion of a sqlcmd command line.
+     *
+     * This is the single source of truth for how a connection string maps to go-sqlcmd
+     * authentication flags. Both script execution and the firewall connectivity probe use
+     * it so the two can never authenticate as different identities.
+     *
+     * Per spec: UTF-8 encoding is preserved by default with go-sqlcmd (no codepage flag needed).
+     *
+     * @param database Overrides the database from the connection string (the probe uses master).
+     * @param loginTimeoutSeconds Value for -l.
+     */
+    public static buildConnectionArguments(
+        connectionConfig: SqlConnectionConfig,
+        credentials?: SqlcmdCredentials,
+        loginTimeoutSeconds: number = 30,
+        database?: string
     ): string[] {
+        const tenantId = credentials?.tenantId;
+        const authMethodOverride = credentials?.authMethodOverride;
         const args: string[] = [];
 
         // Server (with port if specified)
@@ -60,9 +102,10 @@ export class SqlcmdExecutor {
         );
 
         // Database
-        if (connectionConfig.Database) {
+        const targetDatabase = database || connectionConfig.Database;
+        if (targetDatabase) {
             args.push('-d');
-            args.push(connectionConfig.Database);
+            args.push(targetDatabase);
         }
 
         const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
@@ -81,11 +124,15 @@ export class SqlcmdExecutor {
 
         switch (authType) {
             case 'activedirectorydefault':
-                addAuthenticationMethod('ActiveDirectoryDefault');
+                // A Workload Identity Federation service connection cannot authenticate
+                // through the DefaultAzureCredential chain, so the caller substitutes
+                // ActiveDirectoryAzurePipelines. That credential takes its client/tenant/
+                // connection id from AZURESUBSCRIPTION_* env vars, so no -U is passed.
+                addAuthenticationMethod(authMethodOverride ?? 'ActiveDirectoryDefault');
                 break;
 
             case 'activedirectoryintegrated':
-                addAuthenticationMethod('ActiveDirectoryIntegrated');
+                addAuthenticationMethod(authMethodOverride ?? 'ActiveDirectoryIntegrated');
                 break;
 
             case 'activedirectorypassword':
@@ -109,8 +156,10 @@ export class SqlcmdExecutor {
 
             case 'activedirectorymanagedidentity':
                 // Optional UserId for user-assigned managed identity
-                addAuthenticationMethod('ActiveDirectoryManagedIdentity');
-                addUser();
+                addAuthenticationMethod(authMethodOverride ?? 'ActiveDirectoryManagedIdentity');
+                if (!authMethodOverride) {
+                    addUser();
+                }
                 break;
 
             default:
@@ -119,18 +168,9 @@ export class SqlcmdExecutor {
                 break;
         }
 
-        // Login timeout (30s)
+        // Login timeout
         args.push('-l');
-        args.push('30');
-
-        // Input file
-        args.push('-i');
-        args.push(scriptPath);
-
-        // Additional arguments
-        if (additionalArguments) {
-            args.push(...this.parseAdditionalArguments(additionalArguments));
-        }
+        args.push(String(loginTimeoutSeconds));
 
         return args;
     }

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdHelper.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdHelper.ts
@@ -3,7 +3,14 @@ import * as tool from 'azure-pipelines-tool-lib/tool';
 import * as path from 'path';
 import * as fs from 'fs';
 
-const SQLCMD_VERSION = '1.6.0';
+const SQLCMD_VERSION = '1.10.0';
+
+// Minimum go-sqlcmd version that supports the ActiveDirectoryAzurePipelines
+// authentication method, which is how Workload Identity Federation service
+// connections authenticate. Older binaries found on PATH are rejected so the
+// task never silently falls back to the agent's ambient identity.
+const MIN_SQLCMD_MAJOR = 1;
+const MIN_SQLCMD_MINOR = 9;
 
 export default class SqlcmdHelper {
     /**
@@ -15,8 +22,8 @@ export default class SqlcmdHelper {
      *
      * Discovery order:
      * 1. User-provided sqlcmdPath input (accepted as-is, user's responsibility)
-     * 2. PATH — verified to be go-sqlcmd via --version; falls through to auto-install if ODBC
-     * 3. Auto-install go-sqlcmd 1.6.0 from GitHub releases
+     * 2. PATH — must be go-sqlcmd AND >= 1.9.0; otherwise falls through to auto-install
+     * 3. Auto-install go-sqlcmd from GitHub releases
      */
     public static async findSqlcmd(sqlcmdPathInput?: string): Promise<string> {
         tl.debug('Starting sqlcmd discovery...');
@@ -31,14 +38,18 @@ export default class SqlcmdHelper {
             throw new Error(tl.loc('SqlcmdNotFoundAtPath', sqlcmdPathInput));
         }
 
-        // 2. PATH — only use if the binary is go-sqlcmd, not ODBC sqlcmd (mssql-tools)
+        // 2. PATH — only use if the binary is go-sqlcmd (not ODBC sqlcmd) and new
+        //    enough to support every authentication method the task may request.
         const sqlcmdInPath = tl.which('sqlcmd', false);
-        if (sqlcmdInPath && await this.isGoSqlcmd(sqlcmdInPath)) {
-            tl.debug(`Found go-sqlcmd on PATH: ${sqlcmdInPath}`);
-            return sqlcmdInPath;
-        }
         if (sqlcmdInPath) {
-            tl.debug('sqlcmd on PATH is ODBC sqlcmd (mssql-tools), not go-sqlcmd — auto-installing go-sqlcmd');
+            if (!await this.isGoSqlcmd(sqlcmdInPath)) {
+                tl.debug('sqlcmd on PATH is ODBC sqlcmd (mssql-tools), not go-sqlcmd — auto-installing go-sqlcmd');
+            } else if (!await this.meetsMinimumVersion(sqlcmdInPath)) {
+                tl.debug(`go-sqlcmd on PATH is older than ${MIN_SQLCMD_MAJOR}.${MIN_SQLCMD_MINOR}.0 — auto-installing go-sqlcmd ${SQLCMD_VERSION}`);
+            } else {
+                tl.debug(`Found go-sqlcmd on PATH: ${sqlcmdInPath}`);
+                return sqlcmdInPath;
+            }
         }
 
         // 3. Auto-install go-sqlcmd
@@ -55,6 +66,46 @@ export default class SqlcmdHelper {
     }
 
     /**
+     * Runs the given sqlcmd binary and returns its combined stdout/stderr.
+     */
+    private static async runAndCapture(sqlcmdPath: string, args: string[]): Promise<string> {
+        let output = '';
+        await tl.exec(sqlcmdPath, args, {
+            failOnStdErr: false,
+            ignoreReturnCode: true,
+            outStream: new (require('stream').Writable)({
+                write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
+            }) as NodeJS.WritableStream,
+            errStream: new (require('stream').Writable)({
+                write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
+            }) as NodeJS.WritableStream
+        });
+        return output;
+    }
+
+    /**
+     * Returns true if the go-sqlcmd binary at the given path is at least
+     * MIN_SQLCMD_MAJOR.MIN_SQLCMD_MINOR. Returns false when the version cannot
+     * be determined, so an unknown build is never assumed to be new enough.
+     */
+    private static async meetsMinimumVersion(sqlcmdPath: string): Promise<boolean> {
+        try {
+            const output = await this.runAndCapture(sqlcmdPath, ['--version']);
+            const match = /(\d+)\.(\d+)\.(\d+)/.exec(output);
+            if (!match) {
+                tl.debug('Could not parse go-sqlcmd version from --version output');
+                return false;
+            }
+            const [major, minor] = [parseInt(match[1], 10), parseInt(match[2], 10)];
+            tl.debug(`go-sqlcmd version on PATH: ${major}.${minor}`);
+            return major > MIN_SQLCMD_MAJOR || (major === MIN_SQLCMD_MAJOR && minor >= MIN_SQLCMD_MINOR);
+        } catch {
+            tl.debug('Could not determine go-sqlcmd version');
+            return false;
+        }
+    }
+
+    /**
      * Returns true if the binary at the given path is go-sqlcmd.
      *
      * Detection algorithm (two-step):
@@ -64,20 +115,7 @@ export default class SqlcmdHelper {
      *    "Version:" in output → go-sqlcmd (shown in -? banner).
      */
     private static async isGoSqlcmd(sqlcmdPath: string): Promise<boolean> {
-        const runAndCapture = async (args: string[]): Promise<string> => {
-            let output = '';
-            await tl.exec(sqlcmdPath, args, {
-                failOnStdErr: false,
-                ignoreReturnCode: true,
-                outStream: new (require('stream').Writable)({
-                    write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
-                }) as NodeJS.WritableStream,
-                errStream: new (require('stream').Writable)({
-                    write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
-                }) as NodeJS.WritableStream
-            });
-            return output;
-        };
+        const runAndCapture = (args: string[]) => this.runAndCapture(sqlcmdPath, args);
 
         try {
             // Step 1: --version
@@ -166,15 +204,15 @@ export default class SqlcmdHelper {
      */
     private static getDownloadUrl(platform: string): string {
         const baseUrl = `https://github.com/microsoft/go-sqlcmd/releases/download/v${SQLCMD_VERSION}`;
-        const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+        const arch = process.arch === 'arm64' ? 'arm64' : 'amd64';
 
         // 'win32' is Node.js's platform identifier for all Windows (32-bit and 64-bit)
         if (platform === 'win32') {
-            return `${baseUrl}/sqlcmd-v${SQLCMD_VERSION}-windows-${arch}.zip`;
+            return `${baseUrl}/sqlcmd-windows-${arch}.zip`;
         } else if (platform === 'darwin') {
-            return `${baseUrl}/sqlcmd-v${SQLCMD_VERSION}-darwin-${arch}.tar.bz2`;
+            return `${baseUrl}/sqlcmd-darwin-${arch}.tar.bz2`;
         } else {
-            return `${baseUrl}/sqlcmd-v${SQLCMD_VERSION}-linux-${arch}.tar.bz2`;
+            return `${baseUrl}/sqlcmd-linux-${arch}.tar.bz2`;
         }
     }
 }

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdHelper.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdHelper.ts
@@ -7,20 +7,21 @@ const SQLCMD_VERSION = '1.6.0';
 
 export default class SqlcmdHelper {
     /**
-     * Discovers sqlcmd executable path.
+     * Discovers go-sqlcmd executable path.
+     *
+     * This task targets go-sqlcmd (github.com/microsoft/go-sqlcmd) exclusively.
+     * ODBC sqlcmd (mssql-tools) is NOT supported — its auth flags differ
+     * (no --authentication-method; AAD SP auth is unsupported).
+     *
      * Discovery order:
-     * 1. User-provided sqlcmdPath input (validated)
-     * 2. Check PATH for sqlcmd
-     * 3. Auto-install go-sqlcmd 1.6.0 from GitHub releases (Windows, Linux, macOS)
-     * 
-     * @param sqlcmdPathInput Optional user-provided path to sqlcmd executable
-     * @returns Full path to sqlcmd executable
-     * @throws Error if sqlcmd cannot be found or installed
+     * 1. User-provided sqlcmdPath input (accepted as-is, user's responsibility)
+     * 2. PATH — verified to be go-sqlcmd via --version; falls through to auto-install if ODBC
+     * 3. Auto-install go-sqlcmd 1.6.0 from GitHub releases
      */
     public static async findSqlcmd(sqlcmdPathInput?: string): Promise<string> {
         tl.debug('Starting sqlcmd discovery...');
 
-        // 1. Check user-provided input
+        // 1. User-provided path — accepted without variant check
         if (sqlcmdPathInput) {
             tl.debug(`Checking user-provided sqlcmdPath: ${sqlcmdPathInput}`);
             if (fs.existsSync(sqlcmdPathInput)) {
@@ -30,16 +31,18 @@ export default class SqlcmdHelper {
             throw new Error(tl.loc('SqlcmdNotFoundAtPath', sqlcmdPathInput));
         }
 
-        // 2. Check PATH
+        // 2. PATH — only use if the binary is go-sqlcmd, not ODBC sqlcmd (mssql-tools)
         const sqlcmdInPath = tl.which('sqlcmd', false);
-        if (sqlcmdInPath) {
-            tl.debug(`Found sqlcmd on PATH: ${sqlcmdInPath}`);
+        if (sqlcmdInPath && await this.isGoSqlcmd(sqlcmdInPath)) {
+            tl.debug(`Found go-sqlcmd on PATH: ${sqlcmdInPath}`);
             return sqlcmdInPath;
+        }
+        if (sqlcmdInPath) {
+            tl.debug('sqlcmd on PATH is ODBC sqlcmd (mssql-tools), not go-sqlcmd — auto-installing go-sqlcmd');
         }
 
         // 3. Auto-install go-sqlcmd
         tl.debug(tl.loc('SqlCmdInstalling'));
-        
         try {
             const sqlcmdPath = await this.autoInstallSqlcmd();
             tl.debug(tl.loc('SqlCmdInstalled', sqlcmdPath));
@@ -48,6 +51,66 @@ export default class SqlcmdHelper {
             const message = error instanceof Error ? error.message : String(error);
             tl.debug(`Auto-install failed: ${message}`);
             throw new Error(tl.loc('SqlcmdAutoInstallFailed', message));
+        }
+    }
+
+    /**
+     * Returns true if the binary at the given path is go-sqlcmd.
+     *
+     * Detection algorithm (two-step):
+     * 1. Run --version. If output contains "sqlcmd version" → go-sqlcmd.
+     * 2. If still ambiguous, run -? (help).
+     *    "Microsoft (R) SQL Server Command Line Tool" → ODBC sqlcmd.
+     *    "Version:" in output → go-sqlcmd (shown in -? banner).
+     */
+    private static async isGoSqlcmd(sqlcmdPath: string): Promise<boolean> {
+        const runAndCapture = async (args: string[]): Promise<string> => {
+            let output = '';
+            await tl.exec(sqlcmdPath, args, {
+                failOnStdErr: false,
+                ignoreReturnCode: true,
+                outStream: new (require('stream').Writable)({
+                    write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
+                }) as NodeJS.WritableStream,
+                errStream: new (require('stream').Writable)({
+                    write(chunk: Buffer, _enc: string, cb: () => void) { output += chunk.toString(); cb(); }
+                }) as NodeJS.WritableStream
+            });
+            return output;
+        };
+
+        try {
+            // Step 1: --version
+            // go-sqlcmd prints banner like "sqlcmd - the Microsoft SQL Server command line utility (go-sqlcmd)"
+            // followed by "Version: X.X.X". ODBC sqlcmd does not support --version.
+            const versionOutput = await runAndCapture(['--version']);
+            tl.debug(`sqlcmd --version: ${versionOutput.trim().split('\n')[0]}`);
+            if (/sqlcmd version /i.test(versionOutput) || /Version:\s*\d/i.test(versionOutput)) {
+                return true;
+            }
+
+            // Step 2: -? (help)
+            // ODBC sqlcmd always starts with "Microsoft (R) SQL Server Command Line Tool".
+            // go-sqlcmd does not print that header.
+            const helpOutput = await runAndCapture(['-?']);
+            tl.debug(`sqlcmd -?: ${helpOutput.trim().split('\n')[0]}`);
+            if (/Microsoft \(R\) SQL Server Command Line Tool/i.test(helpOutput)) {
+                return false; // ODBC sqlcmd
+            }
+            // go-sqlcmd-specific help text — none of these appear in ODBC sqlcmd
+            if (
+                /--authentication-method/i.test(helpOutput) ||
+                /driver-logging-level/i.test(helpOutput) ||
+                /Available Commands:/i.test(helpOutput)
+            ) {
+                return true; // go-sqlcmd
+            }
+
+            tl.debug('Could not determine sqlcmd variant — assuming not go-sqlcmd');
+            return false;
+        } catch {
+            tl.debug('Could not determine sqlcmd variant via --version/-? — assuming not go-sqlcmd');
+            return false;
         }
     }
 

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 278,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -168,7 +168,9 @@
     "SqlPackageExecutionFailed": "SqlPackage execution failed with exit code: %s",
     "OutputFileGenerated": "Output file generated: %s",
     "OutputFileNotProduced": "SqlPackage succeeded but the expected output file was not produced: %s",
-    "InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport.",
+    "InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport, sqlScript.",
+    "ExecutingSqlScript": "Executing SQL script: %s",
+    "SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
     "DeploymentSuccessful": "Deployment completed successfully",
     "DeploymentFailed": "Deployment failed: %s",
     "InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -171,6 +171,7 @@
     "InvalidAction": "Invalid action: %s. Supported actions: publish, script, deployReport, sqlScript.",
     "ExecutingSqlScript": "Executing SQL script: %s",
     "SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
+    "SpAuthRequiresTenantId": "Service Principal auth for .sql scripts requires either an azureSubscription (tenant ID is injected automatically) or a User ID in the format clientId@tenantId in the connection string.",
     "DeploymentSuccessful": "Deployment completed successfully",
     "DeploymentFailed": "Deployment failed: %s",
     "InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -172,6 +172,7 @@
     "ExecutingSqlScript": "Executing SQL script: %s",
     "SqlcmdExecutionFailed": "sqlcmd execution failed with exit code: %s",
     "SpAuthRequiresTenantId": "Service Principal auth for .sql scripts requires either an azureSubscription (tenant ID is injected automatically) or a User ID in the format clientId@tenantId in the connection string.",
+    "WifSqlcmdFallbackToAgentIdentity": "Could not resolve the workload identity federation credentials for the service connection. sqlcmd will authenticate using the agent's own identity, which may not have access to the database.",
     "DeploymentSuccessful": "Deployment completed successfully",
     "DeploymentFailed": "Deployment failed: %s",
     "InvalidFileExtension": "Invalid file extension: %s. Expected .dacpac, .sqlproj, or .sql"

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -151,7 +151,7 @@
     "FailedToGetSQLServerDetails": "Failed to get SQL Server '%s' details: %s",
     "ParsingConnectionString": "Parsing connection string",
     "InvalidConnectionString": "Invalid connection string. A valid connection string is a series of keyword/value pairs separated by semi-colons. If there are any special characters like quotes or semi-colons in the keyword value, enclose the value within quotes. Refer to https://aka.ms/sqlconnectionstring for more info.",
-    "UnsupportedAuthentication": "Unsupported Authentication type: '%s'. Supported values: SQL auth (no Authentication keyword), Active Directory Default, Active Directory Password, Active Directory Service Principal, Active Directory Integrated.",
+    "UnsupportedAuthentication": "Unsupported Authentication type: '%s'. Supported values: SQL auth (no Authentication keyword), Active Directory Default, Active Directory Password, Active Directory Service Principal, Active Directory Integrated, Active Directory Managed Identity.",
     "ConnectionStringMissingServer": "Invalid connection string. Please ensure 'Server' or 'Data Source' is provided in the connection string.",
     "ConnectionStringMissingDatabase": "Invalid connection string. Please ensure 'Database' or 'Initial Catalog' is provided in the connection string.",
     "ConnectionStringMissingUserId": "Invalid connection string. Please ensure 'User' or 'User ID' is provided in the connection string.",

--- a/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 278,
-    "Patch": 2
+    "Patch": 3
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
@@ -171,6 +171,7 @@
     "InvalidAction": "ms-resource:loc.messages.InvalidAction",
     "ExecutingSqlScript": "ms-resource:loc.messages.ExecutingSqlScript",
     "SqlcmdExecutionFailed": "ms-resource:loc.messages.SqlcmdExecutionFailed",
+    "SpAuthRequiresTenantId": "ms-resource:loc.messages.SpAuthRequiresTenantId",
     "DeploymentSuccessful": "ms-resource:loc.messages.DeploymentSuccessful",
     "DeploymentFailed": "ms-resource:loc.messages.DeploymentFailed",
     "InvalidFileExtension": "ms-resource:loc.messages.InvalidFileExtension"

--- a/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
@@ -172,6 +172,7 @@
     "ExecutingSqlScript": "ms-resource:loc.messages.ExecutingSqlScript",
     "SqlcmdExecutionFailed": "ms-resource:loc.messages.SqlcmdExecutionFailed",
     "SpAuthRequiresTenantId": "ms-resource:loc.messages.SpAuthRequiresTenantId",
+    "WifSqlcmdFallbackToAgentIdentity": "ms-resource:loc.messages.WifSqlcmdFallbackToAgentIdentity",
     "DeploymentSuccessful": "ms-resource:loc.messages.DeploymentSuccessful",
     "DeploymentFailed": "ms-resource:loc.messages.DeploymentFailed",
     "InvalidFileExtension": "ms-resource:loc.messages.InvalidFileExtension"

--- a/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
@@ -169,6 +169,8 @@
     "OutputFileGenerated": "ms-resource:loc.messages.OutputFileGenerated",
     "OutputFileNotProduced": "ms-resource:loc.messages.OutputFileNotProduced",
     "InvalidAction": "ms-resource:loc.messages.InvalidAction",
+    "ExecutingSqlScript": "ms-resource:loc.messages.ExecutingSqlScript",
+    "SqlcmdExecutionFailed": "ms-resource:loc.messages.SqlcmdExecutionFailed",
     "DeploymentSuccessful": "ms-resource:loc.messages.DeploymentSuccessful",
     "DeploymentFailed": "ms-resource:loc.messages.DeploymentFailed",
     "InvalidFileExtension": "ms-resource:loc.messages.InvalidFileExtension"


### PR DESCRIPTION
## Summary

Adds sqlcmd execution for \.sql\ files (sqlScript action) and task-level telemetry. 

## What this PR adds

### src/SqlcmdExecutor.ts (new)
- Executes .sql files via sqlcmd for the sqlScript action
- Password passed via SQLCMDPASSWORD env var only — never on the command line
- Access token (SQLCMDACCESSTOKEN) used only for AAD Default/Integrated auth — SQL auth and AAD Password continue using the password env var
- Args: -S server[-,port] -d database -U user -l 30 (login timeout) -i script [additionalArguments]

### microsoftsqldeployment.ts
- Import and wire SqlcmdExecutor for SQL file type execution
- Validate action/file type combination: publish/script/deployReport with .sql throws InvalidAction
- Emit telemetry at end of every run (success or failure):
  - action, fileType, authMethod, hasAzureSubscription
  - sqlPackageDiscoveryMethod, sqlcmdDiscoveryMethod
  - 
## Tests (79 passing)
- Updated L0ValidSqlScriptInputs, L0SqlcmdFromPath, L0SqlcmdFromUserPath, L0SqlcmdAutoInstallSuccess with sqlcmd exec mocks (these tests now exercise the full sqlcmd execution path)
- L0SqlcmdExecutionFailed (new): sqlcmd exits non-zero, task fails with SqlcmdExecutionFailed error
- L0.ts: new test case wired
