### PR TITLE
fix(VsTestV2/V3): neutralize ##vso logging-command injection from vstest output (MSRC 128541)

### DIFF
--- a/Tasks/VsTestV2/nondistributedtest.ts
+++ b/Tasks/VsTestV2/nondistributedtest.ts
@@ -82,7 +82,8 @@ export class NonDistributedTest {
             failOnStdErr: false,
             // In effect this will not be called as failOnStdErr is false
             // Keeping this code in case we want to change failOnStdErr
-            errStream: new outStream.StringErrorWritable({ decodeStrings: false })
+            outStream: new outStream.StringErrorWritable(false, { decodeStrings: false }),
+            errStream: new outStream.StringErrorWritable(true, { decodeStrings: false })
         };
 
         // The error codes return below are not the same as tl.TaskResult which follows a different convention.

--- a/Tasks/VsTestV2/outputstream.ts
+++ b/Tasks/VsTestV2/outputstream.ts
@@ -4,9 +4,11 @@ import * as tl from 'azure-pipelines-task-lib/task';
 
 export class StringErrorWritable extends stream.Writable {
     private value: string = '';
+    private isErrorStream: boolean;
 
-    constructor(options: any) {
+    constructor(isErrorStream: boolean, options: any) {
         super(options);
+        this.isErrorStream = isErrorStream;
     }
 
     _write(data: any, encoding: string, callback: Function): void {
@@ -15,8 +17,16 @@ export class StringErrorWritable extends stream.Writable {
         let errorString: string = data.toString();
         let n = errorString.indexOf(os.EOL);
         while (n > -1) {
-            const line = errorString.substring(0, n);
-            tl.error(line);
+            // Neutralize all ##vso logging commands from vstest output to prevent
+            // logging-command injection attacks (CWE-77). Test-authored output is
+            // untrusted and must never reach the agent command parser unfiltered.
+            let line = errorString.substring(0, n).replace(/##vso\[/gi, '#vso[');
+
+            if (this.isErrorStream) {
+                tl.error(line);
+            } else {
+                console.log(line);
+            }
 
             // the rest of the string ...
             errorString = errorString.substring(n + os.EOL.length);

--- a/Tasks/VsTestV2/vstest.ts
+++ b/Tasks/VsTestV2/vstest.ts
@@ -279,7 +279,8 @@ async function executeVstest(parallelRunSettingsFile: string, vsVersion: number,
         failOnStdErr: false,
         // In effect this will not be called as failOnStdErr is false
         // Keeping this code in case we want to change failOnStdErr
-        errStream: new outStream.StringErrorWritable({ decodeStrings: false })
+        outStream: new outStream.StringErrorWritable(false, { decodeStrings: false }),
+        errStream: new outStream.StringErrorWritable(true, { decodeStrings: false })
     };
 
     // The error codes return below are not the same as tl.TaskResult which follows a different convention.

--- a/Tasks/VsTestV3/nondistributedtest.ts
+++ b/Tasks/VsTestV3/nondistributedtest.ts
@@ -9,7 +9,6 @@ import * as uuid from 'uuid';
 import * as fs from 'fs';
 import * as process from 'process';
 import { InputDataContract } from './inputdatacontract';
-import { isFeatureFlagEnabled } from './runvstest';
 
 export class NonDistributedTest {
     constructor(inputDataContract: InputDataContract) {
@@ -77,17 +76,14 @@ export class NonDistributedTest {
             envVars = utils.Helper.setProfilerVariables(envVars);
         }
 
-        const isBlockingCommands = await isFeatureFlagEnabled(tl.getVariable('System.TeamFoundationCollectionUri'),
-            'TestExecution.EnableBlockedCommandInRestrictedMode', tl.getEndpointAuthorization('SystemVssConnection', true).parameters.AccessToken);
-
         const execOptions: tr.IExecOptions = <any>{
             IgnoreTestFailures: this.inputDataContract.TestReportingSettings.ExecutionStatusSettings.IgnoreTestFailures,
             env: envVars,
             failOnStdErr: false,
             // In effect this will not be called as failOnStdErr is false
             // Keeping this code in case we want to change failOnStdErr
-            outStream: new outStream.StringErrorWritable(false, isBlockingCommands, { decodeStrings: false }),
-            errStream: new outStream.StringErrorWritable(true, isBlockingCommands, { decodeStrings: false })
+            outStream: new outStream.StringErrorWritable(false, { decodeStrings: false }),
+            errStream: new outStream.StringErrorWritable(true, { decodeStrings: false })
         };
 
         // The error codes return below are not the same as tl.TaskResult which follows a different convention.

--- a/Tasks/VsTestV3/outputstream.ts
+++ b/Tasks/VsTestV3/outputstream.ts
@@ -6,12 +6,10 @@ import * as tl from 'azure-pipelines-task-lib/task';
 export class StringErrorWritable extends stream.Writable {
     private value: string = '';
     private isErrorStream: boolean;
-    private isBlockingCommands: boolean;
 
-    constructor(isErrorStream: boolean, isBlockingCommands: boolean, options: any) {
+    constructor(isErrorStream: boolean, options: any) {
         super(options);
         this.isErrorStream = isErrorStream;
-        this.isBlockingCommands = isBlockingCommands;
     }
 
     _write(data: any, encoding: string, callback: Function): void {
@@ -22,18 +20,20 @@ export class StringErrorWritable extends stream.Writable {
         while (n > -1) {
             var line = errorString.substring(0, n);
 
-            if (this.isBlockingCommands) {
-                var command = this.getCommand(line);
-                if (command != null) {
-                    const taskProps: { [key: string]: string; } = { command: command };
-                    ci.publishEvent(taskProps);
+            var command = this.getCommand(line);
+            if (command != null) {
+                const taskProps: { [key: string]: string; } = { command: command };
+                ci.publishEvent(taskProps);
 
-                    const allowedCommands = ['task.logdetail', 'task.logissue', 'task.complete', 'task.setprogress',
-                        'task.setsecret', 'task.setvariable', 'task.debug', 'task.settaskvariable', 'task.prependpath'];
+                // Neutralize all ##vso commands except safe informational ones.
+                // task.prependpath and task.setvariable are excluded to prevent
+                // PATH hijack RCE and variable override attacks (CWE-77).
+                // Neutralization is unconditional — no feature flag gate.
+                const allowedCommands = ['task.logdetail', 'task.logissue', 'task.complete', 'task.setprogress',
+                    'task.setsecret', 'task.debug', 'task.settaskvariable'];
 
-                    if (allowedCommands.indexOf(command.toLowerCase()) < 0) {
-                        line = line.replace('##vso', '#vso');
-                    }
+                if (allowedCommands.indexOf(command.toLowerCase()) < 0) {
+                    line = line.replace('##vso', '#vso');
                 }
             }
 

--- a/Tasks/VsTestV3/vstest.ts
+++ b/Tasks/VsTestV3/vstest.ts
@@ -14,8 +14,6 @@ import * as uuid from 'uuid';
 import * as fs from 'fs';
 import * as xml2js from 'xml2js';
 import * as process from 'process';
-import { isFeatureFlagEnabled } from './runvstest';
-
 const runSettingsExt = '.runsettings';
 const testSettingsExt = '.testsettings';
 
@@ -274,17 +272,14 @@ async function executeVstest(parallelRunSettingsFile: string, vsVersion: number,
         utils.Helper.addToProcessEnvVars(envVars, 'COR_PROFILER_PATH_64', vstestConfig.toolsInstallerConfig.x64ProfilerProxyDLLLocation);
     }
 
-    const isBlockingCommands = await isFeatureFlagEnabled(tl.getVariable('System.TeamFoundationCollectionUri'),
-        'TestExecution.EnableBlockedCommandInRestrictedMode', tl.getEndpointAuthorization('SystemVssConnection', true).parameters.AccessToken);
-
     const execOptions: tr.IExecOptions = <any>{
         ignoreReturnCode: ignoreTestFailures,
         env: envVars,
         failOnStdErr: false,
         // In effect this will not be called as failOnStdErr is false
         // Keeping this code in case we want to change failOnStdErr
-        outStream: new outStream.StringErrorWritable(false, isBlockingCommands, { decodeStrings: false }),
-        errStream: new outStream.StringErrorWritable(true, isBlockingCommands, { decodeStrings: false })
+        outStream: new outStream.StringErrorWritable(false, { decodeStrings: false }),
+        errStream: new outStream.StringErrorWritable(true, { decodeStrings: false })
     };
 
     // The error codes return below are not the same as tl.TaskResult which follows a different convention.


### PR DESCRIPTION
## Summary

Fixes **MSRC 128541** — CWE-77 logging-command injection via \stest.console\ output in VsTestV2 and VsTestV3.

A test can emit \##vso[task.prependpath]/tmp/attacker_bin\ to stdout, which the Azure Pipelines agent's CommandManager interprets as a logging command, hijacking PATH for subsequent pipeline steps (RCE on self-hosted agents, credential exfiltration on hosted agents).

## Root causes fixed

### VsTestV2
- \outputstream.ts\: Rebuilt \StringErrorWritable\ with an \isErrorStream\ flag and **unconditional neutralization** of all \##vso[\ sequences on both stdout and stderr.
- \stest.ts\ / \
ondistributedtest.ts\: Added missing \outStream\ wrapper — stdout was entirely unfiltered before this change.

### VsTestV3
- \outputstream.ts\: Removed \	ask.prependpath\ and \	ask.setvariable\ from the allowed-commands list (PATH hijack RCE vector). Made neutralization **unconditional** — previously gated on feature flag \TestExecution.EnableBlockedCommandInRestrictedMode\.
- \stest.ts\ / \
ondistributedtest.ts\: Removed \isBlockingCommands\ feature-flag lookup and unused import.

## Testing
- \
ode make.js build --task VsTestV2 --BypassNpmAudit\ ✅
- \
ode make.js build --task VsTestV3 --BypassNpmAudit\ ✅
- \
ode make.js test --task VsTestV2 --suite L0\ — 23 passing ✅
- \
ode make.js test --task VsTestV3 --suite L0\ — 23 passing ✅

## Related
Same vulnerability class as CVE-2023-21553, MSRC 122404 (Docker@2), MSRC 125125 (JenkinsQueueJob@2), MSRC 125131 (FtpUpload), MSRC 125072 (cURLUploader).