### PR TITLE
Update DownloadBuildArtifactsV0 to ArtifactEngine 2.280

### DIFF
--- a/Tasks/DownloadBuildArtifactsV0/DownloadHandlers/HandlerConfigs.ts
+++ b/Tasks/DownloadBuildArtifactsV0/DownloadHandlers/HandlerConfigs.ts
@@ -1,6 +1,6 @@
 import { ArtifactEngineOptions } from 'artifact-engine/Engine';
 import { BuildArtifact } from 'azure-devops-node-api/interfaces/BuildInterfaces';
-import { PersonalAccessTokenCredentialHandler } from 'artifact-engine/Providers/typed-rest-client/Handlers';
+import { PersonalAccessTokenCredentialHandler } from 'typed-rest-client/Handlers';
 
 export interface IBaseHandlerConfig {
     artifactInfo: BuildArtifact;

--- a/Tasks/DownloadBuildArtifactsV0/main.ts
+++ b/Tasks/DownloadBuildArtifactsV0/main.ts
@@ -10,7 +10,7 @@ import { BuildStatus, BuildResult, BuildQueryOrder, Build, BuildDefinitionRefere
 
 import * as models from 'artifact-engine/Models';
 import * as engine from 'artifact-engine/Engine';
-import * as webHandlers from 'artifact-engine/Providers/typed-rest-client/Handlers';
+import * as webHandlers from 'typed-rest-client/Handlers';
 import { IBaseHandlerConfig, IContainerHandlerConfig, IContainerHandlerZipConfig } from './DownloadHandlers/HandlerConfigs';
 
 import { DownloadHandlerContainer } from './DownloadHandlers/DownloadHandlerContainer';

--- a/Tasks/DownloadBuildArtifactsV0/package-lock.json
+++ b/Tasks/DownloadBuildArtifactsV0/package-lock.json
@@ -11,11 +11,12 @@
       "dependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "^24.10.0",
-        "artifact-engine": "^2.275.2",
+        "artifact-engine": "^2.280.0",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
         "decompress-zip": "0.3.3",
-        "extract-zip": "2.0.1"
+        "extract-zip": "2.0.1",
+        "typed-rest-client": "^3.1.0"
       },
       "devDependencies": {
         "typescript": "^5.7.2"
@@ -85,11 +86,12 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -104,22 +106,15 @@
       }
     },
     "node_modules/artifact-engine": {
-      "version": "2.275.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-2.275.2.tgz",
-      "integrity": "sha1-wFQjAFIZJhoyNQlc5ezBR2cky1w=",
+      "version": "2.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/artifact-engine/-/artifact-engine-2.280.0.tgz",
+      "integrity": "sha1-vjvD//3Aa1tRoNsQOh3QA4yozyQ=",
       "license": "MIT",
       "dependencies": {
-        "azure-pipelines-task-lib": "^5.2.8",
+        "azure-pipelines-task-lib": "^5.278.0",
         "handlebars": "4.7.9",
-        "hash-wasm": "^4.12.0",
-        "minimatch": "^10.0.1",
-        "tunnel": "0.0.4"
+        "typed-rest-client": "^3.0.0"
       }
-    },
-    "node_modules/artifact-engine/node_modules/tunnel": {
-      "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
     },
     "node_modules/azure-devops-node-api": {
       "version": "15.1.3",
@@ -134,19 +129,34 @@
         "node": ">= 16.0.0"
       }
     },
-    "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+    "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "^6.10.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/balanced-match": {
@@ -177,15 +187,6 @@
         "node": "*"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/binary": {
       "version": "0.3.0",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/binary/-/binary-0.3.0.tgz",
@@ -196,18 +197,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha1-7Gj+CmQaKdhxFXnK9kHQW64fIoU=",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -411,9 +400,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -663,16 +652,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash-wasm": {
-      "version": "4.12.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hash-wasm/-/hash-wasm-4.12.0.tgz",
-      "integrity": "sha1-+fGp+RIeAnqay/bbXVlFKs4e+bs=",
-      "license": "MIT"
-    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -832,21 +815,6 @@
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "license": "ISC"
     },
-    "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimist/-/minimist-1.2.8.tgz",
@@ -986,12 +954,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1104,14 +1073,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1262,19 +1231,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1320,16 +1289,6 @@
       "version": "1.0.5",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
       "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/Tasks/DownloadBuildArtifactsV0/package.json
+++ b/Tasks/DownloadBuildArtifactsV0/package.json
@@ -21,11 +21,12 @@
   "dependencies": {
     "@types/mocha": "^5.2.7",
     "@types/node": "^24.10.0",
-    "artifact-engine": "^2.275.2",
+    "artifact-engine": "^2.280.0",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
     "decompress-zip": "0.3.3",
-    "extract-zip": "2.0.1"
+    "extract-zip": "2.0.1",
+    "typed-rest-client": "^3.1.0"
   },
   "devDependencies": {
     "typescript": "^5.7.2"

--- a/Tasks/DownloadBuildArtifactsV0/task.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {

--- a/Tasks/DownloadBuildArtifactsV0/task.loc.json
+++ b/Tasks/DownloadBuildArtifactsV0/task.loc.json
@@ -10,7 +10,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "groups": [
     {


### PR DESCRIPTION
### **Context**
Updates the legacy Download Build Artifacts V0 task to consume the ArtifactEngine remediation used for the archive-extraction issue tracked internally as MSRC 140418 / IcM 31000000699987. V0 remains the compatibility path used for older agents.

---

### **Task Name**
DownloadBuildArtifactsV0

---

### **Description**
- Upgrade `artifact-engine` from `^2.275.2` to `^2.280.0`.
- Replace imports from ArtifactEngine's removed internal `typed-rest-client` re-export with the public `typed-rest-client/Handlers` package and declare it as a direct runtime dependency.
- Bump the task patch version from `0.280.0` to `0.280.1` in `task.json` and `task.loc.json`.

---

### **Risk Assessment** (Low / Medium / High)
**Low.** The change is isolated to DownloadBuildArtifactsV0 and preserves the existing credential-handler API. The task now consumes the maintained public `typed-rest-client` dependency required by ArtifactEngine 2.280. This updates the older-agent compatibility path without changing task inputs, outputs, or routing behavior.

---

### **Change Behind Feature Flag** (Yes / No)
**No.** This is a backwards-compatible dependency remediation within the existing V0 task behavior. Existing platform compatibility and deployment task-selection flags already govern V0/V1 routing; a new task-level flag would not provide additional safety.

---

### **Tech Design / Approach**
- ArtifactEngine 2.280 contains the required remediation.
- ArtifactEngine no longer exposes `artifact-engine/Providers/typed-rest-client/Handlers`; importing `typed-rest-client/Handlers` directly is required to compile and run with this version.
- Adding `typed-rest-client` directly avoids relying on an implementation-detail transitive dependency.

---

### **Documentation Changes Required** (Yes/No)
**No.** No user-facing behavior, API, or operational procedure changes.

---

### **Unit Tests Added or Updated** (Yes / No)
**No.** The existing V0 L0 tests cover the task behavior; no behavior-specific test changes were required for this dependency and import migration.

---

### **Additional Testing Performed**
- `node make.js build --task DownloadBuildArtifactsV0 --BypassNpmAudit`
- Isolated DownloadBuildArtifactsV0 L0 test run: 3/3 passing.
- `git diff --check`

---

### **Logging Added/Updated** (Yes/No)
**No.** Existing logging is unchanged; no new runtime behavior needs instrumentation.

---

### **Telemetry Added/Updated** (Yes/No)
**No.** Existing telemetry is unchanged; this is a dependency remediation.

---

### **Rollback Scenario and Process** (Yes/No)
**Yes.** Revert this PR to restore the prior ArtifactEngine dependency and task package. Standard task version rollout controls apply.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)
**Yes.** ArtifactEngine 2.280's removal of the vendored handler re-export was assessed. Both affected V0 handler imports were migrated to the maintained public package, the lockfile was regenerated from the PipelineTools feed, and the targeted build and L0 tests passed.

---

### **Checklist**
- [x] Related issue linked (if applicable) - internal MSRC 140418 / IcM 31000000699987
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
