### PR TITLE
Update NodeTool task correct deprecation message

### DIFF
--- a/Tasks/NodeToolV0/task.json
+++ b/Tasks/NodeToolV0/task.json
@@ -14,10 +14,10 @@
   "version": {
     "Major": 0,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "deprecated": true,
-  "deprecationMessage": "This task is deprecated and will no longer receive updates. Please use UseNodeV1 as a replacement.",
+  "deprecationMessage": "This task is deprecated and will no longer receive updates. Please use UseNode@1 as a replacement.",
   "satisfies": [
     "Node",
     "npm",

--- a/Tasks/NodeToolV0/task.loc.json
+++ b/Tasks/NodeToolV0/task.loc.json
@@ -14,10 +14,10 @@
   "version": {
     "Major": 0,
     "Minor": 279,
-    "Patch": 0
+    "Patch": 1
   },
   "deprecated": true,
-  "deprecationMessage": "This task is deprecated and will no longer receive updates. Please use UseNodeV1 as a replacement.",
+  "deprecationMessage": "This task is deprecated and will no longer receive updates. Please use UseNode@1 as a replacement.",
   "satisfies": [
     "Node",
     "npm",


### PR DESCRIPTION
This pull request makes minor updates to the `NodeToolV0` task metadata files to clarify the deprecation message and increment the patch version.

- Deprecation message clarification:
  * Updated the deprecation message to recommend using `UseNode@1` instead of `UseNodeV1` for better clarity and consistency. [[1]](diffhunk://#diff-aada123c47bc7fec10b28b3b25e485fcdfe0800687619ce354d46a2793ed702aL17-R20) [[2]](diffhunk://#diff-d8148d5f7bc97f001e77b1fda78b23167c29cb1f5045225f7d16eba07e93c05dL17-R20)