### PR TITLE
Fix NpmV1 debug log discovery for npm 11

### DIFF
--- a/Tasks/NpmV1/Tests/npm-failureDumpsLog-cacheDir.ts
+++ b/Tasks/NpmV1/Tests/npm-failureDumpsLog-cacheDir.ts
@@ -17,10 +17,10 @@ tmr.mockNpmCommand('custom', {
 } as TaskLibAnswerExecResult);
 tmr.answers.exist['C:\\mock\\cache\\npm-debug.log'] = false;
 tmr.answers["stats"] = {"C:\\mock\\cache": {"isDirectory":true}};
-tmr.answers.findMatch['*-debug.log'] = [
-    'someRandomNpm-debug.log'
+tmr.answers.findMatch['*-debug*.log'] = [
+    '2026-09-04T12_39_31_440Z-debug-0.log'
 ];
 let fs = require('fs');
-fs.writeFileSync('someRandomNpm-debug.log', 'NPM_DEBUG_LOG', 'utf-8');
+fs.writeFileSync('2026-09-04T12_39_31_440Z-debug-0.log', 'NPM_DEBUG_LOG', 'utf-8');
 tmr.run();
 

--- a/Tasks/NpmV1/npmtoolrunner.ts
+++ b/Tasks/NpmV1/npmtoolrunner.ts
@@ -207,7 +207,7 @@ export class NpmToolRunner extends tr.ToolRunner {
 
     private _getDebugLogPath(options?: tr.IExecSyncOptions): string {
         // check cache
-        const logs = tl.findMatch(path.join(this.cacheLocation, '_logs'), '*-debug.log');
+        const logs = tl.findMatch(path.join(this.cacheLocation, '_logs'), '*-debug*.log');
         if (logs && logs.length > 0) {
             const debugLog = logs[logs.length - 1];
             console.log(tl.loc('FoundNpmDebugLog', debugLog));

--- a/Tasks/NpmV1/task.json
+++ b/Tasks/NpmV1/task.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 280,
     "Patch": 0
   },
   "runsOn": [

--- a/Tasks/NpmV1/task.loc.json
+++ b/Tasks/NpmV1/task.loc.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "version": {
     "Major": 1,
-    "Minor": 279,
+    "Minor": 280,
     "Patch": 0
   },
   "runsOn": [


### PR DESCRIPTION
### Context
Fixes #22481.

### Task Name
NpmV1

### Description
Match npm debug logs with numbered suffixes such as `*-debug-0.log`, while retaining support for the previous `*-debug.log` form.

### Risk Assessment
Low. The change only broadens the cache debug-log glob.

### Change Behind Feature Flag
No. This restores debug-log discovery after npm's filename change.

### Documentation Changes Required
No.

### Unit Tests Added or Updated
Yes. The existing cache debug-log test now covers npm's numbered filename format.

### Additional Testing Performed
- `node make.js build --task NpmV1 --BypassNpmAudit`
- NpmV1 L0 suite: 16 passing

### Logging Added/Updated
No.

### Telemetry Added/Updated
No.

### Rollback Scenario and Process
Revert this change.

### Dependency Impact Assessed and Regression Tested
Yes. No dependency changes.

### Checklist
- [x] Related issue linked
- [x] Task version bumped to sprint 280
- [x] Verified the task behaves as expected
