### PR TITLE
Improve task input handling for copy and database deployment

### DIFF
--- a/Tasks/MysqlDeploymentOnMachineGroupV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/Strings/resources.resjson/en-US/resources.resjson
@@ -32,5 +32,6 @@
   "loc.messages.UnableToCreateDatabaseException": "Unable to create database.",
   "loc.messages.WindowMysqlClientMissingError": "MySQL client is missing on the Windows agent machine. Please install it by running the MySQL client installer 'https://aka.ms/window-mysqlcli-installer' script file on the agent machine.",
   "loc.messages.LinuxMysqlClientMissingError": "MySQL client is missing on the Linux agent machine. Please install it by running 'sudo apt-get install mysql-client'.",
-  "loc.messages.Nopackagefoundwithspecifiedpattern": "No package found with specified pattern"
+  "loc.messages.Nopackagefoundwithspecifiedpattern": "No package found with specified pattern",
+  "loc.messages.InvalidDatabaseName": "Invalid database name '%s'. Only alphanumeric characters, underscores, hyphens, and dollar signs are allowed."
 }

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/models/MysqlTaskParameter.ts
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/models/MysqlTaskParameter.ts
@@ -1,5 +1,9 @@
 import tl = require("azure-pipelines-task-lib/task");
 
+export function isValidDatabaseName(databaseName: string): boolean {
+	return databaseName.length > 0 && !/[^a-zA-Z0-9_\-$\u0080-\uD7FF\uE000-\uFFFF]/.test(databaseName);
+}
+
 export class MysqlTaskParameter {
 	
 	private taskNameSelector: string;
@@ -18,6 +22,9 @@ export class MysqlTaskParameter {
 			this.sqlInline = tl.getInput('SqlInline', false);
 			this.serverName = tl.getInput('ServerName', true);
 			this.databaseName = tl.getInput('DatabaseName', false);
+			if (this.databaseName && !isValidDatabaseName(this.databaseName)) {
+				throw new Error(tl.loc("InvalidDatabaseName", this.databaseName));
+			}
 			this.sqlUserName = tl.getInput('SqlUsername', true);
 			this.sqlPassword = tl.getInput('SqlPassword', true);
 			this.sqlAdditionalArguments = tl.getInput('SqlAdditionalArguments', false);

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 277,
+    "Minor": 279,
     "Patch": 0
   },
   "demands": [],
@@ -128,6 +128,7 @@
     "UnableToCreateDatabaseException": "Unable to create database.",
     "WindowMysqlClientMissingError": "MySQL client is missing on the Windows agent machine. Please install it by running the MySQL client installer 'https://aka.ms/window-mysqlcli-installer' script file on the agent machine.",
     "LinuxMysqlClientMissingError": "MySQL client is missing on the Linux agent machine. Please install it by running 'sudo apt-get install mysql-client'.",
-    "Nopackagefoundwithspecifiedpattern": "No package found with specified pattern"
+    "Nopackagefoundwithspecifiedpattern": "No package found with specified pattern",
+    "InvalidDatabaseName": "Invalid database name '%s'. Only alphanumeric characters, underscores, hyphens, and dollar signs are allowed."
   }
 }

--- a/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
+++ b/Tasks/MysqlDeploymentOnMachineGroupV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 277,
+    "Minor": 279,
     "Patch": 0
   },
   "demands": [],
@@ -128,6 +128,7 @@
     "UnableToCreateDatabaseException": "ms-resource:loc.messages.UnableToCreateDatabaseException",
     "WindowMysqlClientMissingError": "ms-resource:loc.messages.WindowMysqlClientMissingError",
     "LinuxMysqlClientMissingError": "ms-resource:loc.messages.LinuxMysqlClientMissingError",
-    "Nopackagefoundwithspecifiedpattern": "ms-resource:loc.messages.Nopackagefoundwithspecifiedpattern"
+    "Nopackagefoundwithspecifiedpattern": "ms-resource:loc.messages.Nopackagefoundwithspecifiedpattern",
+    "InvalidDatabaseName": "ms-resource:loc.messages.InvalidDatabaseName"
   }
 }

--- a/Tasks/WindowsMachineFileCopyV2/RoboCopyJob.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/RoboCopyJob.ps1
@@ -11,8 +11,7 @@ param (
     [object]$credential,
     [string]$cleanTargetBeforeCopy,
     [string]$additionalArguments,
-    [string]$scriptRoot,
-    [string]$useSanitizerActivate
+    [string]$scriptRoot
     )
     Import-Module "$scriptRoot\ps_modules\VstsTaskSdk" 
     Import-VstsLocStrings -LiteralPath $scriptRoot/Task.json
@@ -115,7 +114,8 @@ param (
         $guid = [GUID]::NewGuid()
         $tempDirectory = "$scriptRoot\temp$guid" 
         New-Item -ItemType Directory -Force -Path $tempDirectory         
-        Invoke-Expression "robocopy `"$tempDirectory`" `"$destinationNetworkPath`" `"*.*`" $cleanupArgument"
+        $cleanupArguments = @($tempDirectory, $destinationNetworkPath, "*.*") + (Get-RoboCopyArgumentArray -arguments $cleanupArgument)
+        & robocopy @cleanupArguments
         Remove-Item $tempDirectory -Recurse -ErrorAction Ignore
     }
 
@@ -156,6 +156,18 @@ param (
         }
 
         return $robocopyParameters.Trim()
+    }
+
+    function Get-RoboCopyArgumentArray(
+        [string]$arguments
+        )
+    {
+        if([string]::IsNullOrWhiteSpace($arguments))
+        {
+            return @()
+        }
+
+        return [regex]::Split($arguments.Trim(), '\s+(?=(?:[^"]|"[^"]*")*$)')
     }
 
     function Get-MachineShare(
@@ -253,14 +265,8 @@ param (
     {
         $robocopyParameters = Get-RoboCopyParameters -additionalArguments $additionalArguments -fileCopy:$isFileCopy
 
-        if ($useSanitizerActivate -eq "true") {
-            # Splitting arguments on space, but not on space inside quotes
-            $sanitizedArguments = [regex]::Split($robocopyParameters, ' (?=(?:[^"]|"[^"]*")*$)')
-            & robocopy "$sourceDirectory" "$destinationNetworkPath" "$filesToCopy" $sanitizedArguments
-        } else {
-            $command = "robocopy `"$sourceDirectory`" `"$destinationNetworkPath`" `"$filesToCopy`" $robocopyParameters"
-            Invoke-Expression $command
-        }
+        $robocopyArguments = @($sourceDirectory, $destinationNetworkPath, $filesToCopy) + (Get-RoboCopyArgumentArray -arguments $robocopyParameters)
+        & robocopy @robocopyArguments
 
         if ($LASTEXITCODE -ge 8)
         {

--- a/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
+++ b/Tasks/WindowsMachineFileCopyV2/WindowsMachineFileCopy.ps1
@@ -29,7 +29,7 @@ if ($useSanitizerCall) {
 }
 
 if ($useSanitizerActivate) {
-    $additionalArguments = $sanitizedArguments -join " "
+    $additionalArguments = Join-SanitizedArguments -arguments $sanitizedArguments
 }
 
 try 
@@ -65,7 +65,7 @@ try
 
             Write-Output (Get-VstsLocString -Key "WFC_CopyStartedFor0" -ArgumentList $machine)
 
-            Invoke-Command -ScriptBlock $CopyJob -ArgumentList $machine, $sourcePath, $targetPath, $machineCredential, $cleanTargetBeforeCopy, $additionalArguments, $PSScriptRoot, $useSanitizerActivate
+            Invoke-Command -ScriptBlock $CopyJob -ArgumentList $machine, $sourcePath, $targetPath, $machineCredential, $cleanTargetBeforeCopy, $additionalArguments, $PSScriptRoot
         } 
     }
     else
@@ -77,7 +77,7 @@ try
 
             Write-Output (Get-VstsLocString -Key "WFC_CopyStartedFor0" -ArgumentList $machine)
 
-            $job = Start-Job -ScriptBlock $CopyJob -ArgumentList $machine, $sourcePath, $targetPath, $machineCredential, $cleanTargetBeforeCopy, $additionalArguments, $PSScriptRoot, $useSanitizerActivate
+            $job = Start-Job -ScriptBlock $CopyJob -ArgumentList $machine, $sourcePath, $targetPath, $machineCredential, $cleanTargetBeforeCopy, $additionalArguments, $PSScriptRoot
 
             $Jobs.Add($job.Id, $machine)
         }        

--- a/Tasks/WindowsMachineFileCopyV2/task.json
+++ b/Tasks/WindowsMachineFileCopyV2/task.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 278,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "What's new in Version 2.0: <br/>&nbsp;&nbsp;Proxy support is being added. <br/>&nbsp;&nbsp; Removed support of legacy DTL machines.",

--- a/Tasks/WindowsMachineFileCopyV2/task.loc.json
+++ b/Tasks/WindowsMachineFileCopyV2/task.loc.json
@@ -13,7 +13,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 278,
+    "Minor": 279,
     "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",


### PR DESCRIPTION
### **Context**
Improve task input handling for file copy and database deployment scenarios while preserving existing task behavior.

---

### **Task Name**
WindowsMachineFileCopyV2; MysqlDeploymentOnMachineGroupV1

---

### **Description**
- Preserve argument boundaries when processing additional file-copy arguments.
- Invoke the copy utility with structured arguments.
- Validate database-name input before database deployment operations.
- Retain English-only resource updates; translated resources remain owned by the translations team.

---

### **Risk Assessment** (Low / Medium / High)
Low. Changes are limited to two tasks, preserve existing valid-input behavior, and add input handling at the task boundary.

---

### **Change Behind Feature Flag** (Yes / No)
No. This is task-local input handling and does not require a rollout flag.

---

### **Tech Design / Approach**
- Design has been written and reviewed.
- The implementation reuses existing argument sanitization and task validation patterns.
- No architectural decisions or public API changes are introduced.

---

### **Documentation Changes Required** (Yes/No)
No. The task behavior and supported inputs remain self-contained.

---

### **Unit Tests Added or Updated** (Yes / No)
No. Validation was performed with local regression coverage retained separately for follow-up publication.

---

### **Additional Testing Performed**
- `node make.js build --task WindowsMachineFileCopyV2`
- `node make.js build --task MysqlDeploymentOnMachineGroupV1 --BypassNpmAudit`
- `node make.js test --task WindowsMachineFileCopyV2 --suite L0`
- `node make.js test --task MysqlDeploymentOnMachineGroupV1 --suite L0`

---

### **Logging Added/Updated** (Yes/No)
No. Existing logging behavior is unchanged.

---

### **Telemetry Added/Updated** (Yes/No)
No. No new telemetry is required for these task-local changes.

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Revert the change commit and publish a replacement task version if rollback is required.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. The affected task dependencies and input-processing paths were reviewed, and both task L0 suites passed.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
