### PR TITLE
Update picomatch to 2.3.2 in PowerShellV2 and CmdLineV2

### DIFF
--- a/Tasks/CmdLineV2/package-lock.json
+++ b/Tasks/CmdLineV2/package-lock.json
@@ -473,9 +473,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Tasks/CmdLineV2/package.json
+++ b/Tasks/CmdLineV2/package.json
@@ -25,6 +25,9 @@
     "azure-pipelines-task-lib": "^5.2.10",
     "uuid": "^8.3.0"
   },
+  "overrides": {
+    "picomatch": "2.3.2"
+  },
   "devDependencies": {
     "typescript": "^5.7.2"
   }

--- a/Tasks/CmdLineV2/task.json
+++ b/Tasks/CmdLineV2/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 276,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "Script task consistency. Added support for multiple lines.",

--- a/Tasks/CmdLineV2/task.loc.json
+++ b/Tasks/CmdLineV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 276,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",

--- a/Tasks/PowerShellV2/package-lock.json
+++ b/Tasks/PowerShellV2/package-lock.json
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"

--- a/Tasks/PowerShellV2/package.json
+++ b/Tasks/PowerShellV2/package.json
@@ -21,6 +21,9 @@
     "azure-pipelines-tasks-utility-common": "3.272.0",
     "uuid": "^3.0.1"
   },
+  "overrides": {
+    "picomatch": "2.3.2"
+  },
   "devDependencies": {
     "typescript": "^5.7.2"
   }

--- a/Tasks/PowerShellV2/task.json
+++ b/Tasks/PowerShellV2/task.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 278,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "Script task consistency. Added support for macOS and Linux.",

--- a/Tasks/PowerShellV2/task.loc.json
+++ b/Tasks/PowerShellV2/task.loc.json
@@ -17,7 +17,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 278,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
Security scanning identified `picomatch@2.3.1` in PowerShellV2 and CmdLineV2. This version is affected by CVE-2026-33671. 
[AB#2451088](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2451088)

---

### **Task Name**
- PowerShellV2
- CmdLineV2

---

### **Description**
- Updates `picomatch` from `2.3.1` to `2.3.2`.
- Adds npm overrides to enforce the patched version during lock-file regeneration.
- Bumps both tasks to version `2.279.0`.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Additional Testing Performed**
No

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Rollback to the previous version of the task.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
