### PR TITLE
Remove external sprint dependency and update CI networking

### DIFF
--- a/.github/copilot/skills/fix-cg-bug.md
+++ b/.github/copilot/skills/fix-cg-bug.md
@@ -379,7 +379,7 @@ npm ls <PACKAGE_NAME>
 
 This repository has a Copilot hook (`.github/hooks/bump-task-version.sh`) that automatically provides version bumping guidance when you edit task files. Simply ask Copilot to bump the task version, and it will:
 
-1. Fetch the current sprint information from `https://whatsprintis.it/?json`
+1. Calculate the current sprint information with `node ci/sprint.js`
 2. Calculate the target Minor version based on sprint rules
 3. Update both `task.json` and `task.loc.json` accordingly
 
@@ -402,7 +402,7 @@ node make.js bump --sprint 271
 
 This command will:
 - Detect which tasks have been modified
-- Fetch the current sprint information
+- Calculate the current sprint information locally
 - Apply the sprint-based versioning rules automatically
 - Update both `task.json` and `task.loc.json` for each affected task
 
@@ -410,9 +410,9 @@ This command will:
 
 If you need to bump the version manually, follow these sprint-based rules:
 
-1. **Fetch current sprint information:**
+1. **Calculate current sprint information:**
    ```bash
-   curl -s 'https://whatsprintis.it/?json' | jq '{sprint: .sprint, week: .week}'
+   node ci/sprint.js
    ```
 
 2. **Determine target Minor version:**

--- a/.github/hooks/bump-task-version.sh
+++ b/.github/hooks/bump-task-version.sh
@@ -22,8 +22,9 @@ if [[ -z "$TASK_NAME" ]]; then
   exit 0
 fi
 
-# Fetch current sprint info
-SPRINT_JSON=$(curl -sf --max-time 5 "https://whatsprintis.it/?json") || exit 0
+# Calculate current sprint info
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+SPRINT_JSON=$(node "$REPO_ROOT/ci/sprint.js") || exit 0
 SPRINT=$(echo "$SPRINT_JSON" | jq -r '.sprint')
 WEEK=$(echo "$SPRINT_JSON" | jq -r '.week')
 

--- a/.github/instructions/task-version.instructions.md
+++ b/.github/instructions/task-version.instructions.md
@@ -8,7 +8,7 @@ When modifying any file under a task directory (`Tasks/<TaskName>/`), the task v
 
 ## Minor / Patch bumps
 
-1. Fetch the current sprint from https://whatsprintis.it/?json
+1. Calculate the current sprint and week by running `node ci/sprint.js`.
 2. If the sprint week is past Tuesday of week 3 (i.e., week > 3, or week == 3 and today is after Tuesday), target `Minor = sprint + 1`. Otherwise target `Minor = sprint`.
 3. If the task's current `Minor` already equals the target, increment `Patch` by 1.
 4. If the task's current `Minor` differs from the target, set `Minor` to the target and reset `Patch` to 0.

--- a/BuildConfigGen/Program.cs
+++ b/BuildConfigGen/Program.cs
@@ -112,7 +112,7 @@ namespace BuildConfigGen
 
         /// <param name="task">The task to generate build configs for</param>
         /// <param name="configs">List of configs to generate seperated by |</param>
-        /// <param name="currentSprint">Overide current sprint; omit to get from whatsprintis.it</param>
+        /// <param name="currentSprint">Override current sprint; omit to calculate it from the standard three-week cadence</param>
         /// <param name="writeUpdates">Write updates if true, else validate that the output is up-to-date</param>
         /// <param name="allTasks"></param>
         /// <param name="getTaskVersionTable"></param>
@@ -132,7 +132,7 @@ namespace BuildConfigGen
             };
             Option<int?> currentSprintOption = new("--current-sprint")
             {
-                Description = "Overide current sprint; omit to get from whatsprintis.it"
+                Description = "Override current sprint; omit to calculate it from the standard three-week cadence"
             };
             Option<bool> writeUpdatesOption = new("--write-updates")
             {
@@ -644,20 +644,11 @@ namespace BuildConfigGen
             // Scheduled time for Cortesy Push
             var cortesyPushScheduleDay = DayOfWeek.Tuesday;
             var cortesyPushUtcTime = new TimeOnly(8, 30); //UTC time
-
-            string url = "https://whatsprintis.it";
-            var httpClient = new HttpClient();
-            httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
-
-            string json = httpClient.GetStringAsync(url).Result;
-            JsonDocument currentSprintData = JsonDocument.Parse(json);
-            int currentSprint = currentSprintData.RootElement.GetProperty("sprint").GetInt32();
-            int week = currentSprintData.RootElement.GetProperty("week").GetInt32();
+            var nowUtc = DateTimeOffset.UtcNow;
+            (int currentSprint, int week) = CalculateSprint(nowUtc);
 
             if (week == 3) // if it is the end of the current sprint
             {
-                var nowUtc = DateTime.UtcNow;
-
                 // Increase sprint number if scheduled pipeline was already triggered
                 if (nowUtc.DayOfWeek > cortesyPushScheduleDay)
                 {
@@ -665,7 +656,7 @@ namespace BuildConfigGen
                 }
                 else if (nowUtc.DayOfWeek == cortesyPushScheduleDay)
                 {
-                    if (TimeOnly.FromDateTime(nowUtc) >= cortesyPushUtcTime)
+                    if (TimeOnly.FromDateTime(nowUtc.UtcDateTime) >= cortesyPushUtcTime)
                     {
                         currentSprint++;
                     }
@@ -673,6 +664,20 @@ namespace BuildConfigGen
             }
 
             return currentSprint;
+        }
+
+        private static (int Sprint, int Week) CalculateSprint(DateTimeOffset date)
+        {
+            // Sprint 267 started at this UTC instant, establishing the fixed three-week cadence.
+            const int sprintEpochNumber = 267;
+            const int daysPerSprint = 21;
+            const int daysPerWeek = 7;
+            var sprintEpochStart = new DateTimeOffset(2025, 11, 29, 0, 0, 0, TimeSpan.Zero);
+            double elapsedDays = (date.ToUniversalTime() - sprintEpochStart).TotalDays;
+            int sprintOffset = (int)Math.Floor(elapsedDays / daysPerSprint);
+            int dayInSprint = (int)Math.Floor(elapsedDays - sprintOffset * daysPerSprint);
+
+            return (sprintEpochNumber + sprintOffset, dayInSprint / daysPerWeek + 1);
         }
 
         private static void ThrowWithUserFriendlyErrorToRerunWithWriteUpdatesIfVeriferError(string? task, bool skipContentCheck)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3,GitHub
     featureFlags:
       autoBaseline: false
     sdl:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: Monitored.Unrestricted,CFSClean,NuGet
+      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3
     featureFlags:
       autoBaseline: false
     sdl:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ extends:
   parameters:
     settings:
       skipBuildTagsForGitHubPullRequests: true
-      networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3,GitHub
+      networkIsolationPolicy: Monitored.Unrestricted,CFSClean,CFSClean2,CFSClean3,GitHub
     featureFlags:
       autoBaseline: false
     sdl:

--- a/ci/ci-release-notes/package-lock.json
+++ b/ci/ci-release-notes/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@octokit/rest": "^16.43.2",
-        "axios": "1.18.0"
+        "@octokit/rest": "^16.43.2"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -373,41 +372,11 @@
         "undici-types": "~7.19.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "license": "MIT"
-    },
     "node_modules/atob-lite": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/atob-lite/-/atob-lite-2.0.0.tgz",
       "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.18.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/axios/-/axios-1.18.0.tgz",
-      "integrity": "sha1-in+IVK8oD8quBjJy3y7Z84N9I5g=",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
     },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
@@ -420,31 +389,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "license": "MIT"
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "6.0.6",
@@ -462,51 +406,11 @@
         "node": ">=4.8"
       }
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/deprecation": {
       "version": "2.3.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha1-Y2jL20Cr8zc7UlrIfkomDDpwCRk=",
       "license": "ISC"
-    },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -515,51 +419,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/execa": {
@@ -597,88 +456,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha1-KEdKFZ07nRHvYgUKFO1g5N9tYbw=",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
@@ -689,70 +466,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/is-plain-object": {
@@ -815,42 +528,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "license": "MIT"
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -934,15 +611,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha1-p0h1aK2tV3z6qn6IxJyrOrMIGro=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/pump": {

--- a/ci/ci-release-notes/package.json
+++ b/ci/ci-release-notes/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^16.43.2",
-    "axios": "1.18.0"
+    "@octokit/rest": "^16.43.2"
   }
 }

--- a/ci/ci-release-notes/release-notes.js
+++ b/ci/ci-release-notes/release-notes.js
@@ -1,7 +1,7 @@
 const argv = require('minimist')(process.argv.slice(2));
-const axios = require("axios");
 
 const util = require('../ci-util');
+const { getSprintDates } = require('../sprint');
 const tempGen = require('./template-generator');
 
 const { Octokit } = require('@octokit/rest');
@@ -11,7 +11,6 @@ const REPO = 'azure-pipelines-tasks';
 const GIT = 'git';
 const VALID_RELEASE_RE = /^[0-9]{1,3}$/;
 
-const getWhatSprintUrl = sprintVersion => `https://whatsprintis.it/sprint/${sprintVersion}`;
 if (!argv.token) throw Error('token is required');
 
 const octokit = new Octokit({ auth: argv.token });
@@ -103,8 +102,7 @@ async function getPRsFromDate(branch, dateFrom, dateTo) {
 */
 async function fetchPRsForRelease(baseBranch, version) {
     try {
-        const sprintResponse = await axios.get(getWhatSprintUrl(version));
-        const sprintData = sprintResponse.data;
+        const sprintData = getSprintDates(Number(version));
         console.log('Getting latest release');
 
         releaseInfo = await octokit.repos.getLatestRelease({
@@ -126,7 +124,7 @@ async function fetchPRsForRelease(baseBranch, version) {
             process.exit(-1);
         }
     } catch (e) {
-        console.log("Failed to fetch sprint dates for version " + version);
+        console.log("Failed to calculate sprint dates for version " + version);
         console.log(e);
         process.exit(-1);
     }

--- a/ci/set-sprint-variables.ps1
+++ b/ci/set-sprint-variables.ps1
@@ -1,5 +1,9 @@
 # Determine current sprint.
-$currentSprint = (Invoke-WebRequest https://whatsprintis.it -UseBasicParsing -Headers @{"Accept" = "application/json" } | ConvertFrom-Json)
+$sprintOutput = & node (Join-Path $PSScriptRoot "sprint.js")
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to calculate the current sprint"
+}
+$currentSprint = $sprintOutput | ConvertFrom-Json
 
 $sprint = $currentSprint.sprint
 $week = $currentSprint.week

--- a/ci/sprint.js
+++ b/ci/sprint.js
@@ -1,0 +1,65 @@
+const MILLISECONDS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+const MILLISECONDS_PER_SPRINT = 3 * MILLISECONDS_PER_WEEK;
+// Sprint 267 started at this UTC instant, establishing the fixed three-week cadence.
+const SPRINT_EPOCH_NUMBER = 267;
+const SPRINT_EPOCH_START = Date.parse('2025-11-29T00:00:00.000Z');
+
+function getSprintInfo(date = new Date()) {
+    if (!(date instanceof Date) || !Number.isFinite(date.getTime())) {
+        throw new TypeError('Sprint calculation requires a valid date.');
+    }
+
+    const elapsedMilliseconds = date.getTime() - SPRINT_EPOCH_START;
+    const sprintOffset = Math.floor(elapsedMilliseconds / MILLISECONDS_PER_SPRINT);
+    const sprintStart = SPRINT_EPOCH_START + sprintOffset * MILLISECONDS_PER_SPRINT;
+    const week = Math.floor((date.getTime() - sprintStart) / MILLISECONDS_PER_WEEK) + 1;
+
+    return {
+        sprint: SPRINT_EPOCH_NUMBER + sprintOffset,
+        week
+    };
+}
+
+function getSprintDates(sprint) {
+    if (!Number.isInteger(sprint) || sprint <= 0) {
+        throw new TypeError('Sprint must be a positive integer.');
+    }
+
+    const sprintStart = SPRINT_EPOCH_START
+        + (sprint - SPRINT_EPOCH_NUMBER) * MILLISECONDS_PER_SPRINT;
+    const weeks = {};
+
+    for (let week = 1; week <= 3; week++) {
+        const weekStart = sprintStart + (week - 1) * MILLISECONDS_PER_WEEK;
+        weeks[week] = {
+            start: new Date(weekStart).toISOString(),
+            end: new Date(weekStart + MILLISECONDS_PER_WEEK - 1).toISOString()
+        };
+    }
+
+    return {
+        sprint,
+        start: new Date(sprintStart).toISOString(),
+        end: new Date(sprintStart + MILLISECONDS_PER_SPRINT - 1).toISOString(),
+        weeks
+    };
+}
+
+if (require.main === module) {
+    const sprintArgumentIndex = process.argv.indexOf('--sprint');
+
+    try {
+        const result = sprintArgumentIndex === -1
+            ? getSprintInfo()
+            : getSprintDates(Number(process.argv[sprintArgumentIndex + 1]));
+        console.log(JSON.stringify(result));
+    } catch (error) {
+        console.error(error.message);
+        process.exitCode = 1;
+    }
+}
+
+module.exports = {
+    getSprintDates,
+    getSprintInfo
+};

--- a/ci/sprint.test.js
+++ b/ci/sprint.test.js
@@ -1,0 +1,41 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { getSprintDates, getSprintInfo } = require('./sprint');
+
+test('getSprintInfo calculates the sprint and week in UTC', () => {
+    assert.deepEqual(getSprintInfo(new Date('2025-11-29T00:00:00.000Z')), { sprint: 267, week: 1 });
+    assert.deepEqual(getSprintInfo(new Date('2025-12-05T23:59:59.999Z')), { sprint: 267, week: 1 });
+    assert.deepEqual(getSprintInfo(new Date('2025-12-06T00:00:00.000Z')), { sprint: 267, week: 2 });
+    assert.deepEqual(getSprintInfo(new Date('2025-12-13T00:00:00.000Z')), { sprint: 267, week: 3 });
+    assert.deepEqual(getSprintInfo(new Date('2025-12-20T00:00:00.000Z')), { sprint: 268, week: 1 });
+    assert.deepEqual(getSprintInfo(new Date('2025-11-28T23:59:59.999Z')), { sprint: 266, week: 3 });
+});
+
+test('getSprintDates returns the sprint date range and weekly ranges', () => {
+    assert.deepEqual(getSprintDates(267), {
+        sprint: 267,
+        start: '2025-11-29T00:00:00.000Z',
+        end: '2025-12-19T23:59:59.999Z',
+        weeks: {
+            1: {
+                start: '2025-11-29T00:00:00.000Z',
+                end: '2025-12-05T23:59:59.999Z'
+            },
+            2: {
+                start: '2025-12-06T00:00:00.000Z',
+                end: '2025-12-12T23:59:59.999Z'
+            },
+            3: {
+                start: '2025-12-13T00:00:00.000Z',
+                end: '2025-12-19T23:59:59.999Z'
+            }
+        }
+    });
+});
+
+test('sprint helpers reject invalid inputs', () => {
+    assert.throws(() => getSprintInfo(new Date('invalid')), /valid date/);
+    assert.throws(() => getSprintDates(0), /positive integer/);
+    assert.throws(() => getSprintDates(1.5), /positive integer/);
+});

--- a/docs/taskversionbumping.md
+++ b/docs/taskversionbumping.md
@@ -1,6 +1,6 @@
 # Bumping task version
 To bump task version - please change 'version' field in task.json and task.loc.json files following the steps below:
-1. Check current Azure DevOps sprint - https://whatsprintis.it/
+1. Calculate the current Azure DevOps sprint and week by running `node ci/sprint.js`.
 2. If sprint number differs from current minor number - set it to current sprint number, set patch to 0. Since there is cut off on Tuesday of the 3rd week of the sprint - for changes on 3rd sprint week after Tuesday - set it up as (current sprint number) + 1. For this case changes will be shipped with the next release.
 3. If the minor version and the sprint number are the same - increase patch number
 

--- a/make-util.js
+++ b/make-util.js
@@ -15,6 +15,7 @@ const shell = require('shelljs');
 const makeOptions = require('./make-options.json');
 const downloadUtils = require('./build-scripts/download-utils.js');
 const { cleanNodeDistribution } = require('./build-scripts/node-dist-utils.js');
+const { getSprintInfo } = require('./ci/sprint');
 
 const args = minimist(process.argv.slice(2));
 
@@ -2153,13 +2154,7 @@ function getChangedTasks() {
 exports.getChangedTasks = getChangedTasks;
 
 async function getCurrentSprint() {
-    const result = await fetch("https://whatsprintis.it", {
-        headers: {
-            "Accept": "application/json"
-        }
-    });
-
-    return result.json();
+    return getSprintInfo();
 }
 
 exports.getCurrentSprint = getCurrentSprint;


### PR DESCRIPTION
### **Context**
Azure Pipelines sprints follow a fixed three-week cadence. Pipeline and build tooling currently depend on an external service to determine the current sprint, week, and sprint date range. Calculating these values locally removes that network dependency. The CI network isolation policy is also updated to include the required CFS and GitHub policies while retaining `Monitored.Unrestricted`, which is currently required for the pipeline to pass.

[AB#2421765](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2421765)

---

### **Task Name**
N/A — build and pipeline tooling only; no pipeline task was changed.

---

### **Description**
- Add `ci/sprint.js` to calculate the current sprint/week and sprint date ranges in UTC from the fixed three-week cadence.
- Update pipeline variable setup, version bumping, release-note generation, `make-util.js`, and `BuildConfigGen` to calculate sprint information locally.
- Set the CI pipeline network isolation policy to `Monitored.Unrestricted,CFSClean,CFSClean2,CFSClean3,GitHub`, replacing `NuGet` while retaining unrestricted monitoring required by CI.
- Update Copilot guidance and task-version documentation to reference the local utility.
- Remove the now-unused Axios dependency from release-note generation.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** The local utility preserves the existing JSON shapes and uses a known sprint boundary as its epoch. Changes are limited to build, release, and repository-maintenance tooling. The CI policy retains `Monitored.Unrestricted` and adds the requested CFS-clean and GitHub policies. The primary risk is a future sprint cadence change.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** This removes an external runtime dependency and updates internal CI policy configuration. A feature flag would retain the dependency and add unnecessary branching.

---

### **Tech Design / Approach**
- Use sprint 267 (`2025-11-29T00:00:00.000Z`) as the known UTC epoch.
- Calculate sprint offsets in fixed 21-day intervals and weeks in fixed 7-day intervals.
- Expose both the current `{ sprint, week }` response and detailed sprint date ranges for release-note generation.
- Share the JavaScript utility across Node, PowerShell pipelines, and the Copilot hook. `BuildConfigGen` uses the same constants and formula natively to avoid spawning Node from .NET.
- Configure the CI OneES template with `Monitored.Unrestricted`, `CFSClean`, `CFSClean2`, `CFSClean3`, and `GitHub` network isolation policies.

---

### **Documentation Changes Required** (Yes/No)
**Yes.** Task-version documentation, Copilot instructions, and the Component Governance workflow now reference the local sprint utility.

---

### **Unit Tests Added or Updated** (Yes / No)
**Yes.** Added UTC sprint/week boundary tests, sprint date-range contract coverage, and invalid-input cases.

---

### **Additional Testing Performed**
- `node --test ci\sprint.test.js`
- Executed `ci\set-sprint-variables.ps1` and confirmed pipeline variables for sprint 279, week 1.
- `dotnet build BuildConfigGen\BuildConfigGen.csproj --nologo --verbosity:minimal`
- Temporarily changed `BashV3` from `3.278.0` to `3.279.0` and ran `BuildConfigGen` without `--current-sprint`; confirmed it calculated sprint 279, verify mode produced the expected updates-needed error, and write mode generated `Default|3.279.0` and `minified_278|3.279.1`. All temporary changes were restored.
- Verified Node syntax and `make-util.js` integration.
- Parsed `azure-pipelines.yml` successfully with `js-yaml` after changing the isolation policy.
- Confirmed no external sprint-service references remain in tracked repository files.

---

### **Logging Added/Updated** (Yes/No)
**No.** Existing pipeline output is preserved; no new logging is required.

---

### **Telemetry Added/Updated** (Yes/No)
**No.** This internal build-tooling change does not require telemetry.

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert the PR to restore the previous external service calls, Axios dependency, and CI network isolation policy.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** All known sprint-service callers were updated. Axios was only used for sprint date retrieval in release-note generation and was removed from both the manifest and lockfile. CI retains `Monitored.Unrestricted` and adds the requested CFS-clean and GitHub policies.

---

### **Checklist**
- [x] Related issue linked (not applicable — no related issue)
- [x] Task version was bumped (not applicable — no files under `Tasks/` changed)
- [x] Verified the affected build and pipeline tooling behaves as expected