### PR TITLE
Validate publish profile values to prevent command injection in AzureRmWebAppDeployment V4/V5

### DIFF
--- a/Tasks/AzureRmWebAppDeploymentV4/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureRmWebAppDeploymentV4/Strings/resources.resjson/en-US/resources.resjson
@@ -217,6 +217,7 @@
   "loc.messages.InvalidConnectionType": "Invalid service connection type",
   "loc.messages.InvalidImageSourceType": "Invalid Image source Type",
   "loc.messages.InvalidPublishProfile": "Publish profile file is invalid.",
+  "loc.messages.InvalidPublishProfileValue": "The value for '%s' in the publish profile contains characters that are not allowed.",
   "loc.messages.ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release pipeline",
   "loc.messages.ZipDeployLogsURL": "Zip Deploy logs can be viewed at %s",
   "loc.messages.DeployLogsURL": "Deploy logs can be viewed at %s",

--- a/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/Tests/L0.ts
@@ -208,6 +208,54 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
+    it('AzureRmWebAppDeploymentV4 PublishProfile rejects command and argument injection in .pubxml values', async () => {
+        const { PublishProfileUtility } = require('../operations/PublishProfileUtility');
+        const taskParams: any = { PublishProfilePassword: 'p@ss w0rd!&|<>' };
+
+        // The three .pubxml-derived values flow into the msdeploy command line. Reject any value
+        // that could change its command/argument structure: quotes, spaces, boundary backslashes,
+        // shell metacharacters, and msdeploy option/setting separators (',', '=', etc.). CWE-77/78.
+        const maliciousProfiles: any[] = [
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin" x'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443 x'], UserName: ['admin'] },
+            { DeployIisAppPath: ['site x&y'], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin%VAR%'] },
+            // trailing backslash + space (the character combination a metacharacter denylist misses)
+            { DeployIisAppPath: ['w\\'], MSDeployServiceURL: ['host:443'], UserName: ['admin extra'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ["admin' x"] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin,extra=1'] },
+            { DeployIisAppPath: ['Default Web Site/My App'], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+            // non-string (object-shaped xml2js value) must fail closed
+            { DeployIisAppPath: [{}], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+        ];
+        for (const js of maliciousProfiles) {
+            const util: any = new PublishProfileUtility('dummy.pubxml');
+            util._publishProfileJs = js;
+            let threw = false;
+            try { await util.GetTaskParametersFromPublishProfileFile(taskParams); }
+            catch (e) { threw = true; }
+            assert(threw, 'Expected rejection for invalid publish-profile value: ' + JSON.stringify(js));
+        }
+
+        // Regression: real Azure App Service publish-profile values (domain-style and slot
+        // usernames, sub-paths, and a password with special characters) must NOT be rejected and
+        // must be preserved unchanged.
+        const legitProfiles: any[] = [
+            { DeployIisAppPath: ['mysite/sub'], MSDeployServiceURL: ['mysite.scm.azurewebsites.net:443'], UserName: ['$mysite'] },
+            { DeployIisAppPath: ['contoso__staging'], MSDeployServiceURL: ['waws-prod-abc-001.publish.azurewebsites.windows.net:443'], UserName: ['contoso\\$contoso'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:8172'], UserName: ['user@contoso.com'] },
+        ];
+        for (const js of legitProfiles) {
+            const util: any = new PublishProfileUtility('dummy.pubxml');
+            util._publishProfileJs = js;
+            const profile = await util.GetTaskParametersFromPublishProfileFile(taskParams);
+            assert.strictEqual(profile.WebAppName, js.DeployIisAppPath[0], 'legit DeployIisAppPath should be preserved');
+            assert.strictEqual(profile.PublishUrl, js.MSDeployServiceURL[0], 'legit MSDeployServiceURL should be preserved');
+            assert.strictEqual(profile.UserName, js.UserName[0], 'legit UserName should be preserved');
+            assert.strictEqual(profile.UserPWD, 'p@ss w0rd!&|<>', 'password is not validated and must be preserved');
+        }
+    });
+
     it('AzureRmWebAppDeploymentV4 Validate TaskParameters', async () => {
         let tp = path.join(__dirname,'TaskParametersTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/AzureRmWebAppDeploymentV4/operations/PublishProfileUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV4/operations/PublishProfileUtility.ts
@@ -23,8 +23,27 @@ export class PublishProfileUtility {
     private _publishProfileJs: any = null;
     private _publishProfilePath: string;
 
+    // MSDeployServiceURL, DeployIisAppPath and UserName are read from a checked-in .pubxml
+    // (attacker-controllable) and are concatenated into a command line that is run through
+    // cmd.exe and forwarded to msdeploy.exe by PublishProfileWebAppDeploymentProvider
+    // (RunCmd uses windowsVerbatimArguments + shell, so the values are NOT escaped). Both
+    // cmd.exe command injection and msdeploy argument injection are therefore possible
+    // (CWE-77/78). Guard with strict positive allowlists that accept the character set used
+    // by Azure App Service publish profiles and reject anything that could break out of the
+    // command line (spaces, quotes, boundary backslashes, shell metacharacters, msdeploy
+    // option/setting separators, etc.).
+    private static readonly _serviceUrlPattern: RegExp = /^[A-Za-z0-9.-]+(?::[0-9]+)?$/;
+    private static readonly _appPathPattern: RegExp = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+    private static readonly _userNamePattern: RegExp = /^[A-Za-z0-9._$@-]+(?:\\[A-Za-z0-9._$@-]+)*$/;
+
     constructor(publishProfilePath: string) {
         this._publishProfilePath = publishProfilePath;
+    }
+
+    private static validatePublishProfileValue(fieldName: string, value: any, allowedPattern: RegExp): void {
+        if (typeof value !== 'string' || !allowedPattern.test(value)) {
+            throw new Error(tl.loc('InvalidPublishProfileValue', fieldName));
+        }
     }
 
     public async GetTaskParametersFromPublishProfileFile(taskParams: TaskParameters): Promise<PublishingProfile> {
@@ -45,6 +64,11 @@ export class PublishProfileUtility {
             UserName: this._publishProfileJs.UserName[0],
             UserPWD: taskParams.PublishProfilePassword
         }
+
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.MSDeployServiceURL, msDeployPublishingProfile.PublishUrl, PublishProfileUtility._serviceUrlPattern);
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.DeployIisAppPath, msDeployPublishingProfile.WebAppName, PublishProfileUtility._appPathPattern);
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.UserName, msDeployPublishingProfile.UserName, PublishProfileUtility._userNamePattern);
+
         return msDeployPublishingProfile;
     }
 

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",
@@ -657,6 +657,7 @@
     "InvalidConnectionType": "Invalid service connection type",
     "InvalidImageSourceType": "Invalid Image source Type",
     "InvalidPublishProfile": "Publish profile file is invalid.",
+    "InvalidPublishProfileValue": "The value for '%s' in the publish profile contains characters that are not allowed.",
     "ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release pipeline",
     "ZipDeployLogsURL": "Zip Deploy logs can be viewed at %s",
     "DeployLogsURL": "Deploy logs can be viewed at %s",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 4,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",
@@ -657,6 +657,7 @@
     "InvalidConnectionType": "ms-resource:loc.messages.InvalidConnectionType",
     "InvalidImageSourceType": "ms-resource:loc.messages.InvalidImageSourceType",
     "InvalidPublishProfile": "ms-resource:loc.messages.InvalidPublishProfile",
+    "InvalidPublishProfileValue": "ms-resource:loc.messages.InvalidPublishProfileValue",
     "ASE_SSLIssueRecommendation": "ms-resource:loc.messages.ASE_SSLIssueRecommendation",
     "ZipDeployLogsURL": "ms-resource:loc.messages.ZipDeployLogsURL",
     "DeployLogsURL": "ms-resource:loc.messages.DeployLogsURL",

--- a/Tasks/AzureRmWebAppDeploymentV5/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/AzureRmWebAppDeploymentV5/Strings/resources.resjson/en-US/resources.resjson
@@ -224,6 +224,7 @@
   "loc.messages.InvalidConnectionType": "Invalid service connection type",
   "loc.messages.InvalidImageSourceType": "Invalid Image source Type",
   "loc.messages.InvalidPublishProfile": "Publish profile file is invalid.",
+  "loc.messages.InvalidPublishProfileValue": "The value for '%s' in the publish profile contains characters that are not allowed.",
   "loc.messages.ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release pipeline",
   "loc.messages.ZipDeployLogsURL": "Zip Deploy logs can be viewed at %s",
   "loc.messages.DeployLogsURL": "Deploy logs can be viewed at %s",

--- a/Tasks/AzureRmWebAppDeploymentV5/Tests/L0.ts
+++ b/Tasks/AzureRmWebAppDeploymentV5/Tests/L0.ts
@@ -208,6 +208,54 @@ describe('AzureRmWebAppDeployment Suite', function() {
         }
     });
 
+    it('AzureRmWebAppDeploymentV5 PublishProfile rejects command and argument injection in .pubxml values', async () => {
+        const { PublishProfileUtility } = require('../operations/PublishProfileUtility');
+        const taskParams: any = { PublishProfilePassword: 'p@ss w0rd!&|<>' };
+
+        // The three .pubxml-derived values flow into the msdeploy command line. Reject any value
+        // that could change its command/argument structure: quotes, spaces, boundary backslashes,
+        // shell metacharacters, and msdeploy option/setting separators (',', '=', etc.). CWE-77/78.
+        const maliciousProfiles: any[] = [
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin" x'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443 x'], UserName: ['admin'] },
+            { DeployIisAppPath: ['site x&y'], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin%VAR%'] },
+            // trailing backslash + space (the character combination a metacharacter denylist misses)
+            { DeployIisAppPath: ['w\\'], MSDeployServiceURL: ['host:443'], UserName: ['admin extra'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ["admin' x"] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:443'], UserName: ['admin,extra=1'] },
+            { DeployIisAppPath: ['Default Web Site/My App'], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+            // non-string (object-shaped xml2js value) must fail closed
+            { DeployIisAppPath: [{}], MSDeployServiceURL: ['host:443'], UserName: ['admin'] },
+        ];
+        for (const js of maliciousProfiles) {
+            const util: any = new PublishProfileUtility('dummy.pubxml');
+            util._publishProfileJs = js;
+            let threw = false;
+            try { await util.GetTaskParametersFromPublishProfileFile(taskParams); }
+            catch (e) { threw = true; }
+            assert(threw, 'Expected rejection for invalid publish-profile value: ' + JSON.stringify(js));
+        }
+
+        // Regression: real Azure App Service publish-profile values (domain-style and slot
+        // usernames, sub-paths, and a password with special characters) must NOT be rejected and
+        // must be preserved unchanged.
+        const legitProfiles: any[] = [
+            { DeployIisAppPath: ['mysite/sub'], MSDeployServiceURL: ['mysite.scm.azurewebsites.net:443'], UserName: ['$mysite'] },
+            { DeployIisAppPath: ['contoso__staging'], MSDeployServiceURL: ['waws-prod-abc-001.publish.azurewebsites.windows.net:443'], UserName: ['contoso\\$contoso'] },
+            { DeployIisAppPath: ['site'], MSDeployServiceURL: ['host:8172'], UserName: ['user@contoso.com'] },
+        ];
+        for (const js of legitProfiles) {
+            const util: any = new PublishProfileUtility('dummy.pubxml');
+            util._publishProfileJs = js;
+            const profile = await util.GetTaskParametersFromPublishProfileFile(taskParams);
+            assert.strictEqual(profile.WebAppName, js.DeployIisAppPath[0], 'legit DeployIisAppPath should be preserved');
+            assert.strictEqual(profile.PublishUrl, js.MSDeployServiceURL[0], 'legit MSDeployServiceURL should be preserved');
+            assert.strictEqual(profile.UserName, js.UserName[0], 'legit UserName should be preserved');
+            assert.strictEqual(profile.UserPWD, 'p@ss w0rd!&|<>', 'password is not validated and must be preserved');
+        }
+    });
+
     it('AzureRmWebAppDeploymentV5 Validate TaskParameters', async () => {
         let tp = path.join(__dirname,'TaskParametersTests.js');
         let tr : ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/AzureRmWebAppDeploymentV5/operations/PublishProfileUtility.ts
+++ b/Tasks/AzureRmWebAppDeploymentV5/operations/PublishProfileUtility.ts
@@ -23,8 +23,27 @@ export class PublishProfileUtility {
     private _publishProfileJs: any = null;
     private _publishProfilePath: string;
 
+    // MSDeployServiceURL, DeployIisAppPath and UserName are read from a checked-in .pubxml
+    // (attacker-controllable) and are concatenated into a command line that is run through
+    // cmd.exe and forwarded to msdeploy.exe by PublishProfileWebAppDeploymentProvider
+    // (RunCmd uses windowsVerbatimArguments + shell, so the values are NOT escaped). Both
+    // cmd.exe command injection and msdeploy argument injection are therefore possible
+    // (CWE-77/78). Guard with strict positive allowlists that accept the character set used
+    // by Azure App Service publish profiles and reject anything that could break out of the
+    // command line (spaces, quotes, boundary backslashes, shell metacharacters, msdeploy
+    // option/setting separators, etc.).
+    private static readonly _serviceUrlPattern: RegExp = /^[A-Za-z0-9.-]+(?::[0-9]+)?$/;
+    private static readonly _appPathPattern: RegExp = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/;
+    private static readonly _userNamePattern: RegExp = /^[A-Za-z0-9._$@-]+(?:\\[A-Za-z0-9._$@-]+)*$/;
+
     constructor(publishProfilePath: string) {
         this._publishProfilePath = publishProfilePath;
+    }
+
+    private static validatePublishProfileValue(fieldName: string, value: any, allowedPattern: RegExp): void {
+        if (typeof value !== 'string' || !allowedPattern.test(value)) {
+            throw new Error(tl.loc('InvalidPublishProfileValue', fieldName));
+        }
     }
 
     public async GetTaskParametersFromPublishProfileFile(taskParams: TaskParameters): Promise<PublishingProfile> {
@@ -45,6 +64,11 @@ export class PublishProfileUtility {
             UserName: this._publishProfileJs.UserName[0],
             UserPWD: taskParams.PublishProfilePassword
         }
+
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.MSDeployServiceURL, msDeployPublishingProfile.PublishUrl, PublishProfileUtility._serviceUrlPattern);
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.DeployIisAppPath, msDeployPublishingProfile.WebAppName, PublishProfileUtility._appPathPattern);
+        PublishProfileUtility.validatePublishProfileValue(Constant.PublishProfileXml.UserName, msDeployPublishingProfile.UserName, PublishProfileUtility._userNamePattern);
+
         return msDeployPublishingProfile;
     }
 

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",
@@ -721,6 +721,7 @@
     "InvalidConnectionType": "Invalid service connection type",
     "InvalidImageSourceType": "Invalid Image source Type",
     "InvalidPublishProfile": "Publish profile file is invalid.",
+    "InvalidPublishProfileValue": "The value for '%s' in the publish profile contains characters that are not allowed.",
     "ASE_SSLIssueRecommendation": "To use a certificate in App Service, the certificate must be signed by a trusted certificate authority. If your web app gives you certificate validation errors, you're probably using a self-signed certificate and to resolve them you need to set a variable named VSTS_ARM_REST_IGNORE_SSL_ERRORS to the value true in the build or release pipeline",
     "ZipDeployLogsURL": "Zip Deploy logs can be viewed at %s",
     "DeployLogsURL": "Deploy logs can be viewed at %s",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -18,7 +18,7 @@
   "version": {
     "Major": 5,
     "Minor": 277,
-    "Patch": 0
+    "Patch": 1
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",
@@ -721,6 +721,7 @@
     "InvalidConnectionType": "ms-resource:loc.messages.InvalidConnectionType",
     "InvalidImageSourceType": "ms-resource:loc.messages.InvalidImageSourceType",
     "InvalidPublishProfile": "ms-resource:loc.messages.InvalidPublishProfile",
+    "InvalidPublishProfileValue": "ms-resource:loc.messages.InvalidPublishProfileValue",
     "ASE_SSLIssueRecommendation": "ms-resource:loc.messages.ASE_SSLIssueRecommendation",
     "ZipDeployLogsURL": "ms-resource:loc.messages.ZipDeployLogsURL",
     "DeployLogsURL": "ms-resource:loc.messages.DeployLogsURL",


### PR DESCRIPTION
### Context

The `AzureRmWebAppDeployment` **V4** and **V5** tasks, when using the **Publish Profile** connection type, read `UserName`, `MSDeployServiceURL` and `DeployIisAppPath` from the checked-in `.pubxml` and concatenate them into the `msdeploy` command line that is executed through `cmd.exe` (`RunCmd` uses `windowsVerbatimArguments: true` + `shell: true`, so the values are not escaped). Because those values are not validated, a crafted `.pubxml` could inject additional `cmd.exe` or `msdeploy` arguments/commands (CWE-77 / CWE-78). This is the same class of issue addressed for other tasks in #21920, which did not cover these two.

---

### Task Name

AzureRmWebAppDeploymentV4
AzureRmWebAppDeploymentV5

---

### Description

Adds strict input validation for the three publish-profile-derived values that flow into the `msdeploy` command line, in `operations/PublishProfileUtility.ts`:

- **Positive allowlists per field** (reject-by-default), matching the character set produced by Azure App Service publish profiles:
  - `MSDeployServiceURL` → `host[:port]`
  - `DeployIisAppPath` → `name[/subpath]`
  - `UserName` → `segment[\segment]*` (e.g. `$site`, `site__slot`, `domain\user`, `user@host`)
- Values that do not match are rejected with a clear localized error (`InvalidPublishProfileValue`) **before** any command is constructed. Validation **fails closed** on non-string values.
- `PublishProfilePassword` is a task input (not read from the `.pubxml`) and is intentionally **not** validated, so passwords with special characters keep working unchanged.
- The command construction and execution path are **unchanged** — this is validation only, added at the parse boundary.
- Added L0 tests covering rejection of injection payloads (including argument-injection that uses only otherwise-ordinary characters) and acceptance/preservation of legitimate Azure values.
- Bumped task versions to **4.277.1** / **5.277.1** and added the `InvalidPublishProfileValue` message.

---

### Risk Assessment (Low / Medium / High)

**Low.** The `msdeploy` command construction and the execution sink are untouched; only input validation is added. Legitimate Azure App Service publish-profile values (site names, `*.scm.azurewebsites.net:443` / `*.publish.azurewebsites.windows.net:443` endpoints, `$site` / `site__slot` / `domain\user` usernames) are accepted unchanged, verified by tests. **Trade-off:** non-Azure / on-prem MSDeploy publish profiles whose `UserName` or `DeployIisAppPath` contain spaces or other special characters will now be rejected with a clear error rather than silently building an ambiguous command line. **Workaround for such profiles:** rename the affected value to the allowed character set, or use a non–Publish-Profile connection type (e.g. an Azure Resource Manager service connection).

**Threat-model boundary:** only the three `.pubxml`-derived values (`UserName`, `MSDeployServiceURL`, `DeployIisAppPath`) are attacker-controllable via a checked-in file and are validated here. `PublishProfilePassword` and `AdditionalArguments` are **task inputs** supplied by the pipeline author (already inside the trust boundary) and legitimately contain special characters, so they are intentionally left untouched.

---

### Change Behind Feature Flag (Yes / No)

No — it is a security-hardening validation; a flag would leave the gap open when disabled.

---

### Tech Design / Approach

Positive allowlist validation per field, rather than converting the `msdeploy` `*.deploy.cmd` invocation to an argument array. The existing nested quoting (`"\"/P:...\""`, `"\"/M:...\""`) is a contract spanning `cmd.exe` → generated `*.deploy.cmd` (`%*` re-parse) → `msdeploy.exe` (`CommandLineToArgvW`); rewriting it to an arg-array cannot be regression-tested without a live Web Deploy target and risks breaking real deployments (notably passwords with special characters). Allowlisting the attacker-controllable `.pubxml` values closes both the `cmd.exe` command-injection and the `msdeploy` argument-injection vectors while keeping the proven command path and the password handling byte-identical for legitimate inputs.

---

### Documentation Changes Required (Yes/No)

No

---

### Unit Tests Added or Updated (Yes / No)

Yes — `Tests/L0.ts` in both tasks.

---

### Additional Testing Performed

Built both tasks and ran their L0 suites locally; the new tests pass and existing PublishProfile tests are unaffected.

---

### Logging Added/Updated (Yes/No)

No

---

### Telemetry Added/Updated (Yes/No)

No

---

### Rollback Scenario and Process (Yes/No)

Yes — revert this change; task consumers fall back to the previous task version.

---

### Dependency Impact Assessed and Regression Tested (Yes/No)

Yes

---

### Checklist

- [x] Task version was bumped (4.277.1 / 5.277.1)
- [x] Unit tests added
- [x] Verified the task behaves as expected for legitimate Azure App Service publish profiles
