### PR TITLE
[DownloadGitHubReleaseV0] Sanitize release name to prevent ##vso logging-command injection

### DIFF
--- a/Tasks/DownloadGitHubReleaseV0/Tests/L0.ts
+++ b/Tasks/DownloadGitHubReleaseV0/Tests/L0.ts
@@ -1,6 +1,7 @@
 import assert = require('assert');
 import path = require('path');
 import * as ttm from 'azure-pipelines-task-lib/mock-test';
+import { sanitizeForLoggingCommand } from '../sanitize';
 
 describe('DownloadGitHubReleaseV0 Suite', function () {
     before(() => {
@@ -162,4 +163,87 @@ describe('DownloadGitHubReleaseV0 Suite', function () {
         throw err;
     };
   }).timeout(20000);
+
+  it('Release name containing a logging command should be neutralized', async () => {
+    const tp: string = path.join(__dirname, 'L0GetSpecificReleaseWithMaliciousName.js');
+    const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+    try {
+        await tr.runAsync();
+        assert(tr.succeeded, 'task should have succeeded');
+        assert(!tr.stdOutContained('##vso[task.setvariable variable=injected'), 'injected logging command should not be emitted');
+        assert(tr.stdOutContained('__vso[task.setvariable variable=injected'), 'injected logging command should be escaped');
+
+    } catch (err) {
+        console.log(tr.stdout);
+        console.log(tr.stderr);
+        console.log(err);
+        throw err;
+    };
+  }).timeout(20000);
+});
+
+// Unit tests for sanitizeForLoggingCommand (MSRC 125108 - prevent ##vso[ command injection)
+describe('sanitizeForLoggingCommand', function () {
+    it('should return normal release names unchanged', () => {
+        assert.strictEqual(sanitizeForLoggingCommand('v1.0.0'), 'v1.0.0');
+        assert.strictEqual(sanitizeForLoggingCommand('Release 2026-07 (GA)'), 'Release 2026-07 (GA)');
+    });
+
+    it('should strip ##vso[ patterns', () => {
+        const malicious = 'v1.0.0 ##vso[task.setvariable variable=x;isoutput=true]pwned';
+        const sanitized = sanitizeForLoggingCommand(malicious);
+        assert(sanitized.indexOf('##vso[') === -1, 'should not contain ##vso[');
+        assert(sanitized.indexOf('__vso[') !== -1, 'should replace with __vso[');
+    });
+
+    it('should strip ##vso[ case-insensitively', () => {
+        const sanitized = sanitizeForLoggingCommand('v1.0.0 ##VSO[task.setendpoint id=SystemVssConnection;field=url]http://evil');
+        assert(sanitized.indexOf('##VSO[') === -1, 'should not contain ##VSO[');
+    });
+
+    it('should strip ##[ logging command patterns', () => {
+        const sanitized = sanitizeForLoggingCommand('v1.0.0 ##[section]Injected section');
+        assert(sanitized.indexOf('##[') === -1, 'should not contain ##[');
+        assert(sanitized.indexOf('__[') !== -1, 'should replace with __[');
+    });
+
+    it('should replace newlines to prevent line-splitting injection', () => {
+        const sanitized = sanitizeForLoggingCommand('v1.0.0\n##vso[task.prependpath]/tmp/evil');
+        assert(sanitized.indexOf('\n') === -1, 'should not contain newlines');
+        assert(sanitized.indexOf('##vso[') === -1, 'should not contain ##vso[');
+    });
+
+    it('should replace carriage return + newline sequences', () => {
+        const sanitized = sanitizeForLoggingCommand('v1.0.0\r\n##vso[task.complete result=Failed]');
+        assert(sanitized.indexOf('\r') === -1, 'should not contain CR');
+        assert(sanitized.indexOf('\n') === -1, 'should not contain LF');
+    });
+
+    it('should handle null, undefined and empty strings', () => {
+        assert.strictEqual(sanitizeForLoggingCommand(null), null);
+        assert.strictEqual(sanitizeForLoggingCommand(undefined), undefined);
+        assert.strictEqual(sanitizeForLoggingCommand(''), '');
+    });
+
+    it('should handle multiple injections in one string', () => {
+        const sanitized = sanitizeForLoggingCommand('##vso[task.setvariable variable=A]x ##vso[task.setvariable variable=B]y');
+        assert(sanitized.indexOf('##vso[') === -1, 'should not contain any ##vso[');
+    });
+});
+
+// Untrusted GitHub data also reaches stdout through artifact-engine (asset names, raw
+// response bodies), which this task cannot sanitize itself. The restrictions block is the
+// control covering those sinks, so guard it against accidental removal.
+describe('DownloadGitHubReleaseV0 task.json restrictions', function () {
+    const taskJson = require('../task.json');
+
+    it('should run logging commands in restricted mode', () => {
+        assert(taskJson.restrictions, 'task.json should declare restrictions');
+        assert.strictEqual(taskJson.restrictions.commands.mode, 'restricted');
+    });
+
+    it('should not allow the task to set any variables', () => {
+        assert.deepStrictEqual(taskJson.restrictions.settableVariables.allowed, []);
+    });
 });

--- a/Tasks/DownloadGitHubReleaseV0/Tests/L0GetSpecificReleaseWithMaliciousName.ts
+++ b/Tasks/DownloadGitHubReleaseV0/Tests/L0GetSpecificReleaseWithMaliciousName.ts
@@ -1,0 +1,52 @@
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import * as models from 'artifact-engine/Models';
+
+const nock = require('nock');
+const taskPath = path.join(__dirname, '..', 'main.js');
+const tr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tr.setInput('connection', 'connection');
+tr.setInput('userRepository', 'userOrg/repoName');
+tr.setInput('downloadPath', 'usr/bin');
+tr.setInput('defaultVersionType', 'specificVersion');
+tr.setInput('version', '1');
+
+nock('https://api.github.com')
+  .get('/repos/userOrg/repoName/releases/1')
+  .reply(200, {
+    id: 1,
+    name: "release ##vso[task.setvariable variable=injected;isoutput=true]pwned"
+  });
+
+const tl = require('azure-pipelines-task-lib/mock-task');
+const tlClone = Object.assign({}, tl);
+
+tlClone.getEndpointAuthorizationParameter = function (id: string, key: string, optional: boolean) {
+    key = key.toUpperCase();
+    if (key == 'ACCESSTOKEN') {
+      return 'username';
+    }
+
+    if (optional) {
+      return '';
+    }
+    throw new Error(`Endpoint auth data not present: ${id}`);
+}
+tr.registerMock('azure-pipelines-task-lib/mock-task', tlClone);
+
+tr.registerMock("artifact-engine/Engine", {
+  ArtifactEngine: function() {
+      return {
+          processItems: function(A,B,C) {
+            return new Promise<models.ArtifactDownloadTicket[]>(function(res, rej) {
+              res(null);
+            });
+          }
+      }
+  },
+  ArtifactEngineOptions: function() {
+  }
+});
+
+tr.run();

--- a/Tasks/DownloadGitHubReleaseV0/main.ts
+++ b/Tasks/DownloadGitHubReleaseV0/main.ts
@@ -5,6 +5,8 @@ import * as engine from 'artifact-engine/Engine';
 import * as providers from 'artifact-engine/Providers';
 import * as httpc from 'typed-rest-client/HttpClient';
 
+import { sanitizeForLoggingCommand } from './sanitize';
+
 var packagejson = require('./package.json');
 
 tl.setResourcePath(path.join(__dirname, 'task.json'));
@@ -187,7 +189,7 @@ async function main(): Promise<void> {
         var itemsUrl = "https://api.github.com/repos/" + repositoryName + "/releases/" + release.Id + "/assets";
         itemsUrl = itemsUrl.replace(/([^:]\/)\/+/g, "$1");
         
-        console.log(tl.loc("DownloadArtifacts", release.Name, itemsUrl));
+        console.log(tl.loc("DownloadArtifacts", sanitizeForLoggingCommand(release.Name), itemsUrl));
 
         var templatePath = path.join(__dirname, 'githubrelease.handlebars.txt');
         var gitHubReleaseVariables = {

--- a/Tasks/DownloadGitHubReleaseV0/sanitize.ts
+++ b/Tasks/DownloadGitHubReleaseV0/sanitize.ts
@@ -1,0 +1,16 @@
+/**
+ * Strips Azure Pipelines logging-command patterns (##vso[...] and ##[...]) from a string
+ * to prevent command injection via untrusted input printed to stdout.
+ * Also removes newlines that could be used to start a new line with a ##vso[ prefix.
+ */
+export function sanitizeForLoggingCommand(value: string): string;
+export function sanitizeForLoggingCommand(value: null | undefined): null | undefined;
+export function sanitizeForLoggingCommand(value: string | null | undefined): string | null | undefined {
+    if (!value) {
+        return value;
+    }
+    return value
+        .replace(/##vso\[/gi, '__vso[')
+        .replace(/##\[/g, '__[')
+        .replace(/[\r\n]+/g, ' ');
+}

--- a/Tasks/DownloadGitHubReleaseV0/sanitize.ts
+++ b/Tasks/DownloadGitHubReleaseV0/sanitize.ts
@@ -1,7 +1,9 @@
 /**
- * Strips Azure Pipelines logging-command patterns (##vso[...] and ##[...]) from a string
- * to prevent command injection via untrusted input printed to stdout.
- * Also removes newlines that could be used to start a new line with a ##vso[ prefix.
+ * Neutralizes Azure Pipelines logging-command patterns in a string so untrusted input
+ * printed to stdout cannot be executed as an agent command.
+ * `##vso[` and `##[` are rewritten to `__vso[` and `__[`, and any CR/LF run is replaced
+ * with a single space - a space rather than an empty string, so that a value such as
+ * "##\nvso[" cannot be rejoined into a live "##vso[" marker.
  */
 export function sanitizeForLoggingCommand(value: string): string;
 export function sanitizeForLoggingCommand(value: null | undefined): null | undefined;

--- a/Tasks/DownloadGitHubReleaseV0/task.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.json
@@ -10,7 +10,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 278,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
@@ -112,6 +112,14 @@
     "Node24": {
       "target": "main.js",
       "argumentFormat": ""
+    }
+  },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
     }
   },
   "messages": {

--- a/Tasks/DownloadGitHubReleaseV0/task.loc.json
+++ b/Tasks/DownloadGitHubReleaseV0/task.loc.json
@@ -10,7 +10,7 @@
   "demands": [],
   "version": {
     "Major": 0,
-    "Minor": 275,
+    "Minor": 278,
     "Patch": 0
   },
   "minimumAgentVersion": "2.144.0",
@@ -112,6 +112,14 @@
     "Node24": {
       "target": "main.js",
       "argumentFormat": ""
+    }
+  },
+  "restrictions": {
+    "commands": {
+      "mode": "restricted"
+    },
+    "settableVariables": {
+      "allowed": []
     }
   },
   "messages": {


### PR DESCRIPTION
### **Context**

Fixes an agent logging-command injection (CWE-77) in `DownloadGitHubRelease@0`, reported as **MSRC 125108**. Internal tracking: [AB#2440537](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440537).

`DownloadGitHubRelease@0` copies a GitHub release **name** into task stdout via `console.log(tl.loc("DownloadArtifacts", release.Name, itemsUrl))`. The agent parses `##vso[` anywhere in a stdout line as a logging command, so an attacker who controls a release name in a repo a victim pipeline references can inject `task.setvariable`, `task.setendpoint`, `task.prependpath` or `task.complete`. With `task.setendpoint` this repoints `SystemVssConnection` and can exfiltrate `System.AccessToken`.

Only the `specificVersion` path was exploitable: `getSpecificRelease()` assigns `response["name"]` (arbitrary text), whereas `latest`/`specificTag` use `tag_name`, and git ref rules forbid `[` and `]`.

---

### **Task Name**

`DownloadGitHubReleaseV0`

---

### **Description**

- **`sanitize.ts` (new)** — `sanitizeForLoggingCommand()` neutralizes `##vso[` (case-insensitive) and `##[`, and collapses `[\r\n]+` to a space so an injected name cannot start a new line. Byte-identical to the existing `Tasks/KubernetesV1/src/sanitize.ts` introduced for the same bug class in 3482b09 (MSRC 122198).
- **`main.ts`** — applies it to `release.Name` at the `console.log` sink.
- **`task.json` / `task.loc.json`** — adds a `restrictions` block (`commands.mode: restricted`, `settableVariables.allowed: []`) and bumps the version `0.275.0` → `0.278.0`.

**Why `restrictions` as well as the sanitizer.** Release *asset* names and the raw GitHub API response body also reach stdout, but through the third-party `artifact-engine` package, which this task cannot sanitize in-process (`filesystemProvider` logging `item.path` fed by `{{this.name}}` in `githubrelease.handlebars.txt`, and `webProvider`'s `FailedToParseResponse` logging the raw body). Restricted mode is the control that covers those sinks. It blocks `task.setendpoint` and the `artifact.upload` / `task.uploadfile` / `build.upload*` exfiltration family, and `settableVariables.allowed: []` blocks `task.setvariable`/`task.settaskvariable`.

Known residual gap, stated explicitly: `task.prependpath` and `task.complete` **are** on the agent's restricted-mode allow-list, so they are not blocked by `restrictions` on those artifact-engine sinks. They are blocked for `release.Name` by the sanitizer. A complete fix for asset names belongs upstream in `artifact-engine`'s `Logger.logMessage` and is out of scope here.

`minimumAgentVersion` is deliberately left at `2.144.0`. Command restrictions require agent 2.182+; on older agents the block is simply not applied, which is preferable to failing the task outright, and the sanitizer — the fix for the reported vector — is agent-version independent.

---

### **Risk Assessment** (Low / Medium / High)

**Low.**
- The sanitizer only rewrites a string that is used exclusively for a `console.log` message; it does not touch the release id, the assets URL, the download logic or any downloaded content.
- Legitimate release names are unaffected (only `##vso[`, `##[` and CR/LF are rewritten).
- `restrictions` causes no functional change for this task: its only own logging commands are `telemetry.publish` and `task.logissue`, both allowed in restricted mode, and it never calls `tl.setVariable`, so `allowed: []` blocks nothing it does.
- Backward compatible — no input, output or behavioral contract changes.

---

### **Change Behind Feature Flag** (Yes / No)

**No.** This is a security fix for an actively tracked MSRC case; gating it behind a flag would leave the vulnerable path reachable by default. The change is small, self-contained and revertible by reverting the commit.

---

### **Tech Design / Approach**

- Sanitize at the log sink, mirroring the precedent already merged for this bug class in `KubernetesV1` (3482b09), rather than inventing a new pattern.
- Alternatives considered and rejected:
  - *Sanitize at the parse boundary in the three `getXRelease()` functions* — three call sites to keep in sync instead of one choke point, and it does not protect a future sink.
  - *Reject release names containing `[`* — breaks legitimate names such as `[2026-07] Release`.
  - *Rely on `restrictions` alone* — leaves `task.prependpath` and `task.complete` open, and is silently a no-op on agents older than 2.182.
- The duplicated `sanitizeForLoggingCommand()` (now in `KubernetesV1` and here) is a candidate to move into `common-npm-packages` so the next fix of this class inherits it; intentionally left as follow-up to keep this security PR minimal.

---

### **Documentation Changes Required** (Yes/No)

**No.** No user-visible inputs, outputs or behavior change.

---

### **Unit Tests Added or Updated** (Yes / No)

**Yes.**
- `Tests/L0GetSpecificReleaseWithMaliciousName.ts` (new) — nock-mocked `specificVersion` release whose `name` is `release ##vso[task.setvariable variable=injected;isoutput=true]pwned`; `Tests/L0.ts` asserts the task succeeds, that stdout does **not** contain the raw `##vso[task.setvariable variable=injected`, and that it **does** contain the neutralized `__vso[...`. This test fails without the `main.ts` change.
- 8 unit tests for `sanitizeForLoggingCommand()` — pass-through of normal names, `##vso[`, case-insensitive `##VSO[`, `##[`, LF and CRLF line-splitting, `null`/`undefined`/`''`, and multiple injections in one string.
- 3 assertions locking the `restrictions` block in `task.json`, so a future edit cannot silently drop the mitigation while tests stay green.

---

### **Additional Testing Performed**

- `node make.js build --task DownloadGitHubReleaseV0` — succeeds (with `--BypassNpmAudit`; the audit failure is pre-existing on master and unrelated — `package.json`/`package-lock.json` are untouched by this PR).
- `node make.js test --task DownloadGitHubReleaseV0` — **20 passing**, including the 9 pre-existing L0 tests, so the unchanged code paths (`latest`, `specificTag`, all input-validation failures) still behave identically.
- Verified against `azure-pipelines-agent` `master` source which commands restricted mode actually permits (`[CommandRestriction(AllowedInRestrictedMode = true)]` on each `IWorkerCommand`), to confirm the task's own `telemetry.publish` and `task.logissue` keep working and to establish precisely which injected commands the block does and does not stop.

---

### **Logging Added/Updated** (Yes/No)

**Yes** — the existing `DownloadArtifacts` message now logs a sanitized release name. The message text and resource strings are unchanged, no sensitive data is exposed, and log levels are unchanged.

---

### **Telemetry Added/Updated** (Yes/No)

**No.** `publishTelemetry()` is unchanged. Confirmed `telemetry.publish` is allowed in restricted mode, so the existing failure telemetry continues to flow.

---

### **Rollback Scenario and Process** (Yes/No)

**Yes.** Revert this commit and republish the task; pipelines then resolve back to `0.275.0` behavior. There is no state, no migration and no dependency change, so rollback is immediate and safe — at the cost of reopening the vulnerability.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

**Yes.** No dependency versions changed. `sanitize.ts` is a new local module with no imports. `artifact-engine`, `azure-pipelines-task-lib` and `typed-rest-client` usage is unchanged. The `restrictions` block was checked against the agent's command allow-list to confirm nothing this task emits is blocked. Full L0 suite passes.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
