### PR TITLE
Fix: Error thrown when restoring packages does not cause NuGetCommand@2 step to fail

### DIFF
--- a/Tasks/NuGetCommandV2/Tests/L0.ts
+++ b/Tasks/NuGetCommandV2/Tests/L0.ts
@@ -433,6 +433,16 @@ describe('NuGetCommand Suite', function () {
         assert.equal(tr.errorIssues[1], 'loc_mock_PackagesFailedToInstall', 'should have error from task runner');
     });
 
+    it('restore fails when NuGet skips PackageReference projects with exit code 0', async () => {
+        const tp = path.join(__dirname, './RestoreTests/failRestoreGraph.js')
+        const tr = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        assert(tr.failed, 'should have failed');
+        assert.equal(tr.errorIssues.length, 2, 'should have 1 error from nuget and one from task');
+        assert(tr.errorIssues[0].includes('Error reading msbuild project information'), 'should have restore graph error from nuget');
+        assert.equal(tr.errorIssues[1], 'loc_mock_PackagesFailedToInstall', 'should have error from task runner');
+    });
+
     it('restore succeeds on ubuntu 22', async () => {
         const tp = path.join(__dirname, './RestoreTests/singleslnUbuntu22.js')
         const tr = new ttm.MockTestRunner(tp);

--- a/Tasks/NuGetCommandV2/Tests/RestoreTests/failRestoreGraph.ts
+++ b/Tasks/NuGetCommandV2/Tests/RestoreTests/failRestoreGraph.ts
@@ -1,0 +1,49 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import util = require('../NugetMockHelper');
+
+let taskPath = path.join(__dirname, '../..', 'nugetcommandmain.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+let nmh: util.NugetMockHelper = new util.NugetMockHelper(tmr);
+
+nmh.setNugetVersionInputDefault();
+tmr.setInput('command', 'restore');
+tmr.setInput('solution', 'single.sln');
+tmr.setInput('selectOrConfig', 'select');
+
+const restoreGraphWarning = "WARNING: Error reading msbuild project information, ensure that your input solution or project file is valid. NETCore and UAP projects will be skipped, only packages.config files will be restored.";
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "osType": {},
+    "checkPath": {
+        "c:\\agent\\home\\directory\\single.sln": true
+    },
+    "which": {},
+    "exec": {
+        "c:\\from\\tool\\installer\\nuget.exe restore c:\\agent\\home\\directory\\single.sln -NonInteractive -ConfigFile c:\\agent\\home\\directory\\tempNuGet_.config": {
+            "code": 0,
+            "stdout": `NuGet.CommandLine.ExitCodeException: Exception of type 'NuGet.CommandLine.ExitCodeException' was thrown.\n${restoreGraphWarning}`,
+            "stderr": ""
+        }
+    },
+    "exist": {},
+    "stats": {
+        "c:\\agent\\home\\directory\\single.sln": {
+            "isFile": true
+        }
+    },
+    "findMatch": {
+        "single.sln": ["c:\\agent\\home\\directory\\single.sln"]
+    },
+    "rmRF": {
+        "c:\\agent\\home\\directory\\tempNuGet_.config": { success: true }
+    }
+};
+nmh.setAnswers(a);
+
+nmh.registerNugetUtilityMock(["c:\\agent\\home\\directory\\single.sln"]);
+nmh.registerDefaultNugetVersionMock();
+nmh.registerToolRunnerMock();
+nmh.registerNugetConfigMock();
+
+tmr.run();

--- a/Tasks/NuGetCommandV2/nugetrestore.ts
+++ b/Tasks/NuGetCommandV2/nugetrestore.ts
@@ -284,8 +284,11 @@ async function restorePackages(solutionFile: string, options: RestoreOptions): P
         nugetTool.arg(options.configFile);
     }
 
-    // Listen for stderr output to write timeline results for the build.
+    let stdOutText = "";
     let stdErrText = "";
+    nugetTool.on('stdout', (data: Buffer) => {
+        stdOutText += data.toString('utf-8');
+    });
     nugetTool.on('stderr', (data: Buffer) => {
         stdErrText += data.toString('utf-8');
     });
@@ -299,5 +302,15 @@ async function restorePackages(solutionFile: string, options: RestoreOptions): P
             stdErrText.trim());
     }
 
+    const restoreGraphFailure = getRestoreGraphFailure(stdOutText + stdErrText);
+    if (restoreGraphFailure) {
+        throw new Error(restoreGraphFailure);
+    }
+
     return execResult;
+}
+
+function getRestoreGraphFailure(output: string): string | undefined {
+    const match = output.match(/Error reading msbuild project information[^\r\n]*/i);
+    return match ? match[0].trim() : undefined;
 }

--- a/Tasks/NuGetCommandV2/task.json
+++ b/Tasks/NuGetCommandV2/task.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 275,
-    "Patch": 1
+    "Minor": 278,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",

--- a/Tasks/NuGetCommandV2/task.loc.json
+++ b/Tasks/NuGetCommandV2/task.loc.json
@@ -9,8 +9,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 275,
-    "Patch": 1
+    "Minor": 278,
+    "Patch": 0
   },
   "runsOn": [
     "Agent",


### PR DESCRIPTION
### **Context**
Fixes issue #21294.  NuGet may skip PackageReference projects after MSBuild project graph generation fails while still returning exit code  0 , causing  NuGetCommand@2  to report success after an incomplete restore.
---

### **Task Name**
 NuGetCommandV2

---

### **Description**
Capture NuGet stdout and fail restore when NuGet reports that MSBuild project information could not be read. Added an L0 regression test covering this zero-exit-code partial restore scenario and bumped the task version to  2.278.0 .

---

### **Risk Assessment** 

Medium.  Change is limited to NuGet restore failure detection and is backward compatible for successful restores. 

---

### **Change Behind Feature Flag** (Yes / No)

No. This is a bugfix for incomplete restores that report success.

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
No. The change corrects existing task behavior without introducing new inputs or user-facing configuration.

---

### **Unit Tests Added or Updated** (Yes / No)  
Added an L0 regression test verifying that the task fails when NuGet skips PackageReference projects while returning exit code  0 .

---

### **Additional Testing Performed**
 Reproduced the original false-success behavior in an Azure Pipeline.

---

### **Logging Added/Updated** (Yes/No)
No.
--- 

### **Telemetry Added/Updated** (Yes/No) 
No.
---

### **Rollback Scenario and Process** (Yes)
Revert the change and restore the previous NuGetCommandV2 task version if unexpected restore failures occur.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
No dependencies or APIs were changed. Existing NuGetCommandV2 and common L0 tests passed.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected 
