### PR TITLE
Add version file support to UseNode@1

### DIFF
--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -22,5 +22,6 @@
   "loc.messages.NodeVersionNotFound": "Unable to find Node version %s for platform %s and architecture %s.",
   "loc.messages.UnexpectedOS": "Unexpected OS %s",
   "loc.messages.AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
-  "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'"
+  "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
+  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
 }

--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -5,6 +5,8 @@
   "loc.instanceNameFormat": "Use Node $(versionSpec)",
   "loc.input.label.version": "Version",
   "loc.input.help.version": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0",
+  "loc.input.label.versionFilePath": "Version File Path",
+  "loc.input.help.versionFilePath": "File path to get version.  Example: src/.nvmrc",
   "loc.input.label.checkLatest": "Check for Latest Version",
   "loc.input.help.checkLatest": "Always checks online for the latest available version that satisfies the version spec. This is typically false unless you have a specific scenario to always get latest. This will cause it to incur download costs when potentially not necessary, especially with the hosted build pool.",
   "loc.input.label.force32bit": "Use 32 bit version on x64 agents",

--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -23,5 +23,6 @@
   "loc.messages.UnexpectedOS": "Unexpected OS %s",
   "loc.messages.AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
   "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
+  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+  "loc.messages.InvalidVersionSpecification": "Version specification '%s' is invalid."
 }

--- a/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
+++ b/Tasks/UseNodeV1/Strings/resources.resjson/en-US/resources.resjson
@@ -3,6 +3,7 @@
   "loc.helpMarkDown": "",
   "loc.description": "Set up a Node.js environment and add it to the PATH, additionally providing proxy support",
   "loc.instanceNameFormat": "Use Node $(versionSpec)",
+  "loc.input.label.versionSource": "Source of version",
   "loc.input.label.version": "Version",
   "loc.input.help.version": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0",
   "loc.input.label.versionFilePath": "Version File Path",
@@ -23,6 +24,6 @@
   "loc.messages.UnexpectedOS": "Unexpected OS %s",
   "loc.messages.AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
   "loc.messages.InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-  "loc.messages.CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+  "loc.messages.VersionFileIsEmpty": "Version file '%s' is empty.",
   "loc.messages.InvalidVersionSpecification": "Version specification '%s' is invalid."
 }

--- a/Tasks/UseNodeV1/Tests/L0.ts
+++ b/Tasks/UseNodeV1/Tests/L0.ts
@@ -114,4 +114,16 @@ describe('NodeTool Suite', function () {
         assert(tr.stdout.indexOf('DOWNLOAD https://mymirror.example.com/node/v10.15.1/') > -1, 'Should download from the custom mirror base');
       }, tr);
     });
+
+    it('Fails when version and versionFilePath are both specified', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidConfiguration.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_CannotSpecifyVersionAndVersionFilePath'), "Descriptive message should be output");
+      }, tr);
+    });
 });

--- a/Tasks/UseNodeV1/Tests/L0.ts
+++ b/Tasks/UseNodeV1/Tests/L0.ts
@@ -126,4 +126,28 @@ describe('NodeTool Suite', function () {
         assert(tr.stdOutContained('loc_mock_CannotSpecifyVersionAndVersionFilePath'), "Descriptive message should be output");
       }, tr);
     });
+
+    it('Fails when specified version is invalid', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidVersionSpec.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_InvalidVersionSpecification InvalidFromVersion'), "Descriptive message should be output");
+      }, tr);
+    });
+
+    it('Fails when version in specified versionSpecFile is invalid', async () => {
+      let tp: string = path.join(__dirname, 'L0InvalidVersionSpecInFile.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.failed, 'NodeTool should have failed.');
+        assert(tr.stdOutContained('loc_mock_InvalidVersionSpecification InvalidFromFile'), "Descriptive message should be output");
+      }, tr);
+    });
 });

--- a/Tasks/UseNodeV1/Tests/L0.ts
+++ b/Tasks/UseNodeV1/Tests/L0.ts
@@ -115,15 +115,28 @@ describe('NodeTool Suite', function () {
       }, tr);
     });
 
-    it('Fails when version and versionFilePath are both specified', async () => {
-      let tp: string = path.join(__dirname, 'L0InvalidConfiguration.js');
+    it('Reads and trims the version from a file when the version input has its default value', async () => {
+      let tp: string = path.join(__dirname, 'L0VersionFromFile.js');
       let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
 
       await tr.runAsync();
 
       runValidations(() => {
-        assert(tr.failed, 'NodeTool should have failed.');
-        assert(tr.stdOutContained('loc_mock_CannotSpecifyVersionAndVersionFilePath'), "Descriptive message should be output");
+        assert(tr.succeeded, 'NodeTool should have succeeded.');
+        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
+        assert(tr.stdOutContained('VERSION_FROM_FILE 20.11.1'), 'NodeTool should use the trimmed version from the file');
+      }, tr);
+    });
+
+    it('Succeeds without installing Node when no version is supplied', async () => {
+      let tp: string = path.join(__dirname, 'L0NoVersion.js');
+      let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+      await tr.runAsync();
+
+      runValidations(() => {
+        assert(tr.succeeded, 'NodeTool should have succeeded.');
+        assert(tr.stderr.length === 0, 'NodeTool should not have written to stderr');
       }, tr);
     });
 
@@ -150,4 +163,20 @@ describe('NodeTool Suite', function () {
         assert(tr.stdOutContained('loc_mock_InvalidVersionSpecification InvalidFromFile'), "Descriptive message should be output");
       }, tr);
     });
+
+    for (const fileContents of ['empty', 'whitespace']) {
+      it(`Fails when the specified version file is ${fileContents}`, async () => {
+        process.env['__versionFileContents__'] = fileContents;
+        let tp: string = path.join(__dirname, 'L0EmptyVersionSpecInFile.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        await tr.runAsync();
+        delete process.env['__versionFileContents__'];
+
+        runValidations(() => {
+          assert(tr.failed, 'NodeTool should have failed.');
+          assert(tr.stdOutContained('loc_mock_VersionFileIsEmpty .node-version'), 'Descriptive message should be output');
+        }, tr);
+      });
+    }
 });

--- a/Tasks/UseNodeV1/Tests/L0EmptyVersionSpecInFile.ts
+++ b/Tasks/UseNodeV1/Tests/L0EmptyVersionSpecInFile.ts
@@ -1,19 +1,23 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import * as tmrm from 'azure-pipelines-task-lib/mock-run';
 
 const taskPath = path.join(__dirname, '..', 'usenode.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+const fileContents = process.env['__versionFileContents__'] === 'empty' ? '' : ' \r\n ';
 
 tmr.setInput('versionSource', 'fromFile');
+tmr.setInput('version', '10.x');
 tmr.setInput('versionFilePath', '.node-version');
 
 tmr.registerMock('fs', {
-  readFileSync: function (filePath) {
+  ...fs,
+  readFileSync: function (filePath, options) {
     if (filePath === '.node-version') {
-      return 'InvalidFromFile';
+      return fileContents;
     }
 
-    return 'Unexpected file path: ' + filePath;
+    return fs.readFileSync(filePath, options);
   }
 });
 

--- a/Tasks/UseNodeV1/Tests/L0InvalidConfiguration.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidConfiguration.ts
@@ -1,0 +1,10 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('version', '26.x');
+tmr.setInput('versionFilePath', '.node-version');
+
+tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
@@ -1,0 +1,9 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('version', 'InvalidFromVersion');
+
+tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidVersionSpec.ts
@@ -4,6 +4,7 @@ import * as tmrm from 'azure-pipelines-task-lib/mock-run';
 const taskPath = path.join(__dirname, '..', 'usenode.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
+tmr.setInput('versionSource', 'spec');
 tmr.setInput('version', 'InvalidFromVersion');
 
 tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0InvalidVersionSpecInFile.ts
+++ b/Tasks/UseNodeV1/Tests/L0InvalidVersionSpecInFile.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionFilePath', '.node-version');
+
+tmr.registerMock('fs', {
+  readFileSync: function (filePath) {
+    if (filePath === '.node-version') {
+      return 'InvalidFromFile';
+    }
+
+    return 'Unexpected file path: ' + filePath;
+  }
+});
+
+tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0NoVersion.ts
+++ b/Tasks/UseNodeV1/Tests/L0NoVersion.ts
@@ -4,7 +4,13 @@ import * as tmrm from 'azure-pipelines-task-lib/mock-run';
 const taskPath = path.join(__dirname, '..', 'usenode.js');
 const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
 
-tmr.setInput('version', '26.x');
-tmr.setInput('versionFilePath', '.node-version');
+tmr.registerMock('./installer', {
+  getNode: async function () {
+    throw new Error('Node should not be installed when no version is supplied');
+  },
+  normalizeMirrorUrl: function (url: string) {
+    return url;
+  }
+});
 
 tmr.run();

--- a/Tasks/UseNodeV1/Tests/L0VersionFromFile.ts
+++ b/Tasks/UseNodeV1/Tests/L0VersionFromFile.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tmrm from 'azure-pipelines-task-lib/mock-run';
+
+const taskPath = path.join(__dirname, '..', 'usenode.js');
+const tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+tmr.setInput('versionSource', 'fromFile');
+tmr.setInput('version', '10.x');
+tmr.setInput('versionFilePath', '.node-version');
+
+tmr.registerMock('fs', {
+  ...fs,
+  readFileSync: function (filePath, options) {
+    if (filePath === '.node-version') {
+      return '20.11.1\r\n';
+    }
+
+    return fs.readFileSync(filePath, options);
+  }
+});
+
+tmr.registerMock('./installer', {
+  getNode: async function (version: string) {
+    if (version !== '20.11.1') {
+      throw new Error(`Expected version 20.11.1, got ${version}`);
+    }
+
+    console.log(`VERSION_FROM_FILE ${version}`);
+  },
+  normalizeMirrorUrl: function (url: string) {
+    return url;
+  }
+});
+
+tmr.run();

--- a/Tasks/UseNodeV1/package-lock.json
+++ b/Tasks/UseNodeV1/package-lock.json
@@ -12,6 +12,7 @@
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
         "@types/q": "^1.5.1",
+        "@types/semver": "^5.5.0",
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-utility-common": "3.272.0",
         "azure-pipelines-tool-lib": "^2.0.10",
@@ -19,7 +20,6 @@
         "typed-rest-client": "^1.8.4"
       },
       "devDependencies": {
-        "@types/semver": "^5.5.0",
         "typescript": "^5.7.2"
       }
     },

--- a/Tasks/UseNodeV1/package-lock.json
+++ b/Tasks/UseNodeV1/package-lock.json
@@ -15,9 +15,11 @@
         "azure-pipelines-task-lib": "^5.2.8",
         "azure-pipelines-tasks-utility-common": "3.272.0",
         "azure-pipelines-tool-lib": "^2.0.10",
+        "semver": "^5.7.2",
         "typed-rest-client": "^1.8.4"
       },
       "devDependencies": {
+        "@types/semver": "^5.5.0",
         "typescript": "^5.7.2"
       }
     },

--- a/Tasks/UseNodeV1/package.json
+++ b/Tasks/UseNodeV1/package.json
@@ -31,9 +31,11 @@
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-utility-common": "3.272.0",
     "azure-pipelines-tool-lib": "^2.0.10",
+    "semver": "^5.7.2",
     "typed-rest-client": "^1.8.4"
   },
   "devDependencies": {
+    "@types/semver": "^5.5.0",
     "typescript": "^5.7.2"
   }
 }

--- a/Tasks/UseNodeV1/package.json
+++ b/Tasks/UseNodeV1/package.json
@@ -28,6 +28,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^24.10.0",
     "@types/q": "^1.5.1",
+    "@types/semver": "^5.5.0",
     "azure-pipelines-task-lib": "^5.2.8",
     "azure-pipelines-tasks-utility-common": "3.272.0",
     "azure-pipelines-tool-lib": "^2.0.10",
@@ -35,7 +36,6 @@
     "typed-rest-client": "^1.8.4"
   },
   "devDependencies": {
-    "@types/semver": "^5.5.0",
     "typescript": "^5.7.2"
   }
 }

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -111,6 +111,7 @@
     "UnexpectedOS": "Unexpected OS %s",
     "AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
     "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
+    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+    "InvalidVersionSpecification": "Version specification '%s' is invalid."
   }
 }

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -110,6 +110,7 @@
     "NodeVersionNotFound": "Unable to find Node version %s for platform %s and architecture %s.",
     "UnexpectedOS": "Unexpected OS %s",
     "AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
-    "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'"
+    "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
+    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified."
   }
 }

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -36,6 +36,13 @@
       "helpMarkDown": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0"
     },
     {
+      "name": "versionFilePath",
+      "type": "string",
+      "label": "Version File Path",
+      "required": false,
+      "helpMarkDown": "File path to get version.  Example: src/.nvmrc"
+    },
+    {
       "name": "checkLatest",
       "type": "boolean",
       "label": "Check for Latest Version",

--- a/Tasks/UseNodeV1/task.json
+++ b/Tasks/UseNodeV1/task.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 280,
     "Patch": 0
   },
   "satisfies": [
@@ -28,19 +28,32 @@
   "instanceNameFormat": "Use Node $(versionSpec)",
   "inputs": [
     {
+      "name": "versionSource",
+      "type": "radio",
+      "label": "Source of version",
+      "required": true,
+      "defaultValue": "spec",
+      "options": {
+        "spec": "Specify Node version",
+        "fromFile": "Get version from file"
+      }
+    },
+    {
       "name": "version",
       "type": "string",
       "label": "Version",
       "defaultValue": "10.x",
       "required": false,
-      "helpMarkDown": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0"
+      "helpMarkDown": "Version Spec of the version to use.  Examples: 10.x, 10.15.1, >=10.15.0",
+      "visibleRule": "versionSource = spec"
     },
     {
       "name": "versionFilePath",
       "type": "string",
       "label": "Version File Path",
       "required": false,
-      "helpMarkDown": "File path to get version.  Example: src/.nvmrc"
+      "helpMarkDown": "File path to get version.  Example: src/.nvmrc",
+      "visibleRule": "versionSource = fromFile"
     },
     {
       "name": "checkLatest",
@@ -111,7 +124,7 @@
     "UnexpectedOS": "Unexpected OS %s",
     "AgentTempDirNotSet": "Expected Agent.TempDirectory to be set.",
     "InvalidNodejsMirror": "The provided Node.js mirror URL is invalid: '%s'",
-    "CannotSpecifyVersionAndVersionFilePath": "Specifing version is not supported when versionFilePath is also specified.",
+    "VersionFileIsEmpty": "Version file '%s' is empty.",
     "InvalidVersionSpecification": "Version specification '%s' is invalid."
   }
 }

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -111,6 +111,7 @@
     "UnexpectedOS": "ms-resource:loc.messages.UnexpectedOS",
     "AgentTempDirNotSet": "ms-resource:loc.messages.AgentTempDirNotSet",
     "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror",
-    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath"
+    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath",
+    "InvalidVersionSpecification": "ms-resource:loc.messages.InvalidVersionSpecification"
   }
 }

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -110,6 +110,7 @@
     "NodeVersionNotFound": "ms-resource:loc.messages.NodeVersionNotFound",
     "UnexpectedOS": "ms-resource:loc.messages.UnexpectedOS",
     "AgentTempDirNotSet": "ms-resource:loc.messages.AgentTempDirNotSet",
-    "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror"
+    "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror",
+    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath"
   }
 }

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -36,6 +36,13 @@
       "helpMarkDown": "ms-resource:loc.input.help.version"
     },
     {
+      "name": "versionFilePath",
+      "type": "string",
+      "label": "ms-resource:loc.input.label.versionFilePath",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.versionFilePath"
+    },
+    {
       "name": "checkLatest",
       "type": "boolean",
       "label": "ms-resource:loc.input.label.checkLatest",

--- a/Tasks/UseNodeV1/task.loc.json
+++ b/Tasks/UseNodeV1/task.loc.json
@@ -16,7 +16,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 280,
     "Patch": 0
   },
   "satisfies": [
@@ -28,19 +28,32 @@
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
   "inputs": [
     {
+      "name": "versionSource",
+      "type": "radio",
+      "label": "ms-resource:loc.input.label.versionSource",
+      "required": true,
+      "defaultValue": "spec",
+      "options": {
+        "spec": "Specify Node version",
+        "fromFile": "Get version from file"
+      }
+    },
+    {
       "name": "version",
       "type": "string",
       "label": "ms-resource:loc.input.label.version",
       "defaultValue": "10.x",
       "required": false,
-      "helpMarkDown": "ms-resource:loc.input.help.version"
+      "helpMarkDown": "ms-resource:loc.input.help.version",
+      "visibleRule": "versionSource = spec"
     },
     {
       "name": "versionFilePath",
       "type": "string",
       "label": "ms-resource:loc.input.label.versionFilePath",
       "required": false,
-      "helpMarkDown": "ms-resource:loc.input.help.versionFilePath"
+      "helpMarkDown": "ms-resource:loc.input.help.versionFilePath",
+      "visibleRule": "versionSource = fromFile"
     },
     {
       "name": "checkLatest",
@@ -111,7 +124,7 @@
     "UnexpectedOS": "ms-resource:loc.messages.UnexpectedOS",
     "AgentTempDirNotSet": "ms-resource:loc.messages.AgentTempDirNotSet",
     "InvalidNodejsMirror": "ms-resource:loc.messages.InvalidNodejsMirror",
-    "CannotSpecifyVersionAndVersionFilePath": "ms-resource:loc.messages.CannotSpecifyVersionAndVersionFilePath",
+    "VersionFileIsEmpty": "ms-resource:loc.messages.VersionFileIsEmpty",
     "InvalidVersionSpecification": "ms-resource:loc.messages.InvalidVersionSpecification"
   }
 }

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -41,6 +41,10 @@ async function run() {
 }
 
 function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) {
+    if (versionSpecInput && versionFilePathInput) {
+        throw new Error(taskLib.loc('CannotSpecifyVersionAndVersionFilePath'));
+    }
+
     if (versionFilePathInput) {
         return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
     }

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -12,6 +12,7 @@ import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as installer from './installer';
 import * as proxyutil from './proxyutil';
 import * as path from 'path';
+import * as fs from 'fs';
 
 async function run() {
     try {
@@ -20,7 +21,7 @@ async function run() {
         // If not supplied then task is still used to setup proxy, auth, etc...
         //
         taskLib.setResourcePath(path.join(__dirname, 'task.json'));
-        const version = taskLib.getInput('version', false);
+        const version = getNodeVersion(taskLib.getInput('version', false), taskLib.getInput('versionFilePath', false));
         const nodejsMirror = taskLib.getInput('nodejsMirror', false) || 'https://nodejs.org/dist/';
         const retryCountOnDownloadFails = taskLib.getInput('retryCountOnDownloadFails', false) || "5";
         const delayBetweenRetries = taskLib.getInput('delayBetweenRetries', false) || "1000";
@@ -37,6 +38,14 @@ async function run() {
     catch (error) {
         taskLib.setResult(taskLib.TaskResult.Failed, error.message);
     }
+}
+
+function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) {
+    if (versionFilePathInput) {
+        return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
+    }
+
+    return versionSpecInput;
 }
 
 run()

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -9,6 +9,7 @@
 
 import * as taskLib from 'azure-pipelines-task-lib/task';
 //import * as toolLib from 'vsts-task-tool-lib/tool';
+import * as semver from 'semver';
 import * as installer from './installer';
 import * as proxyutil from './proxyutil';
 import * as path from 'path';
@@ -45,11 +46,15 @@ function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) 
         throw new Error(taskLib.loc('CannotSpecifyVersionAndVersionFilePath'));
     }
 
-    if (versionFilePathInput) {
-        return fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' });
+    const version =
+        versionFilePathInput
+            ? fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' })
+            : versionSpecInput;
+    if (semver.validRange(version) === null) {
+        throw new Error(taskLib.loc('InvalidVersionSpecification', version));
     }
 
-    return versionSpecInput;
+    return version;
 }
 
 run()

--- a/Tasks/UseNodeV1/usenode.ts
+++ b/Tasks/UseNodeV1/usenode.ts
@@ -22,7 +22,11 @@ async function run() {
         // If not supplied then task is still used to setup proxy, auth, etc...
         //
         taskLib.setResourcePath(path.join(__dirname, 'task.json'));
-        const version = getNodeVersion(taskLib.getInput('version', false), taskLib.getInput('versionFilePath', false));
+        const versionSource = taskLib.getInput('versionSource', false) || 'spec';
+        const version = getNodeVersion(
+            versionSource,
+            taskLib.getInput('version', false),
+            taskLib.getInput('versionFilePath', versionSource === 'fromFile'));
         const nodejsMirror = taskLib.getInput('nodejsMirror', false) || 'https://nodejs.org/dist/';
         const retryCountOnDownloadFails = taskLib.getInput('retryCountOnDownloadFails', false) || "5";
         const delayBetweenRetries = taskLib.getInput('delayBetweenRetries', false) || "1000";
@@ -41,16 +45,16 @@ async function run() {
     }
 }
 
-function getNodeVersion(versionSpecInput: string, versionFilePathInput: string) {
-    if (versionSpecInput && versionFilePathInput) {
-        throw new Error(taskLib.loc('CannotSpecifyVersionAndVersionFilePath'));
+function getNodeVersion(versionSource: string, versionSpecInput: string, versionFilePathInput: string) {
+    const version = versionSource === 'fromFile'
+        ? fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' }).trim()
+        : versionSpecInput;
+
+    if (versionSource === 'fromFile' && !version) {
+        throw new Error(taskLib.loc('VersionFileIsEmpty', versionFilePathInput));
     }
 
-    const version =
-        versionFilePathInput
-            ? fs.readFileSync(versionFilePathInput, { 'encoding': 'utf8' })
-            : versionSpecInput;
-    if (semver.validRange(version) === null) {
+    if (version && semver.validRange(version) === null) {
         throw new Error(taskLib.loc('InvalidVersionSpecification', version));
     }
 


### PR DESCRIPTION
### **Context**
Fixes #22131.

Supersedes #22189 and preserves the original commits from @bdukes while addressing the review findings discovered there.

---

### **Task Name**
UseNode@1

---

### **Description**
Adds `versionFilePath` support so pipelines can read a Node.js version from files such as `.nvmrc` or `.node-version`.

- Adds `versionSource: spec | fromFile`, defaulting to `spec` for backward compatibility.
- Ignores the existing implicit `version: 10.x` value when `fromFile` is selected.
- Trims version-file contents and rejects empty or whitespace-only files.
- Validates version specifications and reports localized errors.
- Declares `semver` and its TypeScript definitions directly instead of relying on transitive hoisting.
- Updates the task version to `1.280.0` for the current release window.

---

### **Risk Assessment** (Low / Medium / High)
Low. The new source selector defaults to `spec`, so existing pipelines that supply `version` or rely on its default retain their current behavior. File-based selection is opt-in.

---

### **Change Behind Feature Flag** (Yes / No)
No. This is an additive task input whose default preserves existing behavior.

---

### **Tech Design / Approach**
- Uses the established `NodeTool@0` `versionSource` pattern to make the version source explicit.
- Applies conditional visibility to `version` and `versionFilePath` in the task UI.
- Reads the selected file as UTF-8, trims its contents, rejects empty values, and validates the resulting SemVer range.
- Preserves the existing behavior where omitting a version skips Node installation.
- Makes the imported `semver` runtime and type dependencies explicit in the task package.

---

### **Documentation Changes Required** (Yes/No)
Yes. The task manifest and localization resources contain the new inputs used to generate the task reference.

---

### **Unit Tests Added or Updated** (Yes / No)
Yes. Coverage includes successful file selection with the implicit version default present, trimmed file contents, invalid specifications, empty and whitespace-only files, and omitted-version compatibility.

---

### **Additional Testing Performed**
- Compiled `Tasks/UseNodeV1` with TypeScript.
- Ran the complete UseNodeV1 L0 suite: 12 passing.
- Validated parity between `task.json`, `task.loc.json`, and the en-US resource file.
- Validated direct `semver` and `@types/semver` resolution and package-lock consistency.

---

### **Logging Added/Updated** (Yes/No)
Yes. Adds localized errors for invalid specifications and empty version files. No sensitive data is logged.

---

### **Telemetry Added/Updated** (Yes/No)
No.

---

### **Rollback Scenario and Process** (Yes/No)
Yes. Revert this PR before release; no data or service migration is involved.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
Yes. `semver@5.7.2` and `@types/semver@5.5.0` were already resolved transitively; this PR declares them directly without changing their locked versions. Existing version-based behavior is covered by the L0 suite.

---

### **Checklist**
- [x] Related issue linked (if applicable)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
