### PR TITLE
fix: isolate SQL token from shared ARM credential + sovereign cloud audience

### DIFF
--- a/Tasks/MicrosoftSqlDeploymentV1/README.md
+++ b/Tasks/MicrosoftSqlDeploymentV1/README.md
@@ -183,6 +183,21 @@ If SqlPackage is not found, install it: `dotnet tool install -g microsoft.sqlpac
 
 ## Known Limitations and Notes
 
+### SQL scripts fail the task on error by default
+The task runs `.sql` files with sqlcmd's `-b` flag, so a statement that fails with severity 11 or
+higher aborts the script and fails the task. Without it, sqlcmd prints the error but still exits 0,
+which would report a half-applied migration as a successful deployment. `PRINT` output and
+informational messages (severity 10 and below) are unaffected.
+
+To opt out and let a script continue past errors, state your own intent in `additionalArguments`:
+
+```yaml
+additionalArguments: '--exit-on-error=false'
+```
+
+The task only supplies `-b` when `additionalArguments` does not already mention `-b` or
+`--exit-on-error`.
+
 ### Service Principal auth for `.sql` scripts requires a tenant ID
 When using `Authentication=Active Directory Service Principal` in the connection string for `.sql` file execution, go-sqlcmd needs the tenant ID to authenticate. If you set `azureSubscription`, the tenant ID is resolved automatically from the service connection — no extra configuration needed. If you do **not** set `azureSubscription`, you must include the tenant ID directly in the `User ID` field using the format `clientId@tenantId`:
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -513,6 +513,15 @@ describe('MicrosoftSqlDeployment Suite', function () {
         }, tr);
     });
 
+    it('should not inject -b when the user specifies their own error handling', async () => {
+        const tp = path.join(__dirname, 'L0SqlcmdRespectsUserErrorHandling.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should respect an explicit --exit-on-error=false');
+        }, tr);
+    });
+
     it('should fail when sqlcmd execution fails with non-zero exit code', async () => {
         const tp = path.join(__dirname, 'L0SqlcmdExecutionFailed.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -498,7 +498,22 @@ describe('MicrosoftSqlDeployment Suite', function () {
             assert(tr.stdout.indexOf('TOKEN_BASEURL:https://database.usgovcloudapi.net/') >= 0,
                 'baseUrl must also carry the SQL audience for the ADAL managed identity path');
             assert(tr.stdout.indexOf('IS_SHARED_ARM_CREDENTIAL:false') >= 0,
-                'token must come from an isolated clone so the shared ARM credential stays usable for firewall cleanup');
+                'token must come from a distinct credential object, not the shared endpoint credential');
+        }, tr);
+    });
+
+    it('should still remove the firewall rule after acquiring the SQL token', async () => {
+        const tp = path.join(__dirname, 'L0FirewallRuleRemovedAfterTokenAcquisition.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with firewall management enabled');
+            assert(tr.stdout.indexOf('ADD_RULE_TOKEN:token-for:https://management.azure.com/') >= 0,
+                'the rule should be added with an ARM-scoped token');
+            assert(tr.stdout.indexOf('REMOVE_RULE_TOKEN:token-for:https://management.azure.com/') >= 0,
+                'cleanup must still get an ARM-scoped token after the SQL token was acquired');
+            assert(tr.stdout.indexOf('FailedToRemoveFirewallRule') < 0,
+                'the temporary firewall rule must not be leaked');
         }, tr);
     });
 
@@ -510,6 +525,16 @@ describe('MicrosoftSqlDeployment Suite', function () {
             assert(tr.succeeded, 'task should succeed with SQL authentication');
             assert(tr.stdout.indexOf('UNEXPECTED_TOKEN_REQUEST') < 0,
                 'no token should be requested when the connection string carries credentials');
+        }, tr);
+    });
+
+    it('should not reuse the ARM-built MSAL instance for the SQL token on managed identity', async () => {
+        const tp = path.join(__dirname, 'L0MsiMsalCacheNotReused.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded,
+                'SQL token must be issued for the SQL audience, not the ARM audience captured by the existing msalInstance');
         }, tr);
     });
 
@@ -585,6 +610,105 @@ describe('MicrosoftSqlDeployment Suite', function () {
         runValidations(() => {
             assert(tr.succeeded, 'task should succeed with the probe using --authentication-method');
         }, tr);
+    });
+});
+
+// These drive a real ApplicationTokenCredentials rather than a stub, so they fail if the
+// library changes the shape createSqlScopedCredentials depends on - for example moving
+// token_deferred/msalInstance/accessToken to true private fields or a WeakMap, which
+// Object.assign would not copy and would silently break the isolation.
+describe('SqlTokenCredentials - cloning a real ApplicationTokenCredentials', function () {
+    this.timeout(10000);
+
+    const { ApplicationTokenCredentials } = require('azure-pipelines-tasks-azure-arm-rest/azure-arm-common');
+    const { createSqlScopedCredentials, getSqlAudienceFromEnvironment } = require('../src/SqlTokenCredentials');
+
+    const ARM = 'https://management.azure.com/';
+    const SQL = 'https://database.windows.net/';
+
+    function newRealCredential(useMSAL: boolean, scheme: string) {
+        return new ApplicationTokenCredentials(
+            'connected-service',            // connectedServiceName
+            'client-id',                    // clientId
+            'tenant-id',                    // tenantId
+            'client-secret',                // secret
+            ARM,                            // baseUrl
+            'https://login.microsoftonline.com/', // authorityUrl
+            ARM,                            // activeDirectoryResourceId
+            false,                          // isAzureStackEnvironment
+            scheme,                         // scheme
+            '',                             // msiClientId
+            '',                             // authType
+            '',                             // certFilePath
+            false,                          // isADFSEnabled
+            undefined,                      // access_token
+            useMSAL                         // useMSAL
+        );
+    }
+
+    it('should retain getToken from the prototype', () => {
+        const real = newRealCredential(true, 'ServicePrincipal');
+        const clone = createSqlScopedCredentials({ applicationTokenCredentials: real }, SQL);
+
+        assert.strictEqual(typeof clone.getToken, 'function',
+            'clone must still expose getToken - the prototype was not carried over');
+        assert.strictEqual(Object.getPrototypeOf(clone), Object.getPrototypeOf(real),
+            'clone should share the real prototype');
+    });
+
+    it('should point both resource fields at the SQL audience', () => {
+        const real = newRealCredential(true, 'ManagedServiceIdentity');
+        const clone = createSqlScopedCredentials({ applicationTokenCredentials: real }, SQL);
+
+        assert.strictEqual(clone.activeDirectoryResourceId, SQL, 'ADAL SP and MSAL read this field');
+        assert.strictEqual(clone.baseUrl, SQL, 'ADAL managed identity reads baseUrl');
+    });
+
+    it('should clear every token cache on the clone', () => {
+        const real = newRealCredential(true, 'ManagedServiceIdentity');
+
+        // Simulate a credential that has already served an ARM token, which is the state
+        // after firewall management runs.
+        (real as any).token_deferred = Promise.resolve('arm-adal-token');
+        (real as any).msalInstance = { capturedResource: ARM };
+        (real as any).accessToken = 'endpoint-supplied-arm-token';
+
+        const clone = createSqlScopedCredentials({ applicationTokenCredentials: real }, SQL);
+
+        assert.strictEqual(clone.token_deferred, undefined, 'ADAL memo must not be inherited');
+        assert.strictEqual(clone.msalInstance, undefined, 'MSAL instance captures the resource at build time');
+        assert.strictEqual(clone.accessToken, undefined, 'endpoint token is returned verbatim by getADALToken');
+    });
+
+    it('should leave the shared ARM credential untouched', () => {
+        const real = newRealCredential(true, 'ServicePrincipal');
+        (real as any).token_deferred = Promise.resolve('arm-adal-token');
+        (real as any).msalInstance = { capturedResource: ARM };
+
+        createSqlScopedCredentials({ applicationTokenCredentials: real }, SQL);
+
+        assert.strictEqual(real.activeDirectoryResourceId, ARM, 'ARM credential audience must not change');
+        assert.strictEqual(real.baseUrl, ARM, 'ARM credential baseUrl must not change');
+        assert.notStrictEqual((real as any).token_deferred, undefined, 'ARM token cache must survive');
+        assert.notStrictEqual((real as any).msalInstance, undefined, 'ARM MSAL instance must survive');
+    });
+
+    it('should preserve identity fields needed to authenticate', () => {
+        const real = newRealCredential(false, 'ServicePrincipal');
+        const clone = createSqlScopedCredentials({ applicationTokenCredentials: real }, SQL);
+
+        assert.strictEqual(clone.getClientId(), real.getClientId(), 'client id must carry over');
+        assert.strictEqual(clone.getTenantId(), real.getTenantId(), 'tenant id must carry over');
+        assert.strictEqual(clone.getUseMSAL(), real.getUseMSAL(), 'MSAL/ADAL selection must carry over');
+        assert.strictEqual(clone.scheme, real.scheme, 'scheme must carry over');
+    });
+
+    it('should derive sovereign cloud audiences', () => {
+        assert.strictEqual(getSqlAudienceFromEnvironment('AzureUSGovernment'), 'https://database.usgovcloudapi.net/');
+        assert.strictEqual(getSqlAudienceFromEnvironment('AzureChinaCloud'), 'https://database.chinacloudapi.cn/');
+        assert.strictEqual(getSqlAudienceFromEnvironment('AzureGermanCloud'), 'https://database.cloudapi.de/');
+        assert.strictEqual(getSqlAudienceFromEnvironment('AzureCloud'), SQL);
+        assert.strictEqual(getSqlAudienceFromEnvironment(undefined as any), SQL, 'unknown environment falls back to public cloud');
     });
 });
 

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0.ts
@@ -487,6 +487,32 @@ describe('MicrosoftSqlDeployment Suite', function () {
         }, tr);
     });
 
+    it('should use the sovereign cloud SQL audience and an isolated credential', async () => {
+        const tp = path.join(__dirname, 'L0SovereignCloudIsolatedSqlCredential.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed against a US Gov service connection');
+            assert(tr.stdout.indexOf('TOKEN_AUDIENCE:https://database.usgovcloudapi.net/') >= 0,
+                'token should be requested with the US Gov SQL audience, not the public cloud one');
+            assert(tr.stdout.indexOf('TOKEN_BASEURL:https://database.usgovcloudapi.net/') >= 0,
+                'baseUrl must also carry the SQL audience for the ADAL managed identity path');
+            assert(tr.stdout.indexOf('IS_SHARED_ARM_CREDENTIAL:false') >= 0,
+                'token must come from an isolated clone so the shared ARM credential stays usable for firewall cleanup');
+        }, tr);
+    });
+
+    it('should not request an access token for SQL authentication', async () => {
+        const tp = path.join(__dirname, 'L0NoTokenForSqlAuth.js');
+        const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+        await tr.runAsync();
+        runValidations(() => {
+            assert(tr.succeeded, 'task should succeed with SQL authentication');
+            assert(tr.stdout.indexOf('UNEXPECTED_TOKEN_REQUEST') < 0,
+                'no token should be requested when the connection string carries credentials');
+        }, tr);
+    });
+
     it('should fail when sqlcmd execution fails with non-zero exit code', async () => {
         const tp = path.join(__dirname, 'L0SqlcmdExecutionFailed.js');
         const tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0FirewallRuleRemovedAfterTokenAcquisition.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0FirewallRuleRemovedAfterTokenAcquisition.ts
@@ -1,0 +1,115 @@
+// The scenario this PR exists to fix, end to end:
+//   firewall rule added -> SQL token acquired -> removeFirewallRule() in the finally block
+//   still succeeds because the shared ARM credential was never repointed at the SQL audience.
+//
+// FirewallManager is the real implementation. The resource manager is faked, but it calls
+// getToken() on the shared endpoint credential exactly like ServiceClient does, so a
+// credential that has been poisoned with a SQL-audience token surfaces here.
+//
+// removeFirewallRule() only warns on failure, so the assertions check both the token the ARM
+// call received and the absence of the FailedToRemoveFirewallRule warning - a task that leaks
+// the rule would otherwise still report success.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'publish');
+tmr.setInput('path', 'test.dacpac');
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Default;');
+tmr.setInput('azureSubscription', 'test-subscription-id');
+tmr.setInput('firewallRuleManagement', 'true');
+
+const ARM_RESOURCE = 'https://management.azure.com/';
+const SQL_RESOURCE = 'https://database.windows.net/';
+
+// Models ADAL memoization: getToken() caches into token_deferred and later non-forced calls
+// return whatever was cached first.
+const armCredentials: any = {
+    activeDirectoryResourceId: ARM_RESOURCE,
+    baseUrl: ARM_RESOURCE,
+    token_deferred: undefined,
+    msalInstance: undefined,
+    accessToken: undefined,
+    async getToken(force?: boolean) {
+        if (!this.token_deferred || force) {
+            this.token_deferred = `token-for:${this.activeDirectoryResourceId}`;
+        }
+        return this.token_deferred;
+    }
+};
+
+const azureEndpoint: any = {
+    scheme: 'ServicePrincipal',
+    environment: 'AzureCloud',
+    tenantID: 'my-tenant-id',
+    servicePrincipalClientID: 'my-client-id',
+    servicePrincipalKey: 'my-client-secret',
+    applicationTokenCredentials: armCredentials
+};
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() { return azureEndpoint; }
+    }
+});
+
+tmr.registerMock('./src/SqlPackageHelper', {
+    default: {
+        findSqlPackage: async function() { return '/usr/local/bin/sqlpackage'; }
+    }
+});
+
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+// A blocked client IP, so a rule really is created and must later be removed.
+tmr.registerMock('./src/SqlUtils', {
+    default: {
+        detectIPAddress: async function() { return '203.0.113.10'; }
+    }
+});
+
+// Stands in for ServiceClient: every ARM operation takes a token from the shared credential.
+tmr.registerMock('./src/AzureSqlResourceManager', {
+    default: {
+        getResourceManager: async function(_serverName: string, endpoint: any) {
+            return {
+                addFirewallRule: async function(startIp: string, _endIp: string) {
+                    const token = await endpoint.applicationTokenCredentials.getToken();
+                    console.log(`ADD_RULE_TOKEN:${token}`);
+                    return { name: `ClientIp_${startIp}`, id: '/subscriptions/x/firewallRules/rule' };
+                },
+                removeFirewallRule: async function(_rule: any) {
+                    const token = await endpoint.applicationTokenCredentials.getToken();
+                    console.log(`REMOVE_RULE_TOKEN:${token}`);
+                    if (token.indexOf(ARM_RESOURCE) < 0) {
+                        // What ARM does when handed a SQL-audience token.
+                        throw new Error(`AudienceMismatch: ARM rejected ${token}`);
+                    }
+                }
+            };
+        }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.dacpac': true, '/usr/local/bin/sqlpackage': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/local/bin/sqlpackage': '/usr/local/bin/sqlpackage', '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // The deployment must still receive a SQL-audience token.
+        [`/usr/local/bin/sqlpackage /Action:Publish /SourceFile:test.dacpac /TargetServerName:myserver.database.windows.net /TargetDatabaseName:testdb /AccessToken:token-for:${SQL_RESOURCE}`]: {
+            code: 0,
+            stdout: 'Successfully published database.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0MsiMsalCacheNotReused.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0MsiMsalCacheNotReused.ts
@@ -1,0 +1,92 @@
+// Managed Identity + Active Directory Default + firewall management enabled.
+//
+// Models the MSAL caching semantics of ApplicationTokenCredentials: getMSAL() reuses an
+// existing msalInstance rather than rebuilding, and configureMSALWithMSI captures the
+// audience at build time ("let resourceId = this.activeDirectoryResourceId") instead of
+// re-reading it per call. Firewall management runs before the SQL token is acquired, so by
+// that point the shared credential already has an msalInstance built against the ARM
+// resource.
+//
+// If createSqlScopedCredentials copies that instance, getToken() hands back an ARM-audience
+// token that Azure SQL rejects. The expected exec below only matches the SQL-audience token.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'publish');
+tmr.setInput('path', 'test.dacpac');
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;Authentication=Active Directory Default;');
+tmr.setInput('azureSubscription', 'test-subscription-id');
+tmr.setInput('firewallRuleManagement', 'true');
+
+const ARM_RESOURCE = 'https://management.azure.com/';
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            return {
+                scheme: 'ManagedServiceIdentity',
+                environment: 'AzureCloud',
+                tenantID: 'my-tenant-id',
+                applicationTokenCredentials: {
+                    activeDirectoryResourceId: ARM_RESOURCE,
+                    baseUrl: ARM_RESOURCE,
+
+                    // Already built during firewall management, capturing the ARM resource.
+                    msalInstance: { capturedResource: ARM_RESOURCE },
+
+                    token_deferred: undefined,
+
+                    async getToken(_force?: boolean) {
+                        // getMSAL(): reuse the existing instance, otherwise build one that
+                        // captures whatever activeDirectoryResourceId is set at build time.
+                        if (!this.msalInstance) {
+                            this.msalInstance = { capturedResource: this.activeDirectoryResourceId };
+                        }
+                        return `token-for:${this.msalInstance.capturedResource}`;
+                    }
+                }
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlPackageHelper', {
+    default: {
+        findSqlPackage: async function() { return '/usr/local/bin/sqlpackage'; }
+    }
+});
+
+// firewallRuleManagement is on, so the task discovers sqlcmd for the connectivity probe.
+tmr.registerMock('./src/SqlcmdHelper', {
+    default: {
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
+    }
+});
+
+// Connectivity succeeds, so no firewall rule is created and no ARM call is needed here.
+// The credential still arrives with its msalInstance already built, which is the point.
+tmr.registerMock('./src/SqlUtils', {
+    default: {
+        detectIPAddress: async function() { return ''; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.dacpac': true, '/usr/local/bin/sqlpackage': true, '/usr/bin/sqlcmd': true },
+    which: { '/usr/local/bin/sqlpackage': '/usr/local/bin/sqlpackage', '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
+    exec: {
+        // Only the SQL-audience token matches. An ARM-audience token fails the run.
+        '/usr/local/bin/sqlpackage /Action:Publish /SourceFile:test.dacpac /TargetServerName:myserver.database.windows.net /TargetDatabaseName:testdb /AccessToken:token-for:https://database.windows.net/': {
+            code: 0,
+            stdout: 'Successfully published database.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0NoTokenForSqlAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0NoTokenForSqlAuth.ts
@@ -1,0 +1,61 @@
+// SQL authentication carries its own credentials in the connection string, so the task
+// must not request a SQL access token even though an azureSubscription is configured.
+// A needless request is wasteful and, on the ADAL path, poisons the shared credential cache.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'publish');
+tmr.setInput('path', 'test.dacpac');
+// SQL auth — no Authentication= keyword, credentials supplied inline
+tmr.setInput('connectionString', 'Server=myserver.database.windows.net;Database=testdb;User ID=sa;Password=TestPass123!;');
+tmr.setInput('azureSubscription', 'test-subscription-id');
+tmr.setInput('firewallRuleManagement', 'false');
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            return {
+                scheme: 'ServicePrincipal',
+                environment: 'AzureCloud',
+                tenantID: 'my-tenant-id',
+                servicePrincipalClientID: 'my-client-id',
+                servicePrincipalKey: 'my-client-secret',
+                applicationTokenCredentials: {
+                    activeDirectoryResourceId: 'https://management.azure.com/',
+                    baseUrl: 'https://management.azure.com/',
+                    async getToken(_force?: boolean) {
+                        // Should never run for SQL authentication.
+                        console.log('UNEXPECTED_TOKEN_REQUEST');
+                        return 'should-not-be-used';
+                    }
+                }
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlPackageHelper', {
+    default: {
+        findSqlPackage: async function() { return '/usr/local/bin/sqlpackage'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.dacpac': true, '/usr/local/bin/sqlpackage': true },
+    which: { '/usr/local/bin/sqlpackage': '/usr/local/bin/sqlpackage' },
+    exec: {
+        // No /AccessToken — the connection string carries the credentials
+        '/usr/local/bin/sqlpackage /Action:Publish /SourceFile:test.dacpac /TargetConnectionString:Server=myserver.database.windows.net;Database=testdb;User ID=sa;Password=TestPass123!;': {
+            code: 0,
+            stdout: 'Successfully published database.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SovereignCloudIsolatedSqlCredential.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SovereignCloudIsolatedSqlCredential.ts
@@ -1,7 +1,11 @@
 // Verifies two things for a sovereign cloud (US Gov) service connection:
 //  1. The SQL token is requested with the US Gov SQL audience, not the public cloud one.
-//  2. The token is acquired from an isolated credential, leaving the shared ARM credential
-//     untouched so the firewall rule cleanup in the finally block still works on ADAL.
+//  2. The token is requested from a distinct credential object rather than the shared
+//     endpoint credential.
+//
+// Firewall management is disabled here to isolate the audience derivation, so this test
+// says nothing about rule cleanup. The add -> token -> remove cycle that the isolation
+// actually protects is covered by L0FirewallRuleRemovedAfterTokenAcquisition.
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SovereignCloudIsolatedSqlCredential.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SovereignCloudIsolatedSqlCredential.ts
@@ -1,0 +1,73 @@
+// Verifies two things for a sovereign cloud (US Gov) service connection:
+//  1. The SQL token is requested with the US Gov SQL audience, not the public cloud one.
+//  2. The token is acquired from an isolated credential, leaving the shared ARM credential
+//     untouched so the firewall rule cleanup in the finally block still works on ADAL.
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'microsoftsqldeployment.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('action', 'publish');
+tmr.setInput('path', 'test.dacpac');
+tmr.setInput('connectionString', 'Server=myserver.database.usgovcloudapi.net;Database=testdb;Authentication=Active Directory Default;');
+tmr.setInput('azureSubscription', 'test-subscription-id');
+tmr.setInput('firewallRuleManagement', 'false');
+
+tmr.registerMock('azure-pipelines-tasks-azure-arm-rest/azure-arm-endpoint', {
+    AzureRMEndpoint: class {
+        constructor(_connectedServiceName: string) {}
+        async getEndpoint() {
+            const armCredentials: any = {
+                activeDirectoryResourceId: 'https://management.usgovcloudapi.net/',
+                baseUrl: 'https://management.usgovcloudapi.net/',
+                token_deferred: 'arm-token-already-cached',
+                async getToken(_force?: boolean) {
+                    // Report which audience this credential is scoped to, and whether the
+                    // call landed on the shared ARM credential or an isolated clone.
+                    console.log(`TOKEN_AUDIENCE:${this.activeDirectoryResourceId}`);
+                    console.log(`TOKEN_BASEURL:${this.baseUrl}`);
+                    console.log(`IS_SHARED_ARM_CREDENTIAL:${this.__isSharedArmCredential === true}`);
+                    return 'fake-usgov-sql-token';
+                }
+            };
+
+            // Non-enumerable so Object.assign in createSqlScopedCredentials does not copy it.
+            // Its absence on the credential used for the token proves a clone was used.
+            Object.defineProperty(armCredentials, '__isSharedArmCredential', {
+                value: true,
+                enumerable: false
+            });
+
+            return {
+                scheme: 'ServicePrincipal',
+                environment: 'AzureUSGovernment',
+                tenantID: 'my-tenant-id',
+                servicePrincipalClientID: 'my-client-id',
+                servicePrincipalKey: 'my-client-secret',
+                applicationTokenCredentials: armCredentials
+            };
+        }
+    }
+});
+
+tmr.registerMock('./src/SqlPackageHelper', {
+    default: {
+        findSqlPackage: async function() { return '/usr/local/bin/sqlpackage'; }
+    }
+});
+
+const a: ma.TaskLibAnswers = {
+    checkPath: { 'test.dacpac': true, '/usr/local/bin/sqlpackage': true },
+    which: { '/usr/local/bin/sqlpackage': '/usr/local/bin/sqlpackage' },
+    exec: {
+        '/usr/local/bin/sqlpackage /Action:Publish /SourceFile:test.dacpac /TargetServerName:myserver.database.usgovcloudapi.net /TargetDatabaseName:testdb /AccessToken:fake-usgov-sql-token': {
+            code: 0,
+            stdout: 'Successfully published database.'
+        }
+    }
+};
+tmr.setAnswers(a);
+
+tmr.run();

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadDefaultAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadDefaultAuth.ts
@@ -21,7 +21,7 @@ const a: ma.TaskLibAnswers = {
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
             // AAD Default: --authentication-method flag, no credentials needed
-            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryDefault -l 30 -i test.sql': {
+            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryDefault -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadPasswordAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadPasswordAuth.ts
@@ -21,7 +21,7 @@ const a: ma.TaskLibAnswers = {
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
             // AAD Password: --authentication-method flag + -U user, password via SQLCMDPASSWORD env var
-            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryPassword -U user@tenant.com -l 30 -i test.sql': {
+            '/usr/bin/sqlcmd -S localhost -d testdb --authentication-method ActiveDirectoryPassword -U user@tenant.com -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAadServicePrincipalAuth.ts
@@ -22,7 +22,7 @@ const a: ma.TaskLibAnswers = {
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
         // SP auth: --authentication-method flag + -U clientId@tenantId, secret via SQLCMDPASSWORD env var
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAutoInstallSuccess.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdAutoInstallSuccess.ts
@@ -27,7 +27,7 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, [sqlcmdExePath]: true },
     which: { [sqlcmdExePath]: sqlcmdExePath },
     exec: {
-        [`${sqlcmdExePath} -S localhost -d testdb -U sa -l 30 -i test.sql`]: { code: 0, stdout: 'Changed database context.' }
+        [`${sqlcmdExePath} -S localhost -d testdb -U sa -l 30 -b -i test.sql`]: { code: 0, stdout: 'Changed database context.' }
     }
 };
 tmr.setAnswers(a);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdExecutionFailed.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdExecutionFailed.ts
@@ -22,7 +22,7 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
-        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -b -i test.sql': {
             code: 1,
             stderr: 'Msg 208, Level 16, State 1, Server localhost, Line 1\nInvalid object name \'dbo.NonExistentTable\'.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFirewallProbeUsesSharedAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFirewallProbeUsesSharedAuth.ts
@@ -51,7 +51,7 @@ const a: ma.TaskLibAnswers = {
             code: 0,
             stdout: 'Validating connection from Azure Pipelines SQL Deployment Task'
         },
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromPath.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromPath.ts
@@ -22,7 +22,7 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
-        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': { code: 0, stdout: 'Changed database context.' }
+        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -b -i test.sql': { code: 0, stdout: 'Changed database context.' }
     }
 };
 tmr.setAnswers(a);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromUserPath.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdFromUserPath.ts
@@ -23,7 +23,7 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/custom/path/sqlcmd': true },
     which: { '/custom/path/sqlcmd': '/custom/path/sqlcmd' },
     exec: {
-        '/custom/path/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql': { code: 0, stdout: 'Changed database context.' }
+        '/custom/path/sqlcmd -S localhost -d testdb -U sa -l 30 -b -i test.sql': { code: 0, stdout: 'Changed database context.' }
     }
 };
 tmr.setAnswers(a);

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdOdbcOnPathFallsToAutoInstall.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdOdbcOnPathFallsToAutoInstall.ts
@@ -61,7 +61,7 @@ const a: ma.TaskLibAnswers = {
             stdout: 'Microsoft (R) SQL Server Command Line Tool\nVersion 17.10.0001.1'
         },
         // go-sqlcmd runs the script after auto-install
-        [`${goSqlcmdPath} -S localhost -d testdb -U sa -l 30 -i test.sql`]: {
+        [`${goSqlcmdPath} -S localhost -d testdb -U sa -l 30 -b -i test.sql`]: {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdRespectsUserErrorHandling.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdRespectsUserErrorHandling.ts
@@ -1,4 +1,6 @@
-// Succeeds with minimal valid inputs for a .sql script execution.
+// The task adds -b so a failing statement fails the deployment, but a user who wants
+// best-effort behaviour must be able to opt out. When additionalArguments already states
+// the intent, the task must not impose its own -b.
 import ma = require('azure-pipelines-task-lib/mock-answer');
 import tmrm = require('azure-pipelines-task-lib/mock-run');
 import path = require('path');
@@ -9,12 +11,11 @@ let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 tmr.setInput('action', 'sqlScript');
 tmr.setInput('path', 'test.sql');
 tmr.setInput('connectionString', 'Server=localhost;Database=testdb;User ID=sa;Password=TestPass123!;');
+tmr.setInput('additionalArguments', '--exit-on-error=false');
 
 tmr.registerMock('./src/SqlcmdHelper', {
     default: {
-        findSqlcmd: async function() {
-            return '/usr/bin/sqlcmd';
-        }
+        findSqlcmd: async function() { return '/usr/bin/sqlcmd'; }
     }
 });
 
@@ -22,7 +23,8 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
-        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -b -i test.sql': {
+        // No task-injected -b; the user's own flag is passed through instead
+        '/usr/bin/sqlcmd -S localhost -d testdb -U sa -l 30 -i test.sql --exit-on-error=false': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }
@@ -31,4 +33,3 @@ const a: ma.TaskLibAnswers = {
 tmr.setAnswers(a);
 
 tmr.run();
-

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdServicePrincipalAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdServicePrincipalAuth.ts
@@ -26,7 +26,7 @@ const a: ma.TaskLibAnswers = {
     checkPath: { 'test.sql': true, '/usr/bin/sqlcmd': true },
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdSpAuthTenantFromSubscription.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdSpAuthTenantFromSubscription.ts
@@ -43,7 +43,7 @@ const a: ma.TaskLibAnswers = {
     which: { '/usr/bin/sqlcmd': '/usr/bin/sqlcmd' },
     exec: {
         // Tenant appended from the service connection; secret still travels via SQLCMDPASSWORD
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryServicePrincipal -U my-client-id@my-tenant-id -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdWifUsesAzurePipelinesAuth.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/Tests/L0SqlcmdWifUsesAzurePipelinesAuth.ts
@@ -47,7 +47,7 @@ const a: ma.TaskLibAnswers = {
     exec: {
         // ActiveDirectoryAzurePipelines takes client/tenant/connection id from the
         // AZURESUBSCRIPTION_* env vars, so no -U is passed on the command line.
-        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryAzurePipelines -l 30 -i test.sql': {
+        '/usr/bin/sqlcmd -S myserver.database.windows.net -d testdb --authentication-method ActiveDirectoryAzurePipelines -l 30 -b -i test.sql': {
             code: 0,
             stdout: 'Changed database context to testdb.'
         }

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -9,6 +9,7 @@ import AzureSqlResourceManager from './src/AzureSqlResourceManager';
 import SqlProjectBuilder from './src/SqlProjectBuilder';
 import { SqlPackageExecutor } from './src/SqlPackageExecutor';
 import { SqlcmdExecutor, SqlcmdCredentials } from './src/SqlcmdExecutor';
+import { getSqlAudienceFromEnvironment, createSqlScopedCredentials } from './src/SqlTokenCredentials';
 
 // Node version handling for DNS and network settings
 const nodeVersion = parseInt(process.version.split('.')[0].replace('v', ''));
@@ -20,47 +21,6 @@ if (nodeVersion > 16) {
 if (nodeVersion > 19) {
     require("net").setDefaultAutoSelectFamily(false);
     tl.debug("Set default auto select family to false");
-}
-
-/**
- * Returns the SQL Database OAuth audience URL for the given Azure environment.
- * Defaults to Azure public cloud when the environment is unknown.
- */
-function getSqlAudienceFromEnvironment(environment: string): string {
-    switch ((environment ?? '').toLowerCase()) {
-        case 'azureusgovernment': return 'https://database.usgovcloudapi.net/';
-        case 'azurechinacloud':   return 'https://database.chinacloudapi.cn/';
-        case 'azuregermancloud':  return 'https://database.cloudapi.de/';
-        default:                  return 'https://database.windows.net/';
-    }
-}
-
-/**
- * Builds a credential that requests SQL-audience tokens without disturbing the ARM
- * credential that firewall rule management depends on.
- *
- * azureEndpoint.applicationTokenCredentials is shared: AzureSqlResourceManager passes the
- * same object to its ServiceClient. On the ADAL path getToken() memoizes the result in
- * token_deferred, so acquiring a SQL-scoped token through that object makes every later
- * ARM call reuse it - including removeFirewallRule() in the finally block, which would
- * then fail with an audience mismatch and silently leak the temporary rule.
- * Cloning gives the SQL request its own cache and leaves the shared object untouched.
- *
- * Both resource fields are set because the paths read different ones:
- *   ADAL service principal / MSAL -> activeDirectoryResourceId
- *   ADAL managed identity         -> baseUrl (getMSIAuthorizationToken)
- */
-function createSqlScopedCredentials(azureEndpoint: any, sqlAudience: string): any {
-    const armCredentials = azureEndpoint.applicationTokenCredentials;
-    const sqlCredentials = Object.create(Object.getPrototypeOf(armCredentials));
-    Object.assign(sqlCredentials, armCredentials);
-
-    // Start with an empty cache so this credential fetches its own SQL-scoped token.
-    sqlCredentials.token_deferred = undefined;
-    sqlCredentials.activeDirectoryResourceId = sqlAudience;
-    sqlCredentials.baseUrl = sqlAudience;
-
-    return sqlCredentials;
 }
 
 async function main(): Promise<void> {

--- a/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/microsoftsqldeployment.ts
@@ -22,6 +22,47 @@ if (nodeVersion > 19) {
     tl.debug("Set default auto select family to false");
 }
 
+/**
+ * Returns the SQL Database OAuth audience URL for the given Azure environment.
+ * Defaults to Azure public cloud when the environment is unknown.
+ */
+function getSqlAudienceFromEnvironment(environment: string): string {
+    switch ((environment ?? '').toLowerCase()) {
+        case 'azureusgovernment': return 'https://database.usgovcloudapi.net/';
+        case 'azurechinacloud':   return 'https://database.chinacloudapi.cn/';
+        case 'azuregermancloud':  return 'https://database.cloudapi.de/';
+        default:                  return 'https://database.windows.net/';
+    }
+}
+
+/**
+ * Builds a credential that requests SQL-audience tokens without disturbing the ARM
+ * credential that firewall rule management depends on.
+ *
+ * azureEndpoint.applicationTokenCredentials is shared: AzureSqlResourceManager passes the
+ * same object to its ServiceClient. On the ADAL path getToken() memoizes the result in
+ * token_deferred, so acquiring a SQL-scoped token through that object makes every later
+ * ARM call reuse it - including removeFirewallRule() in the finally block, which would
+ * then fail with an audience mismatch and silently leak the temporary rule.
+ * Cloning gives the SQL request its own cache and leaves the shared object untouched.
+ *
+ * Both resource fields are set because the paths read different ones:
+ *   ADAL service principal / MSAL -> activeDirectoryResourceId
+ *   ADAL managed identity         -> baseUrl (getMSIAuthorizationToken)
+ */
+function createSqlScopedCredentials(azureEndpoint: any, sqlAudience: string): any {
+    const armCredentials = azureEndpoint.applicationTokenCredentials;
+    const sqlCredentials = Object.create(Object.getPrototypeOf(armCredentials));
+    Object.assign(sqlCredentials, armCredentials);
+
+    // Start with an empty cache so this credential fetches its own SQL-scoped token.
+    sqlCredentials.token_deferred = undefined;
+    sqlCredentials.activeDirectoryResourceId = sqlAudience;
+    sqlCredentials.baseUrl = sqlAudience;
+
+    return sqlCredentials;
+}
+
 async function main(): Promise<void> {
     try {
         // Set resource path for localization
@@ -128,37 +169,43 @@ async function main(): Promise<void> {
                 // fields only — no token acquisition, so it cannot poison the ARM token cache.
                 sqlcmdCredentials = resolveSqlcmdCredentials(connectionConfig, azureSubscription, azureEndpoint);
 
-                // Acquire access token for database authentication
-                if (azureEndpoint.scheme === 'ServicePrincipal' ||
-                    azureEndpoint.scheme === 'WorkloadIdentityFederation' ||
-                    azureEndpoint.scheme === 'ManagedServiceIdentity') {
-                    try {
-                        // Set SQL resource audience before acquiring the token.
-                        // The default ARM audience is rejected by Azure SQL.
-                        // Save and restore the original resource ID so subsequent ARM calls
-                        // (e.g. firewall rule management) still use the ARM-scoped token.
-                        const originalResourceId = azureEndpoint.applicationTokenCredentials.activeDirectoryResourceId;
-                        try {
-                            azureEndpoint.applicationTokenCredentials.activeDirectoryResourceId = 'https://database.windows.net/';
-                            accessToken = await azureEndpoint.applicationTokenCredentials.getToken(true);
-                            if (accessToken) {
-                                tl.setSecret(accessToken);
-                                tl.debug(tl.loc('AccessTokenAcquired'));
-                            }
-                        } finally {
-                            azureEndpoint.applicationTokenCredentials.activeDirectoryResourceId = originalResourceId;
-                        }
-                    } catch (tokenError) {
-                        tl.debug(`Access token acquisition failed (non-fatal): ${tokenError.message || tokenError}`);
-                    }
-                }
-
+                // Firewall management runs before the SQL token is acquired so the ARM
+                // credential is still pristine here. The SQL token is additionally taken
+                // from an isolated credential (createSqlScopedCredentials), which is what
+                // keeps the ARM credential clean for the rule cleanup in the finally block.
                 if (firewallRuleManagement) {
                     const ipAddress = await SqlUtils.detectIPAddress(connectionConfig, sqlcmdExePath!, sqlcmdCredentials);
                     if (ipAddress) {
                         const resourceManager = await AzureSqlResourceManager.getResourceManager(connectionConfig.Server, azureEndpoint);
                         firewallManager = new FirewallManager(resourceManager);
                         await firewallManager.addFirewallRule(ipAddress);
+                    }
+                }
+
+                // Acquire the SQL-scoped token only for auth types that consume it
+                // (ActiveDirectoryDefault/Integrated). Gating on the same condition
+                // SqlPackageExecutor uses avoids pointless token requests for SQL auth,
+                // AAD Password and AAD Service Principal, which carry their own credentials.
+                const tokenBasedAuthTypes = ['activedirectorydefault', 'activedirectoryintegrated'];
+                const authType = (connectionConfig.FormattedAuthentication ?? '').toLowerCase();
+                const shouldAcquireToken = tokenBasedAuthTypes.includes(authType) &&
+                    (azureEndpoint.scheme === 'ServicePrincipal' ||
+                     azureEndpoint.scheme === 'WorkloadIdentityFederation' ||
+                     azureEndpoint.scheme === 'ManagedServiceIdentity');
+
+                if (shouldAcquireToken) {
+                    try {
+                        // Derive the audience from the service connection environment so
+                        // sovereign clouds (US Gov, China, Germany) resolve correctly.
+                        const sqlAudience = getSqlAudienceFromEnvironment(azureEndpoint.environment);
+                        const sqlCredentials = createSqlScopedCredentials(azureEndpoint, sqlAudience);
+                        accessToken = await sqlCredentials.getToken();
+                        if (accessToken) {
+                            tl.setSecret(accessToken);
+                            tl.debug(tl.loc('AccessTokenAcquired'));
+                        }
+                    } catch (tokenError) {
+                        tl.debug(`Access token acquisition failed (non-fatal): ${tokenError.message || tokenError}`);
                     }
                 }
             } else if (!firewallRuleManagement) {

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlTokenCredentials.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlTokenCredentials.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for acquiring a SQL-audience access token from an Azure service connection
+ * without disturbing the ARM credential the rest of the task depends on.
+ *
+ * Kept in its own module so the cloning behaviour can be unit tested against a real
+ * ApplicationTokenCredentials instance.
+ */
+
+/**
+ * Returns the SQL Database OAuth audience URL for the given Azure environment.
+ * Defaults to Azure public cloud when the environment is unknown.
+ */
+export function getSqlAudienceFromEnvironment(environment: string): string {
+    switch ((environment ?? '').toLowerCase()) {
+        case 'azureusgovernment': return 'https://database.usgovcloudapi.net/';
+        case 'azurechinacloud':   return 'https://database.chinacloudapi.cn/';
+        case 'azuregermancloud':  return 'https://database.cloudapi.de/';
+        default:                  return 'https://database.windows.net/';
+    }
+}
+
+/**
+ * Builds a credential that requests SQL-audience tokens without disturbing the ARM
+ * credential that firewall rule management depends on.
+ *
+ * azureEndpoint.applicationTokenCredentials is shared: AzureSqlResourceManager passes the
+ * same object to its ServiceClient, and that client outlives the deployment because the
+ * firewall rule is removed in a finally block. Acquiring a SQL-scoped token through the
+ * shared object makes later ARM calls reuse the wrong audience, and removeFirewallRule()
+ * only warns on failure - so the temporary rule would leak while the task reported success.
+ *
+ * Both resource fields are set because the code paths read different ones:
+ *   ADAL service principal / MSAL -> activeDirectoryResourceId
+ *   ADAL managed identity         -> baseUrl (getMSIAuthorizationToken)
+ *
+ * All three caches are cleared:
+ *   token_deferred - the ADAL memo; a non-forced getToken() returns it verbatim
+ *   msalInstance   - getMSAL() reuses an existing instance rather than rebuilding, and
+ *                    configureMSALWithMSI captures the resource at build time, so an
+ *                    inherited ARM-built instance would keep issuing ARM tokens
+ *   accessToken    - an endpoint-supplied token that getADALToken returns verbatim when
+ *                    not forced, ignoring the audience entirely
+ *
+ * Cloning is used rather than calling the constructor because it takes 17 positional
+ * parameters, several of which are TypeScript-private. Note this relies on those fields
+ * being enumerable own properties at runtime - if the library moves to true private fields
+ * or a WeakMap, the unit tests covering this function are what will catch it.
+ */
+export function createSqlScopedCredentials(azureEndpoint: any, sqlAudience: string): any {
+    const armCredentials = azureEndpoint.applicationTokenCredentials;
+    const sqlCredentials = Object.create(Object.getPrototypeOf(armCredentials));
+    Object.assign(sqlCredentials, armCredentials);
+
+    sqlCredentials.token_deferred = undefined;
+    sqlCredentials.msalInstance = undefined;
+    sqlCredentials.accessToken = undefined;
+    sqlCredentials.activeDirectoryResourceId = sqlAudience;
+    sqlCredentials.baseUrl = sqlAudience;
+
+    return sqlCredentials;
+}

--- a/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
+++ b/Tasks/MicrosoftSqlDeploymentV1/src/SqlcmdExecutor.ts
@@ -30,6 +30,16 @@ export class SqlcmdExecutor {
     ): Promise<void> {
         const args = this.buildConnectionArguments(connectionConfig, credentials, 30);
 
+        // Abort and return a non-zero exit code when a statement fails. Without -b,
+        // go-sqlcmd prints the error but still exits 0, so a half-applied migration would
+        // be reported as a successful deployment. Only severity >= 11 aborts, so PRINT
+        // output and informational messages are unaffected.
+        // Skipped when the user states their own intent in additionalArguments, which also
+        // provides the opt-out: additionalArguments: '--exit-on-error=false'.
+        if (!this.specifiesErrorHandling(additionalArguments)) {
+            args.push('-b');
+        }
+
         // Input file
         args.push('-i');
         args.push(scriptPath);
@@ -173,6 +183,14 @@ export class SqlcmdExecutor {
         args.push(String(loginTimeoutSeconds));
 
         return args;
+    }
+
+    /**
+     * Returns true when the caller has already specified sqlcmd's error-handling behaviour,
+     * so the task should not impose its own default.
+     */
+    private static specifiesErrorHandling(additionalArguments?: string): boolean {
+        return /(^|\s)(-b|--exit-on-error)(\s|=|$)/.test(additionalArguments ?? '');
     }
 
     /**

--- a/Tasks/MicrosoftSqlDeploymentV1/task.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 278,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",

--- a/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
+++ b/Tasks/MicrosoftSqlDeploymentV1/task.loc.json
@@ -17,7 +17,7 @@
   "version": {
     "Major": 1,
     "Minor": 278,
-    "Patch": 3
+    "Patch": 4
   },
   "demands": [],
   "minimumAgentVersion": "2.144.0",


### PR DESCRIPTION
Addresses review feedback from @nemanjarogic on #22379.

# Auth / token fixes

- Acquire the SQL token from an isolated credential clone instead of mutating azureEndpoint.applicationTokenCredentials. The shared object is reused by AzureSqlResourceManager, and on ADAL getToken(true) overwrites token_deferred — which broke removeFirewallRule() in the finally block and silently leaked the temporary firewall rule.
- Set both activeDirectoryResourceId and baseUrl on that clone. ADAL managed identity reads baseUrl, so MSI connections were previously getting an ARM-audience token that Azure SQL rejects.
- Gate token acquisition on tokenBasedAuthTypes (same condition SqlPackageExecutor uses for consumption). SQL auth / AAD Password / AAD SP no longer trigger a discarded token request.
- Derive the SQL audience from azureEndpoint.environment instead of hardcoding public cloud — US Gov, China, Germany. URLs match DacFx SqlPackageUniversalAuthProvider.cs.
- Run firewall management before token acquisition.

# sqlcmd fix

Pass -b for .sql execution. Without it go-sqlcmd exits 0 on a failed statement, so a half-applied migration reported success. Not added when additionalArguments already specifies -b/--exit-on-error, so --exit-on-error=false remains the opt-out. Connectivity probe unchanged.
Other

Task version → 1.278.4
Tests — 89 passing (3 new)