### PR TITLE
Update 8 Azure App Service/Function tasks to azure-arm-rest 3.280.0 (whitelist-aware Kudu sanitizer)

### DIFF
--- a/Tasks/AzureFunctionAppContainerV1/package-lock.json
+++ b/Tasks/AzureFunctionAppContainerV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "moment": "2.29.4",
         "q": "1.4.1",
@@ -321,11 +321,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -421,18 +422,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -446,9 +446,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -457,8 +457,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -466,7 +466,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -480,6 +480,51 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -491,20 +536,36 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
@@ -2105,14 +2166,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2124,13 +2185,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/Tasks/AzureFunctionAppContainerV1/package.json
+++ b/Tasks/AzureFunctionAppContainerV1/package.json
@@ -25,7 +25,7 @@
     "agent-base": "^6.0.2",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "moment": "2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureFunctionAppContainerV1/task.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppContainerV1/task.loc.json
+++ b/Tasks/AzureFunctionAppContainerV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/package-lock.json
+++ b/Tasks/AzureFunctionAppV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.3",
@@ -328,12 +328,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -486,18 +486,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -512,9 +511,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -523,8 +522,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -532,7 +531,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -548,6 +547,35 @@
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "license": "MIT"
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -560,19 +588,19 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {

--- a/Tasks/AzureFunctionAppV1/package.json
+++ b/Tasks/AzureFunctionAppV1/package.json
@@ -25,7 +25,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.3",

--- a/Tasks/AzureFunctionAppV1/task.json
+++ b/Tasks/AzureFunctionAppV1/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV1/task.loc.json
+++ b/Tasks/AzureFunctionAppV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureFunctionAppV2/package-lock.json
+++ b/Tasks/AzureFunctionAppV2/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "azure-storage": "2.10.7",
         "moment": "^2.29.4",
@@ -328,12 +328,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -486,18 +486,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.11.tgz",
-      "integrity": "sha1-4WT2NUK4K1n7dRDmeuRuTTC/J94=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -512,9 +511,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -523,8 +522,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -532,7 +531,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -548,6 +547,35 @@
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "license": "MIT"
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -560,19 +588,19 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {

--- a/Tasks/AzureFunctionAppV2/package.json
+++ b/Tasks/AzureFunctionAppV2/package.json
@@ -25,7 +25,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "azure-storage": "2.10.7",
     "moment": "^2.29.4",

--- a/Tasks/AzureFunctionAppV2/task.json
+++ b/Tasks/AzureFunctionAppV2/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 2.* <br /> Removed WAR Deploy Support, setting Web.Config options, and the option for the Startup command for Linux Azure Function Apps.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureFunctionAppV2/task.loc.json
+++ b/Tasks/AzureFunctionAppV2/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 2,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "^6.0.2",
         "archiver": "1.2.0",
         "azure-pipelines-task-lib": "^5.2.8",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "decompress-zip": "^0.3.3",
         "ltx": "2.8.0",
@@ -328,11 +328,12 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "node_modules/adm-zip": {
-      "version": "0.5.14",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.14.tgz",
-      "integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -397,47 +398,62 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "15.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-15.1.3.tgz",
-      "integrity": "sha1-X6phYKWoJOiNKVj3nCDsPWbH0VM=",
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "3.1.0"
       },
       "engines": {
         "node": ">= 16.0.0"
       }
     },
+    "node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -451,9 +467,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -462,8 +478,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -471,7 +487,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -957,9 +973,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha1-otCzcyBXJN+lJdI7DD4bHKWCyZs=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1178,9 +1194,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1873,12 +1889,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2051,14 +2068,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2070,13 +2087,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2245,19 +2262,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/typescript": {

--- a/Tasks/AzureRmWebAppDeploymentV3/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/package.json
@@ -25,7 +25,7 @@
     "agent-base": "^6.0.2",
     "archiver": "1.2.0",
     "azure-pipelines-task-lib": "^5.2.8",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "decompress-zip": "^0.3.3",
     "ltx": "2.8.0",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 279,
-    "Patch": 3
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "What's new in Version 3.0: <br/>&nbsp;&nbsp;Supports File Transformations (XDT) <br/>&nbsp;&nbsp;Supports Variable Substitutions(XML, JSON) <br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV3/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 3,
-    "Minor": 279,
-    "Patch": 3
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^5.277.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -308,12 +308,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -398,41 +398,57 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "15.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-15.1.3.tgz",
-      "integrity": "sha1-X6phYKWoJOiNKVj3nCDsPWbH0VM=",
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "3.1.0"
       },
       "engines": {
         "node": ">= 16.0.0"
       }
     },
+    "node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
@@ -452,9 +468,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -463,8 +479,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -472,7 +488,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -1936,12 +1952,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2141,14 +2158,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2337,19 +2354,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
-      "integrity": "sha1-in5IjaFdo4HoLVy73t0LCIKOiX0=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "6.15.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
         "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/typescript": {

--- a/Tasks/AzureRmWebAppDeploymentV4/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/package.json
@@ -24,7 +24,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^5.277.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV4/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 4,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package-lock.json
@@ -14,7 +14,7 @@
         "@types/q": "1.0.7",
         "agent-base": "^6.0.2",
         "azure-pipelines-task-lib": "^5.277.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -308,12 +308,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -398,41 +398,57 @@
       }
     },
     "node_modules/azure-devops-node-api": {
-      "version": "15.1.3",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-15.1.3.tgz",
-      "integrity": "sha1-X6phYKWoJOiNKVj3nCDsPWbH0VM=",
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "2.1.0"
+        "typed-rest-client": "3.1.0"
       },
       "engines": {
         "node": ">= 16.0.0"
       }
     },
+    "node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.10.3",
+        "qs": "6.15.3",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.277.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.277.0.tgz",
-      "integrity": "sha1-IzR+ExQL+R24uw1eROr0Nv+olTQ=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
@@ -452,9 +468,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -463,8 +479,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -472,7 +488,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -1936,12 +1952,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2141,14 +2158,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2337,19 +2354,19 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
-      "integrity": "sha1-in5IjaFdo4HoLVy73t0LCIKOiX0=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "6.15.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
         "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/typescript": {

--- a/Tasks/AzureRmWebAppDeploymentV5/package.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/package.json
@@ -24,7 +24,7 @@
     "@types/q": "1.0.7",
     "agent-base": "^6.0.2",
     "azure-pipelines-task-lib": "^5.277.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "What's new in version 4.*<br />Supports Zip Deploy, Run From Package, War Deploy [Details here](https://aka.ms/appServiceDeploymentMethods)<br />Supports App Service Environments<br />Improved UI for discovering different App service types supported by the task<br/>Run From Package is the preferred deployment method, which makes files in wwwroot folder read-only<br/>Click [here](https://aka.ms/azurermwebdeployreadme) for more information.",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
+++ b/Tasks/AzureRmWebAppDeploymentV5/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 5,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "releaseNotes": "ms-resource:loc.releaseNotes",
   "minimumAgentVersion": "2.104.1",

--- a/Tasks/AzureWebAppContainerV1/package-lock.json
+++ b/Tasks/AzureWebAppContainerV1/package-lock.json
@@ -20,6 +20,7 @@
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
+        "uuid": "3.1.0",
         "xml2js": "^0.6.0"
       },
       "devDependencies": {
@@ -2463,6 +2464,16 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/Tasks/AzureWebAppContainerV1/package-lock.json
+++ b/Tasks/AzureWebAppContainerV1/package-lock.json
@@ -16,7 +16,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "moment": "^2.29.4",
         "q": "1.4.1",
@@ -333,12 +333,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha1-C15Md58H3t6lgFzcyxFHBx2UqQk=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -436,18 +436,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -462,9 +461,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -473,8 +472,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -482,7 +481,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -498,6 +497,51 @@
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "license": "MIT"
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -509,20 +553,36 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.2.0.tgz",
-      "integrity": "sha1-2gcn5AiEm9tpgg2G7mZK/KNHd6M=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "^6.14.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
-        "underscore": "^1.12.1"
+        "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-webdeployment-common": {
@@ -2155,14 +2215,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2174,13 +2234,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha1-EMtZhCYxFdO3oOM2WR4pCoMK+K0=",
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha1-wuC1oUpUCuvuO7xsP4ZmzJtQkSc=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2403,16 +2463,6 @@
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/Tasks/AzureWebAppContainerV1/package.json
+++ b/Tasks/AzureWebAppContainerV1/package.json
@@ -26,7 +26,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "moment": "^2.29.4",
     "q": "1.4.1",

--- a/Tasks/AzureWebAppContainerV1/package.json
+++ b/Tasks/AzureWebAppContainerV1/package.json
@@ -30,6 +30,7 @@
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "moment": "^2.29.4",
     "q": "1.4.1",
+    "uuid": "3.1.0",
     "xml2js": "^0.6.0"
   },
   "devDependencies": {

--- a/Tasks/AzureWebAppContainerV1/task.json
+++ b/Tasks/AzureWebAppContainerV1/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppContainerV1/task.loc.json
+++ b/Tasks/AzureWebAppContainerV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 2
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.104.1",
   "groups": [

--- a/Tasks/AzureWebAppV1/package-lock.json
+++ b/Tasks/AzureWebAppV1/package-lock.json
@@ -15,7 +15,7 @@
         "agent-base": "6.0.2",
         "azure-devops-node-api": "^15.1.3",
         "azure-pipelines-task-lib": "^5.2.10",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
         "azure-pipelines-tasks-utility-common": "3.272.0",
         "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
         "jsonwebtoken": "^9.0.2",
@@ -323,12 +323,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha1-XAtl83ruxcKpSZXAJPkx9i5LvFo=",
+      "version": "0.6.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -435,18 +435,17 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.10",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.10.tgz",
-      "integrity": "sha1-apqbRNVJmH67c+FtYP2PCVNzXf4=",
+      "version": "5.279.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.279.0.tgz",
+      "integrity": "sha1-0Zxrd3tFRpQ8pOalP7kTuWND5Wc=",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
-        "shelljs": "^0.10.0",
-        "uuid": "^3.0.1"
+        "shelljs": "^0.10.0"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/q": {
@@ -461,9 +460,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.279.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.279.2.tgz",
-      "integrity": "sha1-n8jyCelIPXYTZv65wvQivTXbkHQ=",
+      "version": "3.280.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.280.0.tgz",
+      "integrity": "sha1-P1o/o07w5+uNa+YM/OJZxPydG6s=",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -472,8 +471,8 @@
         "@types/node": "^10.17.0",
         "@types/q": "1.5.4",
         "async-mutex": "^0.4.0",
-        "azure-devops-node-api": "^15.1.3",
-        "azure-pipelines-task-lib": "^5.2.4",
+        "azure-devops-node-api": "^17.0.0",
+        "azure-pipelines-task-lib": "^5.279.0",
         "https-proxy-agent": "^4.0.0",
         "jsonwebtoken": "^9.0.3",
         "msalv1": "npm:@azure/msal-node@^1.18.4",
@@ -481,7 +480,7 @@
         "msalv3": "npm:@azure/msal-node@^3.5.3",
         "node-fetch": "^2.6.7",
         "q": "1.5.1",
-        "typed-rest-client": "^2.2.0",
+        "typed-rest-client": "^3.1.0",
         "xml2js": "0.6.2"
       }
     },
@@ -497,6 +496,51 @@
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "license": "MIT"
     },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api": {
+      "version": "17.0.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-devops-node-api/-/azure-devops-node-api-17.0.0.tgz",
+      "integrity": "sha1-WTgKfVSxPVYJtvy0g9ZjsKEvqbE=",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha1-doUhMqWO1cfA72fkRBubtdYGGzs=",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/azure-devops-node-api/node_modules/typed-rest-client": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.0.tgz",
+      "integrity": "sha1-Fgau0uxZ51Fp5gTZD6PTwPY3QtM=",
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.3",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      }
+    },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/q/-/q-1.5.1.tgz",
@@ -509,12 +553,13 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
+      "version": "6.16.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -524,19 +569,19 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/typed-rest-client": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
-      "integrity": "sha1-in5IjaFdo4HoLVy73t0LCIKOiX0=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-3.1.1.tgz",
+      "integrity": "sha1-9ediz9W/4fYbW9wrXkxDNE+52oM=",
       "license": "MIT",
       "dependencies": {
         "des.js": "^1.1.0",
         "js-md4": "^0.3.2",
-        "qs": "6.15.1",
+        "qs": "^6.16.0",
         "tunnel": "0.0.6",
         "underscore": "^1.13.8"
       },
       "engines": {
-        "node": ">= 16.0.0"
+        "node": ">= 20.0.0"
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest/node_modules/xml2js": {
@@ -2311,14 +2356,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha1-w/z/nE2pMnhIczNeyXZfqU/2a8k=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha1-6gLGLgXcS+pn1EQvD7ce4ZL44Ks=",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/Tasks/AzureWebAppV1/package.json
+++ b/Tasks/AzureWebAppV1/package.json
@@ -25,7 +25,7 @@
     "agent-base": "6.0.2",
     "azure-devops-node-api": "^15.1.3",
     "azure-pipelines-task-lib": "^5.2.10",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.279.2",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.280.0",
     "azure-pipelines-tasks-utility-common": "3.272.0",
     "azure-pipelines-tasks-webdeployment-common": "^4.279.0",
     "jsonwebtoken": "^9.0.2",

--- a/Tasks/AzureWebAppV1/task.json
+++ b/Tasks/AzureWebAppV1/task.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.209.0",
   "groups": [

--- a/Tasks/AzureWebAppV1/task.loc.json
+++ b/Tasks/AzureWebAppV1/task.loc.json
@@ -17,8 +17,8 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
-    "Patch": 1
+    "Minor": 280,
+    "Patch": 0
   },
   "minimumAgentVersion": "2.209.0",
   "groups": [


### PR DESCRIPTION
### **Context**

Consumes the whitelist-aware Kudu log sanitizer shipped in `azure-pipelines-tasks-azure-arm-rest` **3.280.0** (common-packages [PR #659](https://github.com/microsoft/azure-pipelines-tasks-common-packages/pull/659)).

Addresses MSRC 125166 (CWE-77 command injection via remote Kudu/Oryx build-log output) — [AB#2440075](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440075).

---

### **Task Name**

AzureRmWebAppDeploymentV3, AzureRmWebAppDeploymentV4, AzureRmWebAppDeploymentV5, AzureWebAppV1, AzureWebAppContainerV1, AzureFunctionAppV1, AzureFunctionAppV2, AzureFunctionAppContainerV1

---

### **Description**

These 8 App Service / Function deployment tasks print remote Kudu/Oryx build logs through `sanitizeKuduLogForConsole` (in `azure-arm-rest`). This PR bumps each task's `azure-pipelines-tasks-azure-arm-rest` dependency to `^3.280.0`, which changes the sanitizer from neutralizing **all** `##vso[` logging commands to neutralizing only **non-whitelisted** ones (allow-list from `agent.allowedLoggingCommands`; empty/unset allow-list = allow all), and **never** touching leading `##[` formatting sequences. Behavior is gated by the `EnableKuduLogVsoCommandSanitization` pipeline feature (telemetry-only when off).

Per task: bumped the dependency to `^3.280.0`, regenerated `package-lock.json` and re-vendored the library via the task build, and bumped the task version to sprint 280 (Minor `279`→`280`, Patch `0`).

| Task | Version |
|------|---------|
| AzureRmWebAppDeploymentV3 | 3.280.0 |
| AzureRmWebAppDeploymentV4 | 4.280.0 |
| AzureRmWebAppDeploymentV5 | 5.280.0 |
| AzureWebAppV1 | 1.280.0 |
| AzureWebAppContainerV1 | 1.280.0 |
| AzureFunctionAppV1 | 1.280.0 |
| AzureFunctionAppV2 | 2.280.0 |
| AzureFunctionAppContainerV1 | 1.280.0 |

---

### **Risk Assessment** (Low / Medium / High)

**Low.** Dependency-version + task-version bump only; no task source logic changed. The behavioral change lives entirely in `azure-arm-rest` and is gated by the `EnableKuduLogVsoCommandSanitization` feature (not broadly enabled). With the allow-all-on-empty default, absence of an allow-list preserves current output.

---

### **Change Behind Feature Flag** (Yes / No)

**Yes** — `EnableKuduLogVsoCommandSanitization`. When off, output is unchanged (telemetry-only).

---

### **Tech Design / Approach**

- Sanitizer design implemented and reviewed in common-packages PR #659 (approved, merged).
- These tasks only vendor the new library version; no per-task design change.

---

### **Documentation Changes Required** (Yes/No)

**No.**

---

### **Unit Tests Added or Updated** (Yes / No)

**No** (task source unchanged). Sanitizer unit tests live in `azure-arm-rest` and were added/updated in PR #659.

---

### **Additional Testing Performed**

- Built all 8 tasks locally against the ADO feed; each vendored `azure-pipelines-tasks-azure-arm-rest@3.280.0` and each `package-lock.json` resolves the library (and its subtree) from the feed with no remaining `3.279.2` references.
- Ran `AzureWebAppV1` L0 suite as a representative smoke test: **10 passing, 0 failing**.

---

### **Logging Added/Updated** (Yes/No)

**No** new task logging. The sanitizer only neutralizes non-whitelisted `##vso[` sequences in remote log output before printing.

---

### **Telemetry Added/Updated** (Yes/No)

**No** task-level telemetry. The library emits sanitizer telemetry (`enforced` / `allowlistPresent` / `escapedCount`), added in PR #659.

---

### **Rollback Scenario and Process** (Yes/No)

**Yes.** Disable the `EnableKuduLogVsoCommandSanitization` feature to revert to telemetry-only behavior; the previous task versions remain available for pinning.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

**Yes.** Only the `azure-arm-rest` dependency changed; lockfile churn is confined to the `azure-pipelines-tasks-azure-arm-rest/node_modules/` subtree (azure-devops-node-api, qs, typed-rest-client). Builds succeed for all 8 tasks; representative L0 suite passes.

---

### **Checklist**
- [x] Related issue linked (if applicable) — [AB#2440075](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440075)
- [x] Task version was bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [x] Verified the task behaves as expected
