### PR TITLE
Exclude non-Windows deasync binaries from Authenticode signing

### DIFF
--- a/ci/sign-task-files.yml
+++ b/ci/sign-task-files.yml
@@ -169,6 +169,8 @@ steps:
         **/node_modules/**/*.exe
         **/node_modules/**/*.dll
         **/node_modules/**/*.node
+        !**/node_modules/deasync/bin/linux-*/**
+        !**/node_modules/deasync/bin/darwin-*/**
       UseMinimatch: true
       signConfigType: inlineSignParams
       inlineOperation: |


### PR DESCRIPTION
### **Context**
The signing step fails because Windows SignTool attempts to sign unsupported Linux and macOS  deasync.node  binaries included with  `AzureKeyVaultV1`

---

### **Task Name**
N/A

---

### **Description**
Exclude Linux and macOS  deasync.node  binaries from Windows Authenticode signing.

---

### **Risk Assessment** (Low / Medium / High)  
Low

---

### **Change Behind Feature Flag** (Yes / No)
No

---

### **Tech Design / Approach**
- Design has been written and reviewed. 
- Any architectural decisions, trade-offs, and alternatives are captured. 

---

### **Documentation Changes Required** (Yes/No)
_Indicate whether related documentation needs to be updated._
- User guides, API specs, system diagrams, or runbooks are updated. 

---

### **Unit Tests Added or Updated** (Yes / No)  
_Indicate whether unit tests were added or modified to reflect these changes._

---

### **Additional Testing Performed**
_List all other tests performed (manual or automated, including integration, regression, scenario tests, etc.)._

---

### **Logging Added/Updated** (Yes/No)
- Appropriate log statements are added with meaningful messages. 
- Logging does not expose sensitive data. 
- Log levels are used correctly (e.g., info, warn, error). 

--- 

### **Telemetry Added/Updated** (Yes/No) 
- Custom telemetry (e.g., counters, timers, error tracking) is added as needed. 
- Events are tagged with proper metadata for filtering and analysis. 
- Telemetry is validated in staging or test environments.

---

### **Rollback Scenario and Process** (Yes/No)
- Rollback plan is documented. 

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
- All impacted internal modules, APIs, services, and third-party libraries are analyzed. 
- Results are reviewed and confirmed to not break existing functionality.

---

### **Checklist**
- [ ] Related issue linked (if applicable)
- [ ] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the task behaves as expected
