### PR TITLE
Revert "Package vulnerability fixes"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
-        "adm-zip": "0.6.0",
+        "adm-zip": "0.4.13",
         "agent-base": "^6.0.2",
-        "azure-devops-node-api": "^17.0.0",
+        "azure-devops-node-api": "^12.2.0",
         "esbuild": "^0.28.1",
-        "fast-xml-parser": "5.11.0",
-        "js-yaml": "^3.15.1",
+        "fast-xml-parser": "4.5.6",
+        "js-yaml": "^3.13.1",
         "minimatch": "3.1.5",
         "minimist": "^1.2.8",
         "mocha": "11.7.5",
@@ -22,23 +22,23 @@
         "node-uuid": "1.4.6",
         "nodejs-file-downloader": "^4.11.1",
         "nyc": "^15.1.0",
-        "pnpm": "^10.34.5",
+        "pnpm": "^10.32.1",
         "q": "1.4.1",
         "semver": "5.7.2",
-        "shelljs": "^0.10.0",
-        "typed-rest-client": "^3.1.0",
+        "shelljs": "^0.8.5",
+        "typed-rest-client": "^1.8.9",
         "typescript": "4.0.2",
         "validator": "^13.7.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
+      "version": "7.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha1-IA9xXmbVKiOyIalDVTSpHME61b4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha1-bwI38PNtLlHAVwpjb67Z0tDv5ik=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha1-lv3xrxuIWchHSrOcKVMSv7fCSwQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -57,21 +57,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha1-gMELFySAgpaLV6hXuRZAlx8gcPc=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha1-EqVQuHlEUt9MiwhPlQA7zhdC1JY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-compilation-targets": "^7.29.7",
-        "@babel/helper-module-transforms": "^7.29.7",
-        "@babel/helpers": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -105,14 +105,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/generator/-/generator-7.29.8.tgz",
-      "integrity": "sha1-SwuIeIVCJkMzngkCIUikxOuqSXk=",
+      "version": "7.28.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha1-libBdBxlDLrDkSFpSg8tdFG47z4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.8",
-        "@babel/types": "^7.29.8",
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -122,14 +122,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha1-eh3vcEMCQBxH9k+oVYnpdK4hcEI=",
+      "version": "7.27.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha1-RqD276uAjVHSnOloWN0Qzocycz0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.29.7",
-        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -149,9 +149,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha1-8EqW+9hHMkGxB5JD9bPwOjAQq3s=",
+      "version": "7.28.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha1-uUMN8qpOF7woZl6t6uiqHZheZnQ=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -159,29 +159,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha1-7yUEilGOgo1zk/rFiC3dc5Idc5Y=",
+      "version": "7.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha1-fvdpoyPiZV4SZnO7bS1pE7vq0gQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha1-sGJ0elmXuhOGNyATKLv/d5YFdK4=",
+      "version": "7.28.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha1-orN9PaOyNE/ghdqyNEJvK5ovpfY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
+      "version": "7.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha1-VNp5YJerGc5n7Z+ItHuy7Ek2doc=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
+      "version": "7.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha1-pwVNzBRaln3U3I/uhFpXwTFsnfg=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha1-zzFb6UAhOzVOtKvMC9Aevj9zvCo=",
+      "version": "7.27.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha1-+lL1sefbGrBJRFtCHERxMDiXcC8=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -221,27 +221,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha1-Rav951SJl+NDdsPmn+tHXP+0pgc=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha1-/gcnR0LpW9988UQ1k+64kmq2OCc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/parser/-/parser-7.29.8.tgz",
-      "integrity": "sha1-llNxai8Qxne5j7xj1L+wAMMCzxc=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha1-2iXUZDUyiQkyzAP3cF/hljfgP6g=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.8"
+        "@babel/types": "^7.28.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -251,33 +251,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha1-TZ1ABPZFzdME3pWMclFieE7KxwA=",
+      "version": "7.27.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha1-+njO7TxOe2Pr9ss55YUvykX2gJ0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/traverse/-/traverse-7.29.8.tgz",
-      "integrity": "sha1-QREBTNxxoPldlHGQdZC6oLimsoo=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha1-jUVhAblqsXXUhySfYGgCIWkrlYs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.8",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.8",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.8",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -285,14 +285,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/types/-/types-7.29.8.tgz",
-      "integrity": "sha1-Einu8x2FFW1w+j9M2Fk3bQ6vaGM=",
+      "version": "7.28.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha1-Ck5hj0xgp81sEcstSAYOTb44rDo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -891,57 +891,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodable/entities/-/entities-3.0.0.tgz",
-      "integrity": "sha1-aUcDvIZNMOrtVcLj3vANvWFJNnA=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -954,13 +903,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
-      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
+      "version": "0.4.13",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.4.13.tgz",
+      "integrity": "sha1-WX4vjMNnIVHhMH0+lc3bx1ZyMUo=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=0.3.0"
       }
     },
     "node_modules/agent-base": {
@@ -1019,19 +968,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anynum": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/anynum/-/anynum-1.0.1.tgz",
-      "integrity": "sha1-KqwA4I3603JsHUYuYNvC+DFlmkQ=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/append-transform": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/append-transform/-/append-transform-2.0.0.tgz",
@@ -1063,17 +999,14 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "17.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
-      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "version": "12.5.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha1-OLnv18WsdDVP5Ojb5CaX2wuOhaU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "3.1.0"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
+        "typed-rest-client": "^1.8.4"
       }
     },
     "node_modules/balanced-match": {
@@ -1083,41 +1016,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.11.15",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
-      "integrity": "sha1-nAysk9fTBPPWG7QQiKECzWLmhnY=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.cjs"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.18",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
-      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
+      "version": "1.1.14",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browser-stdout": {
@@ -1128,9 +1035,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.28.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.28.8.tgz",
-      "integrity": "sha1-o8ec63AChSfl2n2vyIfzIAtRaMA=",
+      "version": "4.25.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/browserslist/-/browserslist-4.25.4.tgz",
+      "integrity": "sha1-690OHRzzkRg0urOmzXuRfZur9a8=",
       "dev": true,
       "funding": [
         {
@@ -1148,11 +1055,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.11.12",
-        "caniuse-lite": "^1.0.30001809",
-        "electron-to-chromium": "^1.5.402",
-        "node-releases": "^2.0.53",
-        "update-browserslist-db": "^1.3.0"
+        "caniuse-lite": "^1.0.30001737",
+        "electron-to-chromium": "^1.5.211",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1219,9 +1125,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001809",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
-      "integrity": "sha1-5s9x8U3f4AjxFN0qhGkjvjwDoHs=",
+      "version": "1.0.30001741",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz",
+      "integrity": "sha1-Z/uSlT7cU2RC88nadDIHdKpSMUM=",
       "dev": true,
       "funding": [
         {
@@ -1473,17 +1379,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/des.js": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/des.js/-/des.js-1.1.0.tgz",
-      "integrity": "sha1-HTf1dm87v/Tuljjocah2jBc7gdo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/diff/-/diff-7.0.0.tgz",
@@ -1517,9 +1412,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.410",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.410.tgz",
-      "integrity": "sha1-CQG8zSsoZZYNjezuFlOtc0obQd4=",
+      "version": "1.5.217",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.217.tgz",
+      "integrity": "sha1-cShYUDVu9IvAgnWybw81VyHg8X0=",
       "dev": true,
       "license": "ISC"
     },
@@ -1551,9 +1446,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1649,75 +1544,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/execa/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
-      "integrity": "sha1-7wWzU7RVl0g9+wnUUKBiorrsOoI=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.6.2",
-        "xml-naming": "^0.3.0"
-      }
-    },
     "node_modules/fast-xml-parser": {
-      "version": "5.11.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-xml-parser/-/fast-xml-parser-5.11.0.tgz",
-      "integrity": "sha1-fNnqDjTBVhnBrwx+LY4YPIke6DI=",
+      "version": "4.5.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha1-T/V9SsoTotEapCrUYElc8A8ytlU=",
       "dev": true,
       "funding": [
         {
@@ -1727,38 +1557,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^3.0.0",
-        "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^2.0.0",
-        "path-expression-matcher": "^1.6.2",
-        "strnum": "^2.4.2",
-        "xml-naming": "^0.3.0"
+        "strnum": "^1.0.5"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/find-cache-dir": {
@@ -1951,19 +1753,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-10.5.0.tgz",
@@ -1985,23 +1774,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2085,9 +1861,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2126,16 +1902,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10.17.0"
       }
     },
     "node_modules/imurmurhash": {
@@ -2177,14 +1943,30 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha1-KpiAGoSfQ+Kt1kT7trxiKbGaTvQ=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2195,29 +1977,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -2272,19 +2031,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-unsafe": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/is-unsafe/-/is-unsafe-2.0.0.tgz",
-      "integrity": "sha1-wNzk4GdCZi3eJjYBYOQU6kh9ouk=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -2472,13 +2218,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/js-md4": {
-      "version": "0.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-md4/-/js-md4-0.3.2.tgz",
-      "integrity": "sha1-zTs9wEWwxARVbIHdtXVsI+WdfPU=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2487,9 +2226,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
+      "version": "3.14.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2612,37 +2351,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
@@ -2665,23 +2373,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -2761,9 +2452,9 @@
       "license": "Python-2.0"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
-      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha1-T0GkEZAhbuNgZ+w4FSb+lTnE8K4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2771,20 +2462,10 @@
       }
     },
     "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2851,14 +2532,11 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.53",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.53.tgz",
-      "integrity": "sha1-D+Wtink14HUXL1dOVvDCDwf6Qa8=",
+      "version": "2.0.20",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-releases/-/node-releases-2.0.20.tgz",
+      "integrity": "sha1-4mu3nb3R5koUbfOJxpkBTGEcvCc=",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
+      "license": "MIT"
     },
     "node_modules/node-uuid": {
       "version": "1.4.6",
@@ -2881,19 +2559,6 @@
         "https-proxy-agent": "^5.0.0",
         "mime-types": "^2.1.27",
         "sanitize-filename": "^1.6.3"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/nyc": {
@@ -3176,22 +2841,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
@@ -3280,22 +2929,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
-      "integrity": "sha1-VnxzwHGX6dzvJOkO3NxXEFZZkWg=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3315,6 +2948,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -3346,19 +2986,6 @@
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -3430,9 +3057,9 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "10.34.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pnpm/-/pnpm-10.34.5.tgz",
-      "integrity": "sha1-apESen8spy/lO7n/VIg+DHWyLxc=",
+      "version": "10.32.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/pnpm/-/pnpm-10.32.1.tgz",
+      "integrity": "sha1-PQIAdFqfrzXKAJ6n/ejWWS/xfEw=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3472,14 +3099,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "version": "6.15.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "es-define-property": "^1.0.1",
-        "side-channel": "^1.1.1"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -3487,27 +3113,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -3521,6 +3126,18 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/release-zalgo": {
@@ -3553,6 +3170,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha1-tmPoP/sJu/I4aURza6roAwKbizk=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3561,17 +3199,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -3611,30 +3238,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sanitize-filename": {
@@ -3698,29 +3301,55 @@
       }
     },
     "node_modules/shelljs": {
-      "version": "0.10.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.10.0.tgz",
-      "integrity": "sha1-47uumbDz8MxdzgW0ajRvriCQ6IM=",
+      "version": "0.8.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha1-3gVUCNg2G+1mxmnS8ABTjO2O4gw=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "execa": "^5.1.1",
-        "fast-glob": "^3.3.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
-      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4",
-        "side-channel-list": "^1.0.1",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3732,14 +3361,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
+        "object-inspect": "^1.13.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3970,16 +3599,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3994,9 +3613,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strnum/-/strnum-2.4.2.tgz",
-      "integrity": "sha1-r0OrUaBtBCJwI/wuQsoikhTsEPA=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha1-V7yk+6pvJxCBcV28ntfO5Uk+KOQ=",
       "dev": true,
       "funding": [
         {
@@ -4004,10 +3623,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "dependencies": {
-        "anynum": "^1.0.1"
-      }
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -4023,6 +3639,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/test-exclude": {
@@ -4060,19 +3689,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -4113,20 +3729,15 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
-      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "des.js": "^1.1.0",
-        "js-md4": "^0.3.2",
-        "qs": "6.15.3",
+        "qs": "^6.9.1",
         "tunnel": "0.0.6",
-        "underscore": "^1.13.8"
-      },
-      "engines": {
-        "node": ">= 20.0.0"
+        "underscore": "^1.12.1"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -4161,9 +3772,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
-      "integrity": "sha1-pxwo3SL1BUgdvEaJCHsY2TPpCv0=",
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha1-NIN33SRSFvnnBg/1CxWht0C3VCA=",
       "dev": true,
       "funding": [
         {
@@ -4387,22 +3998,6 @@
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xml-naming": {
-      "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/xml-naming/-/xml-naming-0.3.0.tgz",
-      "integrity": "sha1-RsHhi/4oWEeZgt0qzPNNFudJ7aI=",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "homepage": "https://github.com/Microsoft/azure-pipelines-tasks",
   "devDependencies": {
-    "adm-zip": "0.6.0",
+    "adm-zip": "0.4.13",
     "agent-base": "^6.0.2",
-    "azure-devops-node-api": "^17.0.0",
+    "azure-devops-node-api": "^12.2.0",
     "esbuild": "^0.28.1",
-    "fast-xml-parser": "5.11.0",
-    "js-yaml": "^3.15.1",
+    "fast-xml-parser": "4.5.6",
+    "js-yaml": "^3.13.1",
     "minimatch": "3.1.5",
     "minimist": "^1.2.8",
     "mocha": "11.7.5",
@@ -48,18 +48,15 @@
     "node-uuid": "1.4.6",
     "nodejs-file-downloader": "^4.11.1",
     "nyc": "^15.1.0",
-    "pnpm": "^10.34.5",
+    "pnpm": "^10.32.1",
     "q": "1.4.1",
     "semver": "5.7.2",
-    "shelljs": "^0.10.0",
-    "typed-rest-client": "^3.1.0",
+    "shelljs": "^0.8.5",
+    "typed-rest-client": "^1.8.9",
     "typescript": "4.0.2",
     "validator": "^13.7.0"
   },
   "overrides": {
-  "js-yaml@4.x": {".": "^4.3.1"},
-  "brace-expansion@1.x": {".": "^1.1.18"},
-  "brace-expansion@2.x": {".": "^2.1.4"},
-  "serialize-javascript": "7.0.5"
+    "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
Reverts microsoft/azure-pipelines-tasks#22448

Shelljs should not be updated.
It was updated for package vunerability fixes however it is a breaking change.
Will override needed packages or see if possible to fix
It is causing test case failures due to moving to fast glob which is causing issues with / and \ on windows platforms

Identified through below CI checks run

https://dev.azure.com/mseng/PipelineTools/PipelineTools%20Team/_build/results?buildId=31969313&view=logs&j=2e88ae7a-d74a-5f0f-dea9-35d1d1ac5e70&t=c095c018-5ccd-56b5-7697-08955f5284fb&l=13114