### PR TITLE
Updated the packages to fix vulnerabilities reported in multiple deprecated tasks.

### DIFF
--- a/Tasks/HelmInstallerV0/package-lock.json
+++ b/Tasks/HelmInstallerV0/package-lock.json
@@ -13,8 +13,8 @@
         "azure-pipelines-tasks-kubernetes-common": "2.209.1",
         "azure-pipelines-tool-lib": "^2.0.10",
         "del": "2.2.0",
-        "js-yaml": "4.1.0",
-        "typed-rest-client": "1.8.9"
+        "js-yaml": "4.3.2",
+        "typed-rest-client": "1.8.11"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -219,14 +219,16 @@
       "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
     },
     "node_modules/balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -281,7 +283,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -424,16 +427,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+      "version": "4.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -581,9 +584,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -702,9 +705,20 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -722,28 +736,31 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.52.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.35",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1019,17 +1036,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/shelljs/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
@@ -1127,9 +1133,10 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
+      "license": "MIT",
       "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
@@ -1155,9 +1162,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.4.tgz",
-      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ=="
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/Tasks/HelmInstallerV0/package.json
+++ b/Tasks/HelmInstallerV0/package.json
@@ -12,13 +12,17 @@
     "azure-pipelines-tasks-kubernetes-common": "2.209.1",
     "azure-pipelines-tool-lib": "^2.0.10",
     "del": "2.2.0",
-    "js-yaml": "4.1.0",
-    "typed-rest-client": "1.8.9"
+    "js-yaml": "4.3.2",
+    "typed-rest-client": "1.8.11"
   },
   "devDependencies": {
     "typescript": "5.1.6"
   },
   "overrides": {
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.6",
+    "brace-expansion": "^1.1.18",
+    "js-yaml": "4.3.2",
+    "minimatch": "^3.1.5",
+    "underscore": "^1.13.8"
   }
 }

--- a/Tasks/HelmInstallerV0/task.json
+++ b/Tasks/HelmInstallerV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/HelmInstallerV0/task.loc.json
+++ b/Tasks/HelmInstallerV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "satisfies": [

--- a/Tasks/KubernetesManifestV0/package-lock.json
+++ b/Tasks/KubernetesManifestV0/package-lock.json
@@ -18,9 +18,9 @@
         "azure-pipelines-tasks-utility-common": "^3.210.0",
         "azure-pipelines-tool-lib": "^2.0.10",
         "del": "2.2.0",
-        "js-yaml": "3.13.1",
+        "js-yaml": "3.15.2",
         "moment": "^2.29.4",
-        "typed-rest-client": "^1.8.9"
+        "typed-rest-client": "^1.8.11"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -321,12 +321,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -381,7 +383,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -515,16 +518,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+      "version": "4.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -607,17 +610,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/globby": {
@@ -703,9 +695,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -811,9 +803,10 @@
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha1-P4OCOsa+F/Vw8jsuze83d/9eo2Q=",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -851,9 +844,10 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1171,9 +1165,10 @@
       }
     },
     "node_modules/typed-rest-client": {
-      "version": "1.8.9",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.9.tgz",
-      "integrity": "sha512-uSmjE38B80wjL85UFX3sTYEUlvZ1JgCRhsWj/fJ4rZ0FqDUFoIuodtiVeE+cUqiVTOKPdKrp/sdftD15MDek6g==",
+      "version": "1.8.11",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha1-aQbwLjyR6NhRV58lWr8P1ggAoE0=",
+      "license": "MIT",
       "dependencies": {
         "qs": "^6.9.1",
         "tunnel": "0.0.6",
@@ -1199,9 +1194,10 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "5.26.5",

--- a/Tasks/KubernetesManifestV0/package.json
+++ b/Tasks/KubernetesManifestV0/package.json
@@ -16,15 +16,19 @@
     "azure-pipelines-tasks-utility-common": "^3.210.0",
     "azure-pipelines-tool-lib": "^2.0.10",
     "del": "2.2.0",
-    "js-yaml": "3.13.1",
+    "js-yaml": "3.15.2",
     "moment": "^2.29.4",
     "agent-base": "^6.0.2",
-    "typed-rest-client": "^1.8.9"
+    "typed-rest-client": "^1.8.11"
   },
   "devDependencies": {
     "typescript": "5.1.6"
   },
   "overrides": {
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.6",
+    "brace-expansion": "^1.1.18",
+    "js-yaml": "3.15.2",
+    "minimatch": "^3.1.5",
+    "underscore": "^1.13.8"
   }
 }

--- a/Tasks/KubernetesManifestV0/task.json
+++ b/Tasks/KubernetesManifestV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesManifestV0/task.loc.json
+++ b/Tasks/KubernetesManifestV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "groups": [],

--- a/Tasks/KubernetesV0/package-lock.json
+++ b/Tasks/KubernetesV0/package-lock.json
@@ -17,7 +17,7 @@
         "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
         "azure-pipelines-tasks-utility-common": "3.267.0",
         "del": "2.2.0",
-        "js-yaml": "3.13.1"
+        "js-yaml": "3.15.2"
       },
       "devDependencies": {
         "typescript": "5.1.6"
@@ -441,19 +441,6 @@
         "uuid": "^3.0.1"
       }
     },
-    "node_modules/azure-pipelines-tasks-utility-common/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/azure-pipelines-tool-lib": {
       "version": "2.0.8",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.8.tgz",
@@ -493,9 +480,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "version": "1.1.18",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -764,16 +751,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
+      "version": "4.0.6",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -926,9 +913,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1076,9 +1063,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "version": "3.15.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha1-P4OCOsa+F/Vw8jsuze83d/9eo2Q=",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -1123,23 +1110,23 @@
       }
     },
     "node_modules/jwa": {
-      "version": "1.4.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha1-dDwymFy56YZVUw1TZBtmyGRbA5o=",
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
       "license": "MIT",
       "dependencies": {
-        "buffer-equal-constant-time": "1.0.1",
+        "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -1222,9 +1209,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha1-TajxKQ7g8PjoPWDKafjxNAaGBKM=",
+      "version": "3.1.5",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1323,9 +1310,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha1-vo2iryQ7JBfV9kancGY6krfp3tM=",
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha1-HHt9i9wtB4c59YKH1YnZA6EbL8I=",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -1566,18 +1553,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1681,18 +1656,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/shelljs/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/side-channel": {
@@ -1864,9 +1827,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha1-lw4zljr5p92iKPF+voOZ5fvmOhA=",
+      "version": "1.13.8",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha1-qTohGGwEnb8OhHSW26cre9jB6Ss=",
       "license": "MIT"
     },
     "node_modules/undici-types": {

--- a/Tasks/KubernetesV0/package-lock.json
+++ b/Tasks/KubernetesV0/package-lock.json
@@ -1097,6 +1097,27 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jsonwebtoken/node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha1-FgEaxttI3nsQJ3fleJeQFSDux7k=",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/jws": {
+      "version": "3.2.3",
+      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha1-WsBpC0YJAKJyZd4kUgUmhTwLjKE=",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.2",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/jsonwebtoken/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/semver/-/semver-7.6.3.tgz",
@@ -1107,27 +1128,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lodash.includes": {

--- a/Tasks/KubernetesV0/package.json
+++ b/Tasks/KubernetesV0/package.json
@@ -16,12 +16,18 @@
     "azure-pipelines-tasks-kubernetes-common": "^2.252.0",
     "azure-pipelines-tasks-utility-common": "3.267.0",
     "del": "2.2.0",
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.15.2"
   },
   "devDependencies": {
     "typescript": "5.1.6"
   },
   "overrides": {
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.6",
+    "brace-expansion": "^1.1.18",
+    "js-yaml": "3.15.2",
+    "jws": "^4.0.0",
+    "minimatch": "^3.1.5",
+    "node-forge": "^1.3.3",
+    "underscore": "^1.13.8"
   }
 }

--- a/Tasks/KubernetesV0/package.json
+++ b/Tasks/KubernetesV0/package.json
@@ -25,7 +25,7 @@
     "form-data": "^4.0.6",
     "brace-expansion": "^1.1.18",
     "js-yaml": "3.15.2",
-    "jws": "^4.0.0",
+    "jws": "^3.2.3",
     "minimatch": "^3.1.5",
     "node-forge": "^1.3.3",
     "underscore": "^1.13.8"

--- a/Tasks/KubernetesV0/task.json
+++ b/Tasks/KubernetesV0/task.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",

--- a/Tasks/KubernetesV0/task.loc.json
+++ b/Tasks/KubernetesV0/task.loc.json
@@ -14,7 +14,7 @@
   "version": {
     "Major": 0,
     "Minor": 280,
-    "Patch": 0
+    "Patch": 1
   },
   "demands": [],
   "preview": "false",


### PR DESCRIPTION
### **Context**

This PR addresses Component Governance alerts in 3 Tasks.


**Associated work items:**

[AB#2338079](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2338079), [AB#2339822](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2339822), [AB#2362008](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362008), [AB#2362009](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362009), [AB#2362012](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362012), [AB#2362013](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2362013), [AB#2433058](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2433058)


Note - All 3 are deprecated tasks.
js-yaml is added under dependencies because the tasks import it directly. The override ensures transitive copies brought in by the existing common packages also resolve to the secure version. did not upgrade the common packages because their newer versions introduce runtime and task-lib changes that caused CI regressions in these deprecated tasks. This keeps the security fix targeted while preserving existing task behavior.

---

### **Task Names**

HelmInstallerV0 , KubernetesManifestV0 , KubernetesV0

---

### **Description**

#### HelmInstallerV0
- Updated `js-yaml` from `4.1.0` to `4.3.2`.
- Updated `typed-rest-client` from `1.8.9` to `1.8.11`
- Updated `form-data` from `^4.0.4` to `^4.0.6`
- Overrides are added for brace-expansion, js-yaml, minimatch, underscore
- Bumped the task version from `0.280.0` to `0.280.1`.
npm audit output (adm-zip and mockery vulnerabilities exists in code)
<img width="683" height="51" alt="image" src="https://github.com/user-attachments/assets/9a041a47-8194-4024-b737-177bcd89587d" />


#### KubernetesManifestV0
- Updated `js-yaml` from `3.13.1` to `3.15.2`.
- Updated `typed-rest-client` from `1.8.9` to `1.8.11`
- Updated `form-data` from `^4.0.4` to `^4.0.6`
- Overrides are added for brace-expansion, js-yaml, minimatch, underscore
- Bumped the task version from `0.280.0` to `0.280.1`.
npm audit output (only mockery vulnerabilities exist in code)
<img width="718" height="64" alt="image" src="https://github.com/user-attachments/assets/4857e195-22e6-4c7e-aca4-4786eb869f1e" />
<img width="750" height="174" alt="image" src="https://github.com/user-attachments/assets/51bab6fd-628c-4a07-9f1a-d6a8dac9d37b" />


#### KubernetesV0
- Updated `js-yaml` from `3.13.1` to `3.15.2`.
- Updated `form-data` from `^4.0.4` to `^4.0.6`
- Overrides are added for brace-expansion, js-yaml, jws, minimatch, node-forge, underscore
- Bumped the task version from `0.280.0` to `0.280.1`.
npm audit output (only adm-zip vulnerabilities exist in code)
<img width="634" height="88" alt="image" src="https://github.com/user-attachments/assets/a8270c22-cd43-4b15-a9ab-69baaf03c563" />

<img width="809" height="274" alt="image" src="https://github.com/user-attachments/assets/e2a8fad2-33a9-45a0-9374-0ea3131dbab5" />


The corresponding package lockfiles and localized task manifests were regenerated.

---

### **Risk Assessment** (Low)

Low

---

### **Change Behind Feature Flag** (No)

No

---

### **Tech Design / Approach**

NA

---

### **Documentation Changes Required** (No)

No 

---

### **Unit Tests Added or Updated** (No)

No

---

### **Additional Testing Performed**

Only CI checks and local build validation were performed. No additional testing is done.

---

### **Logging Added/Updated** (No)

No logging changes were required.

---

### **Telemetry Added/Updated** (No)

No telemetry changes were required.

---

### **Rollback Scenario and Process** (Yes)

NA

---

### **Dependency Impact Assessed and Regression Tested** (Yes)

NA

---

### **Checklist**

- [x] Related PR linked
- [x] Task versions were bumped — see [versioning guide](https://github.com/microsoft/azure-pipelines-tasks/tree/master/docs/taskversionbumping.md)
- [ ] Verified the tasks through PR CI — checks are in progress