### PR TITLE
Fix canary test runner queueing every pipeline in the project

### DIFF
--- a/ci/ci-test-tasks/detect-changed-tasks.js
+++ b/ci/ci-test-tasks/detect-changed-tasks.js
@@ -18,15 +18,30 @@ function getTaskNames(files) {
   // var tasks = new Set();
   // Result:
   // tasks == Set(4) { 'Joe', 'Bob', 'Sue', 'Ralf' }
-  files.filter(filePath => filePath.startsWith('_generated/')).forEach(filePath => { 
-    var taskName = filePath.split('/')[1].split(/_|\./)[0];
-    if(!tasks.has(taskName))   
-    {
-      tasks.add(taskName);
-    }
-  });
+  //
+  // '_generated/_buildConfigs/**' is deliberately excluded. It holds generated
+  // build-config metadata (lock files and the like) rather than task sources, and
+  // a routine refresh of it touches a hundred tasks at once. It is also where the
+  // fan-out bug lived: '_buildConfigs'.split(/_|\./)[0] is the EMPTY STRING, and
+  // an empty task name makes every downstream `startsWith(task)` match
+  // EVERYTHING - which queued every pipeline in the canary project, twice, rather
+  // than the handful of tasks the PR actually changed.
+  files
+    .filter(filePath => filePath.startsWith('_generated/') && !filePath.startsWith('_generated/_buildConfigs/'))
+    .forEach(filePath => {
+      const segment = filePath.split('/')[1];
+      const taskName = segment ? segment.split(/_|\./)[0] : '';
+
+      if (taskName && !tasks.has(taskName)) {
+        tasks.add(taskName);
+      }
+    });
 
   // skip Common folder as this is not a task folder
   tasks.delete('Common');
+
+  // A blank entry here is never a real task, and it is actively dangerous: it
+  // makes the prefix match downstream select every pipeline in the project.
+  tasks.delete('');
   return [...tasks];
 }

--- a/ci/ci-test-tasks/test-and-verify-v2/src/api.ts
+++ b/ci/ci-test-tasks/test-and-verify-v2/src/api.ts
@@ -26,7 +26,14 @@ class API {
             throw new Error('Task list is not provided');
         }
 
-        this.tasks = TaskArg.split(',');
+        // Blank entries must never reach the pipeline matcher: it selects by name
+        // prefix, and every name starts with the empty string, so a single blank
+        // entry fans the run out to every pipeline in the project.
+        this.tasks = TaskArg.split(',').map(task => task.trim()).filter(task => task.length > 0);
+        if (this.tasks.length === 0) {
+            throw new Error(`Task list "${TaskArg}" contains no task names`);
+        }
+
         const authHandler = getPersonalAccessTokenHandler(authToken);
         this.webApi = new WebApi(adoUrl, authHandler);
     }

--- a/ci/ci-test-tasks/test-and-verify-v2/src/index.ts
+++ b/ci/ci-test-tasks/test-and-verify-v2/src/index.ts
@@ -63,6 +63,11 @@ async function main() {
   console.log(`Found ${pipelines.length} total pipelines in the project`);
 
   for (const task of api.tasks) {
+    if (!task) {
+      console.warn('Skipping blank task name: matching by prefix would select every pipeline in the project.');
+      continue;
+    }
+
     console.log(`starting tests for ${task} task`);
 
     // Find all pipelines that start with the task name


### PR DESCRIPTION
### **Context**

The canary CI runner (`ci-tests-tasks-v2`) queues *every* pipeline in the canary test project whenever a PR touches `_generated/_buildConfigs/**`, instead of only the pipelines for the changed tasks.

Observed on PR #22497. Two of its check runs each fanned out to all 226 pipelines in `canarytest/PipelineTasks`, queueing each one twice:

- build `333532` (`refs/pull/22497/merge`, 2026-09-10 14:43)
- build `333901` (same merge commit, re-run, 2026-09-10 22:18)

Both logs contain the same tell-tale line:

```
starting tests for  task
Found 226 pipeline(s) for task "": ci-test-tasks-main, DownloadPackageV1, ..., NodeCompatCI, ..., NodeCompatCI_Janitor
checking buildconfig for
Error reading task.json for : ENOENT ... '/home/vsts/work/1/s/Tasks/task.json'
Detected buildconfigs ["AzureCLIV1","AzureCLIV1_Node24"]
```

Side effects: unrelated pipelines that declare `trigger: none` plus a single nightly cron were repeatedly triggered; the runner also re-queued **itself** (`ci-tests-tasks-v2` is in its own 226-pipeline list), amplifying the sweep.

### **Root cause**

`detect-changed-tasks.js` derives a task name from `_generated/` paths with:

```js
filePath.split('/')[1].split(/_|\./)[0]
```

For `_generated/_buildConfigs/<Task>/LocalPackages/package-lock.json` that evaluates `'_buildConfigs'.split(/_|\./)[0]`, which is the **empty string**. The blank name reaches `test-and-verify-v2`, whose matcher is a name-prefix test:

```ts
pipelines.filter(pipeline => pipeline.name?.startsWith(task))
```

`startsWith('')` is true for every pipeline, so all of them are selected. `getBuildConfigs('')` then fails to read `Tasks//task.json` and falls back to `["AzureCLIV1","AzureCLIV1_Node24"]`, so each pipeline is queued twice.

The defect has been latent since `_generated/_buildConfigs/` was introduced (commit `23db9170`, 2024-11-21); `detect-changed-tasks.js` has not changed since 2023. No commit on `master` touched that directory during 2026, which is why it surfaced only now — it is written by occasional dependency/`package-lock` refresh PRs.

---

### **Task Name**

N/A — CI tooling only. No pipeline task is modified.

---

### **Description**

- `detect-changed-tasks.js`: exclude `_generated/_buildConfigs/**` from task-name derivation, and never emit a blank task name (guard on insert plus `tasks.delete('')`). `_buildConfigs` holds generated build-config metadata rather than task source, and a routine `LocalPackages` refresh touches ~100 tasks, so treating it as "these tasks changed" is both wrong and very expensive.
- `test-and-verify-v2/src/api.ts`: trim and drop empty entries when parsing the `TASKS` argument, and throw if the resulting list is empty — so a malformed input fails loudly instead of silently meaning "everything".
- `test-and-verify-v2/src/index.ts`: skip a blank task name at the fan-out site (defence in depth).

---

### **Risk Assessment** (Low / Medium / High)

**Low.** CI-only change; no shipped task code is touched. The change is strictly *narrowing* — it can only reduce the set of pipelines queued. The failure mode it removes (queue everything, twice) is far more damaging than the worst case it introduces (a `_buildConfigs`-only PR runs no canary tests, which is correct, since no task source changed).

---

### **Change Behind Feature Flag** (Yes / No)

**No.** This is CI orchestration logic, not product code; there is no flag mechanism in this path, and gating a bug fix that prevents runaway queueing would preserve the bad behaviour by default.

---

### **Tech Design / Approach**

Two alternatives were considered for `_generated/_buildConfigs/<Task>/...`:

1. **Map it to the nested task name** (`<Task>`). Semantically defensible, but a single routine `package-lock` refresh would then queue ~110 task pipelines.
2. **Ignore it entirely** (chosen). These files are generated packaging metadata; a change to them does not alter task behaviour, so no canary run is warranted.

The fix is layered rather than applied in one place: correct derivation at the source, sanitisation at the single point where `TASKS` is parsed, and a cheap guard at the actual fan-out site. Any one of the three would stop this specific bug; together they also stop a blank name arriving by some other route (e.g. a hand-supplied `TASKS` value with a trailing comma).

---

### **Documentation Changes Required** (Yes/No)

**No.** The in-file worked example in `detect-changed-tasks.js` was extended to document the `_buildConfigs` exclusion and the fan-out consequence.

---

### **Unit Tests Added or Updated** (Yes / No)

**No.** `ci/ci-test-tasks/` has no existing unit-test harness, and adding one is outside the scope of this fix. Verification was done by executing the changed logic directly against real inputs (below).

---

### **Additional Testing Performed**

- Ran the updated `getTaskNames` against the **actual 228-file change list of PR #22497**: result is **15 task names, 0 blank entries** (previously: 15 tasks **plus a blank entry** that matched all 226 pipelines).
- Re-ran the worked example already documented in the file — `["Tasks/Joe", "Tasks/Bob", "_generated/Sue_Node20", "_generated/Ralf.versionmap"]` still yields `Joe, Bob, Sue, Ralf`, confirming normal `_generated/` handling is unchanged.
- A `_buildConfigs`-only change list now correctly reports `No tasks were changed. Skip testing.`
- `npm i && npm run build` (tsc) in `ci/ci-test-tasks/test-and-verify-v2` compiles clean.

Not yet exercised end-to-end in a live canary run — that is the main thing worth confirming before this leaves draft.

---

### **Logging Added/Updated** (Yes/No)

**Yes.** `index.ts` warns when a blank task name is skipped, and `api.ts` throws with an explicit message when the task list is empty after sanitisation. No sensitive data is logged.

---

### **Telemetry Added/Updated** (Yes/No)

**No.** No telemetry pipeline exists in this tooling.

---

### **Rollback Scenario and Process** (Yes/No)

**Yes.** Revert this commit. It is self-contained across three files with no state, schema, or dependency changes; reverting restores the previous behaviour immediately on the next run.

---

### **Dependency Impact Assessed and Regression Tested** (Yes/No)

**Yes.** `detect-changed-tasks.js` is consumed by `ci/ci-test-tasks/canary-tests-v2.yml` (line 32) and `ci/ci-test-tasks/detect-changes.yml` (line 14); both pass its stdout through as `TASKS`, and both were checked. `api.tasks` is consumed only within `test-and-verify-v2`. No third-party dependencies are affected.

---

### **Checklist**
- [x] Related issue linked (if applicable) — no GitHub issue; evidence is builds `333532` / `333901` in `canarytest/PipelineTasks`
- [x] Task version was bumped — N/A, no task is modified
- [ ] Verified the task behaves as expected — logic verified offline against real inputs; **live canary run still pending**