### PR TITLE
Remove SfSafeParser feature flag

### DIFF
--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -399,22 +399,14 @@ function Publish-UpgradedServiceFabricApplication
             $serviceTypeHealthPolicyMap = $UpgradeParameters["ServiceTypeHealthPolicyMap"]
             if ($serviceTypeHealthPolicyMap -and $serviceTypeHealthPolicyMap -is [string])
             {
-                $useSafeParser = Get-VstsPipelineFeature -FeatureName 'SfSafeParser'
-                if (-not $useSafeParser)
+                try
                 {
-                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = Invoke-Expression $serviceTypeHealthPolicyMap
+                    $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
                 }
-                else
+                catch
                 {
-                    try
-                    {
-                        $UpgradeParameters["ServiceTypeHealthPolicyMap"] = ConvertTo-ServiceTypeHealthPolicyMap -PolicyMapString $serviceTypeHealthPolicyMap
-                    }
-                    catch
-                    {
                         Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorData $_
-                        throw
-                    }
+                    throw
                 }
             }
 

--- a/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
+++ b/Tasks/ServiceFabricDeployV1/ServiceFabricSDK/Publish-UpgradedServiceFabricApplication.ps1
@@ -405,7 +405,7 @@ function Publish-UpgradedServiceFabricApplication
                 }
                 catch
                 {
-                        Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorData $_
+                    Publish-Telemetry -TaskName "ServiceFabricDeploy" -OperationId "SfSafeParserFailure" -ErrorData $_
                     throw
                 }
             }

--- a/Tasks/ServiceFabricDeployV1/task.json
+++ b/Tasks/ServiceFabricDeployV1/task.json
@@ -17,7 +17,7 @@
     ],
     "version": {
         "Major": 1,
-        "Minor": 276,
+        "Minor": 279,
         "Patch": 0
     },
     "demands": [

--- a/Tasks/ServiceFabricDeployV1/task.loc.json
+++ b/Tasks/ServiceFabricDeployV1/task.loc.json
@@ -17,7 +17,7 @@
   ],
   "version": {
     "Major": 1,
-    "Minor": 276,
+    "Minor": 279,
     "Patch": 0
   },
   "demands": [


### PR DESCRIPTION
### **Context**
Removes the fully rolled-out `SfSafeParser` feature flag. Related work item: [AB#2401874](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2401874).

---

### **Task Name**
ServiceFabricDeployV1

---

### **Description**
The safe-parser path is already enabled in production. Removes `SfSafeParser` feature flag

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Documentation Changes Required** (Yes/No)
No

---

### **Unit Tests Added or Updated** (Yes / No)  
No

---

### **Logging Added/Updated** (Yes/No)
No

--- 

### **Telemetry Added/Updated** (Yes/No) 
No

---

### **Rollback Scenario and Process** (Yes/No)
Revert this PR

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
